### PR TITLE
fix: side-effect import with an internal pattern are defined as internal module in sort-imports rule

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -222,24 +222,24 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         if (node.type === 'ImportDeclaration') {
           setCustomGroups(options['custom-groups'].type, node.source.value)
 
-          if (isCoreModule(node.source.value)) {
-            defineGroup('builtin-type')
-          }
-
-          if (isInternal(node)) {
-            defineGroup('internal-type')
-          }
-
           if (isIndex(node.source.value)) {
             defineGroup('index-type')
+          }
+
+          if (isSibling(node.source.value)) {
+            defineGroup('sibling-type')
           }
 
           if (isParent(node.source.value)) {
             defineGroup('parent-type')
           }
 
-          if (isSibling(node.source.value)) {
-            defineGroup('sibling-type')
+          if (isInternal(node)) {
+            defineGroup('internal-type')
+          }
+
+          if (isCoreModule(node.source.value)) {
+            defineGroup('builtin-type')
           }
         }
 
@@ -250,32 +250,32 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       if (node.type === 'ImportDeclaration') {
         setCustomGroups(options['custom-groups'].value, node.source.value)
 
-        if (isCoreModule(node.source.value)) {
-          defineGroup('builtin')
-        }
-
-        if (isInternal(node)) {
-          defineGroup('internal')
+        if (isSideEffectImport(node)) {
+          defineGroup('side-effect')
         }
 
         if (isStyle(node.source.value)) {
           defineGroup('style')
         }
 
-        if (isSideEffectImport(node)) {
-          defineGroup('side-effect')
-        }
-
         if (isIndex(node.source.value)) {
           defineGroup('index')
+        }
+
+        if (isSibling(node.source.value)) {
+          defineGroup('sibling')
         }
 
         if (isParent(node.source.value)) {
           defineGroup('parent')
         }
 
-        if (isSibling(node.source.value)) {
-          defineGroup('sibling')
+        if (isInternal(node)) {
+          defineGroup('internal')
+        }
+
+        if (isCoreModule(node.source.value)) {
+          defineGroup('builtin')
         }
 
         defineGroup('external')

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3608,5 +3608,53 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${RULE_NAME}: define side-effect import with internal pattern as side-effect import`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import { useClient } from '~/hooks/useClient'
+
+              import '~/css/globals.css'
+            `,
+            options: [
+              {
+                groups: ['internal', 'side-effect'],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import { useClient } from '~/hooks/useClient'
+              import '~/css/globals.css'
+            `,
+            output: dedent`
+              import { useClient } from '~/hooks/useClient'
+
+              import '~/css/globals.css'
+            `,
+            options: [
+              {
+                groups: ['internal', 'side-effect'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'missedSpacingBetweenImports',
+                data: {
+                  left: '~/hooks/useClient',
+                  right: '~/css/globals.css',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #72 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I changed the group definition sequence to get the correct behavior.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
- [X] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
