### PR TITLE
feat: all rules: #214: Warn the user/Throw an error when a group entered in config does not exist

### DIFF
--- a/rules/sort-astro-attributes.ts
+++ b/rules/sort-astro-attributes.ts
@@ -139,7 +139,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             groups: [],
           } as const)
 
-          // Validate groups config
           validateGroupsConfiguration(
             options.groups,
             ['astro-shorthand', 'multiline', 'shorthand', 'unknown'],

--- a/rules/sort-astro-attributes.ts
+++ b/rules/sort-astro-attributes.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
@@ -137,6 +138,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             order: 'asc',
             groups: [],
           } as const)
+
+          // Validate groups config
+          validateGroupsConfiguration(
+            options.groups,
+            ['astro-shorthand', 'multiline', 'shorthand', 'unknown'],
+            Object.keys(options.customGroups),
+          )
 
           let sourceCode = getSourceCode(context)
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -6,6 +6,7 @@ import { minimatch } from 'minimatch'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -255,6 +256,35 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     if (!hasUnknownGroup) {
       options.groups = [...options.groups, 'unknown']
     }
+
+    // Validate groups config
+    validateGroupsConfiguration(
+      options.groups,
+      [
+        'side-effect-style',
+        'external-type',
+        'internal-type',
+        'builtin-type',
+        'sibling-type',
+        'parent-type',
+        'side-effect',
+        'index-type',
+        'internal',
+        'external',
+        'sibling',
+        'unknown',
+        'builtin',
+        'parent',
+        'object',
+        'index',
+        'style',
+        'type',
+      ],
+      [
+        ...Object.keys(options.customGroups.type ?? {}),
+        ...Object.keys(options.customGroups.value ?? {}),
+      ],
+    )
 
     let nodes: SortingNode[] = []
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -257,7 +257,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       options.groups = [...options.groups, 'unknown']
     }
 
-    // Validate groups config
     validateGroupsConfiguration(
       options.groups,
       [

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -2,6 +2,7 @@ import { minimatch } from 'minimatch'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { isMemberOptional } from '../utils/is-member-optional'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -150,6 +151,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           order: 'asc',
           groups: [],
         } as const)
+
+        // Validate groups config
+        validateGroupsConfiguration(
+          options.groups,
+          ['multiline', 'unknown'],
+          Object.keys(options.customGroups),
+        )
 
         let sourceCode = getSourceCode(context)
 

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -152,7 +152,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           groups: [],
         } as const)
 
-        // Validate groups config
         validateGroupsConfiguration(
           options.groups,
           ['multiline', 'unknown'],

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -1,5 +1,6 @@
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
@@ -112,6 +113,27 @@ export default createEslintRule<Options, MESSAGE_ID>({
         order: 'asc',
         groups: [],
       } as const)
+
+      // Validate groups config
+      validateGroupsConfiguration(
+        options.groups,
+        [
+          'intersection',
+          'conditional',
+          'function',
+          'operator',
+          'keyword',
+          'literal',
+          'nullish',
+          'unknown',
+          'import',
+          'object',
+          'named',
+          'tuple',
+          'union',
+        ],
+        [],
+      )
 
       let sourceCode = getSourceCode(context)
 

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -114,7 +114,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
         groups: [],
       } as const)
 
-      // Validate groups config
       validateGroupsConfiguration(
         options.groups,
         [

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -140,7 +140,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           groups: [],
         } as const)
 
-        // Validate groups config
         validateGroupsConfiguration(
           options.groups,
           ['multiline', 'shorthand', 'unknown'],

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -4,6 +4,7 @@ import { minimatch } from 'minimatch'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
@@ -138,6 +139,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           order: 'asc',
           groups: [],
         } as const)
+
+        // Validate groups config
+        validateGroupsConfiguration(
+          options.groups,
+          ['multiline', 'shorthand', 'unknown'],
+          Object.keys(options.customGroups),
+        )
 
         let sourceCode = getSourceCode(context)
 

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -2,6 +2,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -24,12 +25,12 @@ type Group<T extends string[]> = 'multiline' | 'unknown' | T[number]
 type Options<T extends string[]> = [
   Partial<{
     groupKind: 'required-first' | 'optional-first' | 'mixed'
+    customGroups: { [key in T[number]]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
     groups: (Group<T>[] | Group<T>)[]
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
-    customGroups: {}
   }>,
 ]
 
@@ -139,6 +140,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           order: 'asc',
           groups: [],
         } as const)
+
+        // Validate groups config
+        validateGroupsConfiguration(
+          options.groups,
+          ['multiline', 'unknown'],
+          Object.keys(options.customGroups),
+        )
 
         let sourceCode = getSourceCode(context)
 

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -141,7 +141,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           groups: [],
         } as const)
 
-        // Validate groups config
         validateGroupsConfiguration(
           options.groups,
           ['multiline', 'unknown'],

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -192,7 +192,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
         groups: [],
       } as const)
 
-      // Validate groups config
       validateGroupsConfiguration(
         options.groups,
         [],

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -31,6 +31,8 @@ export enum Position {
   'ignore' = 'ignore',
 }
 
+type Group = 'unknown' | string
+
 type SortingNodeWithPosition = {
   position: Position
 } & SortingNode
@@ -40,7 +42,7 @@ type Options = [
     customGroups: { [key: string]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
-    groups: (string[] | string)[]
+    groups: (Group[] | Group)[]
     partitionByNewLine: boolean
     styledComponents: boolean
     destructureOnly: boolean
@@ -194,7 +196,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
       validateGroupsConfiguration(
         options.groups,
-        [],
+        ['unknown'],
         Object.keys(options.customGroups),
       )
 

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -5,6 +5,7 @@ import { minimatch } from 'minimatch'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -190,6 +191,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
         order: 'asc',
         groups: [],
       } as const)
+
+      // Validate groups config
+      validateGroupsConfiguration(
+        options.groups,
+        [],
+        Object.keys(options.customGroups),
+      )
 
       let shouldIgnore = false
 

--- a/rules/sort-svelte-attributes.ts
+++ b/rules/sort-svelte-attributes.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
@@ -134,6 +135,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             order: 'asc',
             groups: [],
           } as const)
+
+          // Validate groups config
+          validateGroupsConfiguration(
+            options.groups,
+            ['svelte-shorthand', 'multiline', 'shorthand', 'unknown'],
+            Object.keys(options.customGroups),
+          )
 
           let sourceCode = getSourceCode(context)
 

--- a/rules/sort-svelte-attributes.ts
+++ b/rules/sort-svelte-attributes.ts
@@ -136,7 +136,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             groups: [],
           } as const)
 
-          // Validate groups config
           validateGroupsConfiguration(
             options.groups,
             ['svelte-shorthand', 'multiline', 'shorthand', 'unknown'],

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -1,5 +1,6 @@
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
@@ -112,6 +113,27 @@ export default createEslintRule<Options, MESSAGE_ID>({
         order: 'asc',
         groups: [],
       } as const)
+
+      // Validate groups config
+      validateGroupsConfiguration(
+        options.groups,
+        [
+          'intersection',
+          'conditional',
+          'function',
+          'operator',
+          'keyword',
+          'literal',
+          'nullish',
+          'unknown',
+          'import',
+          'object',
+          'named',
+          'tuple',
+          'union',
+        ],
+        [],
+      )
 
       let sourceCode = getSourceCode(context)
 

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -114,7 +114,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
         groups: [],
       } as const)
 
-      // Validate groups config
       validateGroupsConfiguration(
         options.groups,
         [

--- a/rules/sort-vue-attributes.ts
+++ b/rules/sort-vue-attributes.ts
@@ -148,7 +148,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             groups: [],
           } as const)
 
-          // Validate groups config
           validateGroupsConfiguration(
             options.groups,
             ['multiline', 'shorthand', 'unknown'],

--- a/rules/sort-vue-attributes.ts
+++ b/rules/sort-vue-attributes.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import type { SortingNode } from '../typings'
 
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
@@ -146,6 +147,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             order: 'asc',
             groups: [],
           } as const)
+
+          // Validate groups config
+          validateGroupsConfiguration(
+            options.groups,
+            ['multiline', 'shorthand', 'unknown'],
+            Object.keys(options.customGroups),
+          )
 
           let parts: SortingNode[][] = node.attributes.reduce(
             (accumulator: SortingNode[][], attribute) => {

--- a/test/sort-astro-attributes.test.ts
+++ b/test/sort-astro-attributes.test.ts
@@ -1333,6 +1333,41 @@ describe(ruleName, () => {
     })
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(
+      `${ruleName}: allows predefined groups and defined custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file.astro',
+            code: dedent`
+          ---
+            import Component from '../file2.astro'
+          ---
+          <Component a="a" bb="b" />
+        `,
+            options: [
+              {
+                groups: [
+                  'astro-shorthand',
+                  'multiline',
+                  'shorthand',
+                  'unknown',
+                  'myCustomGroup',
+                ],
+                customGroups: {
+                  myCustomGroup: 'x',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(`${ruleName}: works only for .astro files`, rule, {
       valid: [

--- a/test/sort-astro-attributes.test.ts
+++ b/test/sort-astro-attributes.test.ts
@@ -270,7 +270,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                groups: ['unknown', ['svelte-shorthand', 'shorthand']],
+                groups: ['unknown', ['shorthand']],
               },
             ],
             errors: [
@@ -699,7 +699,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                groups: ['unknown', ['svelte-shorthand', 'shorthand']],
+                groups: ['unknown', ['shorthand']],
               },
             ],
             errors: [
@@ -1130,7 +1130,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                groups: ['unknown', ['svelte-shorthand', 'shorthand']],
+                groups: ['unknown', ['shorthand']],
               },
             ],
             errors: [

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -4179,6 +4179,56 @@ describe(ruleName, () => {
     )
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(
+      `${ruleName}: allows predefined groups and defined custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+            import type { T } from 't'
+
+            // @ts-expect-error missing types
+            import { t } from 't'
+          `,
+            options: [
+              {
+                groups: [
+                  'side-effect-style',
+                  'external-type',
+                  'internal-type',
+                  'builtin-type',
+                  'sibling-type',
+                  'parent-type',
+                  'side-effect',
+                  'index-type',
+                  'internal',
+                  'external',
+                  'sibling',
+                  'unknown',
+                  'builtin',
+                  'parent',
+                  'object',
+                  'index',
+                  'style',
+                  'type',
+                  'myCustomGroup1',
+                ],
+                customGroups: {
+                  type: {
+                    myCustomGroup1: 'x',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -2203,6 +2203,35 @@ describe(ruleName, () => {
     )
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(
+      `${ruleName}: allows predefined groups and defined custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+            interface Interface {
+              a: string
+              b: 'b1' | 'b2',
+              c: string
+            }
+          `,
+            options: [
+              {
+                groups: ['multiline', 'unknown', 'myCustomGroup'],
+                customGroups: {
+                  myCustomGroup: 'x',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -1144,6 +1144,38 @@ describe(ruleName, () => {
     })
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(`${ruleName}: allows predefined groups`, rule, {
+      valid: [
+        {
+          code: dedent`
+            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+          `,
+          options: [
+            {
+              groups: [
+                'intersection',
+                'conditional',
+                'function',
+                'operator',
+                'keyword',
+                'literal',
+                'nullish',
+                'unknown',
+                'import',
+                'object',
+                'named',
+                'tuple',
+                'union',
+              ],
+            },
+          ],
+        },
+      ],
+      invalid: [],
+    })
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/sort-jsx-props.test.ts
+++ b/test/sort-jsx-props.test.ts
@@ -1408,6 +1408,39 @@ describe(ruleName, () => {
     })
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(
+      `${ruleName}: allows predefined groups and defined custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+            let Component = () => (
+              <Element
+                a="aaa"
+                b="bb"
+                c="c"
+              >
+                Value
+              </Element>
+            )
+          `,
+            options: [
+              {
+                groups: ['multiline', 'shorthand', 'unknown', 'myCustomGroup'],
+                customGroups: {
+                  myCustomGroup: 'x',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -1740,6 +1740,35 @@ describe(ruleName, () => {
     )
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(
+      `${ruleName}: allows predefined groups and defined custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+            type Type = {
+              a: 'aaa'
+              b: 'bb'
+              c: 'c'
+            }
+          `,
+            options: [
+              {
+                groups: ['multiline', 'unknown', 'myCustomGroup'],
+                customGroups: {
+                  myCustomGroup: 'x',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+  })
+
   describe('misc', () => {
     ruleTester.run(`${ruleName}: ignores semi at the end of value`, rule, {
       valid: [

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -276,7 +276,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
+              groups: ['top'],
             },
           ],
         },
@@ -303,7 +303,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
+              groups: ['top'],
             },
           ],
           errors: [
@@ -1163,7 +1163,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
+              groups: ['top'],
             },
           ],
         },
@@ -1190,7 +1190,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
+              groups: ['top'],
             },
           ],
           errors: [
@@ -2021,7 +2021,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
+              groups: ['top'],
             },
           ],
         },
@@ -2048,7 +2048,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
+              groups: ['top'],
             },
           ],
           errors: [

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -276,7 +276,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top'],
+              groups: ['top', 'unknown'],
             },
           ],
         },
@@ -303,7 +303,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top'],
+              groups: ['top', 'unknown'],
             },
           ],
           errors: [
@@ -1163,7 +1163,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top'],
+              groups: ['top', 'unknown'],
             },
           ],
         },
@@ -1190,7 +1190,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top'],
+              groups: ['top', 'unknown'],
             },
           ],
           errors: [
@@ -2021,7 +2021,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top'],
+              groups: ['top', 'unknown'],
             },
           ],
         },
@@ -2048,7 +2048,7 @@ describe(ruleName, () => {
             {
               ...options,
               customGroups: { top: ['c', 'b'] },
-              groups: ['top'],
+              groups: ['top', 'unknown'],
             },
           ],
           errors: [

--- a/test/sort-svelte-attributes.test.ts
+++ b/test/sort-svelte-attributes.test.ts
@@ -1340,6 +1340,42 @@ describe(ruleName, () => {
     })
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(
+      `${ruleName}: allows predefined groups and defined custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file.svelte',
+            code: dedent`
+              <script>
+                import Component from '../file2.svelte'
+              </script>
+
+              <Component a="aaa" b="bb" />
+            `,
+            options: [
+              {
+                groups: [
+                  'svelte-shorthand',
+                  'multiline',
+                  'shorthand',
+                  'unknown',
+                  'myCustomGroup',
+                ],
+                customGroups: {
+                  myCustomGroup: 'x',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(`${ruleName}: works only with .svelte files`, rule, {
       valid: [

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -1176,6 +1176,38 @@ describe(ruleName, () => {
     })
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(`${ruleName}: allows predefined groups`, rule, {
+      valid: [
+        {
+          code: dedent`
+            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+          `,
+          options: [
+            {
+              groups: [
+                'intersection',
+                'conditional',
+                'function',
+                'operator',
+                'keyword',
+                'literal',
+                'nullish',
+                'unknown',
+                'import',
+                'object',
+                'named',
+                'tuple',
+                'union',
+              ],
+            },
+          ],
+        },
+      ],
+      invalid: [],
+    })
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/sort-vue-attributes.test.ts
+++ b/test/sort-vue-attributes.test.ts
@@ -857,6 +857,43 @@ describe(ruleName, () => {
     )
   })
 
+  describe(`${ruleName}: validating group configuration`, () => {
+    ruleTester.run(
+      `${ruleName}: allows predefined groups and defined custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file2.vue',
+            code: dedent`
+              <script lang="ts" setup>
+                import Component from '../file.vue'
+
+                let b = 'b'
+              </script>
+
+              <template>
+                <jujutsu-sorcerer
+                  :a="a"
+                  :b="b"
+                />
+              </template>
+            `,
+            options: [
+              {
+                groups: ['multiline', 'shorthand', 'unknown', 'myCustomGroup'],
+                customGroups: {
+                  myCustomGroup: 'x',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+  })
+
   describe(`${ruleName}: misc`, () => {
     ruleTester.run(`${ruleName}: works only with .vue files`, rule, {
       valid: [

--- a/test/validate-groups-configuration.test.ts
+++ b/test/validate-groups-configuration.test.ts
@@ -12,10 +12,10 @@ describe('validate-groups-configuration', () => {
   it('throws an error when an invalid group is provided', () => {
     expect(() => {
       validateGroupsConfiguration(
-        ['predefinedGroup', ['customGroup', 'invalidGroup']],
+        ['predefinedGroup', ['customGroup', 'invalidGroup1'], 'invalidGroup2'],
         ['predefinedGroup'],
         ['customGroup'],
       )
-    }).toThrow('Invalid group(s): invalidGroup')
+    }).toThrow('Invalid group(s): invalidGroup1, invalidGroup2')
   })
 })

--- a/test/validate-groups-configuration.test.ts
+++ b/test/validate-groups-configuration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+
+/**
+ * It is currently not possible to test rules that throw errors (https://github.com/eslint/eslint/issues/13434),
+ * so getting 100% code coverage is not possible only through ESLint's RuleTester as there is no way to catch
+ * the error thrown from `validateGroupsConfiguration`. We can get 100% coverage temporarily with this unit test until that feature is implemented in ESLint.
+ *
+ */
+describe('validate-groups-configuration', () => {
+  it('throws an error when an invalid group is provided', () => {
+    expect(() => {
+      validateGroupsConfiguration(
+        ['predefinedGroup', ['customGroup', 'invalidGroup']],
+        ['predefinedGroup'],
+        ['customGroup'],
+      )
+    }).toThrow('Invalid group(s): invalidGroup')
+  })
+})

--- a/test/validate-groups-configuration.test.ts
+++ b/test/validate-groups-configuration.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from 'vitest'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 
 /**
- * It is currently not possible to test rules that throw errors (https://github.com/eslint/eslint/issues/13434),
- * so getting 100% code coverage is not possible only through ESLint's RuleTester as there is no way to catch
- * the error thrown from `validateGroupsConfiguration`. We can get 100% coverage temporarily with this unit test until that feature is implemented in ESLint.
+ * It is currently not possible to test rules that throw errors
+ * (https://github.com/eslint/eslint/issues/13434), so getting 100% code
+ * coverage is not possible only through ESLint's  RuleTester as there is no way
+ * to catch the error thrown from `validateGroupsConfiguration`. We can get 100%
+ * coverage temporarily with this unit test until that feature is implemented in
+ * ESLint.
  *
  */
 describe('validate-groups-configuration', () => {

--- a/utils/validate-groups-configuration.ts
+++ b/utils/validate-groups-configuration.ts
@@ -1,0 +1,16 @@
+export let validateGroupsConfiguration = (
+  groups: (string[] | string)[],
+  allowedPredefinedGroups: string[],
+  allowedCustomGroups: string[],
+): void => {
+  let allowedGroupsSet = new Set([
+    ...allowedPredefinedGroups,
+    ...allowedCustomGroups,
+  ])
+  let invalidGroups = groups
+    .flat()
+    .filter(group => !allowedGroupsSet.has(group))
+  if (invalidGroups.length) {
+    throw new Error('Invalid groups: ' + invalidGroups.join(', '))
+  }
+}

--- a/utils/validate-groups-configuration.ts
+++ b/utils/validate-groups-configuration.ts
@@ -11,6 +11,6 @@ export let validateGroupsConfiguration = (
     .flat()
     .filter(group => !allowedGroupsSet.has(group))
   if (invalidGroups.length) {
-    throw new Error('Invalid groups: ' + invalidGroups.join(', '))
+    throw new Error('Invalid group(s): ' + invalidGroups.join(', '))
   }
 }


### PR DESCRIPTION
### Description

Resolves (partially) #214. The `sort-classes` rule is not part of this PR as checking if a group entered by the user is part of predefined groups requires a more complex strategy which I believe deserves its own PR.

Checks and validates group configuration for rules using `groups`. Configurations referencing groups that are
- not part of predefined groups
- and not defined in `customGroups`

are very likely user mistakes or typos. These groups are considered invalid and will throw an error, stopping ESLint.

![image](https://github.com/user-attachments/assets/81e166c8-4960-40e6-819f-1de4b206a086)

Affected rules:
- `sort-astro-attributes`
- `sort-imports`
- `sort-interfaces`
- `sort-intersection-types`
- `sort-jsx-props`
- `sort-object-types`
- `sort-object`
- `sort-svelte-attributes`
- `sort-union-types`
- `sort-vue-attributes`

Remaining to do:

- [x] Add tests for each rule affected.

### Additional context

- Some tests have been slightly changed as they were referencing invalid groups. In those cases, invalid groups were removed from the test configuration.

- Ideally, we should be testing that invalid group configurations throw an error for each rule. Unfortunately, it is currently not possible to test rules that throw errors (https://github.com/eslint/eslint/issues/13434 | https://github.com/eslint/eslint/pull/16823). Furthermore, getting 100% code coverage in `validateGroupsConfiguration.ts` is not possible only through ESLint's RuleTester as there is no way to catch
the error thrown. We get 100% coverage temporarily in that file with a simple unit test in `validateGroupsConfiguration.test.ts` until that feature is implemented in ESLint.

### What is the purpose of this pull request?

- [x] New Feature
