### PR TITLE
fix: `sort-switch-case`: #229: case 'default': is confounded with default: clause

### DIFF
--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -1635,6 +1635,8 @@ describe(ruleName, () => {
             break
           case 'default':
             break
+          case 'remove':
+            break
           default:
             break
           }
@@ -1648,6 +1650,8 @@ describe(ruleName, () => {
             break
           case 'add':
             break
+          case 'remove':
+            break
           default:
             break
           }
@@ -1657,6 +1661,8 @@ describe(ruleName, () => {
           case 'add':
             break
           case 'default':
+            break
+          case 'remove':
             break
           default:
             break

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -1626,4 +1626,52 @@ describe(ruleName, () => {
       },
     ],
   })
+
+  ruleTester.run(`${ruleName}: handles default case and default clause`, rule, {
+    valid: [
+      dedent`
+        switch (variable) {
+          case 'add':
+            break
+          case 'default':
+            break
+          default:
+            break
+          }
+        `,
+    ],
+    invalid: [
+      {
+        code: dedent`
+        switch (variable) {
+          case 'default':
+            break
+          case 'add':
+            break
+          default:
+            break
+          }
+        `,
+        output: dedent`
+        switch (variable) {
+          case 'add':
+            break
+          case 'default':
+            break
+          default:
+            break
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: {
+              left: 'default',
+              right: 'add',
+            },
+          },
+        ],
+      },
+    ],
+  })
 })


### PR DESCRIPTION
### Description

Fixes #229.

### What is the purpose of this pull request?

- [x] Bug fix