### PR TITLE
fix(sort-imports): empty named imports being considered side-effect imports

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -217,7 +217,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     let nodes: SortingNode[] = []
 
     let isSideEffectImport = (node: TSESTree.Node) =>
-      node.type === 'ImportDeclaration' && node.specifiers.length === 0
+      node.type === 'ImportDeclaration' &&
+      node.specifiers.length === 0 &&
+      /* Avoid matching on named imports without specifiers */
+      !/}\s*from\s+/.test(context.sourceCode.getText(node))
 
     let computeGroup = (node: ModuleDeclaration): Group<string[]> => {
       let isStyle = (value: string) =>

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3984,5 +3984,28 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${RULE_NAME}: does not consider empty named imports to be side-effects`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import {} from 'node:os'
+              import { hinaAmano } from 'weathering-with-you'
+              import 'node:os'
+            `,
+            options: [
+              {
+                'newlines-between': NewlinesBetweenValue.never,
+                groups: ['builtin', 'external', 'side-effect'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed a bug when writing some code in a project where I have set up this plugin (thank you by the way, it helps out a lot!). When I wrote a named import but didn't specify anything to be imported it was being considered a side-effect import and moved to the bottom of the list of imports. Turns out there is no way to distinguish a side-effect import from an empty named import from looking at the AST, so the only thing I could think of what to look for a `} from` string in the nodes code to make it not being considered a side-effect import 🙂

### Additional context

Output from [AST explorer](https://astexplorer.net/#/gist/090f7d39fb3be4d37c64d13fccc31156/210c0b4ea656f0eee3406d52b63937f5fc34754f)

<img width="500" alt="ast explorer output" src="https://github.com/azat-io/eslint-plugin-perfectionist/assets/104437310/87b0c74d-2ef4-42ae-812a-060026c4c1f9">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
