### PR TITLE
feat: `sort-classes`: #197: Adds `optional` modifier to `property` and `method`

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -223,15 +223,23 @@ Predefined groups are characterized by a single selector and potentially multipl
 - Modifiers: `protected`, `private`, `public`.
 - Example: `protected-constructor`, `private-constructor`, `public-constructor` or `constructor`.
 
-#### Methods and accessors
-- Methods selectors: `get-method`, `set-method`, `method`.
-- Accessors selector: `accessor-property`.
-- Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`.
+#### Methods
+- Selectors: `get-method`, `set-method`, `method`.
+- Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`, `optional`.
 - Example: `private-static-accessor-property`, `protected-abstract-override-method` or `static-get-method`.
+
+The `optional` modifier is incompatible with the `get-method` and `set-method` selectors.
 
 The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.
 
 `constructor`, `get-method` and `set-method` elements will also be matched as `method`.
+
+#### Accessors
+- Selector: `accessor-property`.
+- Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`.
+- Example: `private-static-accessor-property`, `protected-abstract-override-method` or `static-get-method`.
+
+The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.
 
 #### Properties
 - Selectors: `function-property`, `property`.

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -223,8 +223,8 @@ Predefined groups are characterized by a single selector and potentially multipl
 - Modifiers: `protected`, `private`, `public`.
 - Example: `protected-constructor`, `private-constructor`, `public-constructor` or `constructor`.
 
-#### Methods and accessors
-- Method selectors: `get-method`, `set-method`, `method`.
+#### Methods
+- Selectors: `get-method`, `set-method`, `method`.
 - Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`.
 - Example: `protected-abstract-override-method` or `static-get-method`.
 
@@ -233,7 +233,7 @@ The `abstract` modifier is incompatible with the `static`, `private` and `decora
 `constructor`, `get-method` and `set-method` elements will also be matched as `method`.
 
 #### Accessors
-- selector: `accessor-property`.
+- Selector: `accessor-property`.
 - Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`, `optional`.
 - Example: `private-static-accessor-property`.
 

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -223,21 +223,15 @@ Predefined groups are characterized by a single selector and potentially multipl
 - Modifiers: `protected`, `private`, `public`.
 - Example: `protected-constructor`, `private-constructor`, `public-constructor` or `constructor`.
 
-#### Methods
-- Selectors: `get-method`, `set-method`, `method`.
+#### Methods and accessors
+- Methods selectors: `get-method`, `set-method`, `method`.
+- Accessors selector: `accessor-property`.
 - Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`.
-- Example: `protected-abstract-override-method` or `static-get-method`.
+- Example: `private-static-accessor-property`, `protected-abstract-override-method` or `static-get-method`.
 
 The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.
 
 `constructor`, `get-method` and `set-method` elements will also be matched as `method`.
-
-#### Accessors
-- Selector: `accessor-property`.
-- Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`, `optional`.
-- Example: `private-static-accessor-property`.
-
-The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.
 
 #### Properties
 - Selectors: `function-property`, `property`.

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -225,16 +225,23 @@ Predefined groups are characterized by a single selector and potentially multipl
 
 #### Methods and accessors
 - Method selectors: `get-method`, `set-method`, `method`.
-- Accessors selector: `accessor-property`.
 - Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`.
-- Example: `private-static-accessor-property`, `protected-abstract-override-method` or `static-get-method`.
+- Example: `protected-abstract-override-method` or `static-get-method`.
 
 The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.
+
 `constructor`, `get-method` and `set-method` elements will also be matched as `method`.
+
+#### Accessors
+- selector: `accessor-property`.
+- Modifiers: `static`, `abstract`, `decorated`, `override`, `protected`, `private`, `public`, `optional`.
+- Example: `private-static-accessor-property`.
+
+The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.
 
 #### Properties
 - Selectors: `function-property`, `property`.
-- Modifiers: `static`, `declare`, `abstract`, `decorated`, `override`, `readonly`, `protected`, `private`, `public`.
+- Modifiers: `static`, `declare`, `abstract`, `decorated`, `override`, `readonly`, `protected`, `private`, `public`, `optional`.
 - Example: `readonly-decorated-property`.
 
 The `abstract` modifier is incompatible with the `static`, `private` and `decorated` modifiers.

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -101,7 +101,7 @@ type NonDeclarePropertyGroup =
 type MethodOrGetMethodOrSetMethodGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
 type AccessorPropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${AccessorPropertySelector}`
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
 type IndexSignatureGroup =
   `${StaticModifierPrefix}${ReadonlyModifierPrefix}${IndexSignatureSelector}`
 type StaticBlockGroup = `${StaticBlockSelector}`
@@ -452,11 +452,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
               } else {
                 modifiers.push('public')
               }
-
-              if (member.optional) {
-                modifiers.push('optional')
-              }
-
               selectors.push('accessor-property')
             } else {
               // Member is necessarily a Property

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -34,10 +34,12 @@ type OverrideModifier = 'override'
 type ReadonlyModifier = 'readonly'
 type DecoratedModifier = 'decorated'
 type DeclareModifier = 'declare'
+type OptionalModifier = 'optional'
 export type Modifier =
   | ProtectedModifier
   | DecoratedModifier
   | AbstractModifier
+  | OptionalModifier
   | OverrideModifier
   | ReadonlyModifier
   | PrivateModifier
@@ -72,6 +74,7 @@ type PublicOrProtectedOrPrivateModifierPrefix = WithDashSuffixOrEmpty<
 >
 
 type OverrideModifierPrefix = WithDashSuffixOrEmpty<OverrideModifier>
+type OptionalModifierPrefix = WithDashSuffixOrEmpty<OptionalModifier>
 type ReadonlyModifierPrefix = WithDashSuffixOrEmpty<ReadonlyModifier>
 type DecoratedModifierPrefix = WithDashSuffixOrEmpty<DecoratedModifier>
 type DeclareModifierPrefix = WithDashSuffixOrEmpty<DeclareModifier>
@@ -92,13 +95,13 @@ type ConstructorGroup =
 type FunctionPropertyGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${FunctionPropertySelector}`
 type DeclarePropertyGroup =
-  `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${PropertySelector}`
+  `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
 type NonDeclarePropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${PropertySelector}`
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
 type MethodOrGetMethodOrSetMethodGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
 type AccessorPropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${AccessorPropertySelector}`
 type IndexSignatureGroup =
   `${StaticModifierPrefix}${ReadonlyModifierPrefix}${IndexSignatureSelector}`
 type StaticBlockGroup = `${StaticBlockSelector}`
@@ -449,6 +452,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               } else {
                 modifiers.push('public')
               }
+
+              if (member.optional) {
+                modifiers.push('optional')
+              }
+
               selectors.push('accessor-property')
             } else {
               // Member is necessarily a Property
@@ -485,6 +493,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 modifiers.push('private')
               } else {
                 modifiers.push('public')
+              }
+
+              if (member.optional) {
+                modifiers.push('optional')
               }
 
               if (

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -98,7 +98,9 @@ type DeclarePropertyGroup =
   `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
 type NonDeclarePropertyGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
-type MethodOrGetMethodOrSetMethodGroup =
+type MethodGroup =
+  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${MethodSelector}`
+type GetMethodOrSetMethodGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${MethodOrGetMethodOrSetMethodSelector}`
 type AccessorPropertyGroup =
   `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
@@ -112,7 +114,7 @@ type StaticBlockGroup = `${StaticBlockSelector}`
  * - abstract decorated X
  */
 type Group =
-  | MethodOrGetMethodOrSetMethodGroup
+  | GetMethodOrSetMethodGroup
   | NonDeclarePropertyGroup
   | AccessorPropertyGroup
   | FunctionPropertyGroup
@@ -120,6 +122,7 @@ type Group =
   | IndexSignatureGroup
   | ConstructorGroup
   | StaticBlockGroup
+  | MethodGroup
   | 'unknown'
   | string
 
@@ -399,6 +402,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 modifiers.push('private')
               } else {
                 modifiers.push('public')
+              }
+
+              if (member.optional) {
+                modifiers.push('optional')
               }
 
               if (member.kind === 'constructor') {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -181,8 +181,6 @@ describe(ruleName, () => {
             code: dedent`
             abstract class Class {
 
-              accessor p?;
-
               o?;
 
               static {}
@@ -258,8 +256,6 @@ describe(ruleName, () => {
               static {}
 
               o?;
-
-              accessor p?;
             }
           `,
             options: [
@@ -283,20 +279,10 @@ describe(ruleName, () => {
                   'static-readonly-index-signature',
                   'static-block',
                   'public-optional-property',
-                  'public-optional-accessor-property',
                 ],
               },
             ],
             errors: [
-              {
-                messageId: 'unexpectedClassesGroupOrder',
-                data: {
-                  left: 'p',
-                  leftGroup: 'public-optional-accessor-property',
-                  right: 'o',
-                  rightGroup: 'public-optional-property',
-                },
-              },
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
@@ -1063,55 +1049,6 @@ describe(ruleName, () => {
                       leftGroup: 'property',
                       right: 'z',
                       rightGroup: 'override-accessor-property',
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritize ${accessibilityModifier} accessibility over optional`,
-          rule,
-          {
-            valid: [],
-            invalid: [
-              {
-                code: dedent`
-              export class Class {
-
-                a(): void {}
-
-                ${accessibilityModifier} accessor z?: string;
-              }
-            `,
-                output: dedent`
-              export class Class {
-
-                ${accessibilityModifier} accessor z?: string;
-
-                a(): void {}
-              }
-            `,
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      `${accessibilityModifier}-accessor-property`,
-                      'method',
-                      'optional-property',
-                    ],
-                  },
-                ],
-                errors: [
-                  {
-                    messageId: 'unexpectedClassesGroupOrder',
-                    data: {
-                      left: 'a',
-                      leftGroup: 'method',
-                      right: 'z',
-                      rightGroup: `${accessibilityModifier}-accessor-property`,
                     },
                   },
                 ],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -181,6 +181,8 @@ describe(ruleName, () => {
             code: dedent`
             abstract class Class {
 
+              p?(): void;
+
               o?;
 
               static {}
@@ -256,6 +258,8 @@ describe(ruleName, () => {
               static {}
 
               o?;
+
+              p?(): void;
             }
           `,
             options: [
@@ -279,10 +283,20 @@ describe(ruleName, () => {
                   'static-readonly-index-signature',
                   'static-block',
                   'public-optional-property',
+                  'public-optional-method',
                 ],
               },
             ],
             errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'p',
+                  leftGroup: 'public-optional-method',
+                  right: 'o',
+                  rightGroup: 'public-optional-property',
+                },
+              },
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
@@ -847,6 +861,55 @@ describe(ruleName, () => {
                       leftGroup: 'property',
                       right: 'z',
                       rightGroup: 'override-method',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): prioritize ${accessibilityModifier} accessibility over optional`,
+          rule,
+          {
+            valid: [],
+            invalid: [
+              {
+                code: dedent`
+              export class Class {
+
+                a: string;
+
+                ${accessibilityModifier} z?(): string;
+              }
+            `,
+                output: dedent`
+              export class Class {
+
+                ${accessibilityModifier} z?(): string;
+
+                a: string;
+              }
+            `,
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      `${accessibilityModifier}-method`,
+                      'property',
+                      'optional-method',
+                    ],
+                  },
+                ],
+                errors: [
+                  {
+                    messageId: 'unexpectedClassesGroupOrder',
+                    data: {
+                      left: 'a',
+                      leftGroup: 'property',
+                      right: 'z',
+                      rightGroup: `${accessibilityModifier}-method`,
                     },
                   },
                 ],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -181,6 +181,10 @@ describe(ruleName, () => {
             code: dedent`
             abstract class Class {
 
+              accessor p?;
+
+              o?;
+
               static {}
 
               static readonly [key: string]: string;
@@ -252,6 +256,10 @@ describe(ruleName, () => {
               static readonly [key: string]: string;
 
               static {}
+
+              o?;
+
+              accessor p?;
             }
           `,
             options: [
@@ -274,10 +282,30 @@ describe(ruleName, () => {
                   'function-property',
                   'static-readonly-index-signature',
                   'static-block',
+                  'public-optional-property',
+                  'public-optional-accessor-property',
                 ],
               },
             ],
             errors: [
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'p',
+                  leftGroup: 'public-optional-accessor-property',
+                  right: 'o',
+                  rightGroup: 'public-optional-property',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesGroupOrder',
+                data: {
+                  left: 'o',
+                  leftGroup: 'public-optional-property',
+                  right: 'static',
+                  rightGroup: 'static-block',
+                },
+              },
               {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
@@ -1042,6 +1070,55 @@ describe(ruleName, () => {
             ],
           },
         )
+
+        ruleTester.run(
+          `${ruleName}(${type}): prioritize ${accessibilityModifier} accessibility over optional`,
+          rule,
+          {
+            valid: [],
+            invalid: [
+              {
+                code: dedent`
+              export class Class {
+
+                a(): void {}
+
+                ${accessibilityModifier} accessor z?: string;
+              }
+            `,
+                output: dedent`
+              export class Class {
+
+                ${accessibilityModifier} accessor z?: string;
+
+                a(): void {}
+              }
+            `,
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      `${accessibilityModifier}-accessor-property`,
+                      'method',
+                      'optional-property',
+                    ],
+                  },
+                ],
+                errors: [
+                  {
+                    messageId: 'unexpectedClassesGroupOrder',
+                    data: {
+                      left: 'a',
+                      leftGroup: 'method',
+                      right: 'z',
+                      rightGroup: `${accessibilityModifier}-accessor-property`,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        )
       }
     })
 
@@ -1454,6 +1531,55 @@ describe(ruleName, () => {
                       leftGroup: 'method',
                       right: 'z',
                       rightGroup: 'readonly-property',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): prioritize ${accessibilityModifier} accessibility over optional`,
+          rule,
+          {
+            valid: [],
+            invalid: [
+              {
+                code: dedent`
+              export class Class {
+
+                a(): void {}
+
+                ${accessibilityModifier} z?: string;
+              }
+            `,
+                output: dedent`
+              export class Class {
+
+                ${accessibilityModifier} z?: string;
+
+                a(): void {}
+              }
+            `,
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      `${accessibilityModifier}-property`,
+                      'method',
+                      'optional-property',
+                    ],
+                  },
+                ],
+                errors: [
+                  {
+                    messageId: 'unexpectedClassesGroupOrder',
+                    data: {
+                      left: 'a',
+                      leftGroup: 'method',
+                      right: 'z',
+                      rightGroup: `${accessibilityModifier}-property`,
                     },
                   },
                 ],


### PR DESCRIPTION
### Description

Alternative PR to https://github.com/azat-io/eslint-plugin-perfectionist/pull/216, fixes #197 in a different way than the original idea.

The `optional` modifier has a lower priority than accessibility modifiers `public`, `protected` and `private`, meaning that

`a?` gets recognized as a `public-property` before `optional-property`.

Note that these PRs do not solve the exact same cases:

- This PR allows users to place optional members in a different group than the required ones while #216 only sorts optional and required members from the same group.
- This PR does not allow users to put `property` and `method` in the same group while putting optional members from both groups at the top (or at the bottom). #216 allows it.

### What is the purpose of this pull request?

- [x] New Feature