### PR TITLE
feat: `sort-classes`: #201: Improved and extensible custom groups

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -450,9 +450,60 @@ abstract class Example extends BaseExample {
 
 ### customGroups
 
-<sub>default: `{}`</sub>
+<sub>default: `[]`</sub>
 
-You can define your own groups for class members using custom glob patterns for matching.
+You can define your own groups to match very specific members.
+
+A custom group definition may follow one of the two following interfaces:
+
+```ts
+interface CustomGroupDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  selector?: string
+  modifiers?: string[]
+  elementNamePattern?: string
+  decoratorNamePattern?: string
+}
+```
+A class member will match a `CustomGroupDefinition` group if it matches all the filters of the custom group's definition.
+
+or:
+
+```ts
+interface CustomGroupBlockDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  anyOf: Array<{
+      selector?: string
+      modifiers?: string[]
+      elementNamePattern?: string
+      decoratorNamePattern?: string
+  }>
+}
+```
+
+A class member will match a `CustomGroupBlockDefinition` group if it matches all the filters of at least one of the `anyOf` items.
+
+#### Attributes
+
+- `groupName`: The group's name, which needs to be put in the `groups` option.
+- `selector`: Filter on the `selector` of the element.
+- `modifiers`: Filter on the `modifiers` of the element. (All the modifiers of the element must be present in that list)
+- `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
+- `decoratorNamePattern`: If entered, will check that at least one `decorator` matches the pattern entered.
+- `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
+- `order`: Overrides the sort order for that custom group
+
+#### Match importance
+
+The `customGroups` list is ordered:
+The first custom group definition that matches an element will be used.
+
+Custom groups have a higher priority than any predefined group. If you want a predefined group to take precedence over a custom group,
+you must write a custom group definition that does the same as what the predefined group does (using `selector` and `modifiers` filters), and put it first in the list.
 
 Example:
 
@@ -461,23 +512,48 @@ Example:
    groups: [
     'static-block',
     'index-signature',
-    'static-property',
-    ['protected-property', 'protected-accessor-property'],
-    ['private-property', 'private-accessor-property'],
-    ['property', 'accessor-property'],
++   'input-properties',                         // [!code ++]
++   'output-properties',                        // [!code ++]
     'constructor',
-    'static-method',
-    'protected-method',
-    'private-method',
-     'static-private-method',
-    'method',
++   'unsorted-methods-and-other-properties',    // [!code ++]
     ['get-method', 'set-method'],
     'unknown',
-+    'value',         // [!code ++]
    ],
-+  customGroups: {    // [!code ++]
-+    value: 'value',  // [!code ++]
-+  }                  // [!code ++]
++  customGroups: [                               // [!code ++]
++    [                                           // [!code ++]
++      {                                         // [!code ++]
++        // `constructor()` members must not match  // [!code ++]
++        // `unsorted-methods-and-other-properties` // [!code ++]
++        // so make them match this first           // [!code ++]
++         groupName: 'constructor',              // [!code ++]
++         selector: 'constructor',               // [!code ++]
++      },                                        // [!code ++]
++      {                                         // [!code ++]
++         groupName: 'input-properties',         // [!code ++]
++         selector: 'property',                  // [!code ++]
++         modifiers: ['decorated'],              // [!code ++]
++         decoratorNamePattern: 'Input',         // [!code ++]
++      },                                        // [!code ++]
++      {                                         // [!code ++]
++         groupName: 'output-properties',        // [!code ++]
++         selector: 'property',                  // [!code ++]
++         modifiers: ['decorated'],              // [!code ++]
++         decoratorNamePattern: 'Output',        // [!code ++]
++      },                                        // [!code ++]
++      {                                         // [!code ++]
++         groupName: 'unsorted-methods-and-other-properties', // [!code ++]
++         type: 'unsorted',                      // [!code ++]
++         anyOf: [                               // [!code ++]
++           {                                    // [!code ++]
++              selector: 'method',               // [!code ++]
++           },                                   // [!code ++]
++           {                                    // [!code ++]
++              selector: 'property',             // [!code ++]
++           },                                   // [!code ++]
++         ]                                      // [!code ++]
++      },                                        // [!code ++]
++    ]                                           // [!code ++]
++  ]                                             // [!code ++]
  }
 ```
 
@@ -518,7 +594,7 @@ Example:
                     ['get-method', 'set-method'],
                     'unknown',
                   ],
-                  customGroups: {},
+                  customGroups: [],
                 },
               ],
             },
@@ -558,7 +634,7 @@ Example:
                   ['get-method', 'set-method'],
                   'unknown',
                 ],
-                customGroups: {},
+                customGroups: [],
               },
             ],
           },

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -149,12 +149,11 @@ export const getOverloadSignatureGroups = (
 }
 
 export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
-  if (!props.selectors.includes(props.customGroup.selector)) {
+  if (
+    props.customGroup.selector &&
+    !props.selectors.includes(props.customGroup.selector)
+  ) {
     return false
-  }
-
-  if (props.customGroup.selector === 'static-block') {
-    return true
   }
 
   if (props.customGroup.modifiers) {
@@ -166,13 +165,9 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
   }
 
   if (
-    props.customGroup.selector === 'constructor' ||
-    props.customGroup.selector === 'index-signature'
+    'elementNamePattern' in props.customGroup &&
+    props.customGroup.elementNamePattern
   ) {
-    return true
-  }
-
-  if (props.customGroup.elementNamePattern) {
     let matchesElementNamePattern: boolean = minimatch(
       props.elementName,
       props.customGroup.elementNamePattern,
@@ -185,7 +180,10 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
     }
   }
 
-  if (props.customGroup.decoratorNamePattern) {
+  if (
+    'decoratorNamePattern' in props.customGroup &&
+    props.customGroup.decoratorNamePattern
+  ) {
     let decoratorPattern = props.customGroup.decoratorNamePattern
     let matchesDecoratorNamePattern: boolean = props.decorators.some(
       decorator =>

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -5,11 +5,6 @@ import { minimatch } from 'minimatch'
 import type { CustomGroup, Modifier, Selector } from './sort-classes.types'
 
 interface CustomGroupMatchesProps {
-  memberValueType:
-    | 'ArrowFunctionExpression'
-    | 'FunctionExpression'
-    | undefined
-    | string
   customGroup: CustomGroup
   selectors: Selector[]
   modifiers: Modifier[]
@@ -199,31 +194,6 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
         }),
     )
     if (!matchesDecoratorNamePattern) {
-      return false
-    }
-  }
-
-  if (
-    props.customGroup.selector === 'method' ||
-    props.customGroup.selector === 'get-method' ||
-    props.customGroup.selector === 'set-method' ||
-    props.customGroup.selector === 'function-property'
-  ) {
-    return true
-  }
-
-  if (props.customGroup.valueTypePattern) {
-    if (!props.memberValueType) {
-      return false
-    }
-    let matchesValueTypePattern: boolean = minimatch(
-      props.memberValueType,
-      props.customGroup.valueTypePattern,
-      {
-        nocomment: true,
-      },
-    )
-    if (!matchesValueTypePattern) {
       return false
     }
   }

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -155,6 +155,9 @@ export const getOverloadSignatureGroups = (
   ].filter(group => group.length > 1)
 }
 
+/**
+ * Returns whether a custom group matches the given properties
+ */
 export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
   if ('anyOf' in props.customGroup) {
     // At least one subgroup must match
@@ -213,7 +216,8 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
 }
 
 /**
- * Returns the compare options used to sort a given group
+ * Returns the compare options used to sort a given group.
+ * Returns null if the group should not be sorted
  */
 export const getCompareOptions = (
   options: Required<SortClassesOptions[0]>,

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -208,7 +208,8 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
   if (
     props.customGroup.selector === 'method' ||
     props.customGroup.selector === 'get-method' ||
-    props.customGroup.selector === 'set-method'
+    props.customGroup.selector === 'set-method' ||
+    props.customGroup.selector === 'function-property'
   ) {
     return true
   }

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -1,7 +1,6 @@
-import { minimatch } from 'minimatch'
 import type { TSESTree } from '@typescript-eslint/utils'
 
-import type { Modifier, Selector } from './sort-classes'
+import { minimatch } from 'minimatch'
 
 import type { CustomGroup, Modifier, Selector } from './sort-classes.types'
 

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -153,7 +153,6 @@ export const getOverloadSignatureGroups = (
   ].filter(group => group.length > 1)
 }
 
-
 export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
   if (!props.selectors.includes(props.customGroup.selector)) {
     return false

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -156,9 +156,9 @@ export const getOverloadSignatureGroups = (
 }
 
 export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
-  if ('subgroups' in props.customGroup) {
+  if ('anyOf' in props.customGroup) {
     // At least one subgroup must match
-    return props.customGroup.subgroups.some(subgroup =>
+    return props.customGroup.anyOf.some(subgroup =>
       customGroupMatches({ ...props, customGroup: subgroup }),
     )
   }

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -217,6 +217,7 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
 
 /**
  * Returns the compare options used to sort a given group.
+ * If the group is a custom group, its options will be favored over the default options.
  * Returns null if the group should not be sorted
  */
 export const getCompareOptions = (

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -120,7 +120,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                   additionalProperties: false,
                   description: 'Advanced group.',
                   type: 'object',
-                  required: ['groupName', 'selector'],
+                  required: ['groupName'],
                   properties: {
                     groupName: {
                       description: 'Group name',

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -9,9 +9,9 @@ import type {
 import type { SortingNode } from '../typings'
 
 import {
+  getOverloadSignatureGroups,
   generateOfficialGroups,
   customGroupMatches,
-  getOverloadSignatureGroups,
 } from './sort-classes-utils'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { allModifiers, allSelectors } from './sort-classes.types'

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -131,7 +131,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       properties: {
                         ...singleCustomGroupNameGroupSchema,
                         ...singleCustomGroupSortGroupSchema,
-                        subgroups: {
+                        anyOf: {
                           type: 'array',
                           items: {
                             description: 'Custom group.',

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -487,7 +487,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                   })
                 ) {
                   defineGroup(customGroup.groupName, true)
-                  break
+                  // If the custom group is not referenced in the `groups` option, it will be ignored
+                  if (getGroup() === customGroup.groupName) {
+                    break
+                  }
                 }
               }
             } else {

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -1,13 +1,20 @@
 import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
+import type {
+  SortClassesOptions,
+  Modifier,
+  Selector,
+} from './sort-classes.types'
 import type { SortingNode } from '../typings'
 
 import {
-  getOverloadSignatureGroups,
   generateOfficialGroups,
+  customGroupMatches,
+  getOverloadSignatureGroups,
 } from './sort-classes-utils'
 import { isPartitionComment } from '../utils/is-partition-comment'
+import { allModifiers, allSelectors } from './sort-classes.types'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -25,119 +32,7 @@ import { compare } from '../utils/compare'
 
 type MESSAGE_ID = 'unexpectedClassesGroupOrder' | 'unexpectedClassesOrder'
 
-type ProtectedModifier = 'protected'
-type PrivateModifier = 'private'
-type PublicModifier = 'public'
-type StaticModifier = 'static'
-type AbstractModifier = 'abstract'
-type OverrideModifier = 'override'
-type ReadonlyModifier = 'readonly'
-type DecoratedModifier = 'decorated'
-type DeclareModifier = 'declare'
-type OptionalModifier = 'optional'
-export type Modifier =
-  | ProtectedModifier
-  | DecoratedModifier
-  | AbstractModifier
-  | OptionalModifier
-  | OverrideModifier
-  | ReadonlyModifier
-  | PrivateModifier
-  | DeclareModifier
-  | PublicModifier
-  | StaticModifier
-
-type ConstructorSelector = 'constructor'
-type FunctionPropertySelector = 'function-property'
-type PropertySelector = 'property'
-type MethodSelector = 'method'
-type GetMethodSelector = 'get-method'
-type SetMethodSelector = 'set-method'
-type IndexSignatureSelector = 'index-signature'
-type StaticBlockSelector = 'static-block'
-type AccessorPropertySelector = 'accessor-property'
-export type Selector =
-  | AccessorPropertySelector
-  | FunctionPropertySelector
-  | IndexSignatureSelector
-  | ConstructorSelector
-  | StaticBlockSelector
-  | GetMethodSelector
-  | SetMethodSelector
-  | PropertySelector
-  | MethodSelector
-
-type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''
-
-type PublicOrProtectedOrPrivateModifierPrefix = WithDashSuffixOrEmpty<
-  ProtectedModifier | PrivateModifier | PublicModifier
->
-
-type OverrideModifierPrefix = WithDashSuffixOrEmpty<OverrideModifier>
-type OptionalModifierPrefix = WithDashSuffixOrEmpty<OptionalModifier>
-type ReadonlyModifierPrefix = WithDashSuffixOrEmpty<ReadonlyModifier>
-type DecoratedModifierPrefix = WithDashSuffixOrEmpty<DecoratedModifier>
-type DeclareModifierPrefix = WithDashSuffixOrEmpty<DeclareModifier>
-
-type StaticOrAbstractModifierPrefix = WithDashSuffixOrEmpty<
-  AbstractModifier | StaticModifier
->
-
-type StaticModifierPrefix = WithDashSuffixOrEmpty<StaticModifier>
-
-type MethodOrGetMethodOrSetMethodSelector =
-  | GetMethodSelector
-  | SetMethodSelector
-  | MethodSelector
-
-type ConstructorGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${ConstructorSelector}`
-type FunctionPropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${FunctionPropertySelector}`
-type DeclarePropertyGroup =
-  `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
-type NonDeclarePropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
-type MethodGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${MethodSelector}`
-type GetMethodOrSetMethodGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
-type AccessorPropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
-type IndexSignatureGroup =
-  `${StaticModifierPrefix}${ReadonlyModifierPrefix}${IndexSignatureSelector}`
-type StaticBlockGroup = `${StaticBlockSelector}`
-
-/**
- * Some invalid combinations are still handled by this type, such as
- * - private abstract X
- * - abstract decorated X
- */
-type Group =
-  | GetMethodOrSetMethodGroup
-  | NonDeclarePropertyGroup
-  | AccessorPropertyGroup
-  | FunctionPropertyGroup
-  | DeclarePropertyGroup
-  | IndexSignatureGroup
-  | ConstructorGroup
-  | StaticBlockGroup
-  | MethodGroup
-  | 'unknown'
-  | string
-
-type Options = [
-  Partial<{
-    customGroups: { [key: string]: string[] | string }
-    type: 'alphabetical' | 'line-length' | 'natural'
-    partitionByComment: string[] | boolean | string
-    groups: (Group[] | Group)[]
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-  }>,
-]
-
-export default createEslintRule<Options, MESSAGE_ID>({
+export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
   name: 'sort-classes',
   meta: {
     type: 'suggestion',
@@ -202,20 +97,64 @@ export default createEslintRule<Options, MESSAGE_ID>({
           },
           customGroups: {
             description: 'Specifies custom groups.',
-            type: 'object',
-            additionalProperties: {
-              oneOf: [
-                {
-                  type: 'string',
+            anyOf: [
+              {
+                type: 'object',
+                additionalProperties: {
+                  oneOf: [
+                    {
+                      type: 'string',
+                    },
+                    {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                      },
+                    },
+                  ],
                 },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
+              },
+              {
+                type: 'array',
+                items: {
+                  additionalProperties: false,
+                  description: 'Advanced group.',
+                  type: 'object',
+                  required: ['groupName', 'selector'],
+                  properties: {
+                    groupName: {
+                      description: 'Group name',
+                      type: 'string',
+                    },
+                    selector: {
+                      description: 'Selector',
+                      type: 'string',
+                      enum: allSelectors,
+                    },
+                    modifiers: {
+                      description: 'Modifiers',
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                        enum: allModifiers,
+                      },
+                    },
+                    elementNameRegex: {
+                      description: 'Element name regex',
+                      type: 'string',
+                    },
+                    decoratorNamePattern: {
+                      description: 'Decorator name pattern',
+                      type: 'string',
+                    },
+                    valueTypePattern: {
+                      description: 'Value type pattern',
+                      type: 'string',
+                    },
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
         },
         additionalProperties: false,
@@ -369,9 +308,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'key' in member && member.key.type === 'PrivateIdentifier'
             let decorated =
               'decorators' in member && member.decorators.length > 0
+            let decorators: string[] = []
 
             let modifiers: Modifier[] = []
             let selectors: Selector[] = []
+            let memberValueType: undefined | string
+
             if (
               member.type === 'MethodDefinition' ||
               member.type === 'TSAbstractMethodDefinition'
@@ -390,6 +332,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               if (decorated) {
                 modifiers.push('decorated')
+                for (let decorator of member.decorators) {
+                  if (decorator.expression.type === 'Identifier') {
+                    decorators.push(decorator.expression.name)
+                  } else if (
+                    decorator.expression.type === 'CallExpression' &&
+                    decorator.expression.callee.type === 'Identifier'
+                  ) {
+                    decorators.push(decorator.expression.callee.name)
+                  }
+                }
               }
 
               if (member.override) {
@@ -436,6 +388,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
               member.type === 'AccessorProperty' ||
               member.type === 'TSAbstractAccessorProperty'
             ) {
+              memberValueType = member.value?.type
+
               if (member.static) {
                 modifiers.push('static')
               }
@@ -446,6 +400,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               if (decorated) {
                 modifiers.push('decorated')
+                for (let decorator of member.decorators) {
+                  if (decorator.expression.type === 'Identifier') {
+                    decorators.push(decorator.expression.name)
+                  } else if (
+                    decorator.expression.type === 'CallExpression' &&
+                    decorator.expression.callee.type === 'Identifier'
+                  ) {
+                    decorators.push(decorator.expression.callee.name)
+                  }
+                }
               }
 
               if (member.override) {
@@ -465,6 +429,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               // Similarly to above for methods, prioritize 'static', 'declare', 'decorated', 'abstract', 'override' and 'readonly'
               // over accessibility modifiers
+
+              memberValueType = member.value?.type
+
               if (member.static) {
                 modifiers.push('static')
               }
@@ -479,6 +446,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               if (decorated) {
                 modifiers.push('decorated')
+                for (let decorator of member.decorators) {
+                  if (decorator.expression.type === 'Identifier') {
+                    decorators.push(decorator.expression.name)
+                  } else if (
+                    decorator.expression.type === 'CallExpression' &&
+                    decorator.expression.callee.type === 'Identifier'
+                  ) {
+                    decorators.push(decorator.expression.callee.name)
+                  }
+                }
               }
 
               if (member.override) {
@@ -516,9 +493,27 @@ export default createEslintRule<Options, MESSAGE_ID>({
             )) {
               defineGroup(officialGroup)
             }
-            setCustomGroups(options.customGroups, name, {
-              override: true,
-            })
+
+            if (Array.isArray(options.customGroups)) {
+              for (let customGroup of options.customGroups) {
+                if (
+                  customGroupMatches({
+                    customGroup,
+                    elementName: name,
+                    modifiers,
+                    selectors,
+                    decorators,
+                    memberValueType,
+                  })
+                ) {
+                  defineGroup(customGroup.groupName, true)
+                }
+              }
+            } else {
+              setCustomGroups(options.customGroups, name, {
+                override: true,
+              })
+            }
 
             if (member.type === 'PropertyDefinition' && member.value) {
               dependencies = extractDependencies(member.value)

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -9,16 +9,16 @@ import type {
 import type { SortingNode } from '../typings'
 
 import {
-  singleCustomGroupNameJsonSchema,
-  singleCustomGroupSortJsonSchema,
-  singleCustomGroupJsonSchema,
-} from './sort-classes.types'
-import {
   getOverloadSignatureGroups,
   generateOfficialGroups,
   customGroupMatches,
   getCompareOptions,
 } from './sort-classes-utils'
+import {
+  singleCustomGroupJsonSchema,
+  customGroupNameJsonSchema,
+  customGroupSortJsonSchema,
+} from './sort-classes.types'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -129,8 +129,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       type: 'object',
                       additionalProperties: false,
                       properties: {
-                        ...singleCustomGroupNameJsonSchema,
-                        ...singleCustomGroupSortJsonSchema,
+                        ...customGroupNameJsonSchema,
+                        ...customGroupSortJsonSchema,
                         anyOf: {
                           type: 'array',
                           items: {
@@ -149,8 +149,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       type: 'object',
                       additionalProperties: false,
                       properties: {
-                        ...singleCustomGroupNameJsonSchema,
-                        ...singleCustomGroupSortJsonSchema,
+                        ...customGroupNameJsonSchema,
+                        ...customGroupSortJsonSchema,
                         ...singleCustomGroupJsonSchema,
                       },
                     },

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -9,16 +9,16 @@ import type {
 import type { SortingNode } from '../typings'
 
 import {
-  singleCustomGroupNameGroupSchema,
-  singleCustomGroupSortGroupSchema,
-  singleCustomGroupJsonSchema,
-} from './sort-classes.types'
-import {
   getOverloadSignatureGroups,
   generateOfficialGroups,
   customGroupMatches,
   getCompareOptions,
 } from './sort-classes-utils'
+import {
+  singleCustomGroupNameSchema,
+  singleCustomGroupSortSchema,
+  singleCustomGroupJsonSchema,
+} from './sort-classes.types'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -129,8 +129,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       type: 'object',
                       additionalProperties: false,
                       properties: {
-                        ...singleCustomGroupNameGroupSchema,
-                        ...singleCustomGroupSortGroupSchema,
+                        ...singleCustomGroupNameSchema,
+                        ...singleCustomGroupSortSchema,
                         anyOf: {
                           type: 'array',
                           items: {
@@ -149,8 +149,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       type: 'object',
                       additionalProperties: false,
                       properties: {
-                        ...singleCustomGroupNameGroupSchema,
-                        ...singleCustomGroupSortGroupSchema,
+                        ...singleCustomGroupNameSchema,
+                        ...singleCustomGroupSortSchema,
                         ...singleCustomGroupJsonSchema,
                       },
                     },

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -9,12 +9,16 @@ import type {
 import type { SortingNode } from '../typings'
 
 import {
+  singleCustomGroupNameGroupSchema,
+  singleCustomGroupSortGroupSchema,
+  singleCustomGroupJsonSchema,
+} from './sort-classes.types'
+import {
   getOverloadSignatureGroups,
   generateOfficialGroups,
   customGroupMatches,
   getCompareOptions,
 } from './sort-classes-utils'
-import { singleCustomGroupWithNameGroupJsonSchema } from './sort-classes.types'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -125,18 +129,17 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       type: 'object',
                       additionalProperties: false,
                       properties: {
-                        groupName: {
-                          description: 'Custom group name.',
-                          type: 'string',
-                        },
+                        ...singleCustomGroupNameGroupSchema,
+                        ...singleCustomGroupSortGroupSchema,
                         subgroups: {
                           type: 'array',
                           items: {
                             description: 'Custom group.',
                             type: 'object',
                             additionalProperties: false,
-                            properties:
-                              singleCustomGroupWithNameGroupJsonSchema,
+                            properties: {
+                              ...singleCustomGroupJsonSchema,
+                            },
                           },
                         },
                       },
@@ -145,7 +148,11 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       description: 'Custom group.',
                       type: 'object',
                       additionalProperties: false,
-                      properties: singleCustomGroupWithNameGroupJsonSchema,
+                      properties: {
+                        ...singleCustomGroupNameGroupSchema,
+                        ...singleCustomGroupSortGroupSchema,
+                        ...singleCustomGroupJsonSchema,
+                      },
                     },
                   ],
                 },

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -147,10 +147,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       description: 'Decorator name pattern',
                       type: 'string',
                     },
-                    valueTypePattern: {
-                      description: 'Value type pattern',
-                      type: 'string',
-                    },
                   },
                 },
               },
@@ -187,7 +183,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
         ['get-method', 'set-method'],
         'unknown',
       ],
-      customGroups: {},
+      customGroups: [],
     },
   ],
   create: context => ({
@@ -214,7 +210,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           partitionByComment: false,
           type: 'alphabetical',
           ignoreCase: true,
-          customGroups: {},
+          customGroups: [],
           order: 'asc',
         } as const)
 
@@ -312,7 +308,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             let modifiers: Modifier[] = []
             let selectors: Selector[] = []
-            let memberValueType: undefined | string
 
             if (
               member.type === 'MethodDefinition' ||
@@ -388,8 +383,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               member.type === 'AccessorProperty' ||
               member.type === 'TSAbstractAccessorProperty'
             ) {
-              memberValueType = member.value?.type
-
               if (member.static) {
                 modifiers.push('static')
               }
@@ -429,8 +422,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
               // Similarly to above for methods, prioritize 'static', 'declare', 'decorated', 'abstract', 'override' and 'readonly'
               // over accessibility modifiers
-
-              memberValueType = member.value?.type
 
               if (member.static) {
                 modifiers.push('static')
@@ -503,7 +494,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                     modifiers,
                     selectors,
                     decorators,
-                    memberValueType,
                   })
                 ) {
                   defineGroup(customGroup.groupName, true)

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -9,16 +9,16 @@ import type {
 import type { SortingNode } from '../typings'
 
 import {
+  singleCustomGroupNameJsonSchema,
+  singleCustomGroupSortJsonSchema,
+  singleCustomGroupJsonSchema,
+} from './sort-classes.types'
+import {
   getOverloadSignatureGroups,
   generateOfficialGroups,
   customGroupMatches,
   getCompareOptions,
 } from './sort-classes-utils'
-import {
-  singleCustomGroupNameSchema,
-  singleCustomGroupSortSchema,
-  singleCustomGroupJsonSchema,
-} from './sort-classes.types'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -129,8 +129,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       type: 'object',
                       additionalProperties: false,
                       properties: {
-                        ...singleCustomGroupNameSchema,
-                        ...singleCustomGroupSortSchema,
+                        ...singleCustomGroupNameJsonSchema,
+                        ...singleCustomGroupSortJsonSchema,
                         anyOf: {
                           type: 'array',
                           items: {
@@ -149,8 +149,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                       type: 'object',
                       additionalProperties: false,
                       properties: {
-                        ...singleCustomGroupNameSchema,
-                        ...singleCustomGroupSortSchema,
+                        ...singleCustomGroupNameJsonSchema,
+                        ...singleCustomGroupSortJsonSchema,
                         ...singleCustomGroupJsonSchema,
                       },
                     },

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -165,26 +165,26 @@ export interface CustomGroupBlock {
   anyOf: SingleCustomGroup[]
 }
 
-interface BaseCustomGroup<T extends Selector> {
+interface BaseSingleCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   selector?: T
 }
 
-type AdvancedCustomGroup<T extends Selector> = {
+type AdvancedSingleCustomGroup<T extends Selector> = {
   decoratorNamePattern?: string
   elementNamePattern?: string
-} & BaseCustomGroup<T>
+} & BaseSingleCustomGroup<T>
 
 export type SingleCustomGroup =
-  | AdvancedCustomGroup<FunctionPropertySelector>
-  | AdvancedCustomGroup<AccessorPropertySelector>
-  | BaseCustomGroup<IndexSignatureSelector>
-  | AdvancedCustomGroup<GetMethodSelector>
-  | AdvancedCustomGroup<SetMethodSelector>
-  | AdvancedCustomGroup<PropertySelector>
-  | BaseCustomGroup<StaticBlockSelector>
-  | BaseCustomGroup<ConstructorSelector>
-  | AdvancedCustomGroup<MethodSelector>
+  | AdvancedSingleCustomGroup<FunctionPropertySelector>
+  | AdvancedSingleCustomGroup<AccessorPropertySelector>
+  | BaseSingleCustomGroup<IndexSignatureSelector>
+  | AdvancedSingleCustomGroup<GetMethodSelector>
+  | AdvancedSingleCustomGroup<SetMethodSelector>
+  | AdvancedSingleCustomGroup<PropertySelector>
+  | BaseSingleCustomGroup<StaticBlockSelector>
+  | BaseSingleCustomGroup<ConstructorSelector>
+  | AdvancedSingleCustomGroup<MethodSelector>
 
 export type CustomGroup = (
   | {

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -234,7 +234,7 @@ export const singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   },
 }
 
-export const singleCustomGroupSortSchema: Record<string, JSONSchema4> = {
+export const singleCustomGroupSortJsonSchema: Record<string, JSONSchema4> = {
   type: {
     description: 'Custom group sort type.',
     type: 'string',
@@ -247,7 +247,7 @@ export const singleCustomGroupSortSchema: Record<string, JSONSchema4> = {
   },
 }
 
-export const singleCustomGroupNameSchema: Record<string, JSONSchema4> = {
+export const singleCustomGroupNameJsonSchema: Record<string, JSONSchema4> = {
   groupName: {
     description: 'Custom group name.',
     type: 'string',

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -163,14 +163,14 @@ type SortableCustomGroup =
       type?: 'unsorted'
     }
 
-type CustomGroupBlock = {
-  subgroups: CustomGroup[]
-} & SortableCustomGroup
+interface CustomGroupBlock {
+  subgroups: SingleCustomGroup[]
+}
 
-type BaseCustomGroup<T extends Selector> = {
+interface BaseCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   selector?: T
-} & SortableCustomGroup
+}
 
 type AdvancedCustomGroup<T extends Selector> = {
   decoratorNamePattern?: string
@@ -190,7 +190,7 @@ export type SingleCustomGroup =
 
 export type CustomGroup = (SingleCustomGroup | CustomGroupBlock) & {
   groupName: string
-}
+} & SortableCustomGroup
 
 export type SortClassesOptions = [
   Partial<{
@@ -203,7 +203,7 @@ export type SortClassesOptions = [
   }>,
 ]
 
-export const singleCustomGroupGroupJsonSchema: Record<string, JSONSchema4> = {
+export const singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   selector: {
     description: 'Selector filter.',
     type: 'string',
@@ -225,6 +225,9 @@ export const singleCustomGroupGroupJsonSchema: Record<string, JSONSchema4> = {
     description: 'Decorator name pattern.',
     type: 'string',
   },
+}
+
+export const singleCustomGroupSortGroupSchema: Record<string, JSONSchema4> = {
   type: {
     description: 'Custom group sort type.',
     type: 'string',
@@ -237,11 +240,7 @@ export const singleCustomGroupGroupJsonSchema: Record<string, JSONSchema4> = {
   },
 }
 
-export const singleCustomGroupWithNameGroupJsonSchema: Record<
-  string,
-  JSONSchema4
-> = {
-  ...singleCustomGroupGroupJsonSchema,
+export const singleCustomGroupNameGroupSchema: Record<string, JSONSchema4> = {
   groupName: {
     description: 'Custom group name.',
     type: 'string',

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -13,11 +13,13 @@ type OverrideModifier = 'override'
 type ReadonlyModifier = 'readonly'
 type DecoratedModifier = 'decorated'
 type DeclareModifier = 'declare'
+type OptionalModifier = 'optional'
 export type Modifier =
   | PublicOrProtectedOrPrivateModifier
   | DecoratedModifier
   | AbstractModifier
   | OverrideModifier
+  | OptionalModifier
   | ReadonlyModifier
   | DeclareModifier
   | StaticModifier
@@ -73,6 +75,7 @@ type PublicOrProtectedOrPrivateModifierPrefix = WithDashSuffixOrEmpty<
 >
 
 type OverrideModifierPrefix = WithDashSuffixOrEmpty<OverrideModifier>
+type OptionalModifierPrefix = WithDashSuffixOrEmpty<OptionalModifier>
 type ReadonlyModifierPrefix = WithDashSuffixOrEmpty<ReadonlyModifier>
 type DecoratedModifierPrefix = WithDashSuffixOrEmpty<DecoratedModifier>
 type DeclareModifierPrefix = WithDashSuffixOrEmpty<DeclareModifier>
@@ -93,11 +96,11 @@ type ConstructorGroup =
 type FunctionPropertyGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${FunctionPropertySelector}`
 type DeclarePropertyGroup =
-  `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${PropertySelector}`
+  `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
 type NonDeclarePropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${PropertySelector}`
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
 type MethodOrGetMethodOrSetMethodGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
 type AccessorPropertyGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
 type IndexSignatureGroup =

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -130,7 +130,15 @@ interface AllowedModifiersPerSelector {
     | AbstractModifier
     | OverrideModifier
     | ReadonlyModifier
+    | OptionalModifier
     | DeclareModifier
+    | StaticModifier
+  method:
+    | PublicOrProtectedOrPrivateModifier
+    | DecoratedModifier
+    | AbstractModifier
+    | OverrideModifier
+    | OptionalModifier
     | StaticModifier
   'accessor-property':
     | PublicOrProtectedOrPrivateModifier
@@ -143,12 +151,6 @@ interface AllowedModifiersPerSelector {
     | DecoratedModifier
     | OverrideModifier
     | ReadonlyModifier
-    | StaticModifier
-  method:
-    | PublicOrProtectedOrPrivateModifier
-    | DecoratedModifier
-    | AbstractModifier
-    | OverrideModifier
     | StaticModifier
   'index-signature': ReadonlyModifier | StaticModifier
   'set-method': AllowedModifiersPerSelector['method']

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -154,17 +154,8 @@ interface AllowedModifiersPerSelector {
   'static-block': never
 }
 
-type SortableCustomGroup =
-  | {
-      type?: 'alphabetical' | 'line-length' | 'natural'
-      order?: 'desc' | 'asc'
-    }
-  | {
-      type?: 'unsorted'
-    }
-
 export interface CustomGroupBlock {
-  subgroups: SingleCustomGroup[]
+  anyOf: SingleCustomGroup[]
 }
 
 interface BaseCustomGroup<T extends Selector> {
@@ -188,9 +179,18 @@ export type SingleCustomGroup =
   | BaseCustomGroup<ConstructorSelector>
   | AdvancedCustomGroup<MethodSelector>
 
-export type CustomGroup = (SingleCustomGroup | CustomGroupBlock) & {
-  groupName: string
-} & SortableCustomGroup
+export type CustomGroup = (
+  | {
+      type?: 'alphabetical' | 'line-length' | 'natural'
+      order?: 'desc' | 'asc'
+    }
+  | {
+      type?: 'unsorted'
+    }
+) &
+  (SingleCustomGroup | CustomGroupBlock) & {
+    groupName: string
+  }
 
 export type SortClassesOptions = [
   Partial<{

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -1,0 +1,191 @@
+type ProtectedModifier = 'protected'
+type PrivateModifier = 'private'
+type PublicModifier = 'public'
+type PublicOrProtectedOrPrivateModifier =
+  | ProtectedModifier
+  | PrivateModifier
+  | PublicModifier
+type StaticModifier = 'static'
+type AbstractModifier = 'abstract'
+type OverrideModifier = 'override'
+type ReadonlyModifier = 'readonly'
+type DecoratedModifier = 'decorated'
+type DeclareModifier = 'declare'
+export type Modifier =
+  | PublicOrProtectedOrPrivateModifier
+  | DecoratedModifier
+  | AbstractModifier
+  | OverrideModifier
+  | ReadonlyModifier
+  | DeclareModifier
+  | StaticModifier
+
+export const allModifiers: Modifier[] = [
+  'protected',
+  'private',
+  'public',
+  'static',
+  'abstract',
+  'override',
+  'readonly',
+  'decorated',
+  'declare',
+]
+
+type ConstructorSelector = 'constructor'
+type FunctionPropertySelector = 'function-property'
+type PropertySelector = 'property'
+type MethodSelector = 'method'
+type GetMethodSelector = 'get-method'
+type SetMethodSelector = 'set-method'
+type IndexSignatureSelector = 'index-signature'
+type StaticBlockSelector = 'static-block'
+type AccessorPropertySelector = 'accessor-property'
+export type Selector =
+  | AccessorPropertySelector
+  | FunctionPropertySelector
+  | IndexSignatureSelector
+  | ConstructorSelector
+  | StaticBlockSelector
+  | GetMethodSelector
+  | SetMethodSelector
+  | PropertySelector
+  | MethodSelector
+
+export const allSelectors: Selector[] = [
+  'accessor-property',
+  'index-signature',
+  'constructor',
+  'static-block',
+  'get-method',
+  'set-method',
+  'function-property',
+  'property',
+  'method',
+]
+
+type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''
+
+type PublicOrProtectedOrPrivateModifierPrefix = WithDashSuffixOrEmpty<
+  ProtectedModifier | PrivateModifier | PublicModifier
+>
+
+type OverrideModifierPrefix = WithDashSuffixOrEmpty<OverrideModifier>
+type ReadonlyModifierPrefix = WithDashSuffixOrEmpty<ReadonlyModifier>
+type DecoratedModifierPrefix = WithDashSuffixOrEmpty<DecoratedModifier>
+type DeclareModifierPrefix = WithDashSuffixOrEmpty<DeclareModifier>
+
+type StaticOrAbstractModifierPrefix = WithDashSuffixOrEmpty<
+  AbstractModifier | StaticModifier
+>
+
+type StaticModifierPrefix = WithDashSuffixOrEmpty<StaticModifier>
+
+type MethodOrGetMethodOrSetMethodSelector =
+  | GetMethodSelector
+  | SetMethodSelector
+  | MethodSelector
+
+type ConstructorGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${ConstructorSelector}`
+type FunctionPropertyGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${FunctionPropertySelector}`
+type DeclarePropertyGroup =
+  `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${PropertySelector}`
+type NonDeclarePropertyGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${PropertySelector}`
+type MethodOrGetMethodOrSetMethodGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
+type AccessorPropertyGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
+type IndexSignatureGroup =
+  `${StaticModifierPrefix}${ReadonlyModifierPrefix}${IndexSignatureSelector}`
+type StaticBlockGroup = `${StaticBlockSelector}`
+
+/**
+ * Some invalid combinations are still handled by this type, such as
+ * - private abstract X
+ * - abstract decorated X
+ */
+type Group =
+  | MethodOrGetMethodOrSetMethodGroup
+  | NonDeclarePropertyGroup
+  | AccessorPropertyGroup
+  | FunctionPropertyGroup
+  | DeclarePropertyGroup
+  | IndexSignatureGroup
+  | ConstructorGroup
+  | StaticBlockGroup
+  | 'unknown'
+  | string
+interface AllowedModifiersPerSelector {
+  property:
+    | PublicOrProtectedOrPrivateModifier
+    | DecoratedModifier
+    | AbstractModifier
+    | OverrideModifier
+    | ReadonlyModifier
+    | DeclareModifier
+    | StaticModifier
+  'accessor-property':
+    | PublicOrProtectedOrPrivateModifier
+    | DecoratedModifier
+    | AbstractModifier
+    | OverrideModifier
+    | StaticModifier
+  'function-property':
+    | PublicOrProtectedOrPrivateModifier
+    | DecoratedModifier
+    | OverrideModifier
+    | ReadonlyModifier
+    | StaticModifier
+  method:
+    | PublicOrProtectedOrPrivateModifier
+    | DecoratedModifier
+    | AbstractModifier
+    | OverrideModifier
+    | StaticModifier
+  'index-signature': ReadonlyModifier | StaticModifier
+  'set-method': AllowedModifiersPerSelector['method']
+  'get-method': AllowedModifiersPerSelector['method']
+  constructor: PublicOrProtectedOrPrivateModifier
+  'static-block': void
+}
+
+interface BaseCustomGroup<T extends Selector> {
+  modifiers?: AllowedModifiersPerSelector[T][]
+  groupName: string
+  selector: T
+}
+
+interface WithNamePatternFilterCustomGroup<T extends Selector>
+  extends BaseCustomGroup<T> {
+  decoratorNamePattern?: string
+  elementNamePattern?: string
+}
+
+interface WithValueTypePatternCustomGroup<T extends Selector>
+  extends WithNamePatternFilterCustomGroup<T> {
+  valueTypePattern?: string
+}
+
+export type CustomGroup =
+  | WithValueTypePatternCustomGroup<AccessorPropertySelector>
+  | WithNamePatternFilterCustomGroup<GetMethodSelector>
+  | WithNamePatternFilterCustomGroup<SetMethodSelector>
+  | WithValueTypePatternCustomGroup<PropertySelector>
+  | WithNamePatternFilterCustomGroup<MethodSelector>
+  | BaseCustomGroup<IndexSignatureSelector>
+  | BaseCustomGroup<StaticBlockSelector>
+  | BaseCustomGroup<ConstructorSelector>
+
+export type SortClassesOptions = [
+  Partial<{
+    customGroups: { [key: string]: string[] | string } | CustomGroup[]
+    type: 'alphabetical' | 'line-length' | 'natural'
+    partitionByComment: string[] | boolean | string
+    groups: (Group[] | Group)[]
+    order: 'desc' | 'asc'
+    ignoreCase: boolean
+  }>,
+]

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -158,23 +158,23 @@ interface BaseCustomGroup<T extends Selector> {
   selector: T
 }
 
-interface WithNamePatternFilterCustomGroup<T extends Selector>
+interface CustomGroupWithNameAndDecoratorPatternFilter<T extends Selector>
   extends BaseCustomGroup<T> {
   decoratorNamePattern?: string
   elementNamePattern?: string
 }
 
-interface WithValueTypePatternCustomGroup<T extends Selector>
-  extends WithNamePatternFilterCustomGroup<T> {
+interface CustomGroupWithValueTypePattern<T extends Selector>
+  extends CustomGroupWithNameAndDecoratorPatternFilter<T> {
   valueTypePattern?: string
 }
 
 export type CustomGroup =
-  | WithValueTypePatternCustomGroup<AccessorPropertySelector>
-  | WithNamePatternFilterCustomGroup<GetMethodSelector>
-  | WithNamePatternFilterCustomGroup<SetMethodSelector>
-  | WithValueTypePatternCustomGroup<PropertySelector>
-  | WithNamePatternFilterCustomGroup<MethodSelector>
+  | CustomGroupWithNameAndDecoratorPatternFilter<GetMethodSelector>
+  | CustomGroupWithNameAndDecoratorPatternFilter<SetMethodSelector>
+  | CustomGroupWithNameAndDecoratorPatternFilter<MethodSelector>
+  | CustomGroupWithValueTypePattern<AccessorPropertySelector>
+  | CustomGroupWithValueTypePattern<PropertySelector>
   | BaseCustomGroup<IndexSignatureSelector>
   | BaseCustomGroup<StaticBlockSelector>
   | BaseCustomGroup<ConstructorSelector>

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -170,6 +170,7 @@ interface CustomGroupWithValueTypePattern<T extends Selector>
 }
 
 export type CustomGroup =
+  | CustomGroupWithNameAndDecoratorPatternFilter<FunctionPropertySelector>
   | CustomGroupWithNameAndDecoratorPatternFilter<GetMethodSelector>
   | CustomGroupWithNameAndDecoratorPatternFilter<SetMethodSelector>
   | CustomGroupWithNameAndDecoratorPatternFilter<MethodSelector>

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -225,11 +225,11 @@ export const singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
     },
   },
   elementNamePattern: {
-    description: 'Element name pattern.',
+    description: 'Element name pattern filter.',
     type: 'string',
   },
   decoratorNamePattern: {
-    description: 'Decorator name pattern.',
+    description: 'Decorator name pattern filter.',
     type: 'string',
   },
 }

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -163,7 +163,7 @@ type SortableCustomGroup =
       type?: 'unsorted'
     }
 
-interface CustomGroupBlock {
+export interface CustomGroupBlock {
   subgroups: SingleCustomGroup[]
 }
 

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -34,6 +34,7 @@ export const allModifiers: Modifier[] = [
   'readonly',
   'decorated',
   'declare',
+  'optional',
 ]
 
 type ConstructorSelector = 'constructor'
@@ -86,10 +87,7 @@ type StaticOrAbstractModifierPrefix = WithDashSuffixOrEmpty<
 
 type StaticModifierPrefix = WithDashSuffixOrEmpty<StaticModifier>
 
-type MethodOrGetMethodOrSetMethodSelector =
-  | GetMethodSelector
-  | SetMethodSelector
-  | MethodSelector
+type GetMethodOrSetMethodSelector = GetMethodSelector | SetMethodSelector
 
 type ConstructorGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${ConstructorSelector}`
@@ -99,8 +97,10 @@ type DeclarePropertyGroup =
   `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
 type NonDeclarePropertyGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
-type MethodOrGetMethodOrSetMethodGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
+type MethodGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${MethodSelector}`
+type GetMethodOrSetMethodGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${GetMethodOrSetMethodSelector}`
 type AccessorPropertyGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
 type IndexSignatureGroup =
@@ -113,7 +113,7 @@ type StaticBlockGroup = `${StaticBlockSelector}`
  * - abstract decorated X
  */
 type Group =
-  | MethodOrGetMethodOrSetMethodGroup
+  | GetMethodOrSetMethodGroup
   | NonDeclarePropertyGroup
   | AccessorPropertyGroup
   | FunctionPropertyGroup
@@ -121,6 +121,7 @@ type Group =
   | IndexSignatureGroup
   | ConstructorGroup
   | StaticBlockGroup
+  | MethodGroup
   | 'unknown'
   | string
 

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -154,9 +154,14 @@ interface AllowedModifiersPerSelector {
     | OverrideModifier
     | ReadonlyModifier
     | StaticModifier
+  'set-method':
+    | PublicOrProtectedOrPrivateModifier
+    | DecoratedModifier
+    | AbstractModifier
+    | OverrideModifier
+    | StaticModifier
+  'get-method': AllowedModifiersPerSelector['set-method']
   'index-signature': ReadonlyModifier | StaticModifier
-  'set-method': AllowedModifiersPerSelector['method']
-  'get-method': AllowedModifiersPerSelector['method']
   constructor: PublicOrProtectedOrPrivateModifier
   'static-block': never
 }

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -149,13 +149,13 @@ interface AllowedModifiersPerSelector {
   'set-method': AllowedModifiersPerSelector['method']
   'get-method': AllowedModifiersPerSelector['method']
   constructor: PublicOrProtectedOrPrivateModifier
-  'static-block': void
+  'static-block': never
 }
 
 interface BaseCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   groupName: string
-  selector: T
+  selector?: T
 }
 
 interface CustomGroupWithNameAndDecoratorPatternFilter<T extends Selector>

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -164,18 +164,13 @@ interface CustomGroupWithNameAndDecoratorPatternFilter<T extends Selector>
   elementNamePattern?: string
 }
 
-interface CustomGroupWithValueTypePattern<T extends Selector>
-  extends CustomGroupWithNameAndDecoratorPatternFilter<T> {
-  valueTypePattern?: string
-}
-
 export type CustomGroup =
   | CustomGroupWithNameAndDecoratorPatternFilter<FunctionPropertySelector>
+  | CustomGroupWithNameAndDecoratorPatternFilter<AccessorPropertySelector>
   | CustomGroupWithNameAndDecoratorPatternFilter<GetMethodSelector>
   | CustomGroupWithNameAndDecoratorPatternFilter<SetMethodSelector>
+  | CustomGroupWithNameAndDecoratorPatternFilter<PropertySelector>
   | CustomGroupWithNameAndDecoratorPatternFilter<MethodSelector>
-  | CustomGroupWithValueTypePattern<AccessorPropertySelector>
-  | CustomGroupWithValueTypePattern<PropertySelector>
   | BaseCustomGroup<IndexSignatureSelector>
   | BaseCustomGroup<StaticBlockSelector>
   | BaseCustomGroup<ConstructorSelector>

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -24,19 +24,6 @@ export type Modifier =
   | DeclareModifier
   | StaticModifier
 
-export const allModifiers: Modifier[] = [
-  'protected',
-  'private',
-  'public',
-  'static',
-  'abstract',
-  'override',
-  'readonly',
-  'decorated',
-  'declare',
-  'optional',
-]
-
 type ConstructorSelector = 'constructor'
 type FunctionPropertySelector = 'function-property'
 type PropertySelector = 'property'
@@ -56,18 +43,6 @@ export type Selector =
   | SetMethodSelector
   | PropertySelector
   | MethodSelector
-
-export const allSelectors: Selector[] = [
-  'accessor-property',
-  'index-signature',
-  'constructor',
-  'static-block',
-  'get-method',
-  'set-method',
-  'function-property',
-  'property',
-  'method',
-]
 
 type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''
 
@@ -111,6 +86,7 @@ type StaticBlockGroup = `${StaticBlockSelector}`
  * Some invalid combinations are still handled by this type, such as
  * - private abstract X
  * - abstract decorated X
+ * Only used in code, so I don't know if it's worth maintaining this.
  */
 type Group =
   | GetMethodOrSetMethodGroup
@@ -125,6 +101,9 @@ type Group =
   | 'unknown'
   | string
 
+/**
+ * Only used in code as well
+ */
 interface AllowedModifiersPerSelector {
   property:
     | PublicOrProtectedOrPrivateModifier
@@ -215,6 +194,55 @@ export type SortClassesOptions = [
   }>,
 ]
 
+export const allSelectors: Selector[] = [
+  'accessor-property',
+  'index-signature',
+  'constructor',
+  'static-block',
+  'get-method',
+  'set-method',
+  'function-property',
+  'property',
+  'method',
+]
+
+export const allModifiers: Modifier[] = [
+  'protected',
+  'private',
+  'public',
+  'static',
+  'abstract',
+  'override',
+  'readonly',
+  'decorated',
+  'declare',
+  'optional',
+]
+
+export const customGroupSortJsonSchema: Record<string, JSONSchema4> = {
+  type: {
+    description: 'Custom group sort type.',
+    type: 'string',
+    enum: ['alphabetical', 'line-length', 'natural', 'unsorted'],
+  },
+  order: {
+    description: 'Custom group sort order.',
+    type: 'string',
+    enum: ['desc', 'asc'],
+  },
+}
+
+export const customGroupNameJsonSchema: Record<string, JSONSchema4> = {
+  groupName: {
+    description: 'Custom group name.',
+    type: 'string',
+  },
+}
+
+/**
+ * Ideally, we should generate as many schemas as there are selectors, and ensure
+ * that users do not enter invalid modifiers for a given selector
+ */
 export const singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   selector: {
     description: 'Selector filter.',
@@ -235,26 +263,6 @@ export const singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   },
   decoratorNamePattern: {
     description: 'Decorator name pattern filter.',
-    type: 'string',
-  },
-}
-
-export const singleCustomGroupSortJsonSchema: Record<string, JSONSchema4> = {
-  type: {
-    description: 'Custom group sort type.',
-    type: 'string',
-    enum: ['alphabetical', 'line-length', 'natural', 'unsorted'],
-  },
-  order: {
-    description: 'Custom group sort order.',
-    type: 'string',
-    enum: ['desc', 'asc'],
-  },
-}
-
-export const singleCustomGroupNameJsonSchema: Record<string, JSONSchema4> = {
-  groupName: {
-    description: 'Custom group name.',
     type: 'string',
   },
 }

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -123,6 +123,7 @@ type Group =
   | StaticBlockGroup
   | 'unknown'
   | string
+
 interface AllowedModifiersPerSelector {
   property:
     | PublicOrProtectedOrPrivateModifier
@@ -186,8 +187,8 @@ export type SingleCustomGroup =
 
 export type CustomGroup = (
   | {
-      type?: 'alphabetical' | 'line-length' | 'natural'
-      order?: 'desc' | 'asc'
+      order?: SortClassesOptions[0]['order']
+      type?: SortClassesOptions[0]['type']
     }
   | {
       type?: 'unsorted'
@@ -232,7 +233,7 @@ export const singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   },
 }
 
-export const singleCustomGroupSortGroupSchema: Record<string, JSONSchema4> = {
+export const singleCustomGroupSortSchema: Record<string, JSONSchema4> = {
   type: {
     description: 'Custom group sort type.',
     type: 'string',
@@ -245,7 +246,7 @@ export const singleCustomGroupSortGroupSchema: Record<string, JSONSchema4> = {
   },
 }
 
-export const singleCustomGroupNameGroupSchema: Record<string, JSONSchema4> = {
+export const singleCustomGroupNameSchema: Record<string, JSONSchema4> = {
   groupName: {
     description: 'Custom group name.',
     type: 'string',

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -5201,6 +5201,11 @@ describe(ruleName, () => {
               groups: ['propertyGroup', 'constructor', 'privatePropertyGroup'],
               customGroups: [
                 {
+                  groupName: 'unusedCustomGroup',
+                  selector: 'property',
+                  modifiers: ['private'],
+                },
+                {
                   groupName: 'privatePropertyGroup',
                   selector: 'property',
                   modifiers: ['private'],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -5381,7 +5381,7 @@ describe(ruleName, () => {
     })
 
     ruleTester.run(
-      `${ruleName}: sort custom groups with overriden 'type' and 'order'`,
+      `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
       rule,
       {
         valid: [],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -5175,6 +5175,513 @@ describe(ruleName, () => {
     })
   })
 
+  describe(`${ruleName}: custom groups`, () => {
+    ruleTester.run(`${ruleName}: filters on selector and modifiers`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              class Class {
+                private a;
+                private b;
+                c;
+                constructor() {}
+              }
+            `,
+          output: dedent`
+            class Class {
+              c;
+              constructor() {}
+              private a;
+              private b;
+            }
+            `,
+          options: [
+            {
+              groups: ['propertyGroup', 'constructor', 'privatePropertyGroup'],
+              customGroups: [
+                {
+                  groupName: 'privatePropertyGroup',
+                  selector: 'property',
+                  modifiers: ['private'],
+                },
+                {
+                  groupName: 'propertyGroup',
+                  selector: 'property',
+                },
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'b',
+                leftGroup: 'privatePropertyGroup',
+                right: 'c',
+                rightGroup: 'propertyGroup',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              class Class {
+                a;
+
+                b;
+
+                constructor() {}
+
+                method() {}
+
+                helloProperty;
+              }
+            `,
+          output: dedent`
+              class Class {
+                helloProperty;
+
+                constructor() {}
+
+                a;
+
+                b;
+
+                method() {}
+              }
+            `,
+          options: [
+            {
+              groups: ['propertiesStartingWithHello', 'constructor', 'unknown'],
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern: 'hello*',
+                },
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'b',
+                leftGroup: 'unknown',
+                right: 'constructor',
+                rightGroup: 'constructor',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method',
+                leftGroup: 'unknown',
+                right: 'helloProperty',
+                rightGroup: 'propertiesStartingWithHello',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              class Class {
+                @Decorator
+                a;
+
+                b;
+
+                constructor() {}
+
+                method() {}
+
+                @HelloDecorator
+                property;
+
+                @HelloDecorator()
+                anotherProperty;
+              }
+            `,
+          output: dedent`
+            class Class {
+              @HelloDecorator()
+              anotherProperty;
+
+              @HelloDecorator
+              property;
+
+              constructor() {}
+
+              @Decorator
+              a;
+
+              b;
+
+              method() {}
+            }
+            `,
+          options: [
+            {
+              groups: [
+                'propertiesWithDecoratorStartingWithHello',
+                'constructor',
+                'unknown',
+              ],
+              customGroups: [
+                {
+                  groupName: 'propertiesWithDecoratorStartingWithHello',
+                  selector: 'property',
+                  decoratorNamePattern: 'Hello*',
+                },
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'b',
+                leftGroup: 'unknown',
+                right: 'constructor',
+                rightGroup: 'constructor',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method',
+                leftGroup: 'unknown',
+                right: 'property',
+                rightGroup: 'propertiesWithDecoratorStartingWithHello',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesOrder',
+              data: {
+                left: 'property',
+                right: 'anotherProperty',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(
+      `${ruleName}: sort custom groups with overriden 'type' and 'order'`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+            class Class {
+
+              a;
+
+              bb;
+
+              ccc;
+
+              dddd;
+
+              method() {}
+
+              eee;
+
+              ff;
+
+              g;
+
+              constructor() {}
+
+              anotherMethod() {}
+
+              yetAnotherMethod() {}
+            }
+            `,
+            output: dedent`
+            class Class {
+
+              dddd;
+
+              ccc;
+
+              eee;
+
+              bb;
+
+              ff;
+
+              a;
+
+              g;
+
+              constructor() {}
+
+              anotherMethod() {}
+
+              method() {}
+
+              yetAnotherMethod() {}
+            }
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                order: 'asc',
+                groups: [
+                  'reversedPropertiesByLineLength',
+                  'constructor',
+                  'unknown',
+                ],
+                customGroups: [
+                  {
+                    groupName: 'reversedPropertiesByLineLength',
+                    selector: 'property',
+                    type: 'line-length',
+                    order: 'desc',
+                  },
+                ],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'a',
+                  right: 'bb',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'bb',
+                  right: 'ccc',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'ccc',
+                  right: 'dddd',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'method',
+                  leftGroup: 'unknown',
+                  right: 'eee',
+                  rightGroup: 'reversedPropertiesByLineLength',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}: does not sort custom groups with 'unsorted' type`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+            class Class {
+              b;
+
+              a;
+
+              constructor() {}
+
+              d
+
+              e
+
+              method() {}
+
+              c
+            }
+            `,
+            output: dedent`
+            class Class {
+              b;
+
+              a;
+
+              d
+
+              e
+
+              c
+
+              constructor() {}
+
+              method() {}
+            }
+            `,
+            options: [
+              {
+                groups: ['unsortedProperties', 'constructor', 'unknown'],
+                customGroups: [
+                  {
+                    groupName: 'unsortedProperties',
+                    selector: 'property',
+                    type: 'unsorted',
+                  },
+                ],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'constructor',
+                  leftGroup: 'constructor',
+                  right: 'd',
+                  rightGroup: 'unsortedProperties',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'method',
+                  leftGroup: 'unknown',
+                  right: 'c',
+                  rightGroup: 'unsortedProperties',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            class Class {
+              constructor() {}
+
+              protected a;
+
+              private b;
+
+              @Decorator
+              protected e;
+
+              method() {}
+
+              private c;
+
+              protected protectedMethod() {}
+
+              protected d;
+
+              protected anotherProtectedMethod() {}
+            }
+            `,
+          output: dedent`
+            class Class {
+              protected anotherProtectedMethod() {}
+
+              private b;
+
+              private c;
+
+              @Decorator
+              protected e;
+
+              protected protectedMethod() {}
+
+              constructor() {}
+
+              protected a;
+
+              protected d;
+
+              method() {}
+            }
+            `,
+          options: [
+            {
+              groups: [
+                [
+                  'privatePropertiesAndProtectedMethods',
+                  'decorated-protected-property',
+                ],
+                'constructor',
+                'unknown',
+              ],
+              customGroups: [
+                {
+                  groupName: 'privatePropertiesAndProtectedMethods',
+                  anyOf: [
+                    {
+                      selector: 'property',
+                      modifiers: ['private'],
+                    },
+                    {
+                      selector: 'method',
+                      modifiers: ['protected'],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'a',
+                leftGroup: 'unknown',
+                right: 'b',
+                rightGroup: 'privatePropertiesAndProtectedMethods',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method',
+                leftGroup: 'unknown',
+                right: 'c',
+                rightGroup: 'privatePropertiesAndProtectedMethods',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'd',
+                leftGroup: 'unknown',
+                right: 'anotherProtectedMethod',
+                rightGroup: 'privatePropertiesAndProtectedMethods',
+              },
+            },
+          ],
+        },
+      ],
+    })
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,


### PR DESCRIPTION
### Description

Fixes https://github.com/azat-io/eslint-plugin-perfectionist/issues/201

Typings for this rule have been moved in their own file `sort-classes.types.ts`.

Improves the `customGroups` API by allowing an array of `CustomGroup` to be entered rather than an object. Entering an object will still use the currently existing `customGroups` API.

A `CustomGroup` may be one of the following:

```ts
interface SingleCustomGroup {
  groupName: string
  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
  order?: 'asc' | 'desc'
  selector?: string
  modifiers?: string[]
  elementNamePattern?: string
  decoratorNamePattern?: string
}
```

or 

```ts
interface CustomGroupBlock {
  groupName: string
  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
  order?: 'asc' | 'desc'
  anyOf: Array<{
      selector?: string
      modifiers?: string[]
      elementNamePattern?: string
      decoratorNamePattern?: string
  }>
}
```
The objectives are:
- To give the possibility to group elements in a precise way by offering various filters.
- to give the possibility to users to choose the sorting type of each group should they want, in particular: `unsorted`. This allows users to have complex configurations where they would want `methods` to be grouped together below the `constructor`, but remain unsorted. If the custom group's `type` or `order` are not given, the top-level `type` and `order` options are taken.

The `customGroups` list is ordered: the first `CustomGroup` definition that matches an element will be used.
Custom groups have a higher priority than any official group. This is important:

The custom group
```
{
    groupName: 'myCustomGroup',
    selector: 'method',
   ....
}
```

will match `constructor() {}` before the official group `constructor`, because constructors match the `method` selector (this is possibly something that should to be addressed in the future).

As such, users can do
```
customGroups: [
    {
        groupName: 'constructor',
        selector: 'constructor',
    },
    {
        groupName: 'myCustomGroup',
        selector: 'method',
       ....
    }
]
```

to ensure that `constructor() {}` gets matched with the custom group `constructor` (which replicates what the official `constructor` group does) before `myCustomGroup`.

This interface is easily extensible if additional features need to be added later on.

- `groupName`: The group's name. Today in `customGroups`, this is one key of the object.
- `selector`: Filter on the `selector` of the element.
- `modifiers`: Filter on the `modifiers` of the element. (All the modifiers of the element must be present in that list)
- `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered. Today in `customGroups`, this is the value associated to a key of the object.
- `decoratorNamePattern`: If entered, will check that at least one `decorator` matches the pattern entered. (fixes #165)
- `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
- `order`: Overrides the sort order for that custom group

### Code example

Here is the simplified configuration that fixes #165:
```json
  {
            "groups": [
              "input",
              "output"
            ],
            "customGroups": [
              {
                "groupName": "input",
                "decoratorNamePattern": "Input"
              },
              {
                "groupName": "output",
                "decoratorNamePattern": "Output"
              }
            ]
          }
```

Here is an example of configuration that groups methods and properties together without sorting them

```json
{
            "groups": [
              "constructor",
              "unsortedMethodsAndProperties"
            ],
            "customGroups": [
              {
                // Prioritize matching constructor before anything else:
                // `constructor` are methods but should not be treated as such and grouped with properties here.
                "groupName": "constructor",
                "selector": "constructor"
              },
              {
                "groupName": "unsortedMethodsAndProperties",
                "type": "unsorted",
                "anyOf": [
                  {
                    "selector": "property"
                  },
                  {
                    "selector": "method"
                  }
                ]
              }
            ]
          }
```

- [x] Feature implementation
- [x] Tests
- [x] Documentation 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature
- [x] Documentation update
