### PR TITLE
fix: `sort-enums`: #226: enum sorting now takes into account dependencies

### DIFF
--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -159,23 +159,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             }
 
             if ('left' in nodeValue) {
-              traverseNode(nodeValue.left)
+              checkNode(nodeValue.left)
             }
 
             if ('right' in nodeValue) {
-              traverseNode(nodeValue.right)
+              checkNode(nodeValue.right)
             }
           }
 
-          let traverseNode = (nodeValue: TSESTree.Node[] | TSESTree.Node) => {
-            if (Array.isArray(nodeValue)) {
-              nodeValue.forEach(traverseNode)
-            } else {
-              checkNode(nodeValue)
-            }
-          }
-
-          traverseNode(expression)
+          checkNode(expression)
           return dependencies
         }
 

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1703,5 +1703,79 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(`${ruleName}: works with dependencies`, rule, {
+      valid: [
+        {
+          code: dedent`
+              enum Enum {
+                B = 'B',
+                A = B,
+              }
+            `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+        },
+        {
+          code: dedent`
+              enum Enum {
+                B = 'B',
+                A = Enum.B,
+              }
+            `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+        },
+        {
+          code: dedent`
+              enum Enum {
+                B = 0,
+                A = 1 | 2 | B | Enum.B,
+              }
+            `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+        },
+      ],
+      invalid: [
+        {
+          code: dedent`
+              enum Enum {
+                B = 'B',
+                A = AnotherEnum.B,
+              }
+            `,
+          output: dedent`
+            enum Enum {
+              A = AnotherEnum.B,
+              B = 'B',
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'B',
+                right: 'A',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 })

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1705,59 +1705,111 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(`${ruleName}: works with dependencies`, rule, {
-      valid: [
-        {
-          code: dedent`
-              enum Enum {
-                B = 'B',
-                A = B,
-              }
-            `,
-          options: [
-            {
-              type: 'alphabetical',
-            },
-          ],
-        },
-        {
-          code: dedent`
-              enum Enum {
-                B = 'B',
-                A = Enum.B,
-              }
-            `,
-          options: [
-            {
-              type: 'alphabetical',
-            },
-          ],
-        },
-        {
-          code: dedent`
-              enum Enum {
-                B = 0,
-                A = 1 | 2 | B | Enum.B,
-              }
-            `,
-          options: [
-            {
-              type: 'alphabetical',
-            },
-          ],
-        },
-      ],
+      valid: [],
       invalid: [
         {
           code: dedent`
-              enum Enum {
-                B = 'B',
-                A = AnotherEnum.B,
-              }
-            `,
+            enum Enum {
+              C = 'C',
+              B = 0,
+              A = B,
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              B = 0,
+              A = B,
+              C = 'C',
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'C',
+                right: 'B',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+            enum Enum {
+              C = 'C',
+              B = 0,
+              A = Enum.B,
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              B = 0,
+              A = Enum.B,
+              C = 'C',
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'C',
+                right: 'B',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+            enum Enum {
+              C = 3,
+              B = 0,
+              A = 1 | 2 | B | Enum.B,
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              B = 0,
+              A = 1 | 2 | B | Enum.B,
+              C = 3,
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'C',
+                right: 'B',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+            enum Enum {
+              B = 'B',
+              A = AnotherEnum.B,
+              C = 'C',
+            }
+          `,
           output: dedent`
             enum Enum {
               A = AnotherEnum.B,
               B = 'B',
+              C = 'C',
             }
           `,
           options: [


### PR DESCRIPTION
Fixes #226.

### Description

Will not sort

```ts
enum Enum {
    B = 'B',
    A = Enum.B,
}
```
```ts
enum Enum {
    B = 'B',
    A = B,
}
```
```ts
enum Enum {
    A = 0,
    C = 1,
    B = A | Enum.C
}
```
but will sort

```ts
enum Enum {
    B = 'B',
    A = AnotherEnum.B,
}
```

### What is the purpose of this pull request?

- [x] Bug fix
