### PR TITLE
feat: add groups option in sort-interfaces rule

### DIFF
--- a/docs/rules/sort-interfaces.md
+++ b/docs/rules/sort-interfaces.md
@@ -99,6 +99,8 @@ interface Options {
   type?: 'alphabetical' | 'natural' | 'line-length'
   order?: 'asc' | 'desc'
   'ignore-case'?: boolean
+  groups?: (string | string[])[]
+  'custom-groups': { [key: string]: string[] | string }
   'ignore-pattern'?: string[]
 }
 ```
@@ -123,6 +125,28 @@ interface Options {
 <sub>(default: `false`)</sub>
 
 Only affects alphabetical and natural sorting. When `true` the rule ignores the case-sensitivity of the order.
+
+### groups
+
+<sub>(default: `[]`)</sub>
+
+You can set up a list of interface groups for sorting. Groups can be combined. There are predefined group: `'multiline'`.
+
+### custom-groups
+
+<sub>(default: `{}`)</sub>
+
+You can define your own groups for object keys. The [minimatch](https://github.com/isaacs/minimatch) library is used for pattern matching.
+
+Example:
+
+```
+{
+  "custom-groups": {
+    "top": "id"
+  }
+}
+```
 
 ### ignore-pattern
 

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -477,6 +477,89 @@ describe(RULE_NAME, () => {
         invalid: [],
       })
     })
+
+    it(`${RULE_NAME}(${type}): allows to set groups for sorting`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              interface DemonSlayer {
+                id: string
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                age: number
+                gender: 'male' | 'female'
+                onAttack: (enemyId: string) => void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'multiline', 'unknown'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface DemonSlayer {
+                age: number
+                onAttack: (enemyId: string) => void
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                id: string
+                gender: 'male' | 'female'
+              }
+            `,
+            output: dedent`
+              interface DemonSlayer {
+                id: string
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                age: number
+                gender: 'male' | 'female'
+                onAttack: (enemyId: string) => void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'multiline', 'unknown'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'onAttack',
+                  right: 'style',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'style',
+                  right: 'id',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -946,6 +1029,89 @@ describe(RULE_NAME, () => {
         invalid: [],
       })
     })
+
+    it(`${RULE_NAME}(${type}): allows to set groups for sorting`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              interface DemonSlayer {
+                id: string
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                age: number
+                gender: 'male' | 'female'
+                onAttack: (enemyId: string) => void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'multiline', 'unknown'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface DemonSlayer {
+                age: number
+                onAttack: (enemyId: string) => void
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                id: string
+                gender: 'male' | 'female'
+              }
+            `,
+            output: dedent`
+              interface DemonSlayer {
+                id: string
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                age: number
+                gender: 'male' | 'female'
+                onAttack: (enemyId: string) => void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'multiline', 'unknown'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'onAttack',
+                  right: 'style',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'style',
+                  right: 'id',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 
   describe(`${RULE_NAME}: sorting by line length`, () => {
@@ -1363,6 +1529,96 @@ describe(RULE_NAME, () => {
           },
         ],
         invalid: [],
+      })
+    })
+
+    it(`${RULE_NAME}(${type}): allows to set groups for sorting`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              interface DemonSlayer {
+                id: string
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                onAttack: (enemyId: string) => void
+                gender: 'male' | 'female'
+                age: number
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'multiline', 'unknown'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface DemonSlayer {
+                age: number
+                onAttack: (enemyId: string) => void
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                id: string
+                gender: 'male' | 'female'
+              }
+            `,
+            output: dedent`
+              interface DemonSlayer {
+                id: string
+                style: {
+                  'combat-style': string
+                  rank: number
+                }
+                onAttack: (enemyId: string) => void
+                gender: 'male' | 'female'
+                age: number
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'multiline', 'unknown'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'age',
+                  right: 'onAttack',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'onAttack',
+                  right: 'style',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'style',
+                  right: 'id',
+                },
+              },
+            ],
+          },
+        ],
       })
     })
   })


### PR DESCRIPTION
### Description

Add `groups` and `custom-groups` option for `sort-intefaces` rule

### Additional context

#29, #32

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
