### PR TITLE
feat(sort-interfaces): add `optionalityOrder` option

### DIFF
--- a/docs/rules/sort-interfaces.md
+++ b/docs/rules/sort-interfaces.md
@@ -100,6 +100,7 @@ type Group = 'multiline' | CustomGroup
 
 interface Options {
   type?: 'alphabetical' | 'natural' | 'line-length'
+  optionalityOrder?: 'ignore' | 'optional-first' | 'required-first'
   order?: 'asc' | 'desc'
   'ignore-case'?: boolean
   groups?: (Group | Group[])[]
@@ -116,6 +117,13 @@ interface Options {
 - `alphabetical` - sort alphabetically.
 - `natural` - sort in natural order.
 - `line-length` - sort by code line length.
+
+### optionalityOrder
+
+<sub>(default: `'ignore'`)</sub>
+
+- `optional-first` - put all optional members first.
+- `required-first` - put all required members first.
 
 ### order
 

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -2,8 +2,8 @@ import { RuleTester } from '@typescript-eslint/rule-tester'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
+import { OptionalityOrder, SortOrder, SortType } from '../typings'
 import rule, { RULE_NAME } from '../rules/sort-interfaces'
-import { SortOrder, SortType } from '../typings'
 
 describe(RULE_NAME, () => {
   RuleTester.describeSkip = describe.skip
@@ -667,6 +667,369 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    describe(`${RULE_NAME}(${type}): sorting optional members first`, () => {
+      ruleTester.run('sorts interface properties', rule, {
+        valid: [
+          {
+            code: dedent`
+              interface X {
+                a?: string
+                [index: number]: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                onClick?(): void
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                label: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'label',
+                  right: 'primary',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'size',
+                  right: 'onClick?()',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to set groups for sorting', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+                label: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'custom-groups': {
+                  callback: 'on*',
+                },
+                groups: ['unknown', 'callback'],
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'label',
+                  right: 'primary',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to use new line as partition', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface User {
+                email: string
+                firstName?: string
+                id: number
+                lastName?: string
+                password: string
+                username: string
+              
+                biography?: string
+                avatarUrl?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            output: dedent`
+              interface User {
+                firstName?: string
+                lastName?: string
+                email: string
+                id: number
+                password: string
+                username: string
+              
+                avatarUrl?: string
+                biography?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'email',
+                  right: 'firstName',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'id',
+                  right: 'lastName',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'biography',
+                  right: 'avatarUrl',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    describe(`${RULE_NAME}(${type}): sorting required members first`, () => {
+      ruleTester.run('sorts interface properties', rule, {
+        valid: [
+          {
+            code: dedent`
+              interface X {
+                [index: number]: string
+                a?: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                label: string
+                backgroundColor?: string
+                onClick?(): void
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'backgroundColor',
+                  right: 'label',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'size',
+                  right: 'onClick?()',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to set groups for sorting', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                label: string
+                backgroundColor?: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'custom-groups': {
+                  callback: 'on*',
+                },
+                groups: ['unknown', 'callback'],
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'backgroundColor',
+                  right: 'label',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to use new line as partition', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface User {
+                email: string
+                firstName?: string
+                id: number
+                lastName?: string
+                password: string
+                username: string
+              
+                biography?: string
+                avatarUrl?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            output: dedent`
+              interface User {
+                email: string
+                id: number
+                password: string
+                username: string
+                firstName?: string
+                lastName?: string
+              
+                createdAt: Date
+                updatedAt: Date
+                avatarUrl?: string
+                biography?: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'firstName',
+                  right: 'id',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'lastName',
+                  right: 'password',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'biography',
+                  right: 'avatarUrl',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'avatarUrl',
+                  right: 'createdAt',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -1319,6 +1682,369 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    describe(`${RULE_NAME}(${type}): sorting optional members first`, () => {
+      ruleTester.run('sorts interface properties', rule, {
+        valid: [
+          {
+            code: dedent`
+              interface X {
+                a?: string
+                [index: number]: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                onClick?(): void
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                label: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'label',
+                  right: 'primary',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'size',
+                  right: 'onClick?()',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to set groups for sorting', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+                label: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'custom-groups': {
+                  callback: 'on*',
+                },
+                groups: ['unknown', 'callback'],
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'label',
+                  right: 'primary',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to use new line as partition', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface User {
+                email: string
+                firstName?: string
+                id: number
+                lastName?: string
+                password: string
+                username: string
+              
+                biography?: string
+                avatarUrl?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            output: dedent`
+              interface User {
+                firstName?: string
+                lastName?: string
+                email: string
+                id: number
+                password: string
+                username: string
+              
+                avatarUrl?: string
+                biography?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'email',
+                  right: 'firstName',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'id',
+                  right: 'lastName',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'biography',
+                  right: 'avatarUrl',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    describe(`${RULE_NAME}(${type}): sorting required members first`, () => {
+      ruleTester.run('sorts interface properties', rule, {
+        valid: [
+          {
+            code: dedent`
+              interface X {
+                [index: number]: string
+                a?: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                label: string
+                backgroundColor?: string
+                onClick?(): void
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'backgroundColor',
+                  right: 'label',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'size',
+                  right: 'onClick?()',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to set groups for sorting', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                label: string
+                backgroundColor?: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'custom-groups': {
+                  callback: 'on*',
+                },
+                groups: ['unknown', 'callback'],
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'backgroundColor',
+                  right: 'label',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to use new line as partition', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface User {
+                email: string
+                firstName?: string
+                id: number
+                lastName?: string
+                password: string
+                username: string
+              
+                biography?: string
+                avatarUrl?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            output: dedent`
+              interface User {
+                email: string
+                id: number
+                password: string
+                username: string
+                firstName?: string
+                lastName?: string
+              
+                createdAt: Date
+                updatedAt: Date
+                avatarUrl?: string
+                biography?: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'firstName',
+                  right: 'id',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'lastName',
+                  right: 'password',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'biography',
+                  right: 'avatarUrl',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'avatarUrl',
+                  right: 'createdAt',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 
   describe(`${RULE_NAME}: sorting by line length`, () => {
@@ -1933,6 +2659,369 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    describe(`${RULE_NAME}(${type}): sorting optional members first`, () => {
+      ruleTester.run('sorts interface properties', rule, {
+        valid: [
+          {
+            code: dedent`
+              interface X {
+                a?: string
+                [index: number]: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                size?: 'large' | 'medium' | 'small'
+                backgroundColor?: string
+                primary?: boolean
+                onClick?(): void
+                label: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'label',
+                  right: 'primary',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'primary',
+                  right: 'size',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to set groups for sorting', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                size?: 'large' | 'medium' | 'small'
+                backgroundColor?: string
+                primary?: boolean
+                onClick?(): void
+                label: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'custom-groups': {
+                  callback: 'on*',
+                },
+                groups: ['unknown', 'callback'],
+                optionalityOrder: OptionalityOrder['optional-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'label',
+                  right: 'primary',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'primary',
+                  right: 'size',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to use new line as partition', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface User {
+                email: string
+                firstName?: string
+                id: number
+                lastName?: string
+                password: string
+                username: string
+              
+                biography?: string
+                avatarUrl?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            output: dedent`
+              interface User {
+                firstName?: string
+                lastName?: string
+                password: string
+                username: string
+                email: string
+                id: number
+              
+                biography?: string
+                avatarUrl?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['optional-first'],
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'email',
+                  right: 'firstName',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'id',
+                  right: 'lastName',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    describe(`${RULE_NAME}(${type}): sorting required members first`, () => {
+      ruleTester.run('sorts interface properties', rule, {
+        valid: [
+          {
+            code: dedent`
+              interface X {
+                [index: number]: string
+                a?: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                label: string
+                size?: 'large' | 'medium' | 'small'
+                backgroundColor?: string
+                primary?: boolean
+                onClick?(): void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'backgroundColor',
+                  right: 'label',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'primary',
+                  right: 'size',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to set groups for sorting', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface ButtonProps {
+                backgroundColor?: string
+                label: string
+                primary?: boolean
+                size?: 'large' | 'medium' | 'small'
+                onClick?(): void
+              }
+            `,
+            output: dedent`
+              interface ButtonProps {
+                label: string
+                size?: 'large' | 'medium' | 'small'
+                backgroundColor?: string
+                primary?: boolean
+                onClick?(): void
+              }
+            `,
+            options: [
+              {
+                ...options,
+                'custom-groups': {
+                  callback: 'on*',
+                },
+                groups: ['unknown', 'callback'],
+                optionalityOrder: OptionalityOrder['required-first'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'backgroundColor',
+                  right: 'label',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'primary',
+                  right: 'size',
+                },
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run('allows to use new line as partition', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface User {
+                email: string
+                firstName?: string
+                id: number
+                lastName?: string
+                password: string
+                username: string
+              
+                biography?: string
+                avatarUrl?: string
+                createdAt: Date
+                updatedAt: Date
+              }
+            `,
+            output: dedent`
+              interface User {
+                password: string
+                username: string
+                email: string
+                id: number
+                firstName?: string
+                lastName?: string
+              
+                createdAt: Date
+                updatedAt: Date
+                biography?: string
+                avatarUrl?: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                optionalityOrder: OptionalityOrder['required-first'],
+                'partition-by-new-line': true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'firstName',
+                  right: 'id',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'lastName',
+                  right: 'password',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'avatarUrl',
+                  right: 'createdAt',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 
   describe(`${RULE_NAME}: misc`, () => {

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -17,6 +17,12 @@ export enum GroupKind {
   'mixed' = 'mixed',
 }
 
+export enum OptionalityOrder {
+  'optional-first' = 'optional-first',
+  'required-first' = 'required-first',
+  'ignore' = 'ignore',
+}
+
 export type PartitionComment = string[] | boolean | string
 
 export interface SortingNode {

--- a/utils/is-member-optional.ts
+++ b/utils/is-member-optional.ts
@@ -1,0 +1,13 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { AST_NODE_TYPES } from '@typescript-eslint/types'
+
+export let isMemberOptional = (node: TSESTree.Node): boolean => {
+  switch (node.type) {
+    case AST_NODE_TYPES.TSMethodSignature:
+    case AST_NODE_TYPES.TSPropertySignature:
+      return node.optional
+  }
+
+  return false
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds the `optionalityOrder` option to the `sort-interfaces` rule.

This option has three possible values: `ignore`, `optional-first`, `required-first`.

If the `required-first` option is selected, then before any sorting/grouping configurations, we ensure that the members array has all its required elements first and all its optional elements second. We then perform the remaining sorting/grouping checks on the required subset and the optional subset.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

```json
// .eslintrc.json
{
  "custom-groups": {
    "callback": "on*"
  },
  "groups": ["unknown", "callback"],
  "optionalityOrder": "required-first"
}
```

❌ Incorrect

```ts
interface ButtonProps {
  backgroundColor?: string
  label: string
  primary?: boolean
  size?: 'large' | 'medium' | 'small'
  onClick?(): void
}
```

✅ Correct

```ts
interface ButtonProps {
  label: string
  backgroundColor?: string
  primary?: boolean
  size?: 'large' | 'medium' | 'small'
  onClick?(): void
}
```

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
- [X] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
