### PR TITLE
feat: allow separating object properties into logical parts

### DIFF
--- a/docs/rules/sort-objects.md
+++ b/docs/rules/sort-objects.md
@@ -84,6 +84,7 @@ interface Options {
   order?: 'asc' | 'desc'
   'ignore-case'?: boolean
   'always-on-top'?: string[]
+  'partition-by-comment': string[] | string | boolean
 }
 ```
 
@@ -114,6 +115,14 @@ Only affects alphabetical and natural sorting. When `true` the rule ignores the 
 
 You can set a list of key names that will always go at the beginning of the object. For example: `['id', 'name']`
 
+### partition-by-comment
+
+<sub>(default: `false`)</sub>
+
+You can set comments that would separate the properties of objects into logical parts. If set to `true`, all object property comments will be treated as delimiters.
+
+The [minimatch](https://github.com/isaacs/minimatch) library is used for pattern matching.
+
 ## ⚙️ Usage
 
 ::: code-group
@@ -127,7 +136,9 @@ You can set a list of key names that will always go at the beginning of the obje
       "error",
       {
         "type": "natural",
-        "order": "asc"
+        "order": "asc",
+        "always-on-top": ["id", "name"],
+        "partition-by-comment": "Part:**"
       }
     ]
   }
@@ -149,6 +160,8 @@ export default [
         {
           type: 'natural',
           order: 'asc',
+          'always-on-top': ['id', 'name'],
+          'partition-by-comment': 'Part:**',
         },
       ],
     },

--- a/index.ts
+++ b/index.ts
@@ -77,24 +77,25 @@ let createConfigWithOptions = (options: {
         callback: 'ignore',
       },
     ],
+    [sortObjectsName]: [
+      'error',
+      {
+        'partition-by-comment': false,
+        'always-on-top': [],
+      },
+    ],
     [sortArrayIncludesName]: [
       'error',
       {
         'spread-last': true,
       },
     ],
-    [sortObjectsName]: [
-      'error',
-      {
-        'always-on-top': [],
-      },
-    ],
-    [sortNamedImportsName]: ['error'],
     [sortNamedExportsName]: ['error'],
-    [sortObjectTypesName]: ['error'],
+    [sortNamedImportsName]: ['error'],
     [sortMapElementsName]: ['error'],
-    [sortUnionTypesName]: ['error'],
+    [sortObjectTypesName]: ['error'],
     [sortInterfacesName]: ['error'],
+    [sortUnionTypesName]: ['error'],
     [sortExportsName]: ['error'],
     [sortEnumsName]: ['error'],
   }

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -600,6 +600,159 @@ describe(RULE_NAME, () => {
         ],
       })
     })
+
+    it(`${RULE_NAME}(${type}): allows to use partition comments`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              let heroAssociation = {
+                // Part: S-Class
+                blast: 'Blast',
+                tatsumaki: 'Tatsumaki',
+                // Atomic Samurai
+                kamikaze: 'Kamikaze',
+                // Part: A-Class
+                sweet: 'Sweet Mask',
+                iaian: 'Iaian',
+                // Part: B-Class
+                'mountain-ape': 'Mountain Ape',
+                // Member of the Blizzard Group
+                eyelashes: 'Eyelashes',
+              }
+            `,
+            output: dedent`
+              let heroAssociation = {
+                // Part: S-Class
+                blast: 'Blast',
+                // Atomic Samurai
+                kamikaze: 'Kamikaze',
+                tatsumaki: 'Tatsumaki',
+                // Part: A-Class
+                iaian: 'Iaian',
+                sweet: 'Sweet Mask',
+                // Part: B-Class
+                // Member of the Blizzard Group
+                eyelashes: 'Eyelashes',
+                'mountain-ape': 'Mountain Ape',
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+                'partition-by-comment': 'Part**',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'tatsumaki',
+                  right: 'kamikaze',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'sweet',
+                  right: 'iaian',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'mountain-ape',
+                  right: 'eyelashes',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use all comments as parts`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              let brothers = {
+                // Older brother
+                edward: 'Edward Elric',
+                // Younger brother
+                alphonse: 'Alphonse Elric',
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+                'partition-by-comment': true,
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use multiple partition comments`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              let psychoPass = {
+                /* Public Safety Bureau */
+                // Crime Coefficient: Low
+                tsunemori: 'Akane Tsunemori',
+                // Crime Coefficient: High
+                kogami: 'Shinya Kogami',
+                ginoza: 'Nobuchika Ginoza',
+                masaoka: 'Tomomi Masaoka',
+                /* Victims */
+                makishima: 'Shogo Makishima',
+              }
+            `,
+            output: dedent`
+              let psychoPass = {
+                /* Public Safety Bureau */
+                // Crime Coefficient: Low
+                tsunemori: 'Akane Tsunemori',
+                // Crime Coefficient: High
+                ginoza: 'Nobuchika Ginoza',
+                kogami: 'Shinya Kogami',
+                masaoka: 'Tomomi Masaoka',
+                /* Victims */
+                makishima: 'Shogo Makishima',
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+                'partition-by-comment': [
+                  'Public Safety Bureau',
+                  'Crime Coefficient: *',
+                  'Victims',
+                ],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'kogami',
+                  right: 'ginoza',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -1185,6 +1338,159 @@ describe(RULE_NAME, () => {
                 data: {
                   left: 'finalScore',
                   right: 'math',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use partition comments`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              let heroAssociation = {
+                // Part: S-Class
+                blast: 'Blast',
+                tatsumaki: 'Tatsumaki',
+                // Atomic Samurai
+                kamikaze: 'Kamikaze',
+                // Part: A-Class
+                sweet: 'Sweet Mask',
+                iaian: 'Iaian',
+                // Part: B-Class
+                'mountain-ape': 'Mountain Ape',
+                // Member of the Blizzard Group
+                eyelashes: 'Eyelashes',
+              }
+            `,
+            output: dedent`
+              let heroAssociation = {
+                // Part: S-Class
+                blast: 'Blast',
+                // Atomic Samurai
+                kamikaze: 'Kamikaze',
+                tatsumaki: 'Tatsumaki',
+                // Part: A-Class
+                iaian: 'Iaian',
+                sweet: 'Sweet Mask',
+                // Part: B-Class
+                // Member of the Blizzard Group
+                eyelashes: 'Eyelashes',
+                'mountain-ape': 'Mountain Ape',
+              }
+            `,
+            options: [
+              {
+                type: SortType.natural,
+                order: SortOrder.asc,
+                'partition-by-comment': 'Part**',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'tatsumaki',
+                  right: 'kamikaze',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'sweet',
+                  right: 'iaian',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'mountain-ape',
+                  right: 'eyelashes',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use all comments as parts`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              let brothers = {
+                // Older brother
+                edward: 'Edward Elric',
+                // Younger brother
+                alphonse: 'Alphonse Elric',
+              }
+            `,
+            options: [
+              {
+                type: SortType.natural,
+                order: SortOrder.asc,
+                'partition-by-comment': true,
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use multiple partition comments`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              let psychoPass = {
+                /* Public Safety Bureau */
+                // Crime Coefficient: Low
+                tsunemori: 'Akane Tsunemori',
+                // Crime Coefficient: High
+                kogami: 'Shinya Kogami',
+                ginoza: 'Nobuchika Ginoza',
+                masaoka: 'Tomomi Masaoka',
+                /* Victims */
+                makishima: 'Shogo Makishima',
+              }
+            `,
+            output: dedent`
+              let psychoPass = {
+                /* Public Safety Bureau */
+                // Crime Coefficient: Low
+                tsunemori: 'Akane Tsunemori',
+                // Crime Coefficient: High
+                ginoza: 'Nobuchika Ginoza',
+                kogami: 'Shinya Kogami',
+                masaoka: 'Tomomi Masaoka',
+                /* Victims */
+                makishima: 'Shogo Makishima',
+              }
+            `,
+            options: [
+              {
+                type: SortType.natural,
+                order: SortOrder.asc,
+                'partition-by-comment': [
+                  'Public Safety Bureau',
+                  'Crime Coefficient: *',
+                  'Victims',
+                ],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'kogami',
+                  right: 'ginoza',
                 },
               },
             ],
@@ -1784,6 +2090,145 @@ describe(RULE_NAME, () => {
                 data: {
                   left: 'math',
                   right: 'naturalScience',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use partition comments`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              let heroAssociation = {
+                // Part: S-Class
+                blast: 'Blast',
+                tatsumaki: 'Tatsumaki',
+                // Atomic Samurai
+                kamikaze: 'Kamikaze',
+                // Part: A-Class
+                sweet: 'Sweet Mask',
+                iaian: 'Iaian',
+                // Part: B-Class
+                'mountain-ape': 'Mountain Ape',
+                // Member of the Blizzard Group
+                eyelashes: 'Eyelashes',
+              }
+            `,
+            output: dedent`
+              let heroAssociation = {
+                // Part: S-Class
+                tatsumaki: 'Tatsumaki',
+                // Atomic Samurai
+                kamikaze: 'Kamikaze',
+                blast: 'Blast',
+                // Part: A-Class
+                sweet: 'Sweet Mask',
+                iaian: 'Iaian',
+                // Part: B-Class
+                'mountain-ape': 'Mountain Ape',
+                // Member of the Blizzard Group
+                eyelashes: 'Eyelashes',
+              }
+            `,
+            options: [
+              {
+                type: SortType['line-length'],
+                order: SortOrder.desc,
+                'partition-by-comment': 'Part**',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'blast',
+                  right: 'tatsumaki',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use all comments as parts`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              let brothers = {
+                // Older brother
+                edward: 'Edward Elric',
+                // Younger brother
+                alphonse: 'Alphonse Elric',
+              }
+            `,
+            options: [
+              {
+                type: SortType['line-length'],
+                order: SortOrder.desc,
+                'partition-by-comment': true,
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to use multiple partition comments`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              let psychoPass = {
+                /* Public Safety Bureau */
+                // Crime Coefficient: Low
+                tsunemori: 'Akane Tsunemori',
+                // Crime Coefficient: High
+                kogami: 'Shinya Kogami',
+                ginoza: 'Nobuchika Ginoza',
+                masaoka: 'Tomomi Masaoka',
+                /* Victims */
+                makishima: 'Shogo Makishima',
+              }
+            `,
+            output: dedent`
+              let psychoPass = {
+                /* Public Safety Bureau */
+                // Crime Coefficient: Low
+                tsunemori: 'Akane Tsunemori',
+                // Crime Coefficient: High
+                ginoza: 'Nobuchika Ginoza',
+                masaoka: 'Tomomi Masaoka',
+                kogami: 'Shinya Kogami',
+                /* Victims */
+                makishima: 'Shogo Makishima',
+              }
+            `,
+            options: [
+              {
+                type: SortType['line-length'],
+                order: SortOrder.desc,
+                'partition-by-comment': [
+                  'Public Safety Bureau',
+                  'Crime Coefficient: *',
+                  'Victims',
+                ],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'kogami',
+                  right: 'ginoza',
                 },
               },
             ],

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -11,6 +11,8 @@ export enum SortOrder {
   'asc' = 'asc',
 }
 
+export type PartitionComment = string[] | boolean | string
+
 export interface SortingNode {
   dependencies?: string[]
   node: TSESTree.Node

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -1,13 +1,19 @@
-import type { TSESLint } from '@typescript-eslint/utils'
 import type { TSESTree } from '@typescript-eslint/types'
+import type { TSESLint } from '@typescript-eslint/utils'
 
 import { ASTUtils } from '@typescript-eslint/utils'
 
+import type { PartitionComment } from '../typings'
+
+import { isPartitionComment } from './is-partition-comment'
 import { getCommentBefore } from './get-comment-before'
 
 export let getNodeRange = (
   node: TSESTree.Node,
   sourceCode: TSESLint.SourceCode,
+  additionalOptions?: {
+    partitionComment?: PartitionComment
+  },
 ): TSESTree.Range => {
   let start = node.range.at(0)!
   let end = node.range.at(1)!
@@ -42,7 +48,13 @@ export let getNodeRange = (
     }
   }
 
-  if (comment) {
+  if (
+    comment &&
+    !isPartitionComment(
+      additionalOptions?.partitionComment ?? false,
+      comment.value,
+    )
+  ) {
     start = comment.range.at(0)!
   }
 

--- a/utils/is-partition-comment.ts
+++ b/utils/is-partition-comment.ts
@@ -1,0 +1,13 @@
+import { minimatch } from 'minimatch'
+
+import type { PartitionComment } from '../typings'
+
+export let isPartitionComment = (
+  partitionComment: PartitionComment,
+  comment: string,
+) =>
+  (Array.isArray(partitionComment) &&
+    partitionComment.some(pattern => minimatch(comment.trim(), pattern))) ||
+  (typeof partitionComment === 'string' &&
+    minimatch(comment.trim(), partitionComment)) ||
+  partitionComment === true

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { SortingNode } from '../typings'
+import type { PartitionComment, SortingNode } from '../typings'
 
 import { getCommentAfter } from './get-comment-after'
 import { getNodeRange } from './get-node-range'
@@ -11,14 +11,19 @@ export let makeFixes = (
   nodes: SortingNode[],
   sortedNodes: SortingNode[],
   source: TSESLint.SourceCode,
+  additionalOptions?: {
+    partitionComment?: PartitionComment
+  },
 ) => {
   let fixes: TSESLint.RuleFix[] = []
 
   nodes.forEach(({ node }, index) => {
     fixes.push(
       fixer.replaceTextRange(
-        getNodeRange(node, source),
-        source.text.slice(...getNodeRange(sortedNodes[index].node, source)),
+        getNodeRange(node, source, additionalOptions),
+        source.text.slice(
+          ...getNodeRange(sortedNodes[index].node, source, additionalOptions),
+        ),
       ),
     )
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We need to add the functionality of separating object properties into logical parts using comments in the code.

### Additional context

Close #22

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
