### PR TITLE
docs: suggest natural, not line-length, in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Add `eslint-plugin-perfectionist` to the plugins section of the ESLint configura
     "perfectionist/sort-objects": [
       "error",
       {
-        "type": "line-length",
+        "type": "natural",
         "order": "desc"
       }
     ]
@@ -89,7 +89,7 @@ export default [
       'perfectionist/sort-objects': [
         'error',
         {
-          type: 'line-length',
+          type: 'natural',
           order: 'desc',
         },
       ],
@@ -108,7 +108,7 @@ The easiest way to use `eslint-plugin-perfectionist` is to use ready-made config
 ```json
 {
   "extends": [
-    "plugin:perfectionist/recommended-line-length"
+    "plugin:perfectionist/recommended-natural"
   ]
 }
 ```
@@ -117,10 +117,10 @@ The easiest way to use `eslint-plugin-perfectionist` is to use ready-made config
 
 <!-- prettier-ignore -->
 ```js
-import perfectionistLineLength from 'eslint-plugin-perfectionist/configs/recommended-line-length'
+import perfectionistNatural from 'eslint-plugin-perfectionist/configs/recommended-natural'
 
 export default [
-  perfectionistLineLength,
+  perfectionistNatural,
 ]
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Replaces suggested usage references to `line-length` with `natural`.

Fixes #14

### Additional context

n/a

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
