### PR TITLE
feat: allow specifying cross-rule settings

### DIFF
--- a/docs/content/guide/getting-started.mdx
+++ b/docs/content/guide/getting-started.mdx
@@ -131,3 +131,81 @@ type="config-type"
 client:load
 lang="js"
 />
+
+## Settings
+
+Many rules have common settings. You can set them in the `settings` field.
+
+The highest priority is given to the settings of a particular rule. Next comes the settings field and the lowest priority has default values.
+
+In settings you can set the following options:
+
+- `type` — The type of sorting. Possible values are `'alphabetical'`, `'natural'` and `'line-length'`.
+- `order` — The order of sorting. Possible values are `'asc'` and `'desc'`.
+- `ignoreCase` — Ignore case when sorting.
+- `ignorePattern` — Ignore sorting for elements that match the pattern.
+- `partitionByComment` — Partition the sorted elements by comments. Values can be `true`, `false` or glob pattern string.
+- `partitionByNewLine` — Partition the sorted elements by new lines. Values can be `true` or `false`.
+
+Example:
+
+<CodeTabs
+  code={[
+    {
+      source: dedent`
+        // eslint.config.js
+        import perfectionist from 'eslint-plugin-perfectionist'
+
+        export default [
+          {
+            plugins: {
+              perfectionist,
+            },
+            rules: {
+              'perfectionist/sort-objects': ['error', {
+                type: 'alphabetical',
+              }],
+              'perfectionist/sort-interfaces': ['error'],
+            },
+            settings: {
+              perfectionist: {
+                type: 'line-length',
+                partitionByComment: true,
+              },
+            },
+          },
+        ]
+      `,
+      name: 'Flat Config',
+      value: 'flat',
+    },
+    {
+      source: dedent`
+        // .eslintrc.js
+        module.exports = {
+          plugins: [
+            'perfectionist',
+          ],
+          rules: {
+            'perfectionist/sort-objects': ['error', {
+              type: 'alphabetical',
+            }],
+            'perfectionist/sort-interfaces': ['error'],
+          },
+          settings: {
+            perfectionist: {
+              type: 'line-length',
+              partitionByComment: true,
+            },
+          },
+        }
+      `,
+      name: 'Legacy Config',
+      value: 'legacy',
+    },
+
+]}
+type="config-type"
+client:load
+lang="js"
+/>

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -7,6 +7,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -88,8 +89,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ? node.object.elements
             : node.object.arguments
 
+        let settings = getSettings(context.settings)
+
         if (elements.length > 1) {
-          let options = complete(context.options.at(0), {
+          let options = complete(context.options.at(0), settings, {
             groupKind: 'literals-first',
             type: 'alphabetical',
             ignoreCase: true,

--- a/rules/sort-astro-attributes.ts
+++ b/rules/sort-astro-attributes.ts
@@ -9,6 +9,7 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
@@ -127,7 +128,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         let { attributes } = node.openingElement
 
         if (attributes.length > 1) {
-          let options = complete(context.options.at(0), {
+          let settings = getSettings(context.settings)
+
+          let options = complete(context.options.at(0), settings, {
             type: 'alphabetical',
             ignoreCase: true,
             customGroups: {},

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -11,6 +11,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { sortNodes } from '../utils/sort-nodes'
@@ -236,7 +237,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
   create: context => ({
     ClassBody: node => {
       if (node.body.length > 1) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+
+        let options = complete(context.options.at(0), settings, {
           groups: [
             'index-signature',
             'static-property',

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -9,6 +9,7 @@ import { getCommentBefore } from '../utils/get-comment-before'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -113,7 +114,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
         members.length > 1 &&
         members.every(({ initializer }) => initializer)
       ) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+
+        let options = complete(context.options.at(0), settings, {
           partitionByComment: false,
           type: 'alphabetical',
           ignoreCase: true,

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -5,6 +5,7 @@ import type { SortingNode } from '../typings'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -66,7 +67,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
     },
   ],
   create: context => {
-    let options = complete(context.options.at(0), {
+    let settings = getSettings(context.settings)
+
+    let options = complete(context.options.at(0), settings, {
       type: 'alphabetical',
       ignoreCase: true,
       order: 'asc',

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -13,6 +13,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { getNodeRange } from '../utils/get-node-range'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { sortNodes } from '../utils/sort-nodes'
@@ -212,7 +213,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     },
   ],
   create: context => {
-    let options = complete(context.options.at(0), {
+    let settings = getSettings(context.settings)
+
+    let options = complete(context.options.at(0), settings, {
       groups: [
         'type',
         ['builtin', 'external'],

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -9,6 +9,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { sortNodes } from '../utils/sort-nodes'
@@ -138,7 +139,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   create: context => ({
     TSInterfaceDeclaration: node => {
       if (node.body.body.length > 1) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+        let options = complete(context.options.at(0), settings, {
           partitionByNewLine: false,
           type: 'alphabetical',
           groupKind: 'mixed',

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -5,6 +5,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { useGroups } from '../utils/use-groups'
@@ -103,7 +104,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
   ],
   create: context => ({
     TSIntersectionType: node => {
-      let options = complete(context.options.at(0), {
+      let settings = getSettings(context.settings)
+
+      let options = complete(context.options.at(0), settings, {
         type: 'alphabetical',
         ignoreCase: true,
         order: 'asc',

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -8,6 +8,7 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
@@ -127,7 +128,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   create: context => ({
     JSXElement: node => {
       if (node.openingElement.attributes.length > 1) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+
+        let options = complete(context.options.at(0), settings, {
           type: 'alphabetical',
           ignorePattern: [],
           ignoreCase: true,

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -6,6 +6,7 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -78,7 +79,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
         let [{ elements }] = node.arguments
 
         if (elements.length > 1) {
-          let options = complete(context.options.at(0), {
+          let settings = getSettings(context.settings)
+
+          let options = complete(context.options.at(0), settings, {
             type: 'alphabetical',
             ignoreCase: true,
             order: 'asc',

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -4,6 +4,7 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -75,7 +76,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
   create: context => ({
     ExportNamedDeclaration: node => {
       if (node.specifiers.length > 1) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+
+        let options = complete(context.options.at(0), settings, {
           type: 'alphabetical',
           groupKind: 'mixed',
           ignoreCase: true,

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -4,6 +4,7 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -85,7 +86,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       )
 
       if (specifiers.length > 1) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+
+        let options = complete(context.options.at(0), settings, {
           type: 'alphabetical',
           ignoreAlias: false,
           groupKind: 'mixed',

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -8,6 +8,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -127,7 +128,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   create: context => ({
     TSTypeLiteral: node => {
       if (node.members.length > 1) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+
+        let options = complete(context.options.at(0), settings, {
           partitionByNewLine: false,
           type: 'alphabetical',
           groupKind: 'mixed',

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -14,6 +14,7 @@ import { getSourceCode } from '../utils/get-source-code'
 import { getNodeParent } from '../utils/get-node-parent'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
@@ -175,7 +176,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
     let sortObject = (
       node: TSESTree.ObjectExpression | TSESTree.ObjectPattern,
     ) => {
-      let options = complete(context.options.at(0), {
+      let settings = getSettings(context.settings)
+
+      let options = complete(context.options.at(0), settings, {
         partitionByNewLine: false,
         partitionByComment: false,
         styledComponents: true,

--- a/rules/sort-svelte-attributes.ts
+++ b/rules/sort-svelte-attributes.ts
@@ -9,6 +9,7 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { sortNodes } from '../utils/sort-nodes'
@@ -124,7 +125,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     return {
       SvelteStartTag: (node: AST.SvelteStartTag) => {
         if (node.attributes.length > 1) {
-          let options = complete(context.options.at(0), {
+          let settings = getSettings(context.settings)
+
+          let options = complete(context.options.at(0), settings, {
             type: 'alphabetical',
             ignoreCase: true,
             customGroups: {},

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -6,6 +6,7 @@ import type { SortingNode } from '../typings'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { makeFixes } from '../utils/make-fixes'
 import { sortNodes } from '../utils/sort-nodes'
@@ -69,7 +70,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
   ],
   create: context => ({
     SwitchStatement: node => {
-      let options = complete(context.options.at(0), {
+      let settings = getSettings(context.settings)
+
+      let options = complete(context.options.at(0), settings, {
         type: 'alphabetical',
         ignoreCase: true,
         order: 'asc',

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -5,6 +5,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { sortNodes } from '../utils/sort-nodes'
@@ -103,7 +104,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
   ],
   create: context => ({
     TSUnionType: node => {
-      let options = complete(context.options.at(0), {
+      let settings = getSettings(context.settings)
+
+      let options = complete(context.options.at(0), settings, {
         type: 'alphabetical',
         ignoreCase: true,
         order: 'asc',

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -6,6 +6,7 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
@@ -70,7 +71,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
   create: context => ({
     VariableDeclaration: node => {
       if (node.declarations.length > 1) {
-        let options = complete(context.options.at(0), {
+        let settings = getSettings(context.settings)
+
+        let options = complete(context.options.at(0), settings, {
           type: 'alphabetical',
           ignoreCase: true,
           order: 'asc',

--- a/rules/sort-vue-attributes.ts
+++ b/rules/sort-vue-attributes.ts
@@ -135,7 +135,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     return defineTemplateBodyVisitor({
       VStartTag: (node: AST.VStartTag) => {
         if (node.attributes.length > 1) {
-          let options = complete(context.options.at(0), {
+          let settings = context.settings.perfectionist as
+            | Options<string[]>[0]
+            | undefined
+
+          let options = complete(context.options.at(0), settings, {
             type: 'alphabetical',
             ignoreCase: true,
             customGroups: {},

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -3014,5 +3014,27 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(`${ruleName}: works with settings`, rule, {
+      valid: [
+        {
+          code: dedent`
+            let obj = {
+              ccc: 'ccc',
+              bb: 'bb',
+              a: 'a',
+            }
+          `,
+          options: [{}],
+          settings: {
+            perfectionist: {
+              type: 'line-length',
+              order: 'desc',
+            },
+          },
+        },
+      ],
+      invalid: [],
+    })
   })
 })

--- a/utils/complete.ts
+++ b/utils/complete.ts
@@ -1,4 +1,7 @@
+import type { Settings } from './get-settings'
+
 export let complete = <T extends { [key: string]: unknown }>(
   options: Partial<T> = {},
+  settings: Settings = {},
   defaults: T,
-): T => Object.assign(defaults, options)
+): T => Object.assign(defaults, settings, options)

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -1,0 +1,49 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+export type Settings = Partial<{
+  type: 'alphabetical' | 'line-length' | 'natural'
+  partitionByComment: string[] | boolean | string
+  partitionByNewLine: boolean
+  ignorePattern: string[]
+  order: 'desc' | 'asc'
+  ignoreCase: boolean
+}>
+
+export let getSettings = (
+  settings: TSESLint.SharedConfigurationSettings = {},
+) => {
+  if (!settings.perfectionist) {
+    return {}
+  }
+
+  let validateOptions = (object: Record<string, unknown>) => {
+    let allowedOptions = [
+      'partitionByComment',
+      'partitionByNewLine',
+      'ignorePattern',
+      'ignoreCase',
+      'order',
+      'type',
+    ]
+
+    let keys = Object.keys(object)
+    for (let key of keys) {
+      /* c8 ignore start */
+      if (!allowedOptions.includes(key)) {
+        return false
+      }
+      /* c8 ignore end */
+    }
+    return true
+  }
+
+  let perfectionistSettings = settings.perfectionist as Record<string, unknown>
+
+  /* c8 ignore start */
+  if (!validateOptions(perfectionistSettings)) {
+    throw new Error('Invalid Perfectionist settings')
+  }
+  /* c8 ignore end */
+
+  return settings.perfectionist as Settings
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Cross-rule settings. Example:

```js
import perfectionist from 'eslint-plugin-perfectionist'

export default [
  {
    plugins: {
      perfectionist,
    },
    rules: {
      'perfectionist/sort-objects': ['error', {
        type: 'alphabetical',
      }],
      'perfectionist/sort-interfaces': ['error'],
    },
    settings: {
      perfectionist: {
        type: 'line-length',
        partitionByComment: true,
      },
    },
  },
]
```

### Additional context

#202

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
