### PR TITLE
fix(sort-array-includes.md): syntax json `spread-last` => `"spread-la…

### DIFF
--- a/docs/rules/sort-array-includes.md
+++ b/docs/rules/sort-array-includes.md
@@ -148,7 +148,7 @@ export default [
         {
           type: 'natural',
           order: 'asc',
-          spread-last: true,
+          'spread-last': true,
         },
       ],
     },


### PR DESCRIPTION
…st"` etc

<!-- Thank you for contributing! -->

### Description

 Fix Json Syntax error (no quotes in keys which include "-" char)
 
 It wasn't ready to ctrl + c & ctrl + v

### Additional context

-

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
- [X] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
