### PR TITLE
fix: use alphabetical as the default sort type in schemas

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -46,7 +46,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -58,7 +58,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           'ignore-case': {
             type: 'boolean',

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -43,7 +43,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           'ignore-case': {
             type: 'boolean',

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -44,7 +44,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -106,7 +106,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -45,7 +45,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -58,7 +58,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-map-elements.ts
+++ b/rules/sort-map-elements.ts
@@ -45,7 +45,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -40,7 +40,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -42,7 +42,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -43,7 +43,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -64,7 +64,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -41,7 +41,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               SortType.natural,
               SortType['line-length'],
             ],
-            default: SortType.natural,
+            default: SortType.alphabetical,
           },
           order: {
             enum: [SortOrder.asc, SortOrder.desc],

--- a/test/sort-array-includes.test.ts
+++ b/test/sort-array-includes.test.ts
@@ -843,6 +843,17 @@ describe(RULE_NAME, () => {
               'Tomomi Masaoka',
             ].includes(enforcer)
           `,
+          {
+            code: dedent`
+              [
+                'img1.png',
+                'img10.png',
+                'img12.png',
+                'img2.png',
+              ].includes(filename)
+            `,
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -945,4 +945,86 @@ describe(RULE_NAME, () => {
       })
     })
   })
+
+  describe(`${RULE_NAME}: misc`, () => {
+    it(`${RULE_NAME}: sets alphabetical asc sorting as default`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              class Calculator {
+                static log(x) {
+                  return 0;
+                }
+
+                static log10(x) {
+                  return 0;
+                }
+
+                static log1p(x) {
+                  return 0;
+                }
+
+                static log2(x) {
+                  return 0;
+                }
+              }
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              class Calculator {
+                static log(x) {
+                  return 0;
+                }
+
+                static log1p(x) {
+                  return 0;
+                }
+
+                static log10(x) {
+                  return 0;
+                }
+                
+                static log2(x) {
+                  return 0;
+                }
+              }
+            `,
+            output: dedent`
+              class Calculator {
+                static log(x) {
+                  return 0;
+                }
+
+                static log10(x) {
+                  return 0;
+                }
+
+                static log1p(x) {
+                  return 0;
+                }
+                
+                static log2(x) {
+                  return 0;
+                }
+              }
+            `,
+            errors: [
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'log1p',
+                  right: 'log10',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
 })

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -935,6 +935,17 @@ describe(RULE_NAME, () => {
               'Ushio Kofune' = 'Ushio Kofune',
             }
           `,
+          {
+            code: dedent`
+              enum NumberBase {
+                BASE_10 = 10,
+                BASE_16 = 16,
+                BASE_2 = 2,
+                BASE_8 = 8
+              }
+            `,
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-exports.test.ts
+++ b/test/sort-exports.test.ts
@@ -512,6 +512,60 @@ describe(RULE_NAME, () => {
   })
 
   describe('misc', () => {
+    it(`${RULE_NAME}: sets alphabetical asc sorting as default`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          dedent`
+            export { Hizuru } from '~/higotoshima/hizuru'
+            export { Mio } from '~/higotoshima/mio'
+            export { Shinpei } from '~/higotoshima/shinpei'
+            export { Ushio } from '~/higotoshima/ushio'
+          `,
+          {
+            code: dedent`
+              export { log } from './log'
+              export { log10 } from './log10'
+              export { log1p } from './log1p'
+              export { log2 } from './log2'
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              export { Shinpei } from '~/higotoshima/shinpei'
+              export { Mio } from '~/higotoshima/mio'
+              export { Ushio } from '~/higotoshima/ushio'
+              export { Hizuru } from '~/higotoshima/hizuru'
+            `,
+            output: dedent`
+              export { Hizuru } from '~/higotoshima/hizuru'
+              export { Mio } from '~/higotoshima/mio'
+              export { Shinpei } from '~/higotoshima/shinpei'
+              export { Ushio } from '~/higotoshima/ushio'
+            `,
+            errors: [
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: '~/higotoshima/shinpei',
+                  right: '~/higotoshima/mio',
+                },
+              },
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: '~/higotoshima/ushio',
+                  right: '~/higotoshima/hizuru',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
     it(`${RULE_NAME}: ignores exported variables or functions`, () => {
       ruleTester.run(RULE_NAME, rule, {
         valid: [

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3216,6 +3216,15 @@ describe(RULE_NAME, () => {
             import Shinpei from '~/higotoshima/shinpei'
             import Ushio from '~/higotoshima/ushio'
           `,
+          {
+            code: dedent`
+              import { log } from './log'
+              import { log10 } from './log10'
+              import { log1p } from './log1p'
+              import { log2 } from './log2'
+            `,
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -1590,11 +1590,22 @@ describe(RULE_NAME, () => {
       ruleTester.run(RULE_NAME, rule, {
         valid: [
           dedent`
-              interface DeathNoteValue {
-                causeOfDeath: string
-                name: string
+            interface DeathNoteValue {
+              causeOfDeath: string
+              name: string
+            }
+          `,
+          {
+            code: dedent`
+              interface Calculator {
+                log: (x: number) => number,
+                log10: (x: number) => number,
+                log1p: (x: number) => number,
+                log2: (x: number) => number,
               }
             `,
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-jsx-props.test.ts
+++ b/test/sort-jsx-props.test.ts
@@ -1725,6 +1725,18 @@ describe(RULE_NAME, () => {
               />
             )
           `,
+          {
+            code: dedent`
+              const content = (
+                <AppBar
+                  link1="http://www.example.com"
+                  link10="http://www.example.com"
+                  link2="http://www.example.com"
+                />
+              )
+            `,
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-map-elements.test.ts
+++ b/test/sort-map-elements.test.ts
@@ -931,14 +931,25 @@ describe(RULE_NAME, () => {
       ruleTester.run(RULE_NAME, rule, {
         valid: [
           dedent`
+            new Map([
+              ['CNY', 'Renminbi'],
+              ['EUR', 'Euro'],
+              ['GBP', 'Sterling'],
+              ['RUB', 'Russian ruble'],
+              ['USD', 'United States dollar'],
+            ])
+          `,
+          {
+            code: dedent`
               new Map([
-                ['CNY', 'Renminbi'],
-                ['EUR', 'Euro'],
-                ['GBP', 'Sterling'],
-                ['RUB', 'Russian ruble'],
-                ['USD', 'United States dollar'],
+                ['img1.png', 'http://www.example.com/img1.png'],
+                ['img10.png', 'http://www.example.com/img10.png'],
+                ['img12.png', 'http://www.example.com/img12.png'],
+                ['img2.png', 'http://www.example.com/img2.png']
               ])
             `,
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-named-exports.test.ts
+++ b/test/sort-named-exports.test.ts
@@ -172,7 +172,13 @@ describe(RULE_NAME, () => {
   describe(`${RULE_NAME}: misc`, () => {
     it(`${RULE_NAME}: sets alphabetical asc sorting as default`, () => {
       ruleTester.run(RULE_NAME, rule, {
-        valid: ['export { KayoHinazuki, SatoruFujinuma }'],
+        valid: [
+          'export { KayoHinazuki, SatoruFujinuma }',
+          {
+            code: 'export { log, log10, log1p, log2 }',
+            options: [{}],
+          },
+        ],
         invalid: [
           {
             code: dedent`

--- a/test/sort-named-imports.test.ts
+++ b/test/sort-named-imports.test.ts
@@ -851,6 +851,10 @@ describe(RULE_NAME, () => {
       ruleTester.run(RULE_NAME, rule, {
         valid: [
           "import { David, Maine, Rebecca } from 'cyberpunks-edgerunners'",
+          {
+            code: "import { log, log10, log1p, log2 } from 'calculator'",
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -963,5 +963,60 @@ describe(RULE_NAME, () => {
         invalid: [],
       })
     })
+
+    it(`${RULE_NAME}: sets alphabetical asc sorting as default`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          dedent`
+            type Calculator = {
+              log: (x: number) => number,
+              log10: (x: number) => number,
+              log1p: (x: number) => number,
+              log2: (x: number) => number,
+            }
+          `,
+          {
+            code: dedent`
+              type Calculator = {
+                log: (x: number) => number,
+                log10: (x: number) => number,
+                log1p: (x: number) => number,
+                log2: (x: number) => number,
+              }
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              type Calculator = {
+                log: (x: number) => number,
+                log1p: (x: number) => number,
+                log2: (x: number) => number,
+                log10: (x: number) => number,
+              }
+            `,
+            output: dedent`
+              type Calculator = {
+                log: (x: number) => number,
+                log10: (x: number) => number,
+                log1p: (x: number) => number,
+                log2: (x: number) => number,
+              }
+            `,
+            errors: [
+              {
+                messageId: 'unexpectedObjectTypesOrder',
+                data: {
+                  left: 'log2',
+                  right: 'log10',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 })

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -2249,6 +2249,17 @@ describe(RULE_NAME, () => {
               mom: 'Yor Forger',
             }
           `,
+          {
+            code: dedent`
+              const calculator = {
+                log: () => undefined,
+                log10: () => undefined,
+                log1p: () => undefined,
+                log2: () => undefined,
+              }
+            `,
+            options: [{}],
+          },
         ],
         invalid: [
           {

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -758,4 +758,41 @@ describe(RULE_NAME, () => {
       })
     })
   })
+
+  describe(`${RULE_NAME}: misc`, () => {
+    it(`${RULE_NAME}: sets alphabetical asc sorting as default`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          dedent`
+            type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
+          `,
+          {
+            code: dedent`
+              type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              type SupportedNumberBase = NumberBase.BASE_2 | NumberBase.BASE_10 | NumberBase.BASE_16
+            `,
+            output: dedent`
+              type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
+            `,
+            errors: [
+              {
+                messageId: 'unexpectedUnionTypesOrder',
+                data: {
+                  left: 'NumberBase.BASE_2',
+                  right: 'NumberBase.BASE_10',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently, the default `type` specified in the schema of every rule is `SortType.natural`. This will cause inconsistent behavior. For example,  `"perfectionist/sort-array-includes": "error"` and `"perfectionist/sort-array-includes": ["error", {}]` don't work in the same way. The first one uses alphabetical sorting while the second uses natural sorting.

This PR fixes the default `type` for all rules.

### Additional context

N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
