### PR TITLE
docs: fix typo of sibling

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -169,7 +169,7 @@ import axios from 'axios'
 import Button from '~/components/Button'
 // 'parent' - Modules from parent directory
 import formatNumber from '../utils/format-number'
-// 'siblings' - Modules from the same directory
+// 'sibling' - Modules from the same directory
 import config from './config'
 // 'side-effect' - Side effect imports
 import './set-production-env.js'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The docs is showing `siblings` for the `sibling` value which should be `sibling` without `s`.

### Additional context

None

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
