### PR TITLE
feat: `sort-classes`: #197: Adds `group-kind`  option

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -191,6 +191,16 @@ Allows you to use comments to separate the class members into logical groups. Th
 -	`false` — Comments will not be used as delimiters.
 - string — A glob pattern to specify which comments should act as delimiters.
 
+### groupKind
+
+<sub>default: `'mixed'`</sub>
+
+Allows you to group properties by their kind, determining whether required properties should come before or after optional properties.
+
+- `mixed` — Do not group properties by their kind; required properties are sorted together with optional properties.
+- `required-first` — Group all required properties before optional properties.
+- `optional-first` — Group all optional properties before required properties.
+
 ### groups
 
 <sub>
@@ -493,6 +503,7 @@ Example:
                   order: 'asc',
                   ignoreCase: true,
                   partitionByComment: false,
+                  groupKind: 'mixed',
                   groups: [
                     'static-block',
                     'index-signature',
@@ -533,6 +544,7 @@ Example:
                 order: 'asc',
                 ignoreCase: true,
                 partitionByComment: false,
+                groupKind: 'mixed',
                 groups: [
                   'static-block',
                   'index-signature',

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -164,7 +164,8 @@ Allows you to use comments to separate the members of enums into logical groups.
                   order: 'asc',
                   ignoreCase: true,
                   partitionByComment: false,
-                  sortByValue: false
+                  sortByValue: false,
+                  forceNumericSort: false
                 },
               ],
             },

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -559,21 +559,21 @@ export default createEslintRule<Options, MESSAGE_ID>({
             let leftNum = getGroupNumber(options.groups, left)
             let rightNum = getGroupNumber(options.groups, right)
 
-            let compareValue
-            if (
-              options.groupKind !== 'mixed' &&
-              left.isOptional !== right.isOptional
-            ) {
-              compareValue =
-                options.groupKind === 'optional-first'
-                  ? !left.isOptional
-                  : left.isOptional
-            } else if (leftNum > rightNum) {
+            let compareValue = false
+            if (leftNum > rightNum) {
               compareValue = true
             } else if (leftNum === rightNum) {
-              compareValue = isPositive(compare(left, right, options))
-            } else {
-              compareValue = false
+              if (
+                options.groupKind !== 'mixed' &&
+                left.isOptional !== right.isOptional
+              ) {
+                compareValue =
+                  options.groupKind === 'optional-first'
+                    ? !left.isOptional
+                    : left.isOptional
+              } else {
+                compareValue = isPositive(compare(left, right, options))
+              }
             }
 
             if (compareValue) {

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -237,29 +237,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
             let compareValue
             if (
-              options.groupKind === 'optional-first' &&
-              isLeftOptional &&
-              !isRightOptional
+              options.groupKind !== 'mixed' &&
+              isLeftOptional !== isRightOptional
             ) {
-              compareValue = false
-            } else if (
-              options.groupKind === 'optional-first' &&
-              !isLeftOptional &&
-              isRightOptional
-            ) {
-              compareValue = true
-            } else if (
-              options.groupKind === 'required-first' &&
-              !isLeftOptional &&
-              isRightOptional
-            ) {
-              compareValue = false
-            } else if (
-              options.groupKind === 'required-first' &&
-              isLeftOptional &&
-              !isRightOptional
-            ) {
-              compareValue = true
+              compareValue =
+                options.groupKind === 'optional-first'
+                  ? !isLeftOptional
+                  : isLeftOptional
             } else if (leftNum > rightNum) {
               compareValue = true
             } else if (leftNum === rightNum) {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -2736,6 +2736,218 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to sort optional values first`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              class Class {
+
+                private g
+                accessor l?
+                d
+                accessor j?
+                c?
+                private h?
+                b
+                private f?
+                a
+                accessor m
+                private e
+                i?
+                accessor k
+              }
+            `,
+            output: dedent`
+              class Class {
+
+                c?
+                i?
+                a
+                b
+                d
+                accessor j?
+                accessor l?
+                accessor k
+                accessor m
+                private f?
+                private h?
+                private e
+                private g
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: [
+                  'public-property',
+                  'accessor-property',
+                  'private-property',
+                ],
+                groupKind: 'optional-first',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'g',
+                  leftGroup: 'private-property',
+                  right: 'l',
+                  rightGroup: 'accessor-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'd',
+                  leftGroup: 'public-property',
+                  right: 'j',
+                  rightGroup: 'accessor-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'j',
+                  leftGroup: 'accessor-property',
+                  right: 'c',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'b',
+                  leftGroup: 'public-property',
+                  right: 'f',
+                  rightGroup: 'private-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'e',
+                  leftGroup: 'private-property',
+                  right: 'i',
+                  rightGroup: 'public-property',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to sort required values first`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              class Class {
+
+                private g
+                accessor l?
+                d
+                accessor j?
+                c?
+                private h?
+                b
+                private f?
+                a
+                accessor m
+                private e
+                i?
+                accessor k
+              }
+            `,
+            output: dedent`
+              class Class {
+
+                a
+                b
+                d
+                c?
+                i?
+                accessor k
+                accessor m
+                accessor j?
+                accessor l?
+                private e
+                private g
+                private f?
+                private h?
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: [
+                  'public-property',
+                  'accessor-property',
+                  'private-property',
+                ],
+                groupKind: 'required-first',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'l',
+                  leftGroup: 'accessor-property',
+                  right: 'd',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'j',
+                  leftGroup: 'accessor-property',
+                  right: 'c',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'h',
+                  leftGroup: 'private-property',
+                  right: 'b',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'f',
+                  leftGroup: 'private-property',
+                  right: 'a',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'i',
+                  leftGroup: 'public-property',
+                  right: 'k',
+                  rightGroup: 'accessor-property',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {
@@ -4114,6 +4326,218 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to sort optional values first`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              class Class {
+
+                private g
+                accessor l?
+                d
+                accessor j?
+                c?
+                private h?
+                b
+                private f?
+                a
+                accessor m
+                private e
+                i?
+                accessor k
+              }
+            `,
+            output: dedent`
+              class Class {
+
+                c?
+                i?
+                a
+                b
+                d
+                accessor j?
+                accessor l?
+                accessor k
+                accessor m
+                private f?
+                private h?
+                private e
+                private g
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: [
+                  'public-property',
+                  'accessor-property',
+                  'private-property',
+                ],
+                groupKind: 'optional-first',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'g',
+                  leftGroup: 'private-property',
+                  right: 'l',
+                  rightGroup: 'accessor-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'd',
+                  leftGroup: 'public-property',
+                  right: 'j',
+                  rightGroup: 'accessor-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'j',
+                  leftGroup: 'accessor-property',
+                  right: 'c',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'b',
+                  leftGroup: 'public-property',
+                  right: 'f',
+                  rightGroup: 'private-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'e',
+                  leftGroup: 'private-property',
+                  right: 'i',
+                  rightGroup: 'public-property',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to sort required values first`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              class Class {
+
+                private g
+                accessor l?
+                d
+                accessor j?
+                c?
+                private h?
+                b
+                private f?
+                a
+                accessor m
+                private e
+                i?
+                accessor k
+              }
+            `,
+            output: dedent`
+              class Class {
+
+                a
+                b
+                d
+                c?
+                i?
+                accessor k
+                accessor m
+                accessor j?
+                accessor l?
+                private e
+                private g
+                private f?
+                private h?
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: [
+                  'public-property',
+                  'accessor-property',
+                  'private-property',
+                ],
+                groupKind: 'required-first',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'l',
+                  leftGroup: 'accessor-property',
+                  right: 'd',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'j',
+                  leftGroup: 'accessor-property',
+                  right: 'c',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'h',
+                  leftGroup: 'private-property',
+                  right: 'b',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'f',
+                  leftGroup: 'private-property',
+                  right: 'a',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'i',
+                  leftGroup: 'public-property',
+                  right: 'k',
+                  rightGroup: 'accessor-property',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by line length`, () => {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -2804,10 +2804,10 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
-                  left: 'd',
-                  leftGroup: 'public-property',
-                  right: 'j',
-                  rightGroup: 'accessor-property',
+                  left: 'l',
+                  leftGroup: 'accessor-property',
+                  right: 'd',
+                  rightGroup: 'public-property',
                 },
               },
               {
@@ -2822,10 +2822,19 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
-                  left: 'b',
-                  leftGroup: 'public-property',
-                  right: 'f',
-                  rightGroup: 'private-property',
+                  left: 'h',
+                  leftGroup: 'private-property',
+                  right: 'b',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'f',
+                  leftGroup: 'private-property',
+                  right: 'a',
+                  rightGroup: 'public-property',
                 },
               },
               {
@@ -2901,6 +2910,15 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
+                  left: 'g',
+                  leftGroup: 'private-property',
+                  right: 'l',
+                  rightGroup: 'accessor-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
                   left: 'l',
                   leftGroup: 'accessor-property',
                   right: 'd',
@@ -2937,10 +2955,10 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
-                  left: 'i',
-                  leftGroup: 'public-property',
-                  right: 'k',
-                  rightGroup: 'accessor-property',
+                  left: 'e',
+                  leftGroup: 'private-property',
+                  right: 'i',
+                  rightGroup: 'public-property',
                 },
               },
             ],
@@ -4394,10 +4412,10 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
-                  left: 'd',
-                  leftGroup: 'public-property',
-                  right: 'j',
-                  rightGroup: 'accessor-property',
+                  left: 'l',
+                  leftGroup: 'accessor-property',
+                  right: 'd',
+                  rightGroup: 'public-property',
                 },
               },
               {
@@ -4412,10 +4430,19 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
-                  left: 'b',
-                  leftGroup: 'public-property',
-                  right: 'f',
-                  rightGroup: 'private-property',
+                  left: 'h',
+                  leftGroup: 'private-property',
+                  right: 'b',
+                  rightGroup: 'public-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'f',
+                  leftGroup: 'private-property',
+                  right: 'a',
+                  rightGroup: 'public-property',
                 },
               },
               {
@@ -4491,6 +4518,15 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
+                  left: 'g',
+                  leftGroup: 'private-property',
+                  right: 'l',
+                  rightGroup: 'accessor-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
                   left: 'l',
                   leftGroup: 'accessor-property',
                   right: 'd',
@@ -4527,10 +4563,10 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
-                  left: 'i',
-                  leftGroup: 'public-property',
-                  right: 'k',
-                  rightGroup: 'accessor-property',
+                  left: 'e',
+                  leftGroup: 'private-property',
+                  right: 'i',
+                  rightGroup: 'public-property',
                 },
               },
             ],


### PR DESCRIPTION
### Description

Alternative PR: https://github.com/azat-io/eslint-plugin-perfectionist/pull/219. Fixes #197.

This PR adds a `group-kind` option similar to what exists for the `sort-object-types` rule, with 3 possible values:
`mixed` (default), `optional-first` and `required-first`.

Optionality applies to each group, not as a whole: if `optional-first` is selected, each group will have its optional members at its top.

The algorithm used to detect this error is similar to the one used in `sort-object-types`, and is slightly more compact than what existed, so I also updated it in the `sort-object-types.ts` as well.

Also updated a missing documented attribute in `sort-enums`.

Only properties and accessor properties are affected by this flag, so it would be understandable to instead only add an `optional` modifier to properies and accessor properties rather than a top-level flag.

### What is the purpose of this pull request? 

- [x] New Feature
