### PR TITLE
feat: adds `group-kind` option on `sort-named-imports` and `sort-named-exports`

### DIFF
--- a/docs/rules/sort-named-exports.md
+++ b/docs/rules/sort-named-exports.md
@@ -69,6 +69,7 @@ This rule accepts an options object with the following properties:
 interface Options {
   type?: 'alphabetical' | 'natural' | 'line-length'
   order?: 'asc' | 'desc'
+  'group-kind'?: 'mixed' | 'values-first' | 'types-first'
   'ignore-case'?: boolean
 }
 ```
@@ -87,6 +88,16 @@ interface Options {
 
 - `asc` - enforce properties to be in ascending order.
 - `desc` - enforce properties to be in descending order.
+
+### group-kind
+
+<sub>(default: `'mixed'`)</sub>
+
+Allows to group named exports by their kind, with value exports coming either before or after type exports.
+
+- `mixed` - does not group named exports by their kind
+- `values-first` - groups all value exports before type exports
+- `types-first` - groups all type exports before value exports
 
 ### ignore-case
 

--- a/docs/rules/sort-named-imports.md
+++ b/docs/rules/sort-named-imports.md
@@ -85,6 +85,7 @@ This rule accepts an options object with the following properties:
 interface Options {
   type?: 'alphabetical' | 'natural' | 'line-length'
   order?: 'asc' | 'desc'
+  'group-kind'?: 'mixed' | 'values-first' | 'types-first'
   'ignore-case'?: boolean
   'ignore-alias'?: boolean
 }
@@ -104,6 +105,16 @@ interface Options {
 
 - `asc` - enforce properties to be in ascending order.
 - `desc` - enforce properties to be in descending order.
+
+### group-kind
+
+<sub>(default: `'mixed'`)</sub>
+
+Allows to group named imports by their kind, with value imports coming either before or after type imports.
+
+- `mixed` - does not group named imports by their kind
+- `values-first` - groups all value imports before type imports
+- `types-first` - groups all type imports before value imports
 
 ### ignore-case
 

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -1,4 +1,4 @@
-import type { SortingNode } from '../typings'
+import { GroupKind, type SortingNode } from '../typings'
 
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -9,6 +9,7 @@ import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
+import { getGroupNumber } from '../utils/get-group-number'
 
 type MESSAGE_ID = 'unexpectedNamedExportsOrder'
 
@@ -17,6 +18,7 @@ type Options = [
     'ignore-case': boolean
     order: SortOrder
     type: SortType
+    'group-kind': GroupKind
   }>,
 ]
 
@@ -52,6 +54,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'boolean',
             default: false,
           },
+          'group-kind': {
+            enum: [
+              GroupKind.mixed,
+              GroupKind['values-first'],
+              GroupKind['types-first'],
+            ],
+            default: GroupKind.mixed,
+            type: 'string',
+          },
         },
         additionalProperties: false,
       },
@@ -74,16 +85,38 @@ export default createEslintRule<Options, MESSAGE_ID>({
           type: SortType.alphabetical,
           'ignore-case': false,
           order: SortOrder.asc,
+          'group-kind': GroupKind.mixed,
         })
 
         let nodes: SortingNode[] = node.specifiers.map(specifier => ({
           size: rangeToDiff(specifier.range),
           name: specifier.local.name,
           node: specifier,
+          group: specifier.exportKind,
         }))
 
+        let shouldGroupByKind = options['group-kind'] !== GroupKind.mixed
+        let groupKindOrder =
+          options['group-kind'] === GroupKind['values-first']
+            ? ['value', 'type']
+            : ['type', 'value']
+
         pairwise(nodes, (left, right) => {
-          if (isPositive(compare(left, right, options))) {
+          let leftNum = getGroupNumber(groupKindOrder, left)
+          let rightNum = getGroupNumber(groupKindOrder, right)
+
+          if (
+            (shouldGroupByKind && leftNum > rightNum) ||
+            ((!shouldGroupByKind || leftNum === rightNum) &&
+              isPositive(compare(left, right, options)))
+          ) {
+            let sortedNodes = shouldGroupByKind
+              ? groupKindOrder
+                  .map(group => nodes.filter(node => node.group === group))
+                  .map(groupedNodes => sortNodes(groupedNodes, options))
+                  .flat()
+              : sortNodes(nodes, options)
+
             context.report({
               messageId: 'unexpectedNamedExportsOrder',
               data: {
@@ -92,12 +125,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               },
               node: right.node,
               fix: fixer =>
-                makeFixes(
-                  fixer,
-                  nodes,
-                  sortNodes(nodes, options),
-                  context.sourceCode,
-                ),
+                makeFixes(fixer, nodes, sortedNodes, context.sourceCode),
             })
           }
         })

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -1,24 +1,24 @@
-import { GroupKind, type SortingNode } from '../typings'
+import type { SortingNode } from '../typings'
 
 import { createEslintRule } from '../utils/create-eslint-rule'
+import { SortOrder, GroupKind, SortType } from '../typings'
+import { getGroupNumber } from '../utils/get-group-number'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { isPositive } from '../utils/is-positive'
-import { SortOrder, SortType } from '../typings'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
-import { getGroupNumber } from '../utils/get-group-number'
 
 type MESSAGE_ID = 'unexpectedNamedExportsOrder'
 
 type Options = [
   Partial<{
+    'group-kind': GroupKind
     'ignore-case': boolean
     order: SortOrder
     type: SortType
-    'group-kind': GroupKind
   }>,
 ]
 
@@ -112,7 +112,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ) {
             let sortedNodes = shouldGroupByKind
               ? groupKindOrder
-                  .map(group => nodes.filter(node => node.group === group))
+                  .map(group => nodes.filter(n => n.group === group))
                   .map(groupedNodes => sortNodes(groupedNodes, options))
                   .flat()
               : sortNodes(nodes, options)

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -1,4 +1,4 @@
-import type { SortingNode } from '../typings'
+import { GroupKind, type SortingNode } from '../typings'
 
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -9,6 +9,7 @@ import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
+import { getGroupNumber } from '../utils/get-group-number'
 
 type MESSAGE_ID = 'unexpectedNamedImportsOrder'
 
@@ -18,6 +19,7 @@ type Options = [
     'ignore-case': boolean
     order: SortOrder
     type: SortType
+    'group-kind': GroupKind
   }>,
 ]
 
@@ -57,6 +59,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'boolean',
             default: false,
           },
+          'group-kind': {
+            enum: [
+              GroupKind.mixed,
+              GroupKind['values-first'],
+              GroupKind['types-first'],
+            ],
+            default: GroupKind.mixed,
+            type: 'string',
+          },
         },
         additionalProperties: false,
       },
@@ -84,24 +95,50 @@ export default createEslintRule<Options, MESSAGE_ID>({
           'ignore-alias': true,
           'ignore-case': false,
           order: SortOrder.asc,
+          'group-kind': GroupKind.mixed,
         })
 
         let nodes: SortingNode[] = specifiers.map(specifier => {
+          let group
           let { name } = specifier.local
 
-          if (options['ignore-alias'] && specifier.type === 'ImportSpecifier') {
-            ;({ name } = specifier.imported)
+          if (specifier.type === 'ImportSpecifier') {
+            if (options['ignore-alias']) {
+              ;({ name } = specifier.imported)
+            }
+            group = specifier.importKind
           }
 
           return {
             size: rangeToDiff(specifier.range),
             node: specifier,
             name,
+            group,
           }
         })
 
+        let shouldGroupByKind = options['group-kind'] !== GroupKind.mixed
+        let groupKindOrder =
+          options['group-kind'] === GroupKind['values-first']
+            ? ['value', 'type']
+            : ['type', 'value']
+
         pairwise(nodes, (left, right) => {
-          if (isPositive(compare(left, right, options))) {
+          let leftNum = getGroupNumber(groupKindOrder, left)
+          let rightNum = getGroupNumber(groupKindOrder, right)
+
+          if (
+            (shouldGroupByKind && leftNum > rightNum) ||
+            ((!shouldGroupByKind || leftNum === rightNum) &&
+              isPositive(compare(left, right, options)))
+          ) {
+            let sortedNodes = shouldGroupByKind
+              ? groupKindOrder
+                  .map(group => nodes.filter(node => node.group === group))
+                  .map(groupedNodes => sortNodes(groupedNodes, options))
+                  .flat()
+              : sortNodes(nodes, options)
+
             context.report({
               messageId: 'unexpectedNamedImportsOrder',
               data: {
@@ -110,12 +147,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               },
               node: right.node,
               fix: fixer =>
-                makeFixes(
-                  fixer,
-                  nodes,
-                  sortNodes(nodes, options),
-                  context.sourceCode,
-                ),
+                makeFixes(fixer, nodes, sortedNodes, context.sourceCode),
             })
           }
         })

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -1,25 +1,25 @@
-import { GroupKind, type SortingNode } from '../typings'
+import type { SortingNode } from '../typings'
 
 import { createEslintRule } from '../utils/create-eslint-rule'
+import { SortOrder, GroupKind, SortType } from '../typings'
+import { getGroupNumber } from '../utils/get-group-number'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { isPositive } from '../utils/is-positive'
-import { SortOrder, SortType } from '../typings'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
-import { getGroupNumber } from '../utils/get-group-number'
 
 type MESSAGE_ID = 'unexpectedNamedImportsOrder'
 
 type Options = [
   Partial<{
     'ignore-alias': boolean
+    'group-kind': GroupKind
     'ignore-case': boolean
     order: SortOrder
     type: SortType
-    'group-kind': GroupKind
   }>,
 ]
 
@@ -134,7 +134,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ) {
             let sortedNodes = shouldGroupByKind
               ? groupKindOrder
-                  .map(group => nodes.filter(node => node.group === group))
+                  .map(group => nodes.filter(n => n.group === group))
                   .map(groupedNodes => sortNodes(groupedNodes, options))
                   .flat()
               : sortNodes(nodes, options)

--- a/test/sort-named-exports.test.ts
+++ b/test/sort-named-exports.test.ts
@@ -3,7 +3,7 @@ import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
 import rule, { RULE_NAME } from '../rules/sort-named-exports'
-import { SortOrder, SortType } from '../typings'
+import { GroupKind, SortOrder, SortType } from '../typings'
 
 describe(RULE_NAME, () => {
   RuleTester.describeSkip = describe.skip
@@ -62,6 +62,110 @@ describe(RULE_NAME, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${RULE_NAME}: sorts named exports grouping by their kind`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              export { Kenshin, type Sakabotou, Sanosuke, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+          },
+          {
+            code: dedent`
+              export { Kenshin, Sanosuke, type Sakabotou, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+          },
+          {
+            code: dedent`
+              export { type Sakabotou, type Zanbato, Kenshin, Sanosuke }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              export { type Zanbato, Sanosuke, type Sakabotou, Kenshin }
+            `,
+            output: dedent`
+             export { Kenshin, type Sakabotou, Sanosuke, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export { type Zanbato, Sanosuke, type Sakabotou, Kenshin }
+            `,
+            output: dedent`
+              export { Kenshin, Sanosuke, type Sakabotou, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export { type Zanbato, Sanosuke, type Sakabotou, Kenshin }
+            `,
+            output: dedent`
+              export { type Sakabotou, type Zanbato, Kenshin, Sanosuke }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -109,6 +213,110 @@ describe(RULE_NAME, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${RULE_NAME}: sorts named exports grouping by their kind`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              export { Kenshin, type Sakabotou, Sanosuke, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+          },
+          {
+            code: dedent`
+              export { Kenshin, Sanosuke, type Sakabotou, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+          },
+          {
+            code: dedent`
+              export { type Sakabotou, type Zanbato, Kenshin, Sanosuke }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              export { type Zanbato, Sanosuke, type Sakabotou, Kenshin }
+            `,
+            output: dedent`
+             export { Kenshin, type Sakabotou, Sanosuke, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export { type Zanbato, Sanosuke, type Sakabotou, Kenshin }
+            `,
+            output: dedent`
+              export { Kenshin, Sanosuke, type Sakabotou, type Zanbato }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export { type Zanbato, Sanosuke, type Sakabotou, Kenshin }
+            `,
+            output: dedent`
+              export { type Sakabotou, type Zanbato, Kenshin, Sanosuke }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${RULE_NAME}: sorting by line length`, () => {
@@ -155,6 +363,157 @@ describe(RULE_NAME, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${RULE_NAME}: sorts named exports grouping by their kind`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              export {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                type Zanbato,
+                Sanosuke,
+                Kenshin,
+              }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+          },
+          {
+            code: dedent`
+              export {
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+                type Sakabotou,
+                type Zanbato,
+              }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+          },
+          {
+            code: dedent`
+              export {
+                type Sakabotou,
+                type Zanbato,
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+              }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              export {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                Sanosuke,
+                type Zanbato,
+                Kenshin,
+              }
+            `,
+            output: dedent`
+              export {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                type Zanbato,
+                Sanosuke,
+                Kenshin,
+              }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Zanbato',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                Sanosuke,
+                type Zanbato,
+                Kenshin,
+              }
+            `,
+            output: dedent`
+              export {
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+                type Sakabotou,
+                type Zanbato,
+              }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                Sanosuke,
+                type Zanbato,
+                Kenshin,
+              }
+            `,
+            output: dedent`
+              export {
+                type Sakabotou,
+                type Zanbato,
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+              }
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Kaoru',
+                  right: 'Sakabotou',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Zanbato',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${RULE_NAME}: misc`, () => {

--- a/test/sort-named-imports.test.ts
+++ b/test/sort-named-imports.test.ts
@@ -3,7 +3,7 @@ import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
 import rule, { RULE_NAME } from '../rules/sort-named-imports'
-import { SortOrder, SortType } from '../typings'
+import { GroupKind, SortOrder, SortType } from '../typings'
 
 describe(RULE_NAME, () => {
   RuleTester.describeSkip = describe.skip
@@ -300,6 +300,110 @@ describe(RULE_NAME, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${RULE_NAME}: sorts named imports grouping by their kind`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import { Kenshin, type Sakabotou, Sanosuke, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+          },
+          {
+            code: dedent`
+              import { Kenshin, Sanosuke, type Sakabotou, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+          },
+          {
+            code: dedent`
+              import { type Sakabotou, type Zanbato, Kenshin, Sanosuke } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import { type Zanbato, Sanosuke, type Sakabotou, Kenshin } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import { Kenshin, type Sakabotou, Sanosuke, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import { type Zanbato, Sanosuke, type Sakabotou, Kenshin } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import { Kenshin, Sanosuke, type Sakabotou, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import { type Zanbato, Sanosuke, type Sakabotou, Kenshin } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import { type Sakabotou, type Zanbato, Kenshin, Sanosuke } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -585,6 +689,110 @@ describe(RULE_NAME, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${RULE_NAME}: sorts named imports grouping by their kind`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import { Kenshin, type Sakabotou, Sanosuke, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+          },
+          {
+            code: dedent`
+              import { Kenshin, Sanosuke, type Sakabotou, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+          },
+          {
+            code: dedent`
+              import { type Sakabotou, type Zanbato, Kenshin, Sanosuke } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import { type Zanbato, Sanosuke, type Sakabotou, Kenshin } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import { Kenshin, type Sakabotou, Sanosuke, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import { type Zanbato, Sanosuke, type Sakabotou, Kenshin } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import { Kenshin, Sanosuke, type Sakabotou, type Zanbato } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import { type Zanbato, Sanosuke, type Sakabotou, Kenshin } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import { type Sakabotou, type Zanbato, Kenshin, Sanosuke } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Sakabotou',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${RULE_NAME}: sorting by line length`, () => {
@@ -809,6 +1017,157 @@ describe(RULE_NAME, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${RULE_NAME}: sorts named imports grouping by their kind`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                type Zanbato,
+                Sanosuke,
+                Kenshin,
+              } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+          },
+          {
+            code: dedent`
+              import {
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+                type Sakabotou,
+                type Zanbato,
+              } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+          },
+          {
+            code: dedent`
+              import {
+                type Sakabotou,
+                type Zanbato,
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+              } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                Sanosuke,
+                type Zanbato,
+                Kenshin,
+              } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                type Zanbato,
+                Sanosuke,
+                Kenshin,
+              } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind.mixed }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Zanbato',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                Sanosuke,
+                type Zanbato,
+                Kenshin,
+              } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import {
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+                type Sakabotou,
+                type Zanbato,
+              } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['values-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sakabotou',
+                  right: 'Sanosuke',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Zanbato',
+                  right: 'Kenshin',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import {
+                Kaoru as Kamiya,
+                type Sakabotou,
+                Sanosuke,
+                type Zanbato,
+                Kenshin,
+              } from 'rurouni-kenshin'
+            `,
+            output: dedent`
+              import {
+                type Sakabotou,
+                type Zanbato,
+                Kaoru as Kamiya,
+                Sanosuke,
+                Kenshin,
+              } from 'rurouni-kenshin'
+            `,
+            options: [{ ...options, 'group-kind': GroupKind['types-first'] }],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Kamiya',
+                  right: 'Sakabotou',
+                },
+              },
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'Sanosuke',
+                  right: 'Zanbato',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${RULE_NAME}: misc`, () => {

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -12,9 +12,9 @@ export enum SortOrder {
 }
 
 export enum GroupKind {
-  'mixed' = 'mixed',
   'values-first' = 'values-first',
   'types-first' = 'types-first',
+  'mixed' = 'mixed',
 }
 
 export type PartitionComment = string[] | boolean | string

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -11,6 +11,12 @@ export enum SortOrder {
   'asc' = 'asc',
 }
 
+export enum GroupKind {
+  'mixed' = 'mixed',
+  'values-first' = 'values-first',
+  'types-first' = 'types-first',
+}
+
 export type PartitionComment = string[] | boolean | string
 
 export interface SortingNode {


### PR DESCRIPTION
### Description

This PR adds the `group-kind` option to `sort-named-imports` and `sort-named-exports` rules, solving https://github.com/azat-io/eslint-plugin-perfectionist/issues/114

This allows users to group inline named type imports before or after value named imports.

### Additional context

This option has three possible values: `mixed`, `values-first`, and `types-first`.

```tsx
// group-kind: mixed (default, current behavior)
import { A, type B, C, type D} from 'rurouni-kenshin'

// group-kind: values-first
import { A, C, type B, type D } from 'rurouni-kenshin'

// group-kind: types-first
import { type B, type D, A, C } from 'rurouni-kenshin'
```

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
