### PR TITLE
feat: add groups option in sort-intersection-types rule

### DIFF
--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -102,6 +102,62 @@ Controls whether sorting should be case-sensitive or not.
 - `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
 - `false` — Consider case when sorting (e.g., “A” comes before “a”).
 
+### groups
+
+<sub>(default: `[]`)</sub>
+
+Allows you to specify a list of intersection type groups for sorting. Groups help organize types into categories, making your type definitions more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
+
+There are a lot of predefined groups.
+
+Predefined Groups:
+
+- `'conditional`' — Conditional types.
+- `'function`' — Function types.
+- `'import`' — Imported types.
+- `'intersection`' — Intersection types.
+- `'keyword`' — Keyword types.
+- `'literal`' — Literal types.
+- `'named`' — Named types.
+- `'object`' — Object types.
+- `'operator`' — Operator types.
+- `'tuple`' — Tuple types.
+- `'union`' — Union types.
+- `'nullish`' — Nullish types (`null` or `undefined`).
+- `'unknown`' — Types that don’t fit into any other group.
+
+Example:
+
+```ts
+type Example =
+  // 'conditional' — Conditional types.
+  (A extends B ? C : D) &
+  // 'function' — Function types.
+  ((arg: T) => U) &
+  // 'import' — Imported types.
+  import('module').Type &
+  // 'intersection' — Intersection types.
+  (A & B) &
+  // 'keyword' — Keyword types.
+  any &
+  // 'literal' — Literal types.
+  'literal' &
+  42 &
+  // 'named' — Named types.
+  SomeType &
+  AnotherType &
+  // 'object' — Object types.
+  { a: string; b: number; } &
+  // 'operator' — Operator types.
+  keyof T &
+  // 'tuple' — Tuple types.
+  [string, number] &
+  // 'union' — Union types.
+  (A | B) &
+  // 'nullish' — Nullish types.
+  null &
+  undefined;
+```
 
 ## Usage
 

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -261,6 +261,146 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(`${RULE_NAME}: sorts intersections using groups`, rule, {
+      valid: [
+        {
+          code: dedent`
+            type Type =
+              & A
+              & any
+              & bigint
+              & boolean
+              & keyof A
+              & typeof B
+              & 'aaa'
+              & 1
+              & (import('path'))
+              & (A extends B ? C : D)
+              & { name: 'a' }
+              & [A, B, C]
+              & (A & B)
+              & (A | B)
+              & null
+          `,
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'keyword',
+                'operator',
+                'literal',
+                'function',
+                'import',
+                'conditional',
+                'object',
+                'tuple',
+                'intersection',
+                'union',
+                'nullish',
+              ],
+            },
+          ],
+        },
+      ],
+      invalid: [
+        {
+          code: dedent`
+            type Type =
+              & any
+              & { name: 'a' }
+              & boolean
+              & A
+              & keyof A
+              & bigint
+              & typeof B
+              & 'aaa'
+              & (import('path'))
+              & null
+              & 1
+              & (A extends B ? C : D)
+              & [A, B, C]
+              & (A | B)
+              & (A & B)
+          `,
+          output: dedent`
+            type Type =
+              & A
+              & any
+              & bigint
+              & boolean
+              & keyof A
+              & typeof B
+              & 'aaa'
+              & 1
+              & (import('path'))
+              & (A extends B ? C : D)
+              & { name: 'a' }
+              & [A, B, C]
+              & (A & B)
+              & (A | B)
+              & null
+          `,
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'keyword',
+                'operator',
+                'literal',
+                'function',
+                'import',
+                'conditional',
+                'object',
+                'tuple',
+                'intersection',
+                'union',
+                'nullish',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: "{ name: 'a' }",
+                right: 'boolean',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'boolean',
+                right: 'A',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'keyof A',
+                right: 'bigint',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'null',
+                right: '1',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'A | B',
+                right: 'A & B',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 
   describe(`${RULE_NAME}: sorting by natural order`, () => {
@@ -488,6 +628,146 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(`${RULE_NAME}: sorts intersections using groups`, rule, {
+      valid: [
+        {
+          code: dedent`
+            type Type =
+              & A
+              & any
+              & bigint
+              & boolean
+              & keyof A
+              & typeof B
+              & 'aaa'
+              & 1
+              & (import('path'))
+              & (A extends B ? C : D)
+              & { name: 'a' }
+              & [A, B, C]
+              & (A & B)
+              & (A | B)
+              & null
+          `,
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'keyword',
+                'operator',
+                'literal',
+                'function',
+                'import',
+                'conditional',
+                'object',
+                'tuple',
+                'intersection',
+                'union',
+                'nullish',
+              ],
+            },
+          ],
+        },
+      ],
+      invalid: [
+        {
+          code: dedent`
+            type Type =
+              & any
+              & { name: 'a' }
+              & boolean
+              & A
+              & keyof A
+              & bigint
+              & typeof B
+              & 'aaa'
+              & (import('path'))
+              & null
+              & 1
+              & (A extends B ? C : D)
+              & [A, B, C]
+              & (A | B)
+              & (A & B)
+          `,
+          output: dedent`
+            type Type =
+              & A
+              & any
+              & bigint
+              & boolean
+              & keyof A
+              & typeof B
+              & 'aaa'
+              & 1
+              & (import('path'))
+              & (A extends B ? C : D)
+              & { name: 'a' }
+              & [A, B, C]
+              & (A & B)
+              & (A | B)
+              & null
+          `,
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'keyword',
+                'operator',
+                'literal',
+                'function',
+                'import',
+                'conditional',
+                'object',
+                'tuple',
+                'intersection',
+                'union',
+                'nullish',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: "{ name: 'a' }",
+                right: 'boolean',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'boolean',
+                right: 'A',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'keyof A',
+                right: 'bigint',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'null',
+                right: '1',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'A | B',
+                right: 'A & B',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 
   describe(`${RULE_NAME}: sorting by line length`, () => {
@@ -710,6 +990,146 @@ describe(RULE_NAME, () => {
         ],
       },
     )
+
+    ruleTester.run(`${RULE_NAME}: sorts intersections using groups`, rule, {
+      valid: [
+        {
+          code: dedent`
+            type Type =
+              & A
+              & boolean
+              & bigint
+              & any
+              & typeof B
+              & keyof A
+              & 'aaa'
+              & 1
+              & (import('path'))
+              & (A extends B ? C : D)
+              & { name: 'a' }
+              & [A, B, C]
+              & (A & B)
+              & (A | B)
+              & null
+          `,
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'keyword',
+                'operator',
+                'literal',
+                'function',
+                'import',
+                'conditional',
+                'object',
+                'tuple',
+                'intersection',
+                'union',
+                'nullish',
+              ],
+            },
+          ],
+        },
+      ],
+      invalid: [
+        {
+          code: dedent`
+            type Type =
+              & any
+              & { name: 'a' }
+              & boolean
+              & A
+              & keyof A
+              & bigint
+              & typeof B
+              & 'aaa'
+              & (import('path'))
+              & null
+              & 1
+              & (A extends B ? C : D)
+              & [A, B, C]
+              & (A | B)
+              & (A & B)
+          `,
+          output: dedent`
+            type Type =
+              & A
+              & boolean
+              & bigint
+              & any
+              & typeof B
+              & keyof A
+              & 'aaa'
+              & 1
+              & (import('path'))
+              & (A extends B ? C : D)
+              & { name: 'a' }
+              & [A, B, C]
+              & (A & B)
+              & (A | B)
+              & null
+          `,
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'keyword',
+                'operator',
+                'literal',
+                'function',
+                'import',
+                'conditional',
+                'object',
+                'tuple',
+                'intersection',
+                'union',
+                'nullish',
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: "{ name: 'a' }",
+                right: 'boolean',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'boolean',
+                right: 'A',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'keyof A',
+                right: 'bigint',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'null',
+                right: '1',
+              },
+            },
+            {
+              messageId: 'unexpectedIntersectionTypesOrder',
+              data: {
+                left: 'A | B',
+                right: 'A & B',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 
   describe(`${RULE_NAME}: misc`, () => {


### PR DESCRIPTION
### Description

Support groups from [this rule](https://typescript-eslint.io/rules/sort-type-constituents/#grouporder).

### Additional context

#151

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
