### PR TITLE
fix: switch `export default` to `export =` in `dist/index.d.ts`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -96,8 +96,7 @@ export default defineConfig({
           'dist/index.d.ts',
           (await fs.readFile('dist/index.d.ts'))
             .toString()
-            .replace(/\nexport .+/, '')
-             + "export = _default"
+            .replace(/\nexport .+/, '') + 'export = _default',
         )
       },
       include: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,6 +91,15 @@ export default defineConfig({
   },
   plugins: [
     dts({
+      afterBuild: async () => {
+        await fs.writeFile(
+          'dist/index.d.ts',
+          (await fs.readFile('dist/index.d.ts'))
+            .toString()
+            .replace(/\nexport .+/, '')
+             + "export = _default"
+        )
+      },
       include: [
         path.join(__dirname, 'index.ts'),
         path.join(__dirname, 'typings'),


### PR DESCRIPTION
### Description

Manually changes the export from an ESM-style `export default` to a CJS-style `export =`. This better describes `dist/index.js`'s `module.exports = index`.

Fixes #177.

### Additional context

You can test this out locally by either:

* Replacing `node_modules/eslint-plugin-perfectionist/dist/index.d.ts` in https://github.com/JoshuaKGoldberg/repros/tree/repro-eslint-plugin-perfectionist-default-export-types
* Running `npx @arethetypeswrong/cli --pack` on the repo

Before this change, attw's `"eslint-plugin-perfectionist"` report was:

```plaintext
node10: ❗️ Incorrect default export
node16 (from CJS): ❗️ Incorrect default export
node16 (from ESM): 🐛 Used fallback condition
🎭 Masquerading as CJS
bundler: 🐛 Used fallback condition
```

Now:

```plaintext
node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🐛 Used fallback condition
🎭 Masquerading as CJS
bundler: 🐛 Used fallback condition
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- ~[ ] Ideally, include relevant tests that fail without this PR but pass with it.~ _(not sure how to here?)_
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
