### PR TITLE
feat: add groups options in sort-object-types rule

### DIFF
--- a/docs/rules/sort-object-types.md
+++ b/docs/rules/sort-object-types.md
@@ -77,6 +77,8 @@ interface Options {
   type?: 'alphabetical' | 'natural' | 'line-length'
   order?: 'asc' | 'desc'
   'ignore-case'?: boolean
+  groups?: (string | string[])[]
+  'custom-groups': { [key: string]: string[] | string }
 }
 ```
 
@@ -100,6 +102,28 @@ interface Options {
 <sub>(default: `false`)</sub>
 
 Only affects alphabetical and natural sorting. When `true` the rule ignores the case-sensitivity of the order.
+
+### groups
+
+<sub>(default: `[]`)</sub>
+
+You can set up a list of type properties groups for sorting. Groups can be combined. There are predefined group: `'multiline'`.
+
+### custom-groups
+
+<sub>(default: `{}`)</sub>
+
+You can define your own groups for type properties attributes. The [minimatch](https://github.com/isaacs/minimatch) library is used for pattern matching.
+
+Example:
+
+```
+{
+  "custom-groups": {
+    "callback": "on*"
+  }
+}
+```
 
 ## ⚙️ Usage
 

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -16,10 +16,12 @@ import { compare } from '../utils/compare'
 
 type MESSAGE_ID = 'unexpectedInterfacePropertiesOrder'
 
-type Options = [
+type Group<T extends string[]> = 'multiline' | 'unknown' | T[number]
+
+type Options<T extends string[]> = [
   Partial<{
     'custom-groups': { [key: string]: string[] | string }
-    groups: (string[] | string)[]
+    groups: (Group<T>[] | Group<T>)[]
     'ignore-pattern': string[]
     'ignore-case': boolean
     order: SortOrder
@@ -29,7 +31,7 @@ type Options = [
 
 export const RULE_NAME = 'sort-interfaces'
 
-export default createEslintRule<Options, MESSAGE_ID>({
+export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: RULE_NAME,
   meta: {
     type: 'suggestion',

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -267,6 +267,89 @@ describe(RULE_NAME, () => {
         ],
       })
     })
+
+    it(`${RULE_NAME}(${type}): allows to set groups for sorting`, () => {
+      ruleTester.run(RULE_NAME, rule, {
+        valid: [
+          {
+            code: dedent`
+              interface Idol {
+                id: string
+                age: number
+                gender: 'female'
+                name: 'Ai Hoshino'
+                skills: {
+                  actress: number
+                  singer: number
+                }
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'unknown', 'multiline'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              type Idol = {
+                age: number
+                gender: 'female'
+                id: string
+                skills: {
+                  actress: number
+                  singer: number
+                }
+                name: 'Ai Hoshino'
+              }
+            `,
+            output: dedent`
+              type Idol = {
+                id: string
+                age: number
+                gender: 'female'
+                name: 'Ai Hoshino'
+                skills: {
+                  actress: number
+                  singer: number
+                }
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['id', 'unknown', 'multiline'],
+                'custom-groups': {
+                  id: 'id',
+                },
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectTypesOrder',
+                data: {
+                  left: 'gender',
+                  right: 'id',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectTypesOrder',
+                data: {
+                  left: 'skills',
+                  right: 'name',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -617,8 +700,8 @@ describe(RULE_NAME, () => {
             `,
             output: dedent`
               let handleDemonSlayerAttack = (attack: {
-                attackType: string
                 slayerName: string
+                attackType: string
                 demon: string
               }) => {
                 // ...


### PR DESCRIPTION
### Description

Add `groups` and `custom-groups` option for `sort-object-types` rule.

### Additional context

#32

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
