### PR TITLE
feat(sort-classes): add custom-group to sort-classes rule

### DIFF
--- a/docs/rules/sort-classes.md
+++ b/docs/rules/sort-classes.md
@@ -139,6 +139,7 @@ interface Options {
   order?: 'asc' | 'desc'
   'ignore-case'?: boolean
   groups?: (Group | Group[])[]
+  'custom-groups'?: { [key: string]: string[] | string }
 }
 ```
 
@@ -186,6 +187,22 @@ If you use [one of the configs](/configs/) exported by this plugin, you get the 
     ["get-method", "set-method"],
     "unknown"
   ]
+}
+```
+
+### custom-groups
+
+<sub>(default: `{}`)</sub>
+
+You can define your own groups for object keys. The [minimatch](https://github.com/isaacs/minimatch) library is used for pattern matching.
+
+Example:
+
+```
+{
+  "custom-groups": {
+    "top": "id"
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docs:dev": "vitepress dev docs",
     "docs:generate": "eslint-doc-generator --rule-list-columns name,description,fixable,hasSuggestions,deprecated --path-rule-list readme.md --url-rule-doc https://eslint-plugin-perfectionist.azat.io/rules/{name} --url-configs https://eslint-plugin-perfectionist.azat.io/configs && eslint-doc-generator --rule-list-columns name,description,fixable,hasSuggestions,deprecated --rule-doc-title-format name --path-rule-list ./docs/rules/index.md --url-rule-doc /rules/{name} --url-configs /configs/ && prettier --write readme.md ./docs/rules/index.md",
     "docs:build": "vitepress build docs",
+    "format:fix": "prettier --write \"**/*.{js,ts,json,md,yml}\"",
     "release": "pnpm release:check && pnpm release:version && pnpm release:publish",
     "release:check": "pnpm test && pnpm run build",
     "release:publish": "clean-publish",

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -2157,8 +2157,8 @@ describe(RULE_NAME, () => {
           options: [
             {
               ...options,
-              "custom-groups": {
-                'my-last-group': 'custom*'
+              'custom-groups': {
+                'my-last-group': 'custom*',
               },
               groups: [
                 'decorated-accessor-property',

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -588,74 +588,74 @@ describe(RULE_NAME, () => {
             class MyElement {
               @property({ attribute: false })
               data = {}
-            
+
               @property()
               greeting: string = 'Hello'
-            
+
               @state()
               private _counter = 0
-            
+
               private _message = ''
-            
+
               private _prop = 0
-            
+
               constructor() {}
-            
+
               @property()
               get message(): string {
                 return this._message
               }
-            
+
               set message(message: string) {
                 this._message = message
               }
-            
+
               @property()
               set prop(val: number) {
                 this._prop = Math.floor(val)
               }
-            
+
               get prop() {
                 return this._prop
               }
-            
+
               render() {}
             }`,
           output: dedent`
             class MyElement {
               @property({ attribute: false })
               data = {}
-            
+
               @property()
               greeting: string = 'Hello'
-            
+
               @state()
               private _counter = 0
-            
+
               private _message = ''
-            
+
               private _prop = 0
-            
+
               constructor() {}
-            
+
               @property()
               get message(): string {
                 return this._message
               }
-            
+
               @property()
               set prop(val: number) {
                 this._prop = Math.floor(val)
               }
-            
+
               set message(message: string) {
                 this._message = message
               }
-            
+
               get prop() {
                 return this._prop
               }
-            
+
               render() {}
             }`,
           options: [
@@ -693,18 +693,18 @@ describe(RULE_NAME, () => {
           code: dedent`
             class Todo {
               id = Math.random()
-            
+
               constructor() {}
-            
+
               @action
               toggle() {}
-            
+
               @observable
               accessor #active = false
-            
+
               @observable
               accessor finished = false
-            
+
               @observable
               accessor title = ''
             }`,
@@ -712,17 +712,17 @@ describe(RULE_NAME, () => {
             class Todo {
               @observable
               accessor finished = false
-            
+
               @observable
               accessor title = ''
-            
+
               @observable
               accessor #active = false
-            
+
               id = Math.random()
-            
+
               constructor() {}
-            
+
               @action
               toggle() {}
             }`,
@@ -1331,74 +1331,74 @@ describe(RULE_NAME, () => {
             class MyElement {
               @property({ attribute: false })
               data = {}
-            
+
               @property()
               greeting: string = 'Hello'
-            
+
               @state()
               private _counter = 0
-            
+
               private _message = ''
-            
+
               private _prop = 0
-            
+
               constructor() {}
-            
+
               @property()
               get message(): string {
                 return this._message
               }
-            
+
               set message(message: string) {
                 this._message = message
               }
-            
+
               @property()
               set prop(val: number) {
                 this._prop = Math.floor(val)
               }
-            
+
               get prop() {
                 return this._prop
               }
-            
+
               render() {}
             }`,
           output: dedent`
             class MyElement {
               @property({ attribute: false })
               data = {}
-            
+
               @property()
               greeting: string = 'Hello'
-            
+
               @state()
               private _counter = 0
-            
+
               private _message = ''
-            
+
               private _prop = 0
-            
+
               constructor() {}
-            
+
               @property()
               get message(): string {
                 return this._message
               }
-            
+
               @property()
               set prop(val: number) {
                 this._prop = Math.floor(val)
               }
-            
+
               set message(message: string) {
                 this._message = message
               }
-            
+
               get prop() {
                 return this._prop
               }
-            
+
               render() {}
             }`,
           options: [
@@ -1436,18 +1436,18 @@ describe(RULE_NAME, () => {
           code: dedent`
             class Todo {
               id = Math.random()
-            
+
               constructor() {}
-            
+
               @action
               toggle() {}
-            
+
               @observable
               accessor #active = false
-            
+
               @observable
               accessor finished = false
-            
+
               @observable
               accessor title = ''
             }`,
@@ -1455,17 +1455,17 @@ describe(RULE_NAME, () => {
             class Todo {
               @observable
               accessor finished = false
-            
+
               @observable
               accessor title = ''
-            
+
               @observable
               accessor #active = false
-            
+
               id = Math.random()
-            
+
               constructor() {}
-            
+
               @action
               toggle() {}
             }`,
@@ -2018,29 +2018,29 @@ describe(RULE_NAME, () => {
               private _counter = 0
 
               private _message = ''
-            
+
               private _prop = 0
-            
+
               constructor() {}
 
               @property()
               get message(): string {
                 return this._message
               }
-            
+
               set message(message: string) {
                 this._message = message
               }
-            
+
               @property()
               set prop(val: number) {
                 this._prop = Math.floor(val)
               }
-            
+
               get prop() {
                 return this._prop
               }
-            
+
               render() {}
             }`,
           output: dedent`
@@ -2050,16 +2050,16 @@ describe(RULE_NAME, () => {
 
               @property()
               greeting: string = 'Hello'
-            
+
               @state()
               private _counter = 0
-            
+
               private _message = ''
-            
+
               private _prop = 0
-            
+
               constructor() {}
-            
+
               @property()
               set prop(val: number) {
                 this._prop = Math.floor(val)
@@ -2069,15 +2069,15 @@ describe(RULE_NAME, () => {
               get message(): string {
                 return this._message
               }
-            
+
               set message(message: string) {
                 this._message = message
               }
-            
+
               get prop() {
                 return this._prop
               }
-            
+
               render() {}
             }`,
           options: [
@@ -2114,19 +2114,22 @@ describe(RULE_NAME, () => {
         {
           code: dedent`
             class Todo {
+              @observable
+              customLastGroupProperty = 1
+
               id = Math.random()
-            
+
               constructor() {}
-            
+
               @action
               toggle() {}
-            
+
               @observable
               accessor #active = false
-            
+
               @observable
               accessor finished = false
-            
+
               @observable
               accessor title = ''
             }`,
@@ -2134,23 +2137,29 @@ describe(RULE_NAME, () => {
             class Todo {
               @observable
               accessor finished = false
-            
+
               @observable
               accessor title = ''
-            
+
               @observable
               accessor #active = false
-            
+
               id = Math.random()
-            
+
               constructor() {}
-            
+
               @action
               toggle() {}
+
+              @observable
+              customLastGroupProperty = 1
             }`,
           options: [
             {
               ...options,
+              "custom-groups": {
+                'my-last-group': 'custom*'
+              },
               groups: [
                 'decorated-accessor-property',
                 'private-decorated-accessor-property',
@@ -2158,10 +2167,18 @@ describe(RULE_NAME, () => {
                 'constructor',
                 'decorated-method',
                 'unknown',
+                'my-last-group',
               ],
             },
           ],
           errors: [
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'customLastGroupProperty',
+                right: 'id',
+              },
+            },
             {
               messageId: 'unexpectedClassesOrder',
               data: {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -2121,6 +2121,9 @@ describe(RULE_NAME, () => {
 
               constructor() {}
 
+              @observable
+              customFirstGroupProperty = 1
+
               @action
               toggle() {}
 
@@ -2132,9 +2135,13 @@ describe(RULE_NAME, () => {
 
               @observable
               accessor title = ''
+
             }`,
           output: dedent`
             class Todo {
+              @observable
+              customFirstGroupProperty = 1
+
               @observable
               accessor finished = false
 
@@ -2153,14 +2160,17 @@ describe(RULE_NAME, () => {
 
               @observable
               customLastGroupProperty = 1
+
             }`,
           options: [
             {
               ...options,
               'custom-groups': {
-                'my-last-group': 'custom*',
+                'my-first-group': 'customFirst*',
+                'my-last-group': 'customLast*',
               },
               groups: [
+                'my-first-group',
                 'decorated-accessor-property',
                 'private-decorated-accessor-property',
                 'property',
@@ -2177,6 +2187,13 @@ describe(RULE_NAME, () => {
               data: {
                 left: 'customLastGroupProperty',
                 right: 'id',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'constructor',
+                right: 'customFirstGroupProperty',
               },
             },
             {

--- a/utils/use-groups.ts
+++ b/utils/use-groups.ts
@@ -3,8 +3,8 @@ import { minimatch } from 'minimatch'
 export let useGroups = (groups: (string[] | string)[]) => {
   let group: undefined | string
 
-  let defineGroup = (value: string) => {
-    if (!group && groups.flat().includes(value)) {
+  let defineGroup = (value: string, override = false) => {
+    if ((!group || override) && groups.flat().includes(value)) {
       group = value
     }
   }
@@ -16,6 +16,7 @@ export let useGroups = (groups: (string[] | string)[]) => {
         }
       | undefined,
     name: string,
+    params: { override?: boolean } = {},
   ) => {
     if (customGroups) {
       for (let [key, pattern] of Object.entries(customGroups)) {
@@ -27,7 +28,7 @@ export let useGroups = (groups: (string[] | string)[]) => {
             }),
           )
         ) {
-          defineGroup(key)
+          defineGroup(key, params.override)
         }
 
         if (
@@ -36,7 +37,7 @@ export let useGroups = (groups: (string[] | string)[]) => {
             nocomment: true,
           })
         ) {
-          defineGroup(key)
+          defineGroup(key, params.override)
         }
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Today class ordering doesn't work much for classes that represent database entities. For example, using TypeORM, the ordering of properties changes the order of the columns in the database. To make it easier to use, I propose adding a **custom-groups** functionality already present in other rules such as **sort-objects**.

### Code Example
Configuration: 
```
'perfectionist/sort-classes': [
      'error',
      {
        'custom-groups': {
          'entity-id': ['id'],
          'entity-timestamps': ['createdAt'],
        },
        groups: [
          'entity-id',
          'index-signature',
          'static-property',
          'private-property',
          'property',
          'constructor',
          'static-method',
          'private-method',
          'method',
          ['get-method', 'set-method'],
          'unknown',
          'entity-timestamps',
        ],
      },
    ]
```

Input: 
```js
export class TestEntity {
  @PrimaryGeneratedColumn('increment')
  id: number
  
  @Column()
  name: string
  
  @Column()
  description: string

  @CreateDateColumn()
  createdAt: Date
}
```

Problematic output:
```js
export class TestEntity {
  @CreateDateColumn()
  createdAt: Date

  @Column()
  description: string

  @PrimaryGeneratedColumn('increment')
  id: number

  @Column()
  name: string
}
```

Expected Output:
```js
export class TestEntity {
  @PrimaryGeneratedColumn('increment')
  id: number

  @Column()
  description: string

  @Column()
  name: string

  @CreateDateColumn()
  createdAt: Date
}
```
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
