### PR TITLE
feat: Make `test:unit` check fail if code coverage is not 100%

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -113,6 +113,9 @@ export default defineConfig({
   ],
   test: {
     coverage: {
+      thresholds: {
+        100: true,
+      },
       all: false,
     },
   },


### PR DESCRIPTION
### Description

This PR forces code coverage to be at 100% for the `test:unit` check to succeed.

![image](https://github.com/user-attachments/assets/15e84cc1-df3d-4f13-89e5-8c81f23c2b4c)


### What is the purpose of this pull request

- [x] Other
