### PR TITLE
feat: `sort-classes`: #207: Do not sort `unknown` elements if `unknown` is not referenced in `groups`

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -266,7 +266,8 @@ Elements that are not `protected` nor `private` will be matched with the `public
 
 
 ##### The `unknown` group
-Members that don’t fit into any group entered by the user will be placed in the `unknown` group.
+Members that don’t fit into any group entered by the user will be placed in the `unknown` group. If the `unknown` group is not specified in `groups`,
+the members will remain in their original order.
 
 ##### Behavior when multiple groups match an element
 

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -1650,7 +1650,7 @@ describe(ruleName, () => {
                 ...options,
                 groups: [
                   ['static-property', 'private-property', 'property'],
-                  'constructor',
+                  'index-signature',
                 ],
               },
             ],
@@ -1659,7 +1659,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '[k: string];',
-                  leftGroup: 'unknown',
+                  leftGroup: 'index-signature',
                   right: 'a',
                   rightGroup: 'static-property',
                 },
@@ -2730,6 +2730,55 @@ describe(ruleName, () => {
               data: {
                 left: 'b',
                 right: 'a',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              class Class {
+
+                public i = 'i';
+                private z() {}
+                public method3() {}
+                private y() {}
+                public method4() {}
+                public method1() {}
+                private x() {}
+              }
+            `,
+          output: dedent`
+              class Class {
+
+                private x() {}
+                private y() {}
+                public method3() {}
+                private z() {}
+                public method4() {}
+                public method1() {}
+                public i = 'i';
+              }
+            `,
+          options: [
+            {
+              ...options,
+              groups: ['private-method', 'property'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'i',
+                leftGroup: 'property',
+                right: 'z',
+                rightGroup: 'private-method',
               },
             },
           ],
@@ -3028,7 +3077,7 @@ describe(ruleName, () => {
                 ...options,
                 groups: [
                   ['static-property', 'private-property', 'property'],
-                  'constructor',
+                  'index-signature',
                 ],
               },
             ],
@@ -3037,7 +3086,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '[k: string];',
-                  leftGroup: 'unknown',
+                  leftGroup: 'index-signature',
                   right: 'a',
                   rightGroup: 'static-property',
                 },
@@ -4114,6 +4163,55 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              class Class {
+
+                public i = 'i';
+                private z() {}
+                public method3() {}
+                private y() {}
+                public method4() {}
+                public method1() {}
+                private x() {}
+              }
+            `,
+          output: dedent`
+              class Class {
+
+                private x() {}
+                private y() {}
+                public method3() {}
+                private z() {}
+                public method4() {}
+                public method1() {}
+                public i = 'i';
+              }
+            `,
+          options: [
+            {
+              ...options,
+              groups: ['private-method', 'property'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'i',
+                leftGroup: 'property',
+                right: 'z',
+                rightGroup: 'private-method',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 
   describe(`${ruleName}: sorting by line length`, () => {
@@ -4375,7 +4473,7 @@ describe(ruleName, () => {
                 ...options,
                 groups: [
                   ['static-property', 'private-property', 'property'],
-                  'constructor',
+                  'index-signature',
                 ],
               },
             ],
@@ -4384,7 +4482,7 @@ describe(ruleName, () => {
                 messageId: 'unexpectedClassesGroupOrder',
                 data: {
                   left: '[k: string];',
-                  leftGroup: 'unknown',
+                  leftGroup: 'index-signature',
                   right: 'a',
                   rightGroup: 'static-property',
                 },
@@ -4894,6 +4992,55 @@ describe(ruleName, () => {
                 leftGroup: 'private-decorated-accessor-property',
                 right: 'finished',
                 rightGroup: 'decorated-accessor-property',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              class Class {
+
+                public i = 'i';
+                private z() {}
+                public method3() {}
+                private y() {}
+                public method4() {}
+                public method1() {}
+                private x() {}
+              }
+            `,
+          output: dedent`
+              class Class {
+
+                private z() {}
+                private y() {}
+                public method3() {}
+                private x() {}
+                public method4() {}
+                public method1() {}
+                public i = 'i';
+              }
+            `,
+          options: [
+            {
+              ...options,
+              groups: ['private-method', 'property'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'i',
+                leftGroup: 'property',
+                right: 'z',
+                rightGroup: 'private-method',
               },
             },
           ],


### PR DESCRIPTION
Fixes #207.

This PR adds the following:
- A new behavior for the `unknown` group: If the `unknown` group is not referenced in the user's configuration, elements from the `unknown` group will be ignored and not sorted. This prevents `unknown` elements from being put and sorted at the bottom of the class.

I have chosen not to add the `ignoreGroups` option as I believe this can be added in https://github.com/azat-io/eslint-plugin-perfectionist/pull/208 instead. This feature can be added later if needed anyway.


Example configuration that prevents `method` from being sorted:

```
"perfectionist/sort-classes": ["error", {
          "groups": [
            // Groups that do not include `method` nor `unknown`
          ]
        }
]
```

- [x] Implement feature
- [x] Add tests
- [x] Update documentation 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature