### PR TITLE
feat: add partition by new line option to sort-objects rule

### DIFF
--- a/docs/rules/sort-objects.md
+++ b/docs/rules/sort-objects.md
@@ -84,9 +84,10 @@ interface Options {
   order?: 'asc' | 'desc'
   'ignore-case'?: boolean
   groups?: (string | string[])[]
-  'custom-groups': { [key: string]: string[] | string }
-  'styled-components': boolean
-  'partition-by-comment': string[] | string | boolean
+  'custom-groups'?: { [key: string]: string[] | string }
+  'styled-components'?: boolean
+  'partition-by-comment'?: string[] | string | boolean
+  'partition-by-new-line'?: boolean
 }
 ```
 
@@ -146,6 +147,12 @@ When `false`, this rule will be disabled for the styled-components like librarie
 You can set comments that would separate the properties of objects into logical parts. If set to `true`, all object property comments will be treated as delimiters.
 
 The [minimatch](https://github.com/isaacs/minimatch) library is used for pattern matching.
+
+### partition-by-new-line
+
+<sub>(default: `false`)</sub>
+
+When `true`, does not sort the object's keys if there is an empty string between them.
 
 ## ⚙️ Usage
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -8,6 +8,7 @@ import type { SortingNode } from '../typings'
 
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
+import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getNodeRange } from '../utils/get-node-range'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -393,18 +394,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             },
           ).length
 
-        let getLinesBetweenImports = (
-          left: SortingNode,
-          right: SortingNode,
-        ) => {
-          let linesBetweenImports = source.lines.slice(
-            left.node.loc.end.line,
-            right.node.loc.start.line - 1,
-          )
-
-          return linesBetweenImports.filter(line => !line.trim().length).length
-        }
-
         let fix = (
           fixer: TSESLint.RuleFixer,
           nodesToFix: SortingNode[],
@@ -452,7 +441,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               let nextNode = formatted.at(i + 1)
 
               if (nextNode) {
-                let linesBetweenImports = getLinesBetweenImports(
+                let linesBetweenImports = getLinesBetween(
+                  source,
                   nodesToFix.at(i)!,
                   nodesToFix.at(i + 1)!,
                 )
@@ -530,7 +520,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             let leftNum = getGroupNumber(options.groups, left)
             let rightNum = getGroupNumber(options.groups, right)
 
-            let numberOfEmptyLinesBetween = getLinesBetweenImports(left, right)
+            let numberOfEmptyLinesBetween = getLinesBetween(source, left, right)
 
             if (
               !(

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -891,6 +891,82 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${RULE_NAME}(${type}): allows to use new line as partition`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              let terrorist = {
+                name: 'Twelve',
+                nickname: 'Sphinx #2',
+
+                status: Status.Deceased,
+
+                height: '167 cm',
+                weight: '55 kg',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'partition-by-new-line': true,
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              let terrorist = {
+                nickname: 'Sphinx #2',
+                name: 'Twelve',
+
+                status: Status.Deceased,
+
+                weight: '55 kg',
+                height: '167 cm',
+              }
+            `,
+            output: dedent`
+              let terrorist = {
+                name: 'Twelve',
+                nickname: 'Sphinx #2',
+
+                status: Status.Deceased,
+
+                height: '167 cm',
+                weight: '55 kg',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'nickname',
+                  right: 'name',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'weight',
+                  right: 'height',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -1575,6 +1651,82 @@ describe(RULE_NAME, () => {
                 data: {
                   left: 'kogami',
                   right: 'ginoza',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${RULE_NAME}(${type}): allows to use new line as partition`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              let terrorist = {
+                name: 'Twelve',
+                nickname: 'Sphinx #2',
+
+                status: Status.Deceased,
+
+                height: '167 cm',
+                weight: '55 kg',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'partition-by-new-line': true,
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              let terrorist = {
+                nickname: 'Sphinx #2',
+                name: 'Twelve',
+
+                status: Status.Deceased,
+
+                weight: '55 kg',
+                height: '167 cm',
+              }
+            `,
+            output: dedent`
+              let terrorist = {
+                name: 'Twelve',
+                nickname: 'Sphinx #2',
+
+                status: Status.Deceased,
+
+                height: '167 cm',
+                weight: '55 kg',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'nickname',
+                  right: 'name',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'weight',
+                  right: 'height',
                 },
               },
             ],
@@ -2314,6 +2466,75 @@ describe(RULE_NAME, () => {
                 data: {
                   left: 'd',
                   right: 'e',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${RULE_NAME}(${type}): allows to use new line as partition`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              let terrorist = {
+                nickname: 'Sphinx #2',
+                name: 'Twelve',
+
+                status: Status.Deceased,
+
+                height: '167 cm',
+                weight: '55 kg',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'partition-by-new-line': true,
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              let terrorist = {
+                nickname: 'Sphinx #2',
+                name: 'Twelve',
+
+                status: Status.Deceased,
+
+                weight: '55 kg',
+                height: '167 cm',
+              }
+            `,
+            output: dedent`
+              let terrorist = {
+                nickname: 'Sphinx #2',
+                name: 'Twelve',
+
+                status: Status.Deceased,
+
+                height: '167 cm',
+                weight: '55 kg',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'weight',
+                  right: 'height',
                 },
               },
             ],

--- a/utils/get-lines-between.ts
+++ b/utils/get-lines-between.ts
@@ -1,0 +1,16 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { SortingNode } from '../typings'
+
+export let getLinesBetween = (
+  source: TSESLint.SourceCode,
+  left: SortingNode,
+  right: SortingNode,
+) => {
+  let linesBetween = source.lines.slice(
+    left.node.loc.end.line,
+    right.node.loc.start.line - 1,
+  )
+
+  return linesBetween.filter(line => !line.trim().length).length
+}


### PR DESCRIPTION
### Description

Add `partition-by-new-line` option to `sort-objects` rule.

### Additional context

#86

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
