### PR TITLE
Can’t install with engineStrict=true on Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@typescript-eslint/types": "^8.3.0",
     "@typescript-eslint/utils": "^8.3.0",
-    "minimatch": "^10.0.1",
+    "minimatch": "^9.0.5",
     "natural-compare-lite": "^1.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^8.3.0
         version: 8.3.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
       minimatch:
-        specifier: ^10.0.1
-        version: 10.0.1
+        specifier: ^9.0.5
+        version: 9.0.5
       natural-compare-lite:
         specifier: ^1.4.0
         version: 1.4.0


### PR DESCRIPTION
### Description
When installing on Node 18, installation can fail with “Not compatible with your version of node/npm”. This is because one of the dependencies, minimatch 10, [requires Node 20](https://github.com/isaacs/minimatch/blob/0569cd3373408f9d701d3aab187b3f43a24a0db7/package.json#L53), whereas our current version of eslint-plugin-perfectionist [supports Node 18](https://github.com/azat-io/eslint-plugin-perfectionist/blob/0c724e0025ddbcb62eb082ae6c1fe3a7a01815de/package.json#L33).

> npm error code EBADENGINE
> npm error engine Unsupported engine
> npm error engine Not compatible with your version of node/npm: minimatch@10.0.1

This PR downgrades minimatch at no cost, as there were no meaningful changes between 9 and 10 ([changelog](https://github.com/isaacs/minimatch/blob/0569cd3373408f9d701d3aab187b3f43a24a0db7/changelog.md#100)).

Note that the PR is unfinished and can’t be merged as is, the lockfile still needs updating.

Fixup a3982f13f564499.

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
