### PR TITLE
fix: `sort-classes`: #234: Place `static-block` after `static-property` in default groups.

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -197,9 +197,9 @@ Allows you to use comments to separate the class members into logical groups. Th
   default:
   ```
   [
-    'static-block',
     'index-signature',
     'static-property',
+    'static-block',
     ['protected-property', 'protected-accessor-property'],
     ['private-property', 'private-accessor-property'],
     ['property', 'accessor-property'],
@@ -312,11 +312,6 @@ Example 2: (The most important group is written in the comments)
 ```ts
 abstract class Example extends BaseExample {
 
-  // 'static-block'
-  static {
-    console.log("I am a static block");
-  }
-
   // 'index-signature'
   [key: string]: any;
 
@@ -325,6 +320,11 @@ abstract class Example extends BaseExample {
 
   // 'declare-protected-static-readonly-property'
   declare protected static readonly value: string;
+
+  // 'static-block'
+  static {
+    console.log("I am a static block");
+  }
 
   // 'protected-abstract-override-readonly-decorated-property'
   @SomeDecorator

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -234,9 +234,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       ignoreCase: true,
       partitionByComment: false,
       groups: [
-        'static-block',
         'index-signature',
         'static-property',
+        'static-block',
         ['protected-property', 'protected-accessor-property'],
         ['private-property', 'private-accessor-property'],
         ['property', 'accessor-property'],
@@ -258,9 +258,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
         let options = complete(context.options.at(0), settings, {
           groups: [
-            'static-block',
             'index-signature',
             'static-property',
+            'static-block',
             ['protected-property', 'protected-accessor-property'],
             ['private-property', 'private-accessor-property'],
             ['property', 'accessor-property'],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -5290,20 +5290,20 @@ describe(ruleName, () => {
 
                 protected protectedProperty
 
+                static {}
+
                 static staticProperty
 
                 [key: string]: string
-
-                static {}
               }
             `,
           output: dedent`
               class Class {
-                static {}
-
                 [key: string]: string
 
                 static staticProperty
+
+                static {}
 
                 protected accessor protectedAccessorProperty
 
@@ -5417,6 +5417,15 @@ describe(ruleName, () => {
               data: {
                 left: 'protectedProperty',
                 leftGroup: 'protected-property',
+                right: 'static',
+                rightGroup: 'static-block',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'static',
+                leftGroup: 'static-block',
                 right: 'staticProperty',
                 rightGroup: 'static-property',
               },
@@ -5428,15 +5437,6 @@ describe(ruleName, () => {
                 leftGroup: 'static-property',
                 right: '[key: string]',
                 rightGroup: 'index-signature',
-              },
-            },
-            {
-              messageId: 'unexpectedClassesGroupOrder',
-              data: {
-                left: '[key: string]',
-                leftGroup: 'index-signature',
-                right: 'static',
-                rightGroup: 'static-block',
               },
             },
           ],


### PR DESCRIPTION
### Description

Bandaid fix for #234.

This PR places `static-block` right after `static-property` in default options. 

Ideally, we should determine if the `static` section depends on some of the class's static properties and sort them accordingly as well, see #239.

### What is the purpose of this pull request?

- [x] Bug fix
