### PR TITLE
fix: #209 and #212 - `sort-classes` Attributes with the same name but within different groups may not trigger linting + line-length can break overload-signatures

### DIFF
--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -1,3 +1,5 @@
+import type { TSESTree } from '@typescript-eslint/utils'
+
 import type { Modifier, Selector } from './sort-classes'
 
 /**
@@ -94,4 +96,45 @@ const getPermutations = (elements: string[]): string[][] => {
   backtrack(0)
 
   return result
+}
+
+/**
+ * Returns a list of groups of overload signatures.
+ */
+export const getOverloadSignatures = (
+  members: TSESTree.ClassElement[],
+): TSESTree.ClassElement[][] => {
+  let methods = members
+    .filter(
+      member =>
+        member.type === 'MethodDefinition' ||
+        member.type === 'TSAbstractMethodDefinition',
+    )
+    .filter(member => member.kind === 'method')
+  // Static and non-static overload signatures can coexist with the same name
+  let staticOverloadSignaturesByName = new Map<
+    string,
+    TSESTree.ClassElement[]
+  >()
+  let overloadSignaturesByName = new Map<string, TSESTree.ClassElement[]>()
+  for (let method of methods) {
+    if (method.key.type !== 'Identifier') {
+      continue
+    }
+    let { name } = method.key
+    let mapToUse = method.static
+      ? staticOverloadSignaturesByName
+      : overloadSignaturesByName
+    let signatureOverloadsGroup = mapToUse.get(name)
+    if (!signatureOverloadsGroup) {
+      signatureOverloadsGroup = []
+      mapToUse.set(name, signatureOverloadsGroup)
+    }
+    signatureOverloadsGroup.push(method)
+  }
+  // Ignore groups that only have one method
+  return [
+    ...overloadSignaturesByName.values(),
+    ...staticOverloadSignaturesByName.values(),
+  ].filter(group => group.length > 1)
 }

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -101,7 +101,7 @@ const getPermutations = (elements: string[]): string[][] => {
 /**
  * Returns a list of groups of overload signatures.
  */
-export const getOverloadSignatures = (
+export const getOverloadSignatureGroups = (
   members: TSESTree.ClassElement[],
 ): TSESTree.ClassElement[][] => {
   let methods = members

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -511,15 +511,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
               dependencies = extractDependencies(member.value)
             }
 
-            let overloadSignatureGroup = overloadSignatureGroups.find(
-              overloadSignatures => overloadSignatures.includes(member),
-            )
+            // Members belonging to the same overload signature group should have the same size in order to keep sorting between them consistent.
+            // It is unclear what should be considered the size of an overload signature group. Take the size of the implementation by default.
+            let overloadSignatureGroupMember = overloadSignatureGroups
+              .find(overloadSignatures => overloadSignatures.includes(member))
+              ?.at(-1)
 
             let value: SortClassesSortingNode = {
-              // Members belonging to the same overload signature group should have the same size in order to keep sorting between them consistent.
-              // It is unclear what should be considered the size of an overload signature group. Take the size of the implementation by default.
-              size: overloadSignatureGroup
-                ? rangeToDiff(overloadSignatureGroup.at(-1).range)
+              size: overloadSignatureGroupMember
+                ? rangeToDiff(overloadSignatureGroupMember.range)
                 : rangeToDiff(member.range),
               group: getGroup(),
               node: member,

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -509,7 +509,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             let value: SortClassesSortingNode = {
               size: rangeToDiff(member.range),
               group: getGroup(),
-              node: member as TSESTree.ClassElement,
+              node: member,
               selectors,
               dependencies,
               name,

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -523,7 +523,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             let rightNum = getGroupNumber(options.groups, right)
 
             if (
-              left.name !== right.name &&
+              (left.name !== right.name || leftNum !== rightNum) &&
               (leftNum > rightNum ||
                 (leftNum === rightNum &&
                   isPositive(compare(left, right, options))))

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -4916,30 +4916,5 @@ describe(ruleName, () => {
         ],
       },
     )
-
-    ruleTester.run(`${ruleName}: does not sort method overloads`, rule, {
-      valid: [
-        {
-          code: dedent`
-            abstract class Class extends BaseClass {
-
-              a;
-
-              setBackground(color: number, hexFlag: boolean): this
-              override setBackground(r: number, g: number, b: number, a?: number): this
-              setBackground(): this {
-                /* ... */
-              }
-            }
-            `,
-          options: [
-            {
-              groups: ['override-method', 'property', 'method'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
   })
 })

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -4422,7 +4422,75 @@ describe(ruleName, () => {
             ],
           },
         ],
-        invalid: [],
+        invalid: [
+          {
+            code: dedent`
+              class Decorations {
+
+                setBackground(r: number, g: number, b: number, a?: number): this
+                setBackground(color: number, hexFlag: boolean): this
+                setBackground(color: Color | string | CSSColor): this
+                setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
+                  /* ... */
+                }
+
+                static setBackground(r: number, g: number, b: number, a?: number): this
+                static setBackground(color: number, hexFlag: boolean): this
+                static setBackground(color: Color | string | CSSColor): this
+                static setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
+                  /* ... */
+                }
+
+                a
+              }
+            `,
+            output: dedent`
+              class Decorations {
+
+                a
+                static setBackground(r: number, g: number, b: number, a?: number): this
+                static setBackground(color: number, hexFlag: boolean): this
+                static setBackground(color: Color | string | CSSColor): this
+
+                static setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
+                  /* ... */
+                }
+                setBackground(r: number, g: number, b: number, a?: number): this
+                setBackground(color: number, hexFlag: boolean): this
+                setBackground(color: Color | string | CSSColor): this
+
+                setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
+                  /* ... */
+                }
+              }
+            `,
+            options: [
+              {
+                ...options,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'setBackground',
+                  leftGroup: 'method',
+                  right: 'setBackground',
+                  rightGroup: 'static-method',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'setBackground',
+                  leftGroup: 'static-method',
+                  right: 'a',
+                  rightGroup: 'property',
+                },
+              },
+            ],
+          },
+        ],
       },
     )
 

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -1557,6 +1557,49 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
+      `${ruleName}(${type}): sorts class with attributes having the same name`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              class Class {
+                static a;
+
+                a;
+              }
+            `,
+            output: dedent`
+              class Class {
+                a;
+
+                static a;
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['property', 'static-property'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'a',
+                  leftGroup: 'static-property',
+                  right: 'a',
+                  rightGroup: 'property',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
       `${ruleName}(${type}): sorts class with ts index signatures`,
       rule,
       {
@@ -4873,5 +4916,30 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(`${ruleName}: does not sort method overloads`, rule, {
+      valid: [
+        {
+          code: dedent`
+            abstract class Class extends BaseClass {
+
+              a;
+
+              setBackground(color: number, hexFlag: boolean): this
+              override setBackground(r: number, g: number, b: number, a?: number): this
+              setBackground(): this {
+                /* ... */
+              }
+            }
+            `,
+          options: [
+            {
+              groups: ['override-method', 'property', 'method'],
+            },
+          ],
+        },
+      ],
+      invalid: [],
+    })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/azat-io/eslint-plugin-perfectionist/issues/209 and fixes https://github.com/azat-io/eslint-plugin-perfectionist/issues/212

Does **not** correct https://github.com/azat-io/eslint-plugin-perfectionist/issues/211.

This comparison https://github.com/azat-io/eslint-plugin-perfectionist/blob/4f3da85bf2efd779232950ee621904a665d6df17/rules/sort-classes.ts#L526 

seems responsible for the two issues linked.

- #209: Explicit
- #212: I assume that this check was put to prevent overload-signatures from trying to sort themselves. 

This is not a problem with the `natural` and `alphabetical` sort type because overload signatures have the same name in this case and as such do not impact sorting. It is with `line-length` because overload signatures do not necessarily have the same length.

The `left.name !== right.name` check does prevent overload-signature comparisons from activating linting but does not impact the sorting result itself, meaning that if any other class member activates linting because it is unordered, overload-signatures order may still change, and as such break code.

This PR does two things:
- Remove the `left.name !== right.name` check
- Make sure that the line-length for a group of overload signatures is the same between all its members (the size of the method implementation has been chosen).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix