### PR TITLE
Allow `sort-classes` to match `property-function`: properties whose values are directly functions or arrow-functions.

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -232,12 +232,16 @@ The `abstract` modifier is incompatible with the `static`, `private` and `decora
 `constructor`, `get-method` and `set-method` elements will also be matched as `method`.
 
 #### Properties
-- Selector: `property`.
+- Selectors: `function-property`, `property`.
 - Modifiers: `static`, `declare`, `abstract`, `decorated`, `override`, `readonly`, `protected`, `private`, `public`.
 - Example: `readonly-decorated-property`.
 
 The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.
+
 The `declare` modifier is incompatible with the `override` and `decorated` modifiers.
+
+The `function-property` selector will match properties whose values are defined functions or arrow-functions.
+As such, the `declare` and `abstract` modifiers are incompatible with this selector.
 
 #### Index-signatures
 - Selector: `index-signature`.
@@ -316,6 +320,12 @@ abstract class Example extends BaseExample {
   // 'private-decorated-property'
   @SomeDecorator
   private _value: number;
+
+  // private-function-property
+  private arrowProperty = () => {};
+
+  // private-function-property
+  private functionProperty = function() {};
 
   // 'private-property'
   private name: string;

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -43,6 +43,7 @@ export type Modifier =
   | StaticModifier
 
 type ConstructorSelector = 'constructor'
+type FunctionPropertySelector = 'function-property'
 type PropertySelector = 'property'
 type MethodSelector = 'method'
 type GetMethodSelector = 'get-method'
@@ -52,6 +53,7 @@ type StaticBlockSelector = 'static-block'
 type AccessorPropertySelector = 'accessor-property'
 export type Selector =
   | AccessorPropertySelector
+  | FunctionPropertySelector
   | IndexSignatureSelector
   | ConstructorSelector
   | StaticBlockSelector
@@ -84,6 +86,8 @@ type MethodOrGetMethodOrSetMethodSelector =
 
 type ConstructorGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${ConstructorSelector}`
+type FunctionPropertyGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${FunctionPropertySelector}`
 type DeclarePropertyGroup =
   `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${PropertySelector}`
 type NonDeclarePropertyGroup =
@@ -105,6 +109,7 @@ type Group =
   | MethodOrGetMethodOrSetMethodGroup
   | NonDeclarePropertyGroup
   | AccessorPropertyGroup
+  | FunctionPropertyGroup
   | DeclarePropertyGroup
   | IndexSignatureGroup
   | ConstructorGroup
@@ -472,6 +477,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 modifiers.push('private')
               } else {
                 modifiers.push('public')
+              }
+
+              if (
+                member.value?.type === 'ArrowFunctionExpression' ||
+                member.value?.type === 'FunctionExpression'
+              ) {
+                selectors.push('function-property')
               }
 
               selectors.push('property')

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -293,7 +293,7 @@ describe(ruleName, () => {
                   left: 'static readonly [key: string]',
                   leftGroup: 'static-readonly-index-signature',
                   right: 'n',
-                  rightGroup: 'declare-private-static-readonly-property',
+                  rightGroup: 'function-property',
                 },
               },
               {
@@ -304,10 +304,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: 'm',
+                  leftGroup: 'function-property',
                   right: 'l',
+                  rightGroup: 'declare-private-static-readonly-property',
                 },
               },
               {
@@ -1075,10 +1077,12 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'function-property',
                     right: 'z',
+                    rightGroup: 'property',
                   },
                 },
               ],
@@ -1118,10 +1122,12 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesGroupOrder',
                   data: {
                     left: 'a',
+                    leftGroup: 'function-property',
                     right: 'z',
+                    rightGroup: 'property',
                   },
                 },
               ],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -185,6 +185,10 @@ describe(ruleName, () => {
 
               static readonly [key: string]: string;
 
+              private n = function() {};
+
+              private m = () => {};
+
               declare private static readonly l;
 
               private k = 'k';
@@ -241,6 +245,10 @@ describe(ruleName, () => {
 
               declare private static readonly l;
 
+              private m = () => {};
+
+              private n = function() {};
+
               static readonly [key: string]: string;
 
               static {}
@@ -263,6 +271,7 @@ describe(ruleName, () => {
                   'protected-property',
                   'private-property',
                   'declare-private-static-readonly-property',
+                  'function-property',
                   'static-readonly-index-signature',
                   'static-block',
                 ],
@@ -283,8 +292,22 @@ describe(ruleName, () => {
                 data: {
                   left: 'static readonly [key: string]',
                   leftGroup: 'static-readonly-index-signature',
-                  right: 'l',
+                  right: 'n',
                   rightGroup: 'declare-private-static-readonly-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'n',
+                  right: 'm',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'm',
+                  right: 'l',
                 },
               },
               {
@@ -1018,6 +1041,94 @@ describe(ruleName, () => {
           },
         )
       }
+    })
+
+    describe('property selectors priority', () => {
+      ruleTester.run(
+        `${ruleName}(${type}): prioritize function property over property`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+            export class Class {
+
+              a = function() {}
+
+              z: string;
+            }
+          `,
+              output: dedent`
+            export class Class {
+
+              z: string;
+
+              a = function() {}
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property', 'function-property'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'a',
+                    right: 'z',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritize function property over property for arrow functions`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+            export class Class {
+
+              a = () => {}
+
+              z: string;
+            }
+          `,
+              output: dedent`
+            export class Class {
+
+              z: string;
+
+              a = () => {}
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property', 'function-property'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'a',
+                    right: 'z',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
     })
 
     describe('property modifiers priority', () => {


### PR DESCRIPTION
### Description

Solves https://github.com/azat-io/eslint-plugin-perfectionist/issues/189.

- Adds a new `selector`: `property-function`, with a higher priority than `property`. This selector will only match properties whose **values** are **directly** functions or arrow-functions (directly meaning that assigning a property a literal referring to a function will not detect it as a `property-function`). Properties **typed** as a function but without values will not be recognized as `property-function`.

### Additional context

I have been wondering if this feature should be implemented as a custom-group feature instead. (c.f: https://github.com/azat-io/eslint-plugin-perfectionist/issues/189#issuecomment-2276853937)

I agree with @OlivierZal that this is probably worth adding as an official group.

### What is the purpose of this pull request?

- [x] New Feature

