### PR TITLE
fix: `sort-classes` #257: Template literal expressions are not detected as dependencies

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -343,6 +343,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             if ('properties' in nodeValue) {
               nodeValue.properties.forEach(traverseNode)
             }
+
+            if ('expressions' in nodeValue) {
+              nodeValue.expressions.forEach(traverseNode)
+            }
           }
 
           let traverseNode = (nodeValue: TSESTree.Node[] | TSESTree.Node) => {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3449,6 +3449,48 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}(${type}) detects dependencies in template literal expressions`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               class Class {
+                b = 1
+                a = \`\${this.b}\`
+                static b = 1
+                static a = \`\${this.b}\`
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+            {
+              code: dedent`
+               class Class {
+                b = 1
+                a = \`\${this.b}\`
+                static b = 1
+                static a = \`\${Class.b}\`
+               }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['property'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}) separates static from non-static dependencies`,
         rule,
         {


### PR DESCRIPTION
### Description

Fixes #257.

- [x] Tests added.

### What is the purpose of this pull request?

- [x] Bug fix
