### PR TITLE
feat: allow disabling sort-objects rule for styled-components

### DIFF
--- a/docs/rules/sort-objects.md
+++ b/docs/rules/sort-objects.md
@@ -85,6 +85,7 @@ interface Options {
   'ignore-case'?: boolean
   groups?: (string | string[])[]
   'custom-groups': { [key: string]: string[] | string }
+  'styled-components': boolean
   'partition-by-comment': string[] | string | boolean
 }
 ```
@@ -131,6 +132,12 @@ Example:
   }
 }
 ```
+
+### styled-components
+
+<sub>(default: `true`)</sub>
+
+When `false`, this rule will be disabled for the styled-components like libraries.
 
 ### partition-by-comment
 

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -2280,5 +2280,56 @@ describe(RULE_NAME, () => {
         ],
       })
     })
+
+    it(`${RULE_NAME}: allow to disable rule for styled-components`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              const Box = styled.div({
+                background: "palevioletred",
+                width: "50px",
+                height: "50px",
+              })
+            `,
+            options: [
+              {
+                'styled-components': false,
+              },
+            ],
+          },
+          {
+            code: dedent`
+              const PropsBox = styled.div((props) => ({
+                background: props.background,
+                height: "50px",
+                width: "50px",
+              }))
+            `,
+            options: [
+              {
+                'styled-components': false,
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export default styled('div')(() => ({
+                borderRadius: 0,
+                borderWidth: 0,
+                border: 0,
+                borderBottom: hasBorder && \`1px solid \${theme.palette.divider}\`,
+              }))
+            `,
+            options: [
+              {
+                'styled-components': false,
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      })
+    })
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds option `styled-components` to `sort-objects` rule for disabling rule in styled-components like libraries.

### Additional context

#31, #32

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
