### PR TITLE
fix: prefix-only builtin modules are defined as external modules in sort-imports rule

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -201,7 +201,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         tsPaths.some(pattern => minimatch(nodeElement.source.value, pattern))
 
       let isCoreModule = (value: string) =>
-        builtinModules.includes(value.startsWith('node:') ? value.split('node:')[1] : value)
+        builtinModules.includes(
+          value.startsWith('node:') ? value.split('node:')[1] : value,
+        )
 
       if (node.importKind === 'type') {
         if (node.type === 'ImportDeclaration') {

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -201,7 +201,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         tsPaths.some(pattern => minimatch(nodeElement.source.value, pattern))
 
       let isCoreModule = (value: string) =>
-        builtinModules.includes(value.startsWith("node:") ? value.split("node:")[1] : value)
+        builtinModules.includes(value.startsWith('node:') ? value.split('node:')[1] : value)
 
       if (node.importKind === 'type') {
         if (node.type === 'ImportDeclaration') {

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -201,8 +201,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         tsPaths.some(pattern => minimatch(nodeElement.source.value, pattern))
 
       let isCoreModule = (value: string) =>
-        builtinModules.includes(value) ||
-        builtinModules.includes(`node:${value}`)
+        builtinModules.includes(value.startsWith("node:") ? value.split("node:")[1] : value)
 
       if (node.importKind === 'type') {
         if (node.type === 'ImportDeclaration') {

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3240,9 +3240,9 @@ describe(RULE_NAME, () => {
         valid: [
           {
             code: dedent`
-              import { writeFile } from "node:fs/promises"
+              import { writeFile } from 'node:fs/promises'
               
-              import { useEffect } from "react"
+              import { useEffect } from 'react'
             `,
             options: [
               {

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3232,5 +3232,59 @@ describe(RULE_NAME, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${RULE_NAME}: defines prefix-only builtin modules as core node modules`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import { writeFile } from "node:fs/promises"
+              
+              import { useEffect } from "react"
+            `,
+            options: [
+              {
+                groups: [
+                  'builtin',
+                  'external'
+                ],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import { writeFile } from 'node:fs/promises'
+              import { useEffect } from 'react'
+            `,
+            output: dedent`
+              import { writeFile } from 'node:fs/promises'
+
+              import { useEffect } from 'react'
+            `,
+            errors: [
+              {
+                messageId: 'missedSpacingBetweenImports',
+                data: {
+                  left: 'node:fs/promises',
+                  right: 'react',
+                },
+              },
+            ],
+            options: [
+              {
+                groups: [
+                  'builtin',
+                  'external'
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 })

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3246,10 +3246,7 @@ describe(RULE_NAME, () => {
             `,
             options: [
               {
-                groups: [
-                  'builtin',
-                  'external'
-                ],
+                groups: ['builtin', 'external'],
               },
             ],
           },
@@ -3265,6 +3262,11 @@ describe(RULE_NAME, () => {
 
               import { useEffect } from 'react'
             `,
+            options: [
+              {
+                groups: ['builtin', 'external'],
+              },
+            ],
             errors: [
               {
                 messageId: 'missedSpacingBetweenImports',
@@ -3272,14 +3274,6 @@ describe(RULE_NAME, () => {
                   left: 'node:fs/promises',
                   right: 'react',
                 },
-              },
-            ],
-            options: [
-              {
-                groups: [
-                  'builtin',
-                  'external'
-                ],
               },
             ],
           },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix #65

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Because `builtinModules` does not includes modules that start with the prefix `node:` you need to check it manually.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
- [X] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
