### PR TITLE
fix: `sort-classes` #234, #237, #238, #240, #241, #242, #243, #244, #245, #248, #249 and #250: Dependency related issues

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -2,7 +2,11 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
-import type { SortClassesOptions } from './sort-classes.types'
+import type {
+  SortClassesOptions,
+  Modifier,
+  Selector,
+} from './sort-classes.types'
 
 import {
   getOverloadSignatureGroups,

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -227,10 +227,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           `${isStatic ? 'static ' : ''}${nodeName}`
 
         /**
-         * Function expressions (methods) should not be considered as dependencies
+         * Class methods should not be considered as dependencies
          * because they can be put in any order without causing a reference error.
          */
-        let functionExpressionDependencyNames = new Set(
+        let classMethodsDependencyNames = new Set(
           node.body
             .map(member => {
               if (
@@ -275,7 +275,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                 nodeValue.property.name,
                 isStaticDependency,
               )
-              if (!functionExpressionDependencyNames.has(dependencyName)) {
+              if (!classMethodsDependencyNames.has(dependencyName)) {
                 dependencies.push(
                   getDependencyName(
                     nodeValue.property.name,

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -276,21 +276,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                 isStaticDependency,
               )
               if (!classMethodsDependencyNames.has(dependencyName)) {
-                dependencies.push(
-                  getDependencyName(
-                    nodeValue.property.name,
-                    isStaticDependency,
-                  ),
-                )
+                dependencies.push(dependencyName)
               }
-            }
-
-            if (
-              nodeValue.type === 'ExpressionStatement' ||
-              nodeValue.type === 'TSAsExpression' ||
-              nodeValue.type === 'TSTypeAssertion'
-            ) {
-              traverseNode(nodeValue.expression)
             }
 
             if (nodeValue.type === 'Property') {
@@ -302,6 +289,13 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               traverseNode(nodeValue.test)
               traverseNode(nodeValue.consequent)
               traverseNode(nodeValue.alternate)
+            }
+
+            if (
+              'expression' in nodeValue &&
+              typeof nodeValue.expression !== 'boolean'
+            ) {
+              traverseNode(nodeValue.expression)
             }
 
             if ('object' in nodeValue) {

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -285,7 +285,11 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               }
             }
 
-            if (nodeValue.type === 'ExpressionStatement') {
+            if (
+              nodeValue.type === 'ExpressionStatement' ||
+              nodeValue.type === 'TSAsExpression' ||
+              nodeValue.type === 'TSTypeAssertion'
+            ) {
               traverseNode(nodeValue.expression)
             }
 
@@ -298,10 +302,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               traverseNode(nodeValue.test)
               traverseNode(nodeValue.consequent)
               traverseNode(nodeValue.alternate)
-            }
-
-            if (nodeValue.type === 'TSAsExpression') {
-              traverseNode(nodeValue.expression)
             }
 
             if ('object' in nodeValue) {

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -300,6 +300,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               traverseNode(nodeValue.alternate)
             }
 
+            if (nodeValue.type === 'TSAsExpression') {
+              traverseNode(nodeValue.expression)
+            }
+
             if ('object' in nodeValue) {
               traverseNode(nodeValue.object)
             }

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -294,6 +294,12 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               traverseNode(nodeValue.value)
             }
 
+            if (nodeValue.type === 'ConditionalExpression') {
+              traverseNode(nodeValue.test)
+              traverseNode(nodeValue.consequent)
+              traverseNode(nodeValue.alternate)
+            }
+
             if ('object' in nodeValue) {
               traverseNode(nodeValue.object)
             }

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -1,12 +1,8 @@
 import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type {
-  SortClassesOptions,
-  Modifier,
-  Selector,
-} from './sort-classes.types'
-import type { SortingNode } from '../typings'
+import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
+import type { SortClassesOptions } from './sort-classes.types'
 
 import {
   getOverloadSignatureGroups,
@@ -19,6 +15,7 @@ import {
   customGroupNameJsonSchema,
   customGroupSortJsonSchema,
 } from './sort-classes.types'
+import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -27,13 +24,11 @@ import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID = 'unexpectedClassesGroupOrder' | 'unexpectedClassesOrder'
 
@@ -222,19 +217,89 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
         } as const)
 
         let sourceCode = getSourceCode(context)
+        let className = node.parent.id?.name
+
+        let getDependencyName = (nodeName: string, isStatic: boolean) =>
+          `${isStatic ? 'static ' : ''}${nodeName}`
+
+        /**
+         * Function expressions (methods) should not be considered as dependencies
+         * because they can be put in any order without causing a reference error.
+         */
+        let functionExpressionDependencyNames = new Set(
+          node.body
+            .map(member => {
+              if (
+                (member.type === 'MethodDefinition' ||
+                  member.type === 'TSAbstractMethodDefinition') &&
+                'name' in member.key
+              ) {
+                return getDependencyName(member.key.name, member.static)
+              }
+              return null
+            })
+            .filter(m => m !== null),
+        )
 
         let extractDependencies = (
-          expression: TSESTree.Expression,
+          expression: TSESTree.StaticBlock | TSESTree.Expression,
+          isMemberStatic: boolean,
         ): string[] => {
           let dependencies: string[] = []
 
           let checkNode = (nodeValue: TSESTree.Node) => {
+            /**
+             * No need to check the body of functions and arrow functions
+             */
+            if (
+              nodeValue.type === 'ArrowFunctionExpression' ||
+              nodeValue.type === 'FunctionExpression'
+            ) {
+              return
+            }
+
             if (
               nodeValue.type === 'MemberExpression' &&
-              nodeValue.object.type === 'ThisExpression' &&
+              (nodeValue.object.type === 'ThisExpression' ||
+                (nodeValue.object.type === 'Identifier' &&
+                  nodeValue.object.name === className)) &&
               nodeValue.property.type === 'Identifier'
             ) {
-              dependencies.push(nodeValue.property.name)
+              let isStaticDependency =
+                isMemberStatic || nodeValue.object.type === 'Identifier'
+              let dependencyName = getDependencyName(
+                nodeValue.property.name,
+                isStaticDependency,
+              )
+              if (!functionExpressionDependencyNames.has(dependencyName)) {
+                dependencies.push(
+                  getDependencyName(
+                    nodeValue.property.name,
+                    isStaticDependency,
+                  ),
+                )
+              }
+            }
+
+            if (nodeValue.type === 'ExpressionStatement') {
+              traverseNode(nodeValue.expression)
+            }
+
+            if (nodeValue.type === 'Property') {
+              traverseNode(nodeValue.key)
+              traverseNode(nodeValue.value)
+            }
+
+            if ('object' in nodeValue) {
+              traverseNode(nodeValue.object)
+            }
+
+            if ('callee' in nodeValue) {
+              traverseNode(nodeValue.callee)
+            }
+
+            if ('init' in nodeValue && nodeValue.init) {
+              traverseNode(nodeValue.init)
             }
 
             if ('body' in nodeValue && nodeValue.body) {
@@ -255,8 +320,20 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                 .forEach(traverseNode)
             }
 
+            if ('argument' in nodeValue && nodeValue.argument) {
+              traverseNode(nodeValue.argument)
+            }
+
             if ('arguments' in nodeValue) {
               nodeValue.arguments.forEach(traverseNode)
+            }
+
+            if ('declarations' in nodeValue) {
+              nodeValue.declarations.forEach(traverseNode)
+            }
+
+            if ('properties' in nodeValue) {
+              nodeValue.properties.forEach(traverseNode)
             }
           }
 
@@ -274,8 +351,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
         let overloadSignatureGroups = getOverloadSignatureGroups(node.body)
 
-        let formattedNodes: SortingNode[][] = node.body.reduce(
-          (accumulator: SortingNode[][], member) => {
+        let formattedNodes: SortingNodeWithDependencies[][] = node.body.reduce(
+          (accumulator: SortingNodeWithDependencies[][], member) => {
             let comment = getCommentBefore(member, sourceCode)
 
             if (
@@ -389,6 +466,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               selectors.push('index-signature')
             } else if (member.type === 'StaticBlock') {
               selectors.push('static-block')
+
+              dependencies = extractDependencies(member, true)
             } else if (
               member.type === 'AccessorProperty' ||
               member.type === 'TSAbstractAccessorProperty'
@@ -458,15 +537,24 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                 modifiers.push('optional')
               }
 
-              if (
+              let isFunctionProperty =
                 member.value?.type === 'ArrowFunctionExpression' ||
                 member.value?.type === 'FunctionExpression'
-              ) {
+              if (isFunctionProperty) {
                 selectors.push('function-property')
               }
 
               selectors.push('property')
+
+              if (
+                member.type === 'PropertyDefinition' &&
+                member.value &&
+                !isFunctionProperty
+              ) {
+                dependencies = extractDependencies(member.value, member.static)
+              }
             }
+
             for (let officialGroup of generateOfficialGroups(
               modifiers,
               selectors,
@@ -500,17 +588,13 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               })
             }
 
-            if (member.type === 'PropertyDefinition' && member.value) {
-              dependencies = extractDependencies(member.value)
-            }
-
             // Members belonging to the same overload signature group should have the same size in order to keep line-length sorting between them consistent.
             // It is unclear what should be considered the size of an overload signature group. Take the size of the implementation by default.
             let overloadSignatureGroupMember = overloadSignatureGroups
               .find(overloadSignatures => overloadSignatures.includes(member))
               ?.at(-1)
 
-            let value: SortingNode = {
+            let value: SortingNodeWithDependencies = {
               size: overloadSignatureGroupMember
                 ? rangeToDiff(overloadSignatureGroupMember.range)
                 : rangeToDiff(member.range),
@@ -518,6 +602,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               node: member,
               dependencies,
               name,
+              dependencyName: getDependencyName(
+                name,
+                modifiers.includes('static'),
+              ),
             }
 
             accumulator.at(-1)!.push(value)
@@ -528,6 +616,48 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
         )
 
         for (let nodes of formattedNodes) {
+          let nodesByNonIgnoredGroupNumber: {
+            [key: number]: SortingNodeWithDependencies[]
+          } = {}
+          let ignoredNodeIndices: number[] = []
+          for (let [index, sortingNode] of nodes.entries()) {
+            let groupNum = getGroupNumber(options.groups, sortingNode)
+            if (groupNum === options.groups.length) {
+              ignoredNodeIndices.push(index)
+              continue
+            }
+            nodesByNonIgnoredGroupNumber[groupNum] =
+              nodesByNonIgnoredGroupNumber[groupNum] ?? []
+            nodesByNonIgnoredGroupNumber[groupNum].push(sortingNode)
+          }
+
+          let sortedNodes: SortingNodeWithDependencies[] = []
+          for (let groupNumber of Object.keys(
+            nodesByNonIgnoredGroupNumber,
+          ).sort((a, b) => Number(a) - Number(b))) {
+            let compareOptions = getCompareOptions(options, Number(groupNumber))
+            if (!compareOptions) {
+              // Do not sort this group
+              sortedNodes.push(
+                ...nodesByNonIgnoredGroupNumber[Number(groupNumber)],
+              )
+            } else {
+              sortedNodes.push(
+                ...sortNodes(
+                  nodesByNonIgnoredGroupNumber[Number(groupNumber)],
+                  compareOptions,
+                ),
+              )
+            }
+          }
+
+          // Add ignored nodes at the same position as they were before linting
+          for (let ignoredIndex of ignoredNodeIndices) {
+            sortedNodes.splice(ignoredIndex, 0, nodes[ignoredIndex])
+          }
+
+          sortedNodes = sortNodesByDependencies(sortedNodes)
+
           pairwise(nodes, (left, right) => {
             let leftNum = getGroupNumber(options.groups, left)
             let rightNum = getGroupNumber(options.groups, right)
@@ -536,21 +666,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             let isLeftOrRightIgnored =
               leftNum === options.groups.length ||
               rightNum === options.groups.length
-            if (isLeftOrRightIgnored) {
-              return
-            }
 
-            let compareValue = false
-            if (leftNum > rightNum) {
-              compareValue = true
-            } else if (leftNum === rightNum) {
-              let compareOptions = getCompareOptions(options, leftNum)
-              compareValue = compareOptions
-                ? isPositive(compare(left, right, compareOptions))
-                : false
-            }
-
-            if (compareValue) {
+            let indexOfLeft = sortedNodes.indexOf(left)
+            let indexOfRight = sortedNodes.indexOf(right)
+            if (!isLeftOrRightIgnored && indexOfLeft > indexOfRight) {
               context.report({
                 messageId:
                   leftNum !== rightNum
@@ -563,54 +682,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                   rightGroup: right.group,
                 },
                 node: right.node,
-                fix: (fixer: TSESLint.RuleFixer) => {
-                  let nodesByNonIgnoredGroupNumber: {
-                    [key: number]: SortingNode[]
-                  } = {}
-                  let ignoredNodeIndices: number[] = []
-                  for (let [index, sortingNode] of nodes.entries()) {
-                    let groupNum = getGroupNumber(options.groups, sortingNode)
-                    if (groupNum === options.groups.length) {
-                      ignoredNodeIndices.push(index)
-                      continue
-                    }
-                    nodesByNonIgnoredGroupNumber[groupNum] =
-                      nodesByNonIgnoredGroupNumber[groupNum] ?? []
-                    nodesByNonIgnoredGroupNumber[groupNum].push(sortingNode)
-                  }
-
-                  let sortedNodes: SortingNode[] = []
-                  for (let groupNumber of Object.keys(
-                    nodesByNonIgnoredGroupNumber,
-                  ).sort((a, b) => Number(a) - Number(b))) {
-                    let compareOptions = getCompareOptions(
-                      options,
-                      Number(groupNumber),
-                    )
-                    if (!compareOptions) {
-                      // Do not sort this group
-                      sortedNodes.push(
-                        ...nodesByNonIgnoredGroupNumber[Number(groupNumber)],
-                      )
-                    } else {
-                      sortedNodes.push(
-                        ...sortNodes(
-                          nodesByNonIgnoredGroupNumber[Number(groupNumber)],
-                          compareOptions,
-                        ),
-                      )
-                    }
-                  }
-
-                  // Add ignored nodes at the same position as they were before linting
-                  for (let ignoredIndex of ignoredNodeIndices) {
-                    sortedNodes.splice(ignoredIndex, 0, nodes[ignoredIndex])
-                  }
-
-                  return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                fix: (fixer: TSESLint.RuleFixer) =>
+                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
                     partitionComment: options.partitionByComment,
-                  })
-                },
+                  }),
               })
             }
           })

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -1,12 +1,12 @@
 import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 import type {
   SortClassesOptions,
   Modifier,
   Selector,
 } from './sort-classes.types'
+import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
   getOverloadSignatureGroups,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -5,8 +5,8 @@ import { minimatch } from 'minimatch'
 
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
-import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { isPartitionComment } from '../utils/is-partition-comment'
 import { getCommentBefore } from '../utils/get-comment-before'
 import { createEslintRule } from '../utils/create-eslint-rule'

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3169,13 +3169,13 @@ describe(ruleName, () => {
           valid: [
             {
               code: dedent`
-            class Class {
-              b = 1
-              a = this.b as any
-              static b = 1
-              static a = this.b as any
-            }
-          `,
+                class Class {
+                  b = 1
+                  a = this.b as any
+                  static b = 1
+                  static a = this.b as any
+                }
+              `,
               options: [
                 {
                   ...options,
@@ -3185,13 +3185,55 @@ describe(ruleName, () => {
             },
             {
               code: dedent`
-            class Class {
-              b = 1
-              a = this.b as any
-              static b = 1
-              static a = Class.b as any
-            }
-          `,
+                class Class {
+                  b = 1
+                  a = this.b as any
+                  static b = 1
+                  static a = Class.b as any
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects dependencies in type assertion expressions`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                class Class {
+                  b = 1
+                  a = <any>this.b
+                  static b = 1
+                  static a = <any>this.b
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  b = 1
+                  a = <any>this.b
+                  static b = 1
+                  static a = <any>Class.b
+                }
+              `,
               options: [
                 {
                   ...options,

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3217,6 +3217,48 @@ describe(ruleName, () => {
       })
 
       ruleTester.run(
+        `${ruleName}(${type}) detects spread elements dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               class Class {
+                  b = {}
+                  a = {...this.b}
+                  static b = {}
+                  static a = {...this.b}
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                  b = {}
+                  a = {...this.b}
+                  static b = {}
+                  static a = {...Class.b}
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}) detects dependencies in conditional expressions`,
         rule,
         {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3057,6 +3057,112 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}(${type}) detects dependencies in conditional expressions`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+            class Class {
+              b = 1;
+              a = this.b ? 1 : 0;
+              static b = 1;
+              static a = this.b ? 1 : 0;
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+            class Class {
+              b = 1;
+              a = this.b ? 1 : 0;
+              static b = 1;
+              static a = Class.b ? 1 : 0;
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+            class Class {
+              b = 1;
+              a = someCondition ? this.b : 0;
+              static b = 1;
+              static a = someCondition ? this.b : 0;
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+            class Class {
+              b = 1;
+              a = someCondition ? this.b : 0;
+              static b = 1;
+              static a = someCondition ? Class.b : 0;
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+            class Class {
+              b = 1;
+              a = someCondition ? 0 : this.b;
+              static b = 1;
+              static a = someCondition ? 0 : this.b;
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+            class Class {
+              b = 1;
+              a = someCondition ? 0 : this.b;
+              static b = 1;
+              static a = someCondition ? 0 : Class.b;
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}) separates static from non-static dependencies`,
         rule,
         {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3057,6 +3057,78 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}(${type}) detects optional chained dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               class Class {
+                  b = new Subject()
+                  a = this.b?.asObservable()
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                  b = new WhateverObject()
+                  a = this.b?.bProperty
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects non-null asserted dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               class Class {
+                  b = new Subject()
+                  a = this.b!.asObservable()
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                  b = new WhateverObject()
+                  a = this.b!.bProperty
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}) detects dependencies in conditional expressions`,
         rule,
         {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3163,6 +3163,48 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}(${type}) detects dependencies in 'as' expressions`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+            class Class {
+              b = 1
+              a = this.b as any
+              static b = 1
+              static a = this.b as any
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+            class Class {
+              b = 1
+              a = this.b as any
+              static b = 1
+              static a = Class.b as any
+            }
+          `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}) separates static from non-static dependencies`,
         rule,
         {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3016,11 +3016,30 @@ describe(ruleName, () => {
                class Class {
                   b = new Subject()
                   a = this.b.asObservable()
+                  static b = new Subject()
+                  static a = this.b.asObservable()
                }
               `,
               options: [
                 {
                   ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                  b = new Subject()
+                  a = this.b.asObservable()
+                  static b = new Subject()
+                  static a = Class.b.asObservable()
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
                 },
               ],
             },
@@ -3029,11 +3048,30 @@ describe(ruleName, () => {
                class Class {
                   b = new WhateverObject()
                   a = this.b.bProperty
+                  static b = new WhateverObject()
+                  static a = this.b.bProperty
                }
               `,
               options: [
                 {
                   ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                  b = new WhateverObject()
+                  a = this.b.bProperty
+                  static b = new WhateverObject()
+                  static a = Class.b.bProperty
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
                 },
               ],
             },
@@ -3066,24 +3104,30 @@ describe(ruleName, () => {
                class Class {
                   b = new Subject()
                   a = this.b?.asObservable()
+                  static b = new Subject()
+                  static a = this.b?.asObservable()
                }
               `,
               options: [
                 {
                   ...options,
+                  groups: ['property'],
                 },
               ],
             },
             {
               code: dedent`
                class Class {
-                  b = new WhateverObject()
-                  a = this.b?.bProperty
+                  b = new Subject()
+                  a = this.b?.asObservable()
+                  static b = new Subject()
+                  static a = Class.b?.asObservable()
                }
               `,
               options: [
                 {
                   ...options,
+                  groups: ['property'],
                 },
               ],
             },
@@ -3102,24 +3146,30 @@ describe(ruleName, () => {
                class Class {
                   b = new Subject()
                   a = this.b!.asObservable()
+                  static b = new Subject()
+                  static a = this.b!.asObservable()
                }
               `,
               options: [
                 {
                   ...options,
+                  groups: ['property'],
                 },
               ],
             },
             {
               code: dedent`
                class Class {
-                  b = new WhateverObject()
-                  a = this.b!.bProperty
+                  b = new Subject()
+                  a = this.b!.asObservable()
+                  static b = new Subject()
+                  static a = Class.b!.asObservable()
                }
               `,
               options: [
                 {
                   ...options,
+                  groups: ['property'],
                 },
               ],
             },
@@ -3127,6 +3177,44 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      ruleTester.run(`${ruleName}(${type}) detects unary dependencies`, rule, {
+        valid: [
+          {
+            code: dedent`
+               class Class {
+                  b = true
+                  a = !this.b
+                  static b = true
+                  static a = !this.b
+               }
+              `,
+            options: [
+              {
+                ...options,
+                groups: ['property'],
+              },
+            ],
+          },
+          {
+            code: dedent`
+               class Class {
+                  b = true
+                  a = !this.b
+                  static b = true
+                  static a = !Class.b
+               }
+              `,
+            options: [
+              {
+                ...options,
+                groups: ['property'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      })
 
       ruleTester.run(
         `${ruleName}(${type}) detects dependencies in conditional expressions`,

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -493,7 +493,7 @@ describe(ruleName, () => {
       },
     )
 
-    describe('index-signature modifiers priority', () => {
+    describe(`${ruleName}(${type}): index-signature modifiers priority`, () => {
       ruleTester.run(
         `${ruleName}(${type}): prioritize static over readonly`,
         rule,
@@ -544,7 +544,7 @@ describe(ruleName, () => {
       )
     })
 
-    describe('method selectors priority', () => {
+    describe(`${ruleName}(${type}): method selectors priority`, () => {
       ruleTester.run(
         `${ruleName}(${type}): prioritize constructor over method`,
         rule,
@@ -681,7 +681,7 @@ describe(ruleName, () => {
       )
     })
 
-    describe('method modifiers priority', () => {
+    describe(`${ruleName}(${type}): method modifiers priority`, () => {
       ruleTester.run(
         `${ruleName}(${type}): prioritize static over override`,
         rule,
@@ -920,7 +920,7 @@ describe(ruleName, () => {
       }
     })
 
-    describe('accessor modifiers priority', () => {
+    describe(`${ruleName}(${type}): accessor modifiers priority`, () => {
       ruleTester.run(
         `${ruleName}(${type}): prioritize static over override`,
         rule,
@@ -1122,7 +1122,7 @@ describe(ruleName, () => {
       }
     })
 
-    describe('property selectors priority', () => {
+    describe(`${ruleName}(${type}): property selectors priority`, () => {
       ruleTester.run(
         `${ruleName}(${type}): prioritize function property over property`,
         rule,
@@ -1214,7 +1214,7 @@ describe(ruleName, () => {
       )
     })
 
-    describe('property modifiers priority', () => {
+    describe(`${ruleName}(${type}): property modifiers priority`, () => {
       ruleTester.run(
         `${ruleName}(${type}): prioritize static over declare`,
         rule,
@@ -2589,278 +2589,699 @@ describe(ruleName, () => {
       },
     )
 
-    ruleTester.run(
-      `${ruleName}(${type}): works with left and right dependencies`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              class Class {
-                left = 'left'
-                right = 'right'
-
-                aaa = this.left + this.right
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                condition1 = true
-                condition2 = false
-
-                result = this.condition1 && this.condition2
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [
-          {
-            code: dedent`
-              class Class {
-                aaa = this.left + this.right
-
-                left = 'left'
-
-                right = 'right'
-              }
-            `,
-            output: dedent`
-              class Class {
-                left = 'left'
-
-                right = 'right'
-
-                aaa = this.left + this.right
-              }
-            `,
-            options: [options],
-            errors: [
-              {
-                messageId: 'unexpectedClassesOrder',
-                data: {
-                  left: 'aaa',
-                  right: 'left',
+    describe(`${ruleName}(${type}): detects dependencies`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}) ignores function expression dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                class Class {
+                  a = this.b()
+                  static a = this.b()
+                  b() {
+                    return 1
+                  }
+                  static b() {
+                    return 1
+                  }
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
                 },
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): works with body dependencies`, rule, {
-      valid: [
-        {
-          code: dedent`
-              class Class {
-                a = 10
-
-                method = function() {
-                  const b = this.a + 20;
-                  return b;
-                }
-              }
-            `,
-          options: [options],
-        },
-        {
-          code: dedent`
-              class Class {
-                a = 10
-
-                method = () => {
-                  const b = this.a + 20;
-                  return b;
-                }
-              }
-            `,
-          options: [options],
-        },
-        {
-          code: dedent`
-              class Class {
-                a = 10
-                b = 20
-
-                method() {
-                  {
-                    const c = this.a + this.b;
-                    console.log(c);
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  a = this.b()
+                  static a = Class.b()
+                  b() {
+                    return 1
+                  }
+                  static b() {
+                    return 1
                   }
                 }
-              }
-            `,
-          options: [options],
-        },
-        {
-          code: dedent`
-              class Class {
-                a = 10
-                b = this.a + 20
-
-                method() {
-                  return this.b;
-                }
-              }
-            `,
-          options: [options],
-        },
-      ],
-      invalid: [
-        {
-          code: dedent`
-            class Class {
-              method = function() {
-                const b = this.a + 20;
-                return b;
-              }
-
-              a = 10
-            }
-          `,
-          output: dedent`
-            class Class {
-              a = 10
-
-              method = function() {
-                const b = this.a + 20;
-                return b;
-              }
-            }
-          `,
-          options: [options],
-          errors: [
-            {
-              messageId: 'unexpectedClassesOrder',
-              data: {
-                left: 'method',
-                right: 'a',
-              },
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
+                },
+              ],
             },
-          ],
-        },
-        {
-          code: dedent`
-              class Class {
-                method = () => {
-                  const b = this.a + 20;
-                  return b;
-                }
-
-                a = 10
-              }
-            `,
-          output: dedent`
-              class Class {
-                a = 10
-
-                method = () => {
-                  const b = this.a + 20;
-                  return b;
-                }
-              }
-            `,
-          options: [options],
-          errors: [
             {
-              messageId: 'unexpectedClassesOrder',
-              data: {
-                left: 'method',
-                right: 'a',
-              },
-            },
-          ],
-        },
-        {
-          code: dedent`
-              class Class {
-                method() {
-                  {
-                    const c = this.a + this.b;
-                    console.log(c);
+              code: dedent`
+                class Class {
+                  a = [1].map(this.b)
+                  static a = [1].map(this.b)
+                  b() {
+                    return 1
+                  }
+                  static b() {
+                    return 1
                   }
                 }
-
-                a = 10
-
-                b = 20
-              }
-            `,
-          output: dedent`
-              class Class {
-                a = 10
-
-                b = 20
-
-                method() {
-                  {
-                    const c = this.a + this.b;
-                    console.log(c);
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
+                },
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  a = [1].map(this.b)
+                  static a = [1].map(Class.b)
+                  b() {
+                    return 1
+                  }
+                  static b() {
+                    return 1
                   }
                 }
-              }
-            `,
-          options: [options],
-          errors: [
-            {
-              messageId: 'unexpectedClassesGroupOrder',
-              data: {
-                left: 'method',
-                leftGroup: 'method',
-                right: 'a',
-                rightGroup: 'property',
-              },
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
+                },
+              ],
             },
           ],
+          invalid: [],
         },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects arrow function expression dependencies`,
+        rule,
         {
-          code: dedent`
-              class Class {
-                method() {
-                  return this.b;
-                }
-
-                b = this.a + 20
-
-                a = 10
-              }
-            `,
-          output: dedent`
-              class Class {
-                a = 10
-
-                b = this.a + 20
-
-                method() {
-                  return this.b;
-                }
-              }
-            `,
-          options: [options],
-          errors: [
+          valid: [
             {
-              messageId: 'unexpectedClassesGroupOrder',
-              data: {
-                left: 'method',
-                leftGroup: 'method',
-                right: 'b',
-                rightGroup: 'property',
-              },
+              code: dedent`
+                class Class {
+                  b = () => {
+                    return 1
+                  }
+                  a = this.b()
+                  static b = () => {
+                    return 1
+                  }
+                  static a = this.b()
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
+                },
+              ],
             },
             {
-              messageId: 'unexpectedClassesOrder',
-              data: {
-                left: 'b',
-                right: 'a',
-              },
+              code: dedent`
+                class Class {
+                  b = () => {
+                    return 1
+                  }
+                  a = [1].map(this.b)
+                  static b = () => {
+                    return 1
+                  }
+                  static a = [1].map(this.b)
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
+                },
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  b = () => {
+                    return 1
+                  }
+                  a = [1].map(this.b)
+                  static b = () => {
+                    return 1
+                  }
+                  static a = [1].map(Class.b)
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects static block dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                class Class {
+                  static {
+                    return true || OtherClass.z;
+                  }
+                  static z = true;
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['static-block', 'static-property']],
+                },
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  static {
+                    const method = () => {
+                      return (Class.z || true) && (false || this.z);
+                    };
+                    method();
+                  }
+                  static z = true;
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['static-block', 'static-property']],
+                },
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  static z = true;
+                  static {
+                    const method = () => {
+                      return (Class.z || true) && (false || this.z);
+                    };
+                    method();
+                    return (Class.z || true) && (false || this.z);
+                  }
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['static-block', 'static-property']],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects property expression dependencies`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                class Class {
+                  static e = 10 + this.c
+
+                  d = this.b
+
+                  static a = 10 + OtherClass.z
+
+                  b = 10 + Class.z
+
+                  static c = 10 + this.z
+
+                  static z = 1
+                }
+              `,
+              output: dedent`
+                class Class {
+                  static a = 10 + OtherClass.z
+
+                  static z = 1
+
+                  b = 10 + Class.z
+
+                  static c = 10 + this.z
+
+                  d = this.b
+
+                  static e = 10 + this.c
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'e',
+                    right: 'd',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'd',
+                    right: 'a',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'c',
+                    right: 'z',
+                  },
+                },
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  a = this.c
+                  b = 10
+                  c = 10
+                }
+              `,
+              output: dedent`
+                class Class {
+                  c = 10
+                  a = this.c
+                  b = 10
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'c',
+                  },
+                },
+              ],
             },
           ],
         },
-      ],
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects dependencies in objects`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               class Class {
+                 b = 1
+                 a = {
+                   b: this.b
+                 }
+                 static b = 1
+                 static a = {
+                   b: this.b
+                 }
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                 b = 1
+                 a = {
+                   b: this.b
+                 }
+                 static b = 1
+                 static a = {
+                   b: Class.b
+                 }
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                 b = 1
+                 a = {
+                   [this.b]: 1
+                 }
+                 static b = 1
+                 static a = {
+                   [this.b]: A
+                 }
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                 b = 1
+                 a = {
+                   [this.b]: 1
+                 }
+                 static b = 1
+                 static a = {
+                   [Class.b]: 1
+                 }
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects nested property references`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               class Class {
+                  b = new Subject()
+                  a = this.b.asObservable()
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                  b = new WhateverObject()
+                  a = this.b.bProperty
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                  static c = 1
+                  static b = new WhateverObject(this.c)
+                  static a = Class.b.bMethod().anotherNestedMethod(this.c).finalMethod()
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) separates static from non-static dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              export class Class{
+                b = 1;
+                a = this.b;
+                static b = 1;
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+          ],
+          invalid: [
+            {
+              code: dedent`
+                class Class {
+                  static a = Class.c
+                  b = this.c
+                  static b = this.c
+                  c = 10
+                  static c = 10
+                }
+              `,
+              output: dedent`
+                class Class {
+                  static c = 10
+                  static a = Class.c
+                  c = 10
+                  b = this.c
+                  static b = this.c
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'c',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'c',
+                    right: 'c',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) detects circular dependencies`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                class Class {
+                  b = this.e
+                  a
+                  e = this.g
+                  f
+                  g = this.b
+                }
+              `,
+              output: dedent`
+                class Class {
+                  a
+                  g = this.b
+                  e = this.g
+                  b = this.e
+                  f
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'f',
+                    right: 'g',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}) ignores function body dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                class Class {
+                  static a = true;
+
+                  static b() {
+                     return this.a || Class.a
+                  }
+
+                  static c = () => {
+                     return this.a || Class.a
+                  }
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['method', 'property']],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over group configuration`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                class Class {
+                  public b = 1;
+                  private a = this.b;
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['private-property', 'public-property'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): works with left and right dependencies`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              class Class {
+                left = 'left'
+                right = 'right'
+
+                aaa = this.left + this.right
+              }
+            `,
+              options: [options],
+            },
+          ],
+          invalid: [
+            {
+              code: dedent`
+              class Class {
+                aaa = this.left + this.right
+
+                left = 'left'
+
+                right = 'right'
+              }
+            `,
+              output: dedent`
+              class Class {
+                left = 'left'
+
+                right = 'right'
+
+                aaa = this.left + this.right
+              }
+            `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'aaa',
+                    right: 'left',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
     })
 
     ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
@@ -4032,17 +4453,6 @@ describe(ruleName, () => {
             `,
             options: [options],
           },
-          {
-            code: dedent`
-              class Class {
-                condition1 = true
-                condition2 = false
-
-                result = this.condition1 && this.condition2
-              }
-            `,
-            options: [options],
-          },
         ],
         invalid: [
           {
@@ -4078,217 +4488,6 @@ describe(ruleName, () => {
         ],
       },
     )
-
-    ruleTester.run(`${ruleName}(${type}): works with body dependencies`, rule, {
-      valid: [
-        {
-          code: dedent`
-              class Class {
-                a = 10
-
-                method = function() {
-                  const b = this.a + 20;
-                  return b;
-                }
-              }
-            `,
-          options: [options],
-        },
-        {
-          code: dedent`
-              class Class {
-                a = 10
-
-                method = () => {
-                  const b = this.a + 20;
-                  return b;
-                }
-              }
-            `,
-          options: [options],
-        },
-        {
-          code: dedent`
-              class Class {
-                a = 10
-                b = 20
-
-                method() {
-                  {
-                    const c = this.a + this.b;
-                    console.log(c);
-                  }
-                }
-              }
-            `,
-          options: [options],
-        },
-        {
-          code: dedent`
-              class Class {
-                a = 10
-                b = this.a + 20
-
-                method() {
-                  return this.b;
-                }
-              }
-            `,
-          options: [options],
-        },
-      ],
-      invalid: [
-        {
-          code: dedent`
-            class Class {
-              method = function() {
-                const b = this.a + 20;
-                return b;
-              }
-
-              a = 10
-            }
-          `,
-          output: dedent`
-            class Class {
-              a = 10
-
-              method = function() {
-                const b = this.a + 20;
-                return b;
-              }
-            }
-          `,
-          options: [options],
-          errors: [
-            {
-              messageId: 'unexpectedClassesOrder',
-              data: {
-                left: 'method',
-                right: 'a',
-              },
-            },
-          ],
-        },
-        {
-          code: dedent`
-              class Class {
-                method = () => {
-                  const b = this.a + 20;
-                  return b;
-                }
-
-                a = 10
-              }
-            `,
-          output: dedent`
-              class Class {
-                a = 10
-
-                method = () => {
-                  const b = this.a + 20;
-                  return b;
-                }
-              }
-            `,
-          options: [options],
-          errors: [
-            {
-              messageId: 'unexpectedClassesOrder',
-              data: {
-                left: 'method',
-                right: 'a',
-              },
-            },
-          ],
-        },
-        {
-          code: dedent`
-              class Class {
-                method() {
-                  {
-                    const c = this.a + this.b;
-                    console.log(c);
-                  }
-                }
-
-                a = 10
-
-                b = 20
-              }
-            `,
-          output: dedent`
-              class Class {
-                a = 10
-
-                b = 20
-
-                method() {
-                  {
-                    const c = this.a + this.b;
-                    console.log(c);
-                  }
-                }
-              }
-            `,
-          options: [options],
-          errors: [
-            {
-              messageId: 'unexpectedClassesGroupOrder',
-              data: {
-                left: 'method',
-                leftGroup: 'method',
-                right: 'a',
-                rightGroup: 'property',
-              },
-            },
-          ],
-        },
-        {
-          code: dedent`
-              class Class {
-                method() {
-                  return this.b;
-                }
-
-                b = this.a + 20
-
-                a = 10
-              }
-            `,
-          output: dedent`
-              class Class {
-                a = 10
-
-                b = this.a + 20
-
-                method() {
-                  return this.b;
-                }
-              }
-            `,
-          options: [options],
-          errors: [
-            {
-              messageId: 'unexpectedClassesGroupOrder',
-              data: {
-                left: 'method',
-                leftGroup: 'method',
-                right: 'b',
-                rightGroup: 'property',
-              },
-            },
-            {
-              messageId: 'unexpectedClassesOrder',
-              data: {
-                left: 'b',
-                right: 'a',
-              },
-            },
-          ],
-        },
-      ],
-    })
 
     ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
       valid: [],

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1827,6 +1827,85 @@ describe(ruleName, () => {
             },
           ],
         },
+        {
+          code: dedent`
+            enum Enum {
+              A = Enum.C,
+              B = 10,
+              C = 10,
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              C = 10,
+              A = Enum.C,
+              B = 10,
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'B',
+                right: 'C',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${ruleName}: detects circular dependencies`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = F,
+              C = 'C',
+              D = B,
+              E = 'E',
+              F = D
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              A = 'A',
+              D = B,
+              F = D,
+              B = F,
+              C = 'C',
+              E = 'E'
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'C',
+                right: 'D',
+              },
+            },
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'E',
+                right: 'F',
+              },
+            },
+          ],
+        },
       ],
     })
   })

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -257,6 +257,25 @@ describe(ruleName, () => {
               },
             ],
           },
+          {
+            code: dedent`
+              const a = c,
+                    b = 10,
+                    c = 10;
+            `,
+            output: dedent`
+              const c = 10,
+                    a = c,
+                    b = 10;
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedVariableDeclarationsOrder',
+                data: { left: 'b', right: 'c' },
+              },
+            ],
+          },
         ],
       },
     )
@@ -500,6 +519,45 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedVariableDeclarationsOrder',
                 data: { left: 'value', right: 'getValue' },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): detects circular dependencies`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              const a,
+                    b = f + 1,
+                    c,
+                    d = b + 1,
+                    e,
+                    f = d + 1
+            `,
+            output: dedent`
+              const a,
+                    d = b + 1,
+                    f = d + 1,
+                    b = f + 1,
+                    c,
+                    e
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedVariableDeclarationsOrder',
+                data: { left: 'c', right: 'd' },
+              },
+              {
+                messageId: 'unexpectedVariableDeclarationsOrder',
+                data: { left: 'e', right: 'f' },
               },
             ],
           },

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -2,7 +2,6 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
   hasMultipleImportDeclarations?: boolean
-  dependencies?: string[]
   group?: string
   name: string
   size: number

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -35,12 +35,6 @@ export let compare = (
   b: SortingNode,
   options: CompareOptions,
 ): number => {
-  if (b.dependencies?.includes(a.name)) {
-    return -1
-  } else if (a.dependencies?.includes(b.name)) {
-    return 1
-  }
-
   let orderCoefficient = options.order === 'asc' ? 1 : -1
   let sortingFunction: (a: SortingNode, b: SortingNode) => number
 

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -1,0 +1,50 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+import type { SortingNode } from '../typings'
+
+export interface SortingNodeWithDependencies<
+  Node extends TSESTree.Node = TSESTree.Node,
+> extends SortingNode<Node> {
+  /**
+   * Custom name used to check if a node is a dependency of another node. If unspecified, defaults to the SortingNode's name.
+   */
+  dependencyName?: string
+  dependencies: string[]
+}
+
+/**
+ * Returns nodes topologically sorted by their dependencies
+ */
+export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
+  nodes: T[],
+): T[] => {
+  let result: T[] = []
+  let visitedNodes = new Set<T>()
+  let inProcessNodes = new Set<T>()
+
+  let visitNode = (node: T) => {
+    if (visitedNodes.has(node)) {
+      return
+    }
+    if (inProcessNodes.has(node)) {
+      // Circular dependency
+      return
+    }
+    inProcessNodes.add(node)
+    let dependentNodes = nodes.filter(n =>
+      node.dependencies.includes(n.dependencyName ?? n.name),
+    )
+    for (let dependentNode of dependentNodes) {
+      visitNode(dependentNode)
+    }
+    visitedNodes.add(node)
+    inProcessNodes.delete(node)
+    result.push(node)
+  }
+
+  for (let node of nodes) {
+    visitNode(node)
+  }
+
+  return result
+}


### PR DESCRIPTION
### Description

Fixes #234.
Fixes #237.
Fixes #238.
Fixes #240.
Fixes #241.
Fixes #242.
Fixes #243.
Fixes #244.
Fixes #245.
Fixes #248.
Fixes #249.
Fixes #250.

This PR fixes various issues related to dependency detection.

### #234: static section incorrectly placed before static properties definition

`static` block's body dependencies will now be taken into account.

- [x] Tests added

### #237 Static properties referenced using MyClass.x are not detected as dependencies

Static properties referenced with the class's name keyword will now be detected as dependencies.

- [x] Tests added

### #238 Function properties's body dependencies are not properly detected when tests say they should

I have chosen to consider that function property's body, just like method's body, should not be affected by dependencies, because they don't depend on their order to compile or run correctly.
This means that the `works with body dependencies` tests become irrelevant.

These tests were not working as expected in the first place:

_Example 1_ (code considered valid)
https://github.com/azat-io/eslint-plugin-perfectionist/blob/305d88c6a7a901321eaed5313edc13a9989d59f8/test/sort-classes.test.ts#L2683-L2698

This test for example does nothing as the sort type is `alphabetical` or `natural`, and `groups` options is the default one, meaning that methods are expected to be after properties. 

This test is also confusing because the code https://github.com/azat-io/eslint-plugin-perfectionist/blob/305d88c6a7a901321eaed5313edc13a9989d59f8/rules/sort-classes.ts#L523-L525 shows that only properties will have their dependencies extracted, and not methods (which makes sense: methods compilation/runtime are not affected by their dependencies order). Is the test supposed to show that methods order is unaffected by their body dependencies, or is the implementation wrong and methods should be sorted after their body dependencies?

_Example 2_ (code considered valid)
https://github.com/azat-io/eslint-plugin-perfectionist/blob/305d88c6a7a901321eaed5313edc13a9989d59f8/test/sort-classes.test.ts#L2658-L2668
This test does nothing as well because `a` and `method` are both properties that are already sorted alphabetically/naturally, so `method` depending (or not) on `a` has no impact.

- [x] Dead tests removed
- [x] New tests added

### #240 Dependencies ignore the notion of static

This requires:
- Keeping track of whether `this` refers to the static context or not.
- Making a distinction between the name of a node and its "dependency name" (`a` and `static a` have the same node name, but a different dependency name). Today, dependencies are currently linked by the node's name.

- [x] Tests added

### #241 Group configuration order takes precedence over dependencies

Other rules that also use dependencies and groups have been updated.

- [x] Tests added

### #242 Dependencies can cause undefined sorting behavior

Node sorting has been separated into two stages:

1. Sorting by alphabetical/natural/line-length type
2. Sorting by dependencies

Dependency sorting uses topological sorting and detects circular dependencies.

Other rules that also use dependencies have been updated.

- [x] Tests added

### #243 Nested/Optional chained/Non-null asserted/Unary property references are not detected as dependencies

- [x] Tests added

### #244 Arrow function property calls are not detected as dependencies

Arrow function property references will be detected as dependencies, but not methods.

- [x] Tests added

### #245 Properties referenced in objects are not detected as dependencies

Detects dependencies in keys and values of objects.

- [x] Tests added

### #248 Ternary conditions are not detected as dependencies

- [x] Tests added

### #249 `as` expressions are not detected as dependencies

- [x] Tests added

### #250 Type assertion expressions are not detected as dependencies

- [x] Tests added
---

### What is the purpose of this pull request?

- [x] Bug fix