### PR TITLE
feat: all rules: Add the element's matched group in ESlint error messages

### DIFF
--- a/rules/sort-astro-attributes.ts
+++ b/rules/sort-astro-attributes.ts
@@ -9,7 +9,6 @@ import { validateGroupsConfiguration } from '../utils/validate-groups-configurat
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'

--- a/rules/sort-astro-attributes.ts
+++ b/rules/sort-astro-attributes.ts
@@ -9,6 +9,7 @@ import { validateGroupsConfiguration } from '../utils/validate-groups-configurat
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
+import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isPositive } from '../utils/is-positive'
@@ -26,7 +27,9 @@ type Group<T extends string[]> =
   | 'unknown'
   | T[number]
 
-type MESSAGE_ID = 'unexpectedAstroAttributesOrder'
+type MESSAGE_ID =
+  | 'unexpectedAstroAttributesGroupOrder'
+  | 'unexpectedAstroAttributesOrder'
 
 type Options<T extends string[]> = [
   Partial<{
@@ -105,6 +108,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedAstroAttributesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedAstroAttributesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -201,10 +206,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   isPositive(compare(left, right, options)))
               ) {
                 context.report({
-                  messageId: 'unexpectedAstroAttributesOrder',
+                  messageId:
+                    leftNum !== rightNum
+                      ? 'unexpectedAstroAttributesGroupOrder'
+                      : 'unexpectedAstroAttributesOrder',
                   data: {
                     left: left.name,
                     right: right.name,
+                    leftGroup: left.group,
+                    rightGroup: right.group,
                   },
                   node: right.node,
                   fix: fixer => {

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -24,6 +24,7 @@ import { compare } from '../utils/compare'
 
 type MESSAGE_ID =
   | 'missedSpacingBetweenImports'
+  | 'unexpectedImportsGroupOrder'
   | 'extraSpacingBetweenImports'
   | 'unexpectedImportsOrder'
 
@@ -190,6 +191,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedImportsGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
       missedSpacingBetweenImports:
         'Missed spacing between "{{left}}" and "{{right}}" imports.',
@@ -665,10 +668,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   isPositive(compare(left, right, options))))
             ) {
               context.report({
-                messageId: 'unexpectedImportsOrder',
+                messageId:
+                  leftNum !== rightNum
+                    ? 'unexpectedImportsGroupOrder'
+                    : 'unexpectedImportsOrder',
                 data: {
                   left: left.name,
+                  leftGroup: left.group,
                   right: right.name,
+                  rightGroup: right.group,
                 },
                 node: right.node,
                 fix: fixer => fix(fixer, nodeList),

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -19,7 +19,9 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedInterfacePropertiesOrder'
+type MESSAGE_ID =
+  | 'unexpectedInterfacePropertiesGroupOrder'
+  | 'unexpectedInterfacePropertiesOrder'
 
 type Group<T extends string[]> = 'multiline' | 'unknown' | T[number]
 
@@ -121,6 +123,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedInterfacePropertiesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedInterfacePropertiesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -310,11 +314,18 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           for (let nodes of formattedMembers) {
             pairwise(nodes, (left, right, iteration) => {
               if (checkOrder(nodes, left, right, iteration)) {
+                let leftNum = getGroupNumber(options.groups, left)
+                let rightNum = getGroupNumber(options.groups, right)
                 context.report({
-                  messageId: 'unexpectedInterfacePropertiesOrder',
+                  messageId:
+                    leftNum !== rightNum
+                      ? 'unexpectedInterfacePropertiesGroupOrder'
+                      : 'unexpectedInterfacePropertiesOrder',
                   data: {
                     left: toSingleLine(left.name),
+                    leftGroup: left.group,
                     right: toSingleLine(right.name),
+                    rightGroup: right.group,
                   },
                   node: right.node,
                   fix: fixer => {

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -15,7 +15,9 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedIntersectionTypesOrder'
+type MESSAGE_ID =
+  | 'unexpectedIntersectionTypesGroupOrder'
+  | 'unexpectedIntersectionTypesOrder'
 
 type Group =
   | 'intersection'
@@ -91,6 +93,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedIntersectionTypesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedIntersectionTypesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -215,10 +219,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
           (leftNum === rightNum && isPositive(compare(left, right, options)))
         ) {
           context.report({
-            messageId: 'unexpectedIntersectionTypesOrder',
+            messageId:
+              leftNum !== rightNum
+                ? 'unexpectedIntersectionTypesGroupOrder'
+                : 'unexpectedIntersectionTypesOrder',
             data: {
               left: toSingleLine(left.name),
+              leftGroup: left.group,
               right: toSingleLine(right.name),
+              rightGroup: right.group,
             },
             node: right.node,
             fix: fixer => {

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -18,7 +18,7 @@ import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedJSXPropsOrder'
+type MESSAGE_ID = 'unexpectedJSXPropsGroupOrder' | 'unexpectedJSXPropsOrder'
 
 type Group<T extends string[]> =
   | 'multiline'
@@ -112,6 +112,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedJSXPropsGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedJSXPropsOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -211,10 +213,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   isPositive(compare(left, right, options)))
               ) {
                 context.report({
-                  messageId: 'unexpectedJSXPropsOrder',
+                  messageId:
+                    leftNum !== rightNum
+                      ? 'unexpectedJSXPropsGroupOrder'
+                      : 'unexpectedJSXPropsOrder',
                   data: {
                     left: left.name,
+                    leftGroup: left.group,
                     right: right.name,
+                    rightGroup: right.group,
                   },
                   node: right.node,
                   fix: fixer => {

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -18,7 +18,9 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedObjectTypesOrder'
+type MESSAGE_ID =
+  | 'unexpectedObjectTypesGroupOrder'
+  | 'unexpectedObjectTypesOrder'
 
 type Group<T extends string[]> = 'multiline' | 'unknown' | T[number]
 
@@ -111,6 +113,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedObjectTypesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedObjectTypesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -277,10 +281,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
             if (compareValue) {
               context.report({
-                messageId: 'unexpectedObjectTypesOrder',
+                messageId:
+                  leftNum !== rightNum
+                    ? 'unexpectedObjectTypesGroupOrder'
+                    : 'unexpectedObjectTypesOrder',
                 data: {
                   left: toSingleLine(left.name),
+                  leftGroup: left.group,
                   right: toSingleLine(right.name),
+                  rightGroup: right.group,
                 },
                 node: right.node,
                 fix: fixer => {

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -23,12 +23,13 @@ import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
-type MESSAGE_ID = 'unexpectedObjectsOrder'
+type MESSAGE_ID = 'unexpectedObjectsGroupOrder' | 'unexpectedObjectsOrder'
 
 export enum Position {
   'exception' = 'exception',
   'ignore' = 'ignore',
 }
+
 type Group = 'unknown' | string
 type SortingNodeWithPosition = SortingNodeWithDependencies & {
   position: Position
@@ -155,6 +156,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedObjectsGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedObjectsOrder: 'Expected "{{right}}" to come before "{{left}}".',
     },
   },
@@ -435,12 +438,18 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 makeFixes(fixer, nodes, sortedNodes, sourceCode, {
                   partitionComment: options.partitionByComment,
                 })
-
+              let leftNum = getGroupNumber(options.groups, left)
+              let rightNum = getGroupNumber(options.groups, right)
               context.report({
-                messageId: 'unexpectedObjectsOrder',
+                messageId:
+                  leftNum !== rightNum
+                    ? 'unexpectedObjectsGroupOrder'
+                    : 'unexpectedObjectsOrder',
                 data: {
                   left: toSingleLine(left.name),
+                  leftGroup: left.group,
                   right: toSingleLine(right.name),
+                  rightGroup: right.group,
                 },
                 node: right.node,
                 fix,

--- a/rules/sort-svelte-attributes.ts
+++ b/rules/sort-svelte-attributes.ts
@@ -19,7 +19,9 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedSvelteAttributesOrder'
+type MESSAGE_ID =
+  | 'unexpectedSvelteAttributesGroupOrder'
+  | 'unexpectedSvelteAttributesOrder'
 
 type Group<T extends string[]> =
   | 'svelte-shorthand'
@@ -105,6 +107,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedSvelteAttributesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedSvelteAttributesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -208,10 +212,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   isPositive(compare(left, right, options)))
               ) {
                 context.report({
-                  messageId: 'unexpectedSvelteAttributesOrder',
+                  messageId:
+                    leftNum !== rightNum
+                      ? 'unexpectedSvelteAttributesGroupOrder'
+                      : 'unexpectedSvelteAttributesOrder',
                   data: {
                     left: left.name,
+                    leftGroup: left.group,
                     right: right.name,
+                    rightGroup: right.group,
                   },
                   node: right.node,
                   fix: fixer => {

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -15,7 +15,7 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedUnionTypesOrder'
+type MESSAGE_ID = 'unexpectedUnionTypesGroupOrder' | 'unexpectedUnionTypesOrder'
 
 type Group =
   | 'intersection'
@@ -91,6 +91,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedUnionTypesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedUnionTypesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -215,10 +217,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
           (leftNum === rightNum && isPositive(compare(left, right, options)))
         ) {
           context.report({
-            messageId: 'unexpectedUnionTypesOrder',
+            messageId:
+              leftNum !== rightNum
+                ? 'unexpectedUnionTypesGroupOrder'
+                : 'unexpectedUnionTypesOrder',
             data: {
               left: toSingleLine(left.name),
+              leftGroup: left.group,
               right: toSingleLine(right.name),
+              rightGroup: right.group,
             },
             node: right.node,
             fix: fixer => {

--- a/rules/sort-vue-attributes.ts
+++ b/rules/sort-vue-attributes.ts
@@ -18,7 +18,9 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { compare } from '../utils/compare'
 
-type MESSAGE_ID = 'unexpectedVueAttributesOrder'
+type MESSAGE_ID =
+  | 'unexpectedVueAttributesGroupOrder'
+  | 'unexpectedVueAttributesOrder'
 
 type Group<T extends string[]> =
   | 'multiline'
@@ -103,6 +105,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
     ],
     messages: {
+      unexpectedVueAttributesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedVueAttributesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -212,10 +216,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   isPositive(compare(left, right, options)))
               ) {
                 context.report({
-                  messageId: 'unexpectedVueAttributesOrder',
+                  messageId:
+                    leftNum !== rightNum
+                      ? 'unexpectedVueAttributesGroupOrder'
+                      : 'unexpectedVueAttributesOrder',
                   data: {
                     left: left.name,
+                    leftGroup: left.group,
                     right: right.name,
+                    rightGroup: right.group,
                   },
                   // @ts-ignore
                   node: right.node,

--- a/test/sort-astro-attributes.test.ts
+++ b/test/sort-astro-attributes.test.ts
@@ -275,10 +275,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedAstroAttributesOrder',
+                messageId: 'unexpectedAstroAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'shorthand',
                   right: 'dd',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -358,10 +360,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedAstroAttributesOrder',
+                messageId: 'unexpectedAstroAttributesGroupOrder',
                 data: {
                   left: 'a',
+                  leftGroup: 'unknown',
                   right: 'b',
+                  rightGroup: 'multiline',
                 },
               },
             ],
@@ -440,17 +444,21 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedAstroAttributesOrder',
+              messageId: 'unexpectedAstroAttributesGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'unknown',
                 right: 'b',
+                rightGroup: 'primary',
               },
             },
             {
-              messageId: 'unexpectedAstroAttributesOrder',
+              messageId: 'unexpectedAstroAttributesGroupOrder',
               data: {
                 left: 'c',
+                leftGroup: 'unknown',
                 right: 'd',
+                rightGroup: 'secondary',
               },
             },
           ],
@@ -704,10 +712,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedAstroAttributesOrder',
+                messageId: 'unexpectedAstroAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'shorthand',
                   right: 'dd',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -790,10 +800,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedAstroAttributesOrder',
+                messageId: 'unexpectedAstroAttributesGroupOrder',
                 data: {
                   left: 'a',
+                  leftGroup: 'unknown',
                   right: 'b',
+                  rightGroup: 'multiline',
                 },
               },
             ],
@@ -872,17 +884,21 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedAstroAttributesOrder',
+              messageId: 'unexpectedAstroAttributesGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'unknown',
                 right: 'b',
+                rightGroup: 'primary',
               },
             },
             {
-              messageId: 'unexpectedAstroAttributesOrder',
+              messageId: 'unexpectedAstroAttributesGroupOrder',
               data: {
                 left: 'c',
+                leftGroup: 'unknown',
                 right: 'd',
+                rightGroup: 'secondary',
               },
             },
           ],
@@ -1135,10 +1151,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedAstroAttributesOrder',
+                messageId: 'unexpectedAstroAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'shorthand',
                   right: 'dd',
+                  rightGroup: 'unknown',
                 },
               },
               {
@@ -1225,10 +1243,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedAstroAttributesOrder',
+                messageId: 'unexpectedAstroAttributesGroupOrder',
                 data: {
                   left: 'a',
+                  leftGroup: 'unknown',
                   right: 'b',
+                  rightGroup: 'multiline',
                 },
               },
               {
@@ -1314,17 +1334,21 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedAstroAttributesOrder',
+              messageId: 'unexpectedAstroAttributesGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'unknown',
                 right: 'b',
+                rightGroup: 'primary',
               },
             },
             {
-              messageId: 'unexpectedAstroAttributesOrder',
+              messageId: 'unexpectedAstroAttributesGroupOrder',
               data: {
                 left: 'c',
+                leftGroup: 'unknown',
                 right: 'd',
+                rightGroup: 'secondary',
               },
             },
           ],

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -185,10 +185,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '~/b',
+                leftGroup: 'internal',
                 right: '~/i',
+                rightGroup: 'internal-type',
               },
             },
             {
@@ -199,10 +201,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './d',
+                leftGroup: 'sibling-type',
                 right: 'fs',
+                rightGroup: 'builtin',
               },
             },
             {
@@ -220,17 +224,21 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '../../h',
+                leftGroup: 'parent',
                 right: './index.d.ts',
+                rightGroup: 'index-type',
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '.',
+                leftGroup: 'index',
                 right: 't',
+                rightGroup: 'type',
               },
             },
             {
@@ -321,17 +329,21 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '.',
+                leftGroup: 'index',
                 right: 'a',
+                rightGroup: 'external',
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '~/c',
+                leftGroup: 'internal',
                 right: 't',
+                rightGroup: 'type',
               },
             },
             {
@@ -342,10 +354,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '../../e',
+                leftGroup: 'parent',
                 right: '~/b',
+                rightGroup: 'internal',
               },
             },
             {
@@ -906,10 +920,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './b',
+                leftGroup: 'sibling',
                 right: 'c',
+                rightGroup: 'external',
               },
             },
             {
@@ -1191,10 +1207,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'external',
                 right: 'bun:test',
+                rightGroup: 'builtin',
               },
             },
           ],
@@ -1338,10 +1356,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/b',
+                  leftGroup: 'internal',
                   right: 'fs',
+                  rightGroup: 'builtin',
                 },
               },
               {
@@ -1439,10 +1459,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: 'bbb',
+                  leftGroup: 'side-effect',
                   right: 'e',
+                  rightGroup: 'external',
                 },
               },
               {
@@ -1672,10 +1694,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '~/b',
+                leftGroup: 'internal',
                 right: '~/i',
+                rightGroup: 'internal-type',
               },
             },
             {
@@ -1686,10 +1710,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './d',
+                leftGroup: 'sibling-type',
                 right: 'fs',
+                rightGroup: 'builtin',
               },
             },
             {
@@ -1707,17 +1733,21 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '../../h',
+                leftGroup: 'parent',
                 right: './index.d.ts',
+                rightGroup: 'index-type',
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '.',
+                leftGroup: 'index',
                 right: 't',
+                rightGroup: 'type',
               },
             },
             {
@@ -1808,17 +1838,21 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '.',
+                leftGroup: 'index',
                 right: 'a',
+                rightGroup: 'external',
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '~/c',
+                leftGroup: 'internal',
                 right: 't',
+                rightGroup: 'type',
               },
             },
             {
@@ -1829,10 +1863,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '../../e',
+                leftGroup: 'parent',
                 right: '~/b',
+                rightGroup: 'internal',
               },
             },
             {
@@ -2393,10 +2429,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './b',
+                leftGroup: 'sibling',
                 right: 'c',
+                rightGroup: 'external',
               },
             },
             {
@@ -2678,10 +2716,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'external',
                 right: 'bun:test',
+                rightGroup: 'builtin',
               },
             },
           ],
@@ -2825,10 +2865,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/b',
+                  leftGroup: 'internal',
                   right: 'fs',
+                  rightGroup: 'builtin',
                 },
               },
               {
@@ -2926,10 +2968,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: 'bbb',
+                  leftGroup: 'side-effect',
                   right: 'e',
+                  rightGroup: 'external',
                 },
               },
               {
@@ -3151,10 +3195,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '~/b',
+                leftGroup: 'internal',
                 right: '~/i',
+                rightGroup: 'internal-type',
               },
             },
             {
@@ -3165,10 +3211,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './d',
+                leftGroup: 'sibling-type',
                 right: 'fs',
+                rightGroup: 'builtin',
               },
             },
             {
@@ -3200,17 +3248,21 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '../../h',
+                leftGroup: 'parent',
                 right: './index.d.ts',
+                rightGroup: 'index-type',
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '.',
+                leftGroup: 'index',
                 right: 't',
+                rightGroup: 'type',
               },
             },
             {
@@ -3308,17 +3360,21 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '.',
+                leftGroup: 'index',
                 right: 'a',
+                rightGroup: 'external',
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '~/c',
+                leftGroup: 'internal',
                 right: 't',
+                rightGroup: 'type',
               },
             },
             {
@@ -3329,10 +3385,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: '../../e',
+                leftGroup: 'parent',
                 right: '~/b',
+                rightGroup: 'internal',
               },
             },
             {
@@ -3893,10 +3951,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './b',
+                leftGroup: 'sibling',
                 right: 'c',
+                rightGroup: 'external',
               },
             },
             {
@@ -4253,10 +4313,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedImportsOrder',
+              messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'external',
                 right: 'bun:test',
+                rightGroup: 'builtin',
               },
             },
           ],
@@ -4393,10 +4455,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/b',
+                  leftGroup: 'internal',
                   right: 'fs',
+                  rightGroup: 'builtin',
                 },
               },
               {
@@ -4508,10 +4572,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: 'bbb',
+                  leftGroup: 'side-effect',
                   right: 'e',
+                  rightGroup: 'external',
                 },
               },
               {
@@ -4947,24 +5013,30 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: './cart/CartComponentB.vue',
+                  leftGroup: 'sibling',
                   right: '~/utils/ws.ts',
+                  rightGroup: 'utils',
                 },
               },
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/utils/ws.ts',
+                  leftGroup: 'utils',
                   right: '~/services/cartService.ts',
+                  rightGroup: 'services',
                 },
               },
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/services/cartService.ts',
+                  leftGroup: 'services',
                   right: '~/stores/userStore.ts',
+                  rightGroup: 'stores',
                 },
               },
               {
@@ -4975,10 +5047,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/composable/useFetch.ts',
+                  leftGroup: 'composable',
                   right: '~/stores/cartStore.ts',
+                  rightGroup: 'stores',
                 },
               },
               {

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -555,17 +555,21 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedInterfacePropertiesOrder',
+                messageId: 'unexpectedInterfacePropertiesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'd',
+                  rightGroup: 'multiline',
                 },
               },
               {
-                messageId: 'unexpectedInterfacePropertiesOrder',
+                messageId: 'unexpectedInterfacePropertiesGroupOrder',
                 data: {
                   left: 'd',
+                  leftGroup: 'multiline',
                   right: 'g',
+                  rightGroup: 'g',
                 },
               },
             ],
@@ -749,10 +753,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedInterfacePropertiesOrder',
+                messageId: 'unexpectedInterfacePropertiesGroupOrder',
                 data: {
                   left: 'a',
+                  leftGroup: 'last',
                   right: 'b',
+                  rightGroup: 'unknown',
                 },
               },
               {
@@ -1854,17 +1860,21 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedInterfacePropertiesOrder',
+                messageId: 'unexpectedInterfacePropertiesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'd',
+                  rightGroup: 'multiline',
                 },
               },
               {
-                messageId: 'unexpectedInterfacePropertiesOrder',
+                messageId: 'unexpectedInterfacePropertiesGroupOrder',
                 data: {
                   left: 'd',
+                  leftGroup: 'multiline',
                   right: 'g',
+                  rightGroup: 'g',
                 },
               },
             ],

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -367,38 +367,48 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: "{ name: 'a' }",
+                leftGroup: 'object',
                 right: 'boolean',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'boolean',
+                leftGroup: 'keyword',
                 right: 'A',
+                rightGroup: 'named',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'keyof A',
+                leftGroup: 'operator',
                 right: 'bigint',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'null',
+                leftGroup: 'nullish',
                 right: '1',
+                rightGroup: 'literal',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'A | B',
+                leftGroup: 'union',
                 right: 'A & B',
+                rightGroup: 'intersection',
               },
             },
           ],
@@ -738,38 +748,48 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: "{ name: 'a' }",
+                leftGroup: 'object',
                 right: 'boolean',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'boolean',
+                leftGroup: 'keyword',
                 right: 'A',
+                rightGroup: 'named',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'keyof A',
+                leftGroup: 'operator',
                 right: 'bigint',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'null',
+                leftGroup: 'nullish',
                 right: '1',
+                rightGroup: 'literal',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'A | B',
+                leftGroup: 'union',
                 right: 'A & B',
+                rightGroup: 'intersection',
               },
             },
           ],
@@ -1104,38 +1124,48 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: "{ name: 'a' }",
+                leftGroup: 'object',
                 right: 'boolean',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'boolean',
+                leftGroup: 'keyword',
                 right: 'A',
+                rightGroup: 'named',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'keyof A',
+                leftGroup: 'operator',
                 right: 'bigint',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'null',
+                leftGroup: 'nullish',
                 right: '1',
+                rightGroup: 'literal',
               },
             },
             {
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
               data: {
                 left: 'A | B',
+                leftGroup: 'union',
                 right: 'A & B',
+                rightGroup: 'intersection',
               },
             },
           ],

--- a/test/sort-jsx-props.test.ts
+++ b/test/sort-jsx-props.test.ts
@@ -276,10 +276,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'aaaaaa',
+                  leftGroup: 'shorthand',
                   right: 'b',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -335,10 +337,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'onChange',
+                  leftGroup: 'callback',
                   right: 'a',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -413,10 +417,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'd',
+                  rightGroup: 'multiline',
                 },
               },
             ],
@@ -475,10 +481,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedJSXPropsOrder',
+              messageId: 'unexpectedJSXPropsGroupOrder',
               data: {
                 left: 'c',
+                leftGroup: 'unknown',
                 right: 'd',
+                rightGroup: 'top',
               },
             },
           ],
@@ -733,10 +741,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'aaaaaa',
+                  leftGroup: 'shorthand',
                   right: 'b',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -792,10 +802,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'onChange',
+                  leftGroup: 'callback',
                   right: 'a',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -870,10 +882,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'd',
+                  rightGroup: 'multiline',
                 },
               },
             ],
@@ -932,10 +946,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedJSXPropsOrder',
+              messageId: 'unexpectedJSXPropsGroupOrder',
               data: {
                 left: 'c',
+                leftGroup: 'unknown',
                 right: 'd',
+                rightGroup: 'top',
               },
             },
           ],
@@ -1189,10 +1205,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'aaaaaa',
+                  leftGroup: 'shorthand',
                   right: 'b',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -1248,10 +1266,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'onChange',
+                  leftGroup: 'callback',
                   right: 'a',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -1326,10 +1346,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedJSXPropsOrder',
+                messageId: 'unexpectedJSXPropsGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'd',
+                  rightGroup: 'multiline',
                 },
               },
               {
@@ -1396,10 +1418,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedJSXPropsOrder',
+              messageId: 'unexpectedJSXPropsGroupOrder',
               data: {
                 left: 'c',
+                leftGroup: 'unknown',
                 right: 'd',
+                rightGroup: 'top',
               },
             },
           ],

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -344,10 +344,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedObjectTypesOrder',
+                messageId: 'unexpectedObjectTypesGroupOrder',
                 data: {
                   left: 'a',
+                  leftGroup: 'unknown',
                   right: 'b',
+                  rightGroup: 'b',
                 },
               },
               {
@@ -941,10 +943,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedObjectTypesOrder',
+                messageId: 'unexpectedObjectTypesGroupOrder',
                 data: {
                   left: 'a',
+                  leftGroup: 'unknown',
                   right: 'b',
+                  rightGroup: 'b',
                 },
               },
               {
@@ -1511,10 +1515,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedObjectTypesOrder',
+                messageId: 'unexpectedObjectTypesGroupOrder',
                 data: {
                   left: 'a',
+                  leftGroup: 'unknown',
                   right: 'b',
+                  rightGroup: 'b',
                 },
               },
               {

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -308,10 +308,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedObjectsOrder',
+              messageId: 'unexpectedObjectsGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'unknown',
                 right: 'b',
+                rightGroup: 'top',
               },
             },
           ],
@@ -1308,10 +1310,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedObjectsOrder',
+              messageId: 'unexpectedObjectsGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'unknown',
                 right: 'b',
+                rightGroup: 'top',
               },
             },
           ],
@@ -2166,10 +2170,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedObjectsOrder',
+              messageId: 'unexpectedObjectsGroupOrder',
               data: {
                 left: 'a',
+                leftGroup: 'unknown',
                 right: 'b',
+                rightGroup: 'top',
               },
             },
             {

--- a/test/sort-svelte-attributes.test.ts
+++ b/test/sort-svelte-attributes.test.ts
@@ -284,10 +284,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedSvelteAttributesOrder',
+                messageId: 'unexpectedSvelteAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'svelte-shorthand',
                   right: 'b',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -370,10 +372,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedSvelteAttributesOrder',
+                messageId: 'unexpectedSvelteAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'onClick',
+                  rightGroup: 'multiline',
                 },
               },
             ],
@@ -721,10 +725,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedSvelteAttributesOrder',
+                messageId: 'unexpectedSvelteAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'svelte-shorthand',
                   right: 'b',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -807,10 +813,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedSvelteAttributesOrder',
+                messageId: 'unexpectedSvelteAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'onClick',
+                  rightGroup: 'multiline',
                 },
               },
             ],
@@ -1157,10 +1165,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedSvelteAttributesOrder',
+                messageId: 'unexpectedSvelteAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'svelte-shorthand',
                   right: 'b',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -1243,10 +1253,12 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedSvelteAttributesOrder',
+                messageId: 'unexpectedSvelteAttributesGroupOrder',
                 data: {
                   left: 'c',
+                  leftGroup: 'unknown',
                   right: 'onClick',
+                  rightGroup: 'multiline',
                 },
               },
             ],
@@ -1328,10 +1340,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedSvelteAttributesOrder',
+              messageId: 'unexpectedSvelteAttributesGroupOrder',
               data: {
                 left: 'b',
+                leftGroup: 'unknown',
                 right: 'c',
+                rightGroup: 'ce',
               },
             },
           ],

--- a/test/sort-svelte-attributes.test.ts
+++ b/test/sort-svelte-attributes.test.ts
@@ -459,10 +459,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedSvelteAttributesOrder',
+              messageId: 'unexpectedSvelteAttributesGroupOrder',
               data: {
                 left: 'b',
+                leftGroup: 'unknown',
                 right: 'c',
+                rightGroup: 'ce',
               },
             },
           ],
@@ -900,10 +902,12 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedSvelteAttributesOrder',
+              messageId: 'unexpectedSvelteAttributesGroupOrder',
               data: {
                 left: 'b',
+                leftGroup: 'unknown',
                 right: 'c',
+                rightGroup: 'ce',
               },
             },
           ],

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -370,38 +370,48 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: "{ name: 'a' }",
+                leftGroup: 'object',
                 right: 'boolean',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'boolean',
+                leftGroup: 'keyword',
                 right: 'A',
+                rightGroup: 'named',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'keyof A',
+                leftGroup: 'operator',
                 right: 'bigint',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'null',
+                leftGroup: 'nullish',
                 right: '1',
+                rightGroup: 'literal',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'A | B',
+                leftGroup: 'union',
                 right: 'A & B',
+                rightGroup: 'intersection',
               },
             },
           ],
@@ -757,38 +767,48 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: "{ name: 'a' }",
+                leftGroup: 'object',
                 right: 'boolean',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'boolean',
+                leftGroup: 'keyword',
                 right: 'A',
+                rightGroup: 'named',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'keyof A',
+                leftGroup: 'operator',
                 right: 'bigint',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'null',
+                leftGroup: 'nullish',
                 right: '1',
+                rightGroup: 'literal',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'A | B',
+                leftGroup: 'union',
                 right: 'A & B',
+                rightGroup: 'intersection',
               },
             },
           ],
@@ -1136,38 +1156,48 @@ describe(ruleName, () => {
           ],
           errors: [
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: "{ name: 'a' }",
+                leftGroup: 'object',
                 right: 'boolean',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'boolean',
+                leftGroup: 'keyword',
                 right: 'A',
+                rightGroup: 'named',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'keyof A',
+                leftGroup: 'operator',
                 right: 'bigint',
+                rightGroup: 'keyword',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'null',
+                leftGroup: 'nullish',
                 right: '1',
+                rightGroup: 'literal',
               },
             },
             {
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'unexpectedUnionTypesGroupOrder',
               data: {
                 left: 'A | B',
+                leftGroup: 'union',
                 right: 'A & B',
+                rightGroup: 'intersection',
               },
             },
           ],

--- a/test/sort-vue-attributes.test.ts
+++ b/test/sort-vue-attributes.test.ts
@@ -286,17 +286,21 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedVueAttributesOrder',
+                messageId: 'unexpectedVueAttributesGroupOrder',
                 data: {
                   left: 'b',
+                  leftGroup: 'unknown',
                   right: '@a',
+                  rightGroup: 'multiline',
                 },
               },
               {
-                messageId: 'unexpectedVueAttributesOrder',
+                messageId: 'unexpectedVueAttributesGroupOrder',
                 data: {
                   left: 'e-f',
+                  leftGroup: 'shorthand',
                   right: 'c',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -562,17 +566,21 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedVueAttributesOrder',
+                messageId: 'unexpectedVueAttributesGroupOrder',
                 data: {
                   left: 'b',
+                  leftGroup: 'unknown',
                   right: '@a',
+                  rightGroup: 'multiline',
                 },
               },
               {
-                messageId: 'unexpectedVueAttributesOrder',
+                messageId: 'unexpectedVueAttributesGroupOrder',
                 data: {
                   left: 'e-f',
+                  leftGroup: 'shorthand',
                   right: 'c',
+                  rightGroup: 'unknown',
                 },
               },
             ],
@@ -837,17 +845,21 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedVueAttributesOrder',
+                messageId: 'unexpectedVueAttributesGroupOrder',
                 data: {
                   left: 'b',
+                  leftGroup: 'unknown',
                   right: '@a',
+                  rightGroup: 'multiline',
                 },
               },
               {
-                messageId: 'unexpectedVueAttributesOrder',
+                messageId: 'unexpectedVueAttributesGroupOrder',
                 data: {
                   left: 'e-f',
+                  leftGroup: 'shorthand',
                   right: 'c',
+                  rightGroup: 'unknown',
                 },
               },
             ],


### PR DESCRIPTION
### Description

This PR extends #204 to other rules using groups: Comparisons between members that do not belong in the same group will have a more detailed error message, allowing the user to know which element belong to which group.

Affected rules:
- [x] `sort-astro-attributes`
- [x] `sort-imports`
- [x] `sort-interfaces`
- [x] `sort-intersection-types`
- [x] `sort-jsx-props`
- [x] `sort-object-types`
- [x] `sort-object`
- [x] `sort-svelte-attributes`
- [x] `sort-union-types`
- [x] `sort-vue-attributes`

### What is the purpose of this pull request?

- [x] New Feature