### PR TITLE
docs: note on usage of prettier-plugin-sort-imports in sort-imports conflicts

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -21,6 +21,8 @@ Sorting imports ensures that imports are easily locatable and quickly scannable,
 
 :::info Important
 If you use the [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) rule or the [`order`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) rule from the [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import) plugin, it is highly recommended to [disable them](https://eslint.org/docs/latest/use/configure/rules#using-configuration-files-1) to avoid conflicts.
+
+If you use the [`prettier-plugin-sort-imports`](https://github.com/trivago/prettier-plugin-sort-imports) plugin, remove them from the prettier config to avoid conflicts.
 :::
 
 Rule `perfectionist/sort-imports` works in a similar way to rule `import/order`, but with some differences:


### PR DESCRIPTION
### Description

note on usage of prettier-plugin-sort-imports in sort-imports conflicts

### Additional context

I got this conflicts and spent hours trying to figure this out. Hopefully this note will help others avoid this.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
