### PR TITLE
fix(docs): change html lang to English

### DIFF
--- a/docs/components/Html.astro
+++ b/docs/components/Html.astro
@@ -3,4 +3,4 @@
 ---
 
 <!doctype html>
-<html lang="ru"><slot /></html>
+<html lang="en"><slot /></html>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes issue where browsers try to translate https://perfectionist.dev/ from English -> English due to HTML lang being set to ru

### Additional context
<img width="1223" alt="Screenshot 2024-07-24 at 14 56 20" src="https://github.com/user-attachments/assets/b3ba3738-04fb-449f-bed9-33cfb5fe0f06">


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
