### PR TITLE
feat: `sort-classes`: improved checks done to identify if a member is #private

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -352,7 +352,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
               }
             }
 
-            let isPrivateName = name.startsWith('#')
+            let isPrivateHash =
+              'key' in member && member.key.type === 'PrivateIdentifier'
             let decorated =
               'decorators' in member && member.decorators.length > 0
 
@@ -384,7 +385,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               if (member.accessibility === 'protected') {
                 modifiers.push('protected')
-              } else if (member.accessibility === 'private' || isPrivateName) {
+              } else if (member.accessibility === 'private' || isPrivateHash) {
                 modifiers.push('private')
               } else {
                 modifiers.push('public')
@@ -436,7 +437,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               if (member.accessibility === 'protected') {
                 modifiers.push('protected')
-              } else if (member.accessibility === 'private' || isPrivateName) {
+              } else if (member.accessibility === 'private' || isPrivateHash) {
                 modifiers.push('private')
               } else {
                 modifiers.push('public')
@@ -473,7 +474,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               if (member.accessibility === 'protected') {
                 modifiers.push('protected')
-              } else if (member.accessibility === 'private' || isPrivateName) {
+              } else if (member.accessibility === 'private' || isPrivateHash) {
                 modifiers.push('private')
               } else {
                 modifiers.push('public')


### PR DESCRIPTION
### Description

 As mentioned by @OlivierZal, the current way of checking if a class member is `#private` is done by analyzing its first character. This PR replaces this check with official ESLint typings.

### What is the purpose of this pull request?

- [x] Other