### PR TITLE
`sort-classes` Add the element's matched group in ESlint error messages

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -514,9 +514,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   isPositive(compare(left, right, options))))
             ) {
               context.report({
-                messageId: leftNum !== rightNum
-                  ? 'unexpectedClassesGroupOrder'
-                  : 'unexpectedClassesOrder',
+                messageId:
+                  leftNum !== rightNum
+                    ? 'unexpectedClassesGroupOrder'
+                    : 'unexpectedClassesOrder',
                 data: {
                   left: toSingleLine(left.name),
                   leftGroup: left.group,

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -207,7 +207,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
-      unexpectedClassesOrder: 'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedClassesOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
     },
   },
   defaultOptions: [
@@ -515,7 +516,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: toSingleLine(left.name),
+                  leftGroup: left.group,
                   right: toSingleLine(right.name),
+                  rightGroup: right.group,
                 },
                 node: right.node,
                 fix: (fixer: TSESLint.RuleFixer) => {

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -19,7 +19,7 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedClassesOrder'
+type MESSAGE_ID = 'unexpectedClassesGroupOrder' | 'unexpectedClassesOrder'
 
 type ProtectedModifier = 'protected'
 type PrivateModifier = 'private'
@@ -207,8 +207,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
-      unexpectedClassesOrder:
+      unexpectedClassesGroupOrder:
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+      unexpectedClassesOrder: 'Expected "{{right}}" to come before "{{left}}".',
     },
   },
   defaultOptions: [
@@ -513,7 +514,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   isPositive(compare(left, right, options))))
             ) {
               context.report({
-                messageId: 'unexpectedClassesOrder',
+                messageId: leftNum !== rightNum
+                  ? 'unexpectedClassesGroupOrder'
+                  : 'unexpectedClassesOrder',
                 data: {
                   left: toSingleLine(left.name),
                   leftGroup: left.group,

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -154,14 +154,18 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'e',
+                leftGroup: 'property',
                 right: 'd',
+                rightGroup: 'property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'f',
+                leftGroup: 'static-method',
                 right: 'constructor',
+                rightGroup: 'constructor',
               },
             },
           ],
@@ -271,91 +275,120 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'static',
+                  leftGroup: 'static-block',
                   right: 'static readonly [key: string]',
+                  rightGroup: 'static-readonly-index-signature',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'static readonly [key: string]',
+                  leftGroup: 'static-readonly-index-signature',
                   right: 'l',
+                  rightGroup: 'declare-private-static-readonly-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'l',
+                  leftGroup: 'declare-private-static-readonly-property',
                   right: 'k',
+                  rightGroup: 'private-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'k',
+                  leftGroup: 'private-property',
                   right: 'j',
+                  rightGroup: 'protected-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'j',
+                  leftGroup: 'protected-property',
                   right: 'i',
+                  rightGroup: 'public-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'i',
+                  leftGroup: 'public-property',
                   right: 'h',
+                  rightGroup: 'private-readonly-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'h',
+                  leftGroup: 'private-readonly-property',
                   right: 'g',
+                  rightGroup: 'protected-readonly-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'g',
+                  leftGroup: 'protected-readonly-property',
                   right: 'f',
+                  rightGroup: 'public-readonly-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'f',
+                  leftGroup: 'public-readonly-property',
                   right: 'e',
+                  rightGroup: 'static-private-override-readonly-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'e',
+                  leftGroup: 'static-private-override-readonly-property',
                   right: 'd',
+                  rightGroup: 'static-protected-override-readonly-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'd',
+                  leftGroup: 'static-protected-override-readonly-property',
                   right: 'c',
+                  rightGroup: 'static-public-override-readonly-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'static-public-override-readonly-property',
                   right: 'b',
+                  rightGroup:
+                    'protected-abstract-override-readonly-decorated-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'b',
+                  leftGroup:
+                    'protected-abstract-override-readonly-decorated-property',
                   right: 'a',
+                  rightGroup:
+                    'public-abstract-override-readonly-decorated-property',
                 },
               },
             ],
@@ -398,7 +431,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'method',
+                  leftGroup: 'public-abstract-override-method',
                   right: 'fields',
+                  rightGroup: 'get-method',
                 },
               },
             ],
@@ -446,7 +481,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'property',
                     right: 'static readonly [key: string]',
+                    rightGroup: 'static-index-signature',
                   },
                 },
               ],
@@ -491,7 +528,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'constructor',
+                    rightGroup: 'constructor',
                   },
                 },
               ],
@@ -534,7 +573,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'get-method',
                   },
                 },
               ],
@@ -577,7 +618,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'set-method',
                   },
                 },
               ],
@@ -622,7 +665,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'property',
                     right: 'z',
+                    rightGroup: 'static-method',
                   },
                 },
               ],
@@ -665,7 +710,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'property',
                     right: 'z',
+                    rightGroup: 'abstract-method',
                   },
                 },
               ],
@@ -710,7 +757,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'property',
                     right: 'z',
+                    rightGroup: 'decorated-method',
                   },
                 },
               ],
@@ -758,7 +807,9 @@ describe(ruleName, () => {
                     messageId: 'unexpectedClassesOrder',
                     data: {
                       left: 'a',
+                      leftGroup: 'property',
                       right: 'z',
+                      rightGroup: 'override-method',
                     },
                   },
                 ],
@@ -808,7 +859,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'property',
                     right: 'z',
+                    rightGroup: 'static-accessor-property',
                   },
                 },
               ],
@@ -855,7 +908,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'property',
                     right: 'z',
+                    rightGroup: 'abstract-accessor-property',
                   },
                 },
               ],
@@ -904,7 +959,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'property',
                     right: 'z',
+                    rightGroup: 'decorated-accessor-property',
                   },
                 },
               ],
@@ -952,7 +1009,9 @@ describe(ruleName, () => {
                     messageId: 'unexpectedClassesOrder',
                     data: {
                       left: 'a',
+                      leftGroup: 'property',
                       right: 'z',
+                      rightGroup: 'override-accessor-property',
                     },
                   },
                 ],
@@ -998,7 +1057,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'static-property',
                   },
                 },
               ],
@@ -1041,7 +1102,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'declare-property',
                   },
                 },
               ],
@@ -1084,7 +1147,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'abstract-property',
                   },
                 },
               ],
@@ -1129,7 +1194,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'decorated-property',
                   },
                 },
               ],
@@ -1174,7 +1241,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'decorated-property',
                   },
                 },
               ],
@@ -1217,7 +1286,9 @@ describe(ruleName, () => {
                   messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'method',
                     right: 'z',
+                    rightGroup: 'override-property',
                   },
                 },
               ],
@@ -1265,7 +1336,9 @@ describe(ruleName, () => {
                     messageId: 'unexpectedClassesOrder',
                     data: {
                       left: 'a',
+                      leftGroup: 'method',
                       right: 'z',
+                      rightGroup: 'readonly-property',
                     },
                   },
                 ],
@@ -1352,14 +1425,18 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'key in O',
+                  leftGroup: 'property',
                   right: 'b',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'b',
+                  leftGroup: 'static-property',
                   right: 'a',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -1428,7 +1505,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '[k: string];',
+                  leftGroup: 'unknown',
                   right: 'a',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -1545,35 +1624,45 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#aPrivateStaticMethod',
+                  leftGroup: 'static-method',
                   right: '#somePrivateProperty',
+                  rightGroup: 'private-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#somePrivateProperty',
+                  leftGroup: 'private-property',
                   right: '#someOtherPrivateProperty',
+                  rightGroup: 'private-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#someOtherPrivateProperty',
+                  leftGroup: 'private-property',
                   right: 'someStaticProperty',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'someStaticProperty',
+                  leftGroup: 'static-property',
                   right: '#someStaticPrivateProperty',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aStaticMethod',
+                  leftGroup: 'static-method',
                   right: '#aPrivateInstanceMethod',
+                  rightGroup: 'private-method',
                 },
               },
             ],
@@ -1629,14 +1718,18 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'x',
+                  leftGroup: 'method',
                   right: 'b',
+                  rightGroup: 'method',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'z',
+                  leftGroup: 'get-method',
                   right: 'c',
+                  rightGroup: 'get-method',
                 },
               },
             ],
@@ -1692,7 +1785,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'email',
+                leftGroup: 'decorated-property',
                 right: 'lastName',
+                rightGroup: 'property',
               },
             },
           ],
@@ -1799,7 +1894,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'message',
+                leftGroup: 'set-method',
                 right: 'prop',
+                rightGroup: 'decorated-set-method',
               },
             },
           ],
@@ -1872,14 +1969,18 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'toggle',
+                leftGroup: 'decorated-method',
                 right: '#active',
+                rightGroup: 'private-decorated-accessor-property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: '#active',
+                leftGroup: 'private-decorated-accessor-property',
                 right: 'finished',
+                rightGroup: 'decorated-accessor-property',
               },
             },
           ],
@@ -1977,21 +2078,27 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'updateTable',
+                leftGroup: 'protected-method',
                 right: 'onSortChanged',
+                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'onSortChanged',
+                leftGroup: 'protected-method',
                 right: 'onPaginationChanged',
+                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'setFormValue',
+                leftGroup: 'protected-method',
                 right: 'onValueChanged',
+                rightGroup: 'protected-method',
               },
             },
           ],
@@ -2083,7 +2190,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
+                  leftGroup: 'property',
                   right: 'b',
+                  rightGroup: 'property',
                 },
               },
             ],
@@ -2113,7 +2222,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'getAaa',
+                  leftGroup: 'method',
                   right: 'b',
+                  rightGroup: 'property',
                 },
               },
             ],
@@ -2139,7 +2250,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'b',
+                  leftGroup: 'property',
                   right: 'c',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -2169,7 +2282,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'getAaa',
+                  leftGroup: 'method',
                   right: '#b',
+                  rightGroup: 'private-property',
                 },
               },
             ],
@@ -2199,7 +2314,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'getAaa',
+                  leftGroup: 'static-method',
                   right: 'b',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -2262,7 +2379,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
+                  leftGroup: 'property',
                   right: 'left',
+                  rightGroup: 'property',
                 },
               },
             ],
@@ -2357,7 +2476,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'property',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -2389,7 +2510,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'property',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -2429,7 +2552,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'method',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -2463,14 +2588,18 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'method',
                 right: 'b',
+                rightGroup: 'property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'b',
+                leftGroup: 'property',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -2609,14 +2738,18 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'e',
+                leftGroup: 'property',
                 right: 'd',
+                rightGroup: 'property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'f',
+                leftGroup: 'static-method',
                 right: 'constructor',
+                rightGroup: 'constructor',
               },
             },
           ],
@@ -2700,14 +2833,18 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'key in O',
+                  leftGroup: 'property',
                   right: 'b',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'b',
+                  leftGroup: 'static-property',
                   right: 'a',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -2776,7 +2913,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '[k: string];',
+                  leftGroup: 'unknown',
                   right: 'a',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -2893,35 +3032,45 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#aPrivateStaticMethod',
+                  leftGroup: 'static-method',
                   right: '#somePrivateProperty',
+                  rightGroup: 'private-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#somePrivateProperty',
+                  leftGroup: 'private-property',
                   right: '#someOtherPrivateProperty',
+                  rightGroup: 'private-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#someOtherPrivateProperty',
+                  leftGroup: 'private-property',
                   right: 'someStaticProperty',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'someStaticProperty',
+                  leftGroup: 'static-property',
                   right: '#someStaticPrivateProperty',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aStaticMethod',
+                  leftGroup: 'static-method',
                   right: '#aPrivateInstanceMethod',
+                  rightGroup: 'private-method',
                 },
               },
             ],
@@ -2977,14 +3126,18 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'x',
+                  leftGroup: 'method',
                   right: 'b',
+                  rightGroup: 'method',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'z',
+                  leftGroup: 'get-method',
                   right: 'c',
+                  rightGroup: 'get-method',
                 },
               },
             ],
@@ -3040,7 +3193,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'email',
+                leftGroup: 'decorated-property',
                 right: 'lastName',
+                rightGroup: 'property',
               },
             },
           ],
@@ -3147,7 +3302,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'message',
+                leftGroup: 'set-method',
                 right: 'prop',
+                rightGroup: 'decorated-set-method',
               },
             },
           ],
@@ -3220,14 +3377,18 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'toggle',
+                leftGroup: 'decorated-method',
                 right: '#active',
+                rightGroup: 'private-decorated-accessor-property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: '#active',
+                leftGroup: 'private-decorated-accessor-property',
                 right: 'finished',
+                rightGroup: 'decorated-accessor-property',
               },
             },
           ],
@@ -3325,21 +3486,27 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'updateTable',
+                leftGroup: 'protected-method',
                 right: 'onSortChanged',
+                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'onSortChanged',
+                leftGroup: 'protected-method',
                 right: 'onPaginationChanged',
+                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'setFormValue',
+                leftGroup: 'protected-method',
                 right: 'onValueChanged',
+                rightGroup: 'protected-method',
               },
             },
           ],
@@ -3431,7 +3598,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
+                  leftGroup: 'property',
                   right: 'b',
+                  rightGroup: 'property',
                 },
               },
             ],
@@ -3461,7 +3630,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'getAaa',
+                  leftGroup: 'method',
                   right: 'b',
+                  rightGroup: 'property',
                 },
               },
             ],
@@ -3487,7 +3658,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'b',
+                  leftGroup: 'property',
                   right: 'c',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -3517,7 +3690,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'getAaa',
+                  leftGroup: 'method',
                   right: '#b',
+                  rightGroup: 'private-property',
                 },
               },
             ],
@@ -3547,7 +3722,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'getAaa',
+                  leftGroup: 'static-method',
                   right: 'b',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -3610,7 +3787,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
+                  leftGroup: 'property',
                   right: 'left',
+                  rightGroup: 'property',
                 },
               },
             ],
@@ -3705,7 +3884,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'property',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -3737,7 +3918,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'property',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -3777,7 +3960,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'method',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -3811,14 +3996,18 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
+                leftGroup: 'method',
                 right: 'b',
+                rightGroup: 'property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'b',
+                leftGroup: 'property',
                 right: 'a',
+                rightGroup: 'property',
               },
             },
           ],
@@ -3940,7 +4129,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'e',
+                leftGroup: 'static-method',
                 right: 'constructor',
+                rightGroup: 'constructor',
               },
             },
           ],
@@ -4024,7 +4215,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'key in O',
+                  leftGroup: 'property',
                   right: 'b',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -4093,7 +4286,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '[k: string];',
+                  leftGroup: 'unknown',
                   right: 'a',
+                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -4210,35 +4405,45 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#aPrivateStaticMethod',
+                  leftGroup: 'static-method',
                   right: '#somePrivateProperty',
+                  rightGroup: 'private-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#somePrivateProperty',
+                  leftGroup: 'private-property',
                   right: '#someOtherPrivateProperty',
+                  rightGroup: 'private-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#someOtherPrivateProperty',
+                  leftGroup: 'private-property',
                   right: 'someStaticProperty',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'someStaticProperty',
+                  leftGroup: 'static-property',
                   right: '#someStaticPrivateProperty',
+                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aStaticMethod',
+                  leftGroup: 'static-method',
                   right: '#aPrivateInstanceMethod',
+                  rightGroup: 'private-method',
                 },
               },
             ],
@@ -4294,7 +4499,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'email',
+                leftGroup: 'decorated-property',
                 right: 'lastName',
+                rightGroup: 'property',
               },
             },
           ],
@@ -4400,7 +4607,9 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'message',
+                leftGroup: 'set-method',
                 right: 'prop',
+                rightGroup: 'decorated-set-method',
               },
             },
           ],
@@ -4493,28 +4702,36 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'customLastGroupProperty',
+                leftGroup: 'my-last-group',
                 right: 'id',
+                rightGroup: 'property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'constructor',
+                leftGroup: 'constructor',
                 right: 'customFirstGroupProperty',
+                rightGroup: 'my-first-group',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'toggle',
+                leftGroup: 'decorated-method',
                 right: '#active',
+                rightGroup: 'private-decorated-accessor-property',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: '#active',
+                leftGroup: 'private-decorated-accessor-property',
                 right: 'finished',
+                rightGroup: 'decorated-accessor-property',
               },
             },
           ],
@@ -4597,7 +4814,9 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'log1p',
+                  leftGroup: 'static-method',
                   right: 'log10',
+                  rightGroup: 'static-method',
                 },
               },
             ],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -154,13 +154,11 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'e',
-                leftGroup: 'property',
                 right: 'd',
-                rightGroup: 'property',
               },
             },
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'f',
                 leftGroup: 'static-method',
@@ -272,7 +270,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'static',
                   leftGroup: 'static-block',
@@ -281,7 +279,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'static readonly [key: string]',
                   leftGroup: 'static-readonly-index-signature',
@@ -290,7 +288,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'l',
                   leftGroup: 'declare-private-static-readonly-property',
@@ -299,7 +297,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'k',
                   leftGroup: 'private-property',
@@ -308,7 +306,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'j',
                   leftGroup: 'protected-property',
@@ -317,7 +315,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'i',
                   leftGroup: 'public-property',
@@ -326,7 +324,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'h',
                   leftGroup: 'private-readonly-property',
@@ -335,7 +333,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'g',
                   leftGroup: 'protected-readonly-property',
@@ -344,7 +342,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'f',
                   leftGroup: 'public-readonly-property',
@@ -353,7 +351,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'e',
                   leftGroup: 'static-private-override-readonly-property',
@@ -362,7 +360,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'd',
                   leftGroup: 'static-protected-override-readonly-property',
@@ -371,7 +369,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'c',
                   leftGroup: 'static-public-override-readonly-property',
@@ -381,7 +379,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'b',
                   leftGroup:
@@ -428,7 +426,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'method',
                   leftGroup: 'public-abstract-override-method',
@@ -478,7 +476,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'property',
@@ -525,7 +523,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -570,7 +568,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -615,7 +613,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -662,7 +660,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'property',
@@ -707,7 +705,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'property',
@@ -754,7 +752,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'property',
@@ -804,7 +802,7 @@ describe(ruleName, () => {
                 ],
                 errors: [
                   {
-                    messageId: 'unexpectedClassesOrder',
+                    messageId: 'unexpectedClassesGroupOrder',
                     data: {
                       left: 'a',
                       leftGroup: 'property',
@@ -856,7 +854,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'property',
@@ -905,7 +903,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'property',
@@ -956,7 +954,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'property',
@@ -1006,7 +1004,7 @@ describe(ruleName, () => {
                 ],
                 errors: [
                   {
-                    messageId: 'unexpectedClassesOrder',
+                    messageId: 'unexpectedClassesGroupOrder',
                     data: {
                       left: 'a',
                       leftGroup: 'property',
@@ -1054,7 +1052,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -1099,7 +1097,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -1144,7 +1142,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -1191,7 +1189,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -1238,7 +1236,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -1283,7 +1281,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
                     leftGroup: 'method',
@@ -1333,7 +1331,7 @@ describe(ruleName, () => {
                 ],
                 errors: [
                   {
-                    messageId: 'unexpectedClassesOrder',
+                    messageId: 'unexpectedClassesGroupOrder',
                     data: {
                       left: 'a',
                       leftGroup: 'method',
@@ -1425,18 +1423,14 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'key in O',
-                  leftGroup: 'property',
                   right: 'b',
-                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'b',
-                  leftGroup: 'static-property',
                   right: 'a',
-                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -1502,7 +1496,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '[k: string];',
                   leftGroup: 'unknown',
@@ -1621,7 +1615,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '#aPrivateStaticMethod',
                   leftGroup: 'static-method',
@@ -1633,13 +1627,11 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#somePrivateProperty',
-                  leftGroup: 'private-property',
                   right: '#someOtherPrivateProperty',
-                  rightGroup: 'private-property',
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '#someOtherPrivateProperty',
                   leftGroup: 'private-property',
@@ -1651,13 +1643,11 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'someStaticProperty',
-                  leftGroup: 'static-property',
                   right: '#someStaticPrivateProperty',
-                  rightGroup: 'static-property',
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'aStaticMethod',
                   leftGroup: 'static-method',
@@ -1718,18 +1708,14 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'x',
-                  leftGroup: 'method',
                   right: 'b',
-                  rightGroup: 'method',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'z',
-                  leftGroup: 'get-method',
                   right: 'c',
-                  rightGroup: 'get-method',
                 },
               },
             ],
@@ -1782,7 +1768,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'email',
                 leftGroup: 'decorated-property',
@@ -1891,7 +1877,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'message',
                 leftGroup: 'set-method',
@@ -1966,7 +1952,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'toggle',
                 leftGroup: 'decorated-method',
@@ -1975,7 +1961,7 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: '#active',
                 leftGroup: 'private-decorated-accessor-property',
@@ -2078,27 +2064,21 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'updateTable',
-                leftGroup: 'protected-method',
                 right: 'onSortChanged',
-                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'onSortChanged',
-                leftGroup: 'protected-method',
                 right: 'onPaginationChanged',
-                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'setFormValue',
-                leftGroup: 'protected-method',
                 right: 'onValueChanged',
-                rightGroup: 'protected-method',
               },
             },
           ],
@@ -2190,9 +2170,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
-                  leftGroup: 'property',
                   right: 'b',
-                  rightGroup: 'property',
                 },
               },
             ],
@@ -2219,7 +2197,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'getAaa',
                   leftGroup: 'method',
@@ -2247,7 +2225,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'b',
                   leftGroup: 'property',
@@ -2279,7 +2257,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'getAaa',
                   leftGroup: 'method',
@@ -2311,7 +2289,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'getAaa',
                   leftGroup: 'static-method',
@@ -2379,9 +2357,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
-                  leftGroup: 'property',
                   right: 'left',
-                  rightGroup: 'property',
                 },
               },
             ],
@@ -2476,9 +2452,7 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
-                leftGroup: 'property',
                 right: 'a',
-                rightGroup: 'property',
               },
             },
           ],
@@ -2510,9 +2484,7 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
-                leftGroup: 'property',
                 right: 'a',
-                rightGroup: 'property',
               },
             },
           ],
@@ -2549,7 +2521,7 @@ describe(ruleName, () => {
           options: [options],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'method',
                 leftGroup: 'method',
@@ -2585,7 +2557,7 @@ describe(ruleName, () => {
           options: [options],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'method',
                 leftGroup: 'method',
@@ -2597,9 +2569,7 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'b',
-                leftGroup: 'property',
                 right: 'a',
-                rightGroup: 'property',
               },
             },
           ],
@@ -2738,13 +2708,11 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'e',
-                leftGroup: 'property',
                 right: 'd',
-                rightGroup: 'property',
               },
             },
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'f',
                 leftGroup: 'static-method',
@@ -2833,18 +2801,14 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'key in O',
-                  leftGroup: 'property',
                   right: 'b',
-                  rightGroup: 'static-property',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'b',
-                  leftGroup: 'static-property',
                   right: 'a',
-                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -2910,7 +2874,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '[k: string];',
                   leftGroup: 'unknown',
@@ -3029,7 +2993,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '#aPrivateStaticMethod',
                   leftGroup: 'static-method',
@@ -3041,13 +3005,11 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#somePrivateProperty',
-                  leftGroup: 'private-property',
                   right: '#someOtherPrivateProperty',
-                  rightGroup: 'private-property',
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '#someOtherPrivateProperty',
                   leftGroup: 'private-property',
@@ -3059,13 +3021,11 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'someStaticProperty',
-                  leftGroup: 'static-property',
                   right: '#someStaticPrivateProperty',
-                  rightGroup: 'static-property',
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'aStaticMethod',
                   leftGroup: 'static-method',
@@ -3126,18 +3086,14 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'x',
-                  leftGroup: 'method',
                   right: 'b',
-                  rightGroup: 'method',
                 },
               },
               {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'z',
-                  leftGroup: 'get-method',
                   right: 'c',
-                  rightGroup: 'get-method',
                 },
               },
             ],
@@ -3190,7 +3146,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'email',
                 leftGroup: 'decorated-property',
@@ -3299,7 +3255,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'message',
                 leftGroup: 'set-method',
@@ -3374,7 +3330,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'toggle',
                 leftGroup: 'decorated-method',
@@ -3383,7 +3339,7 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: '#active',
                 leftGroup: 'private-decorated-accessor-property',
@@ -3486,27 +3442,21 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'updateTable',
-                leftGroup: 'protected-method',
                 right: 'onSortChanged',
-                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'onSortChanged',
-                leftGroup: 'protected-method',
                 right: 'onPaginationChanged',
-                rightGroup: 'protected-method',
               },
             },
             {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'setFormValue',
-                leftGroup: 'protected-method',
                 right: 'onValueChanged',
-                rightGroup: 'protected-method',
               },
             },
           ],
@@ -3598,9 +3548,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
-                  leftGroup: 'property',
                   right: 'b',
-                  rightGroup: 'property',
                 },
               },
             ],
@@ -3627,7 +3575,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'getAaa',
                   leftGroup: 'method',
@@ -3655,7 +3603,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'b',
                   leftGroup: 'property',
@@ -3687,7 +3635,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'getAaa',
                   leftGroup: 'method',
@@ -3719,7 +3667,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'getAaa',
                   leftGroup: 'static-method',
@@ -3787,9 +3735,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'aaa',
-                  leftGroup: 'property',
                   right: 'left',
-                  rightGroup: 'property',
                 },
               },
             ],
@@ -3884,9 +3830,7 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
-                leftGroup: 'property',
                 right: 'a',
-                rightGroup: 'property',
               },
             },
           ],
@@ -3918,9 +3862,7 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'method',
-                leftGroup: 'property',
                 right: 'a',
-                rightGroup: 'property',
               },
             },
           ],
@@ -3957,7 +3899,7 @@ describe(ruleName, () => {
           options: [options],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'method',
                 leftGroup: 'method',
@@ -3993,7 +3935,7 @@ describe(ruleName, () => {
           options: [options],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'method',
                 leftGroup: 'method',
@@ -4005,9 +3947,7 @@ describe(ruleName, () => {
               messageId: 'unexpectedClassesOrder',
               data: {
                 left: 'b',
-                leftGroup: 'property',
                 right: 'a',
-                rightGroup: 'property',
               },
             },
           ],
@@ -4126,7 +4066,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'e',
                 leftGroup: 'static-method',
@@ -4215,9 +4155,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'key in O',
-                  leftGroup: 'property',
                   right: 'b',
-                  rightGroup: 'static-property',
                 },
               },
             ],
@@ -4283,7 +4221,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '[k: string];',
                   leftGroup: 'unknown',
@@ -4402,7 +4340,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '#aPrivateStaticMethod',
                   leftGroup: 'static-method',
@@ -4414,13 +4352,11 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: '#somePrivateProperty',
-                  leftGroup: 'private-property',
                   right: '#someOtherPrivateProperty',
-                  rightGroup: 'private-property',
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '#someOtherPrivateProperty',
                   leftGroup: 'private-property',
@@ -4432,13 +4368,11 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'someStaticProperty',
-                  leftGroup: 'static-property',
                   right: '#someStaticPrivateProperty',
-                  rightGroup: 'static-property',
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'aStaticMethod',
                   leftGroup: 'static-method',
@@ -4496,7 +4430,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'email',
                 leftGroup: 'decorated-property',
@@ -4604,7 +4538,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'message',
                 leftGroup: 'set-method',
@@ -4699,7 +4633,7 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'customLastGroupProperty',
                 leftGroup: 'my-last-group',
@@ -4708,7 +4642,7 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'constructor',
                 leftGroup: 'constructor',
@@ -4717,7 +4651,7 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: 'toggle',
                 leftGroup: 'decorated-method',
@@ -4726,7 +4660,7 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
               data: {
                 left: '#active',
                 leftGroup: 'private-decorated-accessor-property',
@@ -4814,9 +4748,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesOrder',
                 data: {
                   left: 'log1p',
-                  leftGroup: 'static-method',
                   right: 'log10',
-                  rightGroup: 'static-method',
                 },
               },
             ],


### PR DESCRIPTION
### Description

I believe that the `modifiers` and `selectors` priority order for `sort-classes` is intuitive enough to do what users expect the rule to do in cases where an element matches multiple user-entered groups. However, giving the matched group's name in the ESLint error message would still be a good idea. This can help users in debugging their configuration, especially complex ones involving custom groups.

New error added: `unexpectedClassesGroupOrder`. This error will show the element's respective group they matched.

_Note_:  Elements that do not belong in the same group but end up being regrouped together by the user's configuration will not throw an `unexpectedClassesGroupOrder` error, but a usual `unexpectedClassOrder` instead.

### Code example 1

Configuration: 

```json
   "perfectionist/sort-classes": ["error", {
          "groups": [
            "get-method",
            "constructor",
            "protected-abstract-override-method"
          ]
        }]
```

Code: 
```ts
abstract class Class extends AbstractClass {
  
  constructor() {

  }

  protected abstract override get getMethod() {
    // This is a get-method before being a method, so it should go above the constructor
  }

}
```

Message:
![image](https://github.com/user-attachments/assets/cbc510f9-2367-4970-8d80-2991df18fc66)

### Code example 2

Configuration:
```
 "groups": [
              ["static-property", "private-property", "property"],
              "constructor",
              ["static-method", "private-method", "method"],
              "unknown"
            ]
```

Code:
```ts
class Class {

  method() {}

  static b = 'b'

  private a
}
```

Message:
![image](https://github.com/user-attachments/assets/fdc9bf92-45b2-4fcc-99b0-a5b729d0edcd)
 
### What is the purpose of this pull request?

- [x] New Feature
