### PR TITLE
feat(sort-classes): add decorators support

### DIFF
--- a/docs/rules/sort-classes.md
+++ b/docs/rules/sort-classes.md
@@ -114,6 +114,13 @@ This rule accepts an options object with the following properties:
 
 ```ts
 type Group =
+  | 'decorated-accessor-property'
+  | 'decorated-method'
+  | 'decorated-property'
+  | 'decorated-set-method'
+  | 'decorated-get-method'
+  | 'private-decorated-accessor-property'
+  | 'private-decorated-property'
   | 'static-private-method'
   | 'private-property'
   | 'static-property'

--- a/docs/rules/sort-classes.md
+++ b/docs/rules/sort-classes.md
@@ -114,14 +114,14 @@ This rule accepts an options object with the following properties:
 
 ```ts
 type Group =
-  | 'decorated-accessor-property'
-  | 'decorated-method'
-  | 'decorated-property'
-  | 'decorated-set-method'
-  | 'decorated-get-method'
   | 'private-decorated-accessor-property'
+  | 'decorated-accessor-property'
   | 'private-decorated-property'
   | 'static-private-method'
+  | 'decorated-set-method'
+  | 'decorated-get-method'
+  | 'decorated-property'
+  | 'decorated-method'
   | 'private-property'
   | 'static-property'
   | 'index-signature'

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -128,8 +128,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
           let isPrivate = name.startsWith('_') || name.startsWith('#')
 
-          let decorated =
-            'decorators' in member && member.decorators.length > 0
+          let decorated = 'decorators' in member && member.decorators.length > 0
 
           if (member.type === 'MethodDefinition') {
             if (member.kind === 'constructor') {

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -18,6 +18,13 @@ import { compare } from '../utils/compare'
 type MESSAGE_ID = 'unexpectedClassesOrder'
 
 type Group =
+  | 'decorated-accessor-property'
+  | 'decorated-method'
+  | 'decorated-property'
+  | 'decorated-set-method'
+  | 'decorated-get-method'
+  | 'private-decorated-accessor-property'
+  | 'private-decorated-property'
   | 'static-private-method'
   | 'private-property'
   | 'static-property'
@@ -121,6 +128,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
           let isPrivate = name.startsWith('_') || name.startsWith('#')
 
+          const decorated =
+            'decorators' in member && member.decorators.length > 0
+
           if (member.type === 'MethodDefinition') {
             if (member.kind === 'constructor') {
               defineGroup('constructor')
@@ -130,6 +140,18 @@ export default createEslintRule<Options, MESSAGE_ID>({
               member.accessibility === 'private' || isPrivate
 
             let isStaticMethod = member.static
+
+            if (decorated) {
+              if (member.kind === 'get') {
+                defineGroup('decorated-get-method')
+              }
+
+              if (member.kind === 'set') {
+                defineGroup('decorated-set-method')
+              }
+
+              defineGroup('decorated-method')
+            }
 
             if (isPrivateMethod && isStaticMethod) {
               defineGroup('static-private-method')
@@ -154,7 +176,23 @@ export default createEslintRule<Options, MESSAGE_ID>({
             defineGroup('method')
           } else if (member.type === 'TSIndexSignature') {
             defineGroup('index-signature')
+          } else if (member.type === 'AccessorProperty') {
+            if (decorated) {
+              if (member.accessibility === 'private' || isPrivate) {
+                defineGroup('private-decorated-accessor-property')
+              }
+
+              defineGroup('decorated-accessor-property')
+            }
           } else if (member.type === 'PropertyDefinition') {
+            if (decorated) {
+              if (member.accessibility === 'private' || isPrivate) {
+                defineGroup('private-decorated-property')
+              }
+
+              defineGroup('decorated-property')
+            }
+
             if (member.accessibility === 'private' || isPrivate) {
               defineGroup('private-property')
             }

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -18,14 +18,14 @@ import { compare } from '../utils/compare'
 type MESSAGE_ID = 'unexpectedClassesOrder'
 
 type Group =
-  | 'decorated-accessor-property'
-  | 'decorated-method'
-  | 'decorated-property'
-  | 'decorated-set-method'
-  | 'decorated-get-method'
   | 'private-decorated-accessor-property'
+  | 'decorated-accessor-property'
   | 'private-decorated-property'
   | 'static-private-method'
+  | 'decorated-set-method'
+  | 'decorated-get-method'
+  | 'decorated-property'
+  | 'decorated-method'
   | 'private-property'
   | 'static-property'
   | 'index-signature'
@@ -128,7 +128,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
           let isPrivate = name.startsWith('_') || name.startsWith('#')
 
-          const decorated =
+          let decorated =
             'decorators' in member && member.decorators.length > 0
 
           if (member.type === 'MethodDefinition') {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -530,6 +530,234 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(`${RULE_NAME}(${type}): sorts decorated properties`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            class User {
+              firstName: string
+
+              id: number
+
+              @Index({ name: 'born_index' })
+              @Property()
+              born: string
+
+              @Property()
+              @Unique()
+              email: string
+
+              lastName: string
+            }`,
+          output: dedent`
+            class User {
+              firstName: string
+
+              id: number
+
+              lastName: string
+
+              @Index({ name: 'born_index' })
+              @Property()
+              born: string
+
+              @Property()
+              @Unique()
+              email: string
+            }`,
+          options: [
+            {
+              ...options,
+              groups: ['property', 'decorated-property', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'email',
+                right: 'lastName',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+            class MyElement {
+              @property({ attribute: false })
+              data = {}
+            
+              @property()
+              greeting: string = 'Hello'
+            
+              @state()
+              private _counter = 0
+            
+              private _message = ''
+            
+              private _prop = 0
+            
+              constructor() {}
+            
+              @property()
+              get message(): string {
+                return this._message
+              }
+            
+              set message(message: string) {
+                this._message = message
+              }
+            
+              @property()
+              set prop(val: number) {
+                this._prop = Math.floor(val)
+              }
+            
+              get prop() {
+                return this._prop
+              }
+            
+              render() {}
+            }`,
+          output: dedent`
+            class MyElement {
+              @property({ attribute: false })
+              data = {}
+            
+              @property()
+              greeting: string = 'Hello'
+            
+              @state()
+              private _counter = 0
+            
+              private _message = ''
+            
+              private _prop = 0
+            
+              constructor() {}
+            
+              @property()
+              get message(): string {
+                return this._message
+              }
+            
+              @property()
+              set prop(val: number) {
+                this._prop = Math.floor(val)
+              }
+            
+              set message(message: string) {
+                this._message = message
+              }
+            
+              get prop() {
+                return this._prop
+              }
+            
+              render() {}
+            }`,
+          options: [
+            {
+              ...options,
+              groups: [
+                'decorated-property',
+                'property',
+                'private-decorated-property',
+                'private-property',
+                'constructor',
+                ['decorated-get-method', 'decorated-set-method'],
+                ['get-method', 'set-method'],
+                'unknown',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'message',
+                right: 'prop',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${RULE_NAME}(${type}): sorts decorated accessors`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            class Todo {
+              id = Math.random()
+            
+              constructor() {}
+            
+              @action
+              toggle() {}
+            
+              @observable
+              accessor #active = false
+            
+              @observable
+              accessor finished = false
+            
+              @observable
+              accessor title = ''
+            }`,
+          output: dedent`
+            class Todo {
+              @observable
+              accessor finished = false
+            
+              @observable
+              accessor title = ''
+            
+              @observable
+              accessor #active = false
+            
+              id = Math.random()
+            
+              constructor() {}
+            
+              @action
+              toggle() {}
+            }`,
+          options: [
+            {
+              ...options,
+              groups: [
+                'decorated-accessor-property',
+                'private-decorated-accessor-property',
+                'property',
+                'constructor',
+                'decorated-method',
+                'unknown',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'toggle',
+                right: '#active',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: '#active',
+                right: 'finished',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -1045,6 +1273,234 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(`${RULE_NAME}(${type}): sorts decorated properties`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            class User {
+              firstName: string
+
+              id: number
+
+              @Index({ name: 'born_index' })
+              @Property()
+              born: string
+
+              @Property()
+              @Unique()
+              email: string
+
+              lastName: string
+            }`,
+          output: dedent`
+            class User {
+              firstName: string
+
+              id: number
+
+              lastName: string
+
+              @Index({ name: 'born_index' })
+              @Property()
+              born: string
+
+              @Property()
+              @Unique()
+              email: string
+            }`,
+          options: [
+            {
+              ...options,
+              groups: ['property', 'decorated-property', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'email',
+                right: 'lastName',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+            class MyElement {
+              @property({ attribute: false })
+              data = {}
+            
+              @property()
+              greeting: string = 'Hello'
+            
+              @state()
+              private _counter = 0
+            
+              private _message = ''
+            
+              private _prop = 0
+            
+              constructor() {}
+            
+              @property()
+              get message(): string {
+                return this._message
+              }
+            
+              set message(message: string) {
+                this._message = message
+              }
+            
+              @property()
+              set prop(val: number) {
+                this._prop = Math.floor(val)
+              }
+            
+              get prop() {
+                return this._prop
+              }
+            
+              render() {}
+            }`,
+          output: dedent`
+            class MyElement {
+              @property({ attribute: false })
+              data = {}
+            
+              @property()
+              greeting: string = 'Hello'
+            
+              @state()
+              private _counter = 0
+            
+              private _message = ''
+            
+              private _prop = 0
+            
+              constructor() {}
+            
+              @property()
+              get message(): string {
+                return this._message
+              }
+            
+              @property()
+              set prop(val: number) {
+                this._prop = Math.floor(val)
+              }
+            
+              set message(message: string) {
+                this._message = message
+              }
+            
+              get prop() {
+                return this._prop
+              }
+            
+              render() {}
+            }`,
+          options: [
+            {
+              ...options,
+              groups: [
+                'decorated-property',
+                'property',
+                'private-decorated-property',
+                'private-property',
+                'constructor',
+                ['decorated-get-method', 'decorated-set-method'],
+                ['get-method', 'set-method'],
+                'unknown',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'message',
+                right: 'prop',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${RULE_NAME}(${type}): sorts decorated accessors`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            class Todo {
+              id = Math.random()
+            
+              constructor() {}
+            
+              @action
+              toggle() {}
+            
+              @observable
+              accessor #active = false
+            
+              @observable
+              accessor finished = false
+            
+              @observable
+              accessor title = ''
+            }`,
+          output: dedent`
+            class Todo {
+              @observable
+              accessor finished = false
+            
+              @observable
+              accessor title = ''
+            
+              @observable
+              accessor #active = false
+            
+              id = Math.random()
+            
+              constructor() {}
+            
+              @action
+              toggle() {}
+            }`,
+          options: [
+            {
+              ...options,
+              groups: [
+                'decorated-accessor-property',
+                'private-decorated-accessor-property',
+                'property',
+                'constructor',
+                'decorated-method',
+                'unknown',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'toggle',
+                right: '#active',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: '#active',
+                right: 'finished',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 
   describe(`${RULE_NAME}: sorting by line length`, () => {
@@ -1496,6 +1952,234 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(`${RULE_NAME}(${type}): sorts decorated properties`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            class User {
+              firstName: string
+
+              id: number
+
+              @Index({ name: 'born_index' })
+              @Property()
+              born: string
+
+              @Property()
+              @Unique()
+              email: string
+
+              lastName: string
+            }`,
+          output: dedent`
+            class User {
+              firstName: string
+
+              lastName: string
+
+              id: number
+
+              @Index({ name: 'born_index' })
+              @Property()
+              born: string
+
+              @Property()
+              @Unique()
+              email: string
+            }`,
+          options: [
+            {
+              ...options,
+              groups: ['property', 'decorated-property', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'email',
+                right: 'lastName',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+            class MyElement {
+              @property({ attribute: false })
+              data = {}
+
+              @property()
+              greeting: string = 'Hello'
+
+              @state()
+              private _counter = 0
+
+              private _message = ''
+            
+              private _prop = 0
+            
+              constructor() {}
+
+              @property()
+              get message(): string {
+                return this._message
+              }
+            
+              set message(message: string) {
+                this._message = message
+              }
+            
+              @property()
+              set prop(val: number) {
+                this._prop = Math.floor(val)
+              }
+            
+              get prop() {
+                return this._prop
+              }
+            
+              render() {}
+            }`,
+          output: dedent`
+            class MyElement {
+              @property({ attribute: false })
+              data = {}
+
+              @property()
+              greeting: string = 'Hello'
+            
+              @state()
+              private _counter = 0
+            
+              private _message = ''
+            
+              private _prop = 0
+            
+              constructor() {}
+            
+              @property()
+              set prop(val: number) {
+                this._prop = Math.floor(val)
+              }
+
+              @property()
+              get message(): string {
+                return this._message
+              }
+            
+              set message(message: string) {
+                this._message = message
+              }
+            
+              get prop() {
+                return this._prop
+              }
+            
+              render() {}
+            }`,
+          options: [
+            {
+              ...options,
+              groups: [
+                'decorated-property',
+                'property',
+                'private-decorated-property',
+                'private-property',
+                'constructor',
+                ['decorated-get-method', 'decorated-set-method'],
+                ['get-method', 'set-method'],
+                'unknown',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'message',
+                right: 'prop',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${RULE_NAME}(${type}): sorts decorated accessors`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            class Todo {
+              id = Math.random()
+            
+              constructor() {}
+            
+              @action
+              toggle() {}
+            
+              @observable
+              accessor #active = false
+            
+              @observable
+              accessor finished = false
+            
+              @observable
+              accessor title = ''
+            }`,
+          output: dedent`
+            class Todo {
+              @observable
+              accessor finished = false
+            
+              @observable
+              accessor title = ''
+            
+              @observable
+              accessor #active = false
+            
+              id = Math.random()
+            
+              constructor() {}
+            
+              @action
+              toggle() {}
+            }`,
+          options: [
+            {
+              ...options,
+              groups: [
+                'decorated-accessor-property',
+                'private-decorated-accessor-property',
+                'property',
+                'constructor',
+                'decorated-method',
+                'unknown',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'toggle',
+                right: '#active',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: '#active',
+                right: 'finished',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 
   describe(`${RULE_NAME}: misc`, () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #93!

This PR adds support for grouping decorated fields and methods separately, optionally specifying their accessibility.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
- [X] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
