### PR TITLE
fix: handle more complex expressions in sort-objects

### DIFF
--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -597,6 +597,191 @@ describe(RULE_NAME, () => {
               },
             ],
           },
+          {
+            code: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                finalScore = () => biology + math,
+                math,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            output: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                math,
+                finalScore = () => biology + math,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'finalScore',
+                  right: 'math',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                finalScore = 1 === 1 ? 1 === 1 ? math : biology : biology,
+                math,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            output: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                math,
+                finalScore = 1 === 1 ? 1 === 1 ? math : biology : biology,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'finalScore',
+                  right: 'math',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                finalScore = ['a', 'b', 'c'].includes(naturalScience, math, biology),
+                math,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            output: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                math,
+                naturalScience,
+                finalScore = ['a', 'b', 'c'].includes(naturalScience, math, biology),
+              }) => {
+                // ...
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'finalScore',
+                  right: 'math',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                finalScore = math || biology,
+                math,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            output: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                math,
+                finalScore = math || biology,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'finalScore',
+                  right: 'math',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                finalScore = 1 === 1 ? math : biology,
+                math,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            output: dedent`
+              let countPrisonSchoolGrade = ({
+                biology,
+                math,
+                finalScore = 1 === 1 ? math : biology,
+                naturalScience,
+              }) => {
+                // ...
+              }
+            `,
+            options: [
+              {
+                type: SortType.alphabetical,
+                order: SortOrder.asc,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'finalScore',
+                  right: 'math',
+                },
+              },
+            ],
+          },
         ],
       })
     })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

3e987ae7e6fa9fc21caa7e23fb8b17d9ece027f0 fixes references to dependencies/earlier params (#9), but not in some more complex cases. Examples are provided in tests.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Do you think this is a good approach? I think we should try to search all of the nested nodes for `Identifier`s, which would be pushed to the `dependencies` array. I'm not sure I covered all the possible cases with this approach.

The tests also probably need some more work on the semantics :)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
