### PR TITLE
feat(multiple-rules): #270: add `dependencyOrder` errors

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -6,10 +6,7 @@ import type {
   Modifier,
   Selector,
 } from './sort-classes.types'
-import {
-  getFirstUnorderedDependency,
-  type SortingNodeWithDependencies,
-} from '../utils/sort-nodes-by-dependencies'
+import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
   getOverloadSignatureGroups,
@@ -22,7 +19,10 @@ import {
   customGroupNameJsonSchema,
   customGroupSortJsonSchema,
 } from './sort-classes.types'
-import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
+import {
+  getFirstUnorderedDependency,
+  sortNodesByDependencies,
+} from '../utils/sort-nodes-by-dependencies'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -20,7 +20,7 @@ import {
   customGroupSortJsonSchema,
 } from './sort-classes.types'
 import {
-  getFirstUnorderedDependency,
+  getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -688,16 +688,14 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             let indexOfLeft = sortedNodes.indexOf(left)
             let indexOfRight = sortedNodes.indexOf(right)
-            let firstRightUnorderedDependency = getFirstUnorderedDependency(
-              right,
-              nodes,
-            )
+            let firstUnorderedNodeDependentOnRight =
+              getFirstUnorderedNodeDependentOn(right, nodes)
             if (
-              firstRightUnorderedDependency ||
+              firstUnorderedNodeDependentOnRight ||
               (!isLeftOrRightIgnored && indexOfLeft > indexOfRight)
             ) {
               let messageId: MESSAGE_ID
-              if (firstRightUnorderedDependency) {
+              if (firstUnorderedNodeDependentOnRight) {
                 messageId = 'unexpectedClassesDependencyOrder'
               } else {
                 messageId =
@@ -712,7 +710,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                   leftGroup: left.group,
                   right: toSingleLine(right.name),
                   rightGroup: right.group,
-                  nodeDependentOnRight: firstRightUnorderedDependency?.name,
+                  nodeDependentOnRight:
+                    firstUnorderedNodeDependentOnRight?.name,
                 },
                 node: right.node,
                 fix: (fixer: TSESLint.RuleFixer) =>

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -688,8 +688,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             let indexOfLeft = sortedNodes.indexOf(left)
             let indexOfRight = sortedNodes.indexOf(right)
-            let firstRightUnorderedDependency: SortingNodeWithDependencies | null =
-              getFirstUnorderedDependency(right, nodes)
+            let firstRightUnorderedDependency = getFirstUnorderedDependency(
+              right,
+              nodes,
+            )
             if (
               firstRightUnorderedDependency ||
               (!isLeftOrRightIgnored && indexOfLeft > indexOfRight)

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -173,7 +173,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       unexpectedClassesOrder: 'Expected "{{right}}" to come before "{{left}}".',
       unexpectedClassesDependencyOrder:
-        'Expected dependency "{{dependency}}" to come before "{{left}}".',
+        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
     },
   },
   defaultOptions: [
@@ -688,14 +688,14 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             let indexOfLeft = sortedNodes.indexOf(left)
             let indexOfRight = sortedNodes.indexOf(right)
-            let firstLeftUnorderedDependency: SortingNodeWithDependencies | null =
-              getFirstUnorderedDependency(left, nodes, sortedNodes)
+            let firstRightUnorderedDependency: SortingNodeWithDependencies | null =
+              getFirstUnorderedDependency(right, nodes)
             if (
-              firstLeftUnorderedDependency ||
+              firstRightUnorderedDependency ||
               (!isLeftOrRightIgnored && indexOfLeft > indexOfRight)
             ) {
               let messageId: MESSAGE_ID
-              if (firstLeftUnorderedDependency) {
+              if (firstRightUnorderedDependency) {
                 messageId = 'unexpectedClassesDependencyOrder'
               } else {
                 messageId =
@@ -707,10 +707,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                 messageId,
                 data: {
                   left: toSingleLine(left.name),
-                  dependency: firstLeftUnorderedDependency?.name,
                   leftGroup: left.group,
                   right: toSingleLine(right.name),
                   rightGroup: right.group,
+                  nodeDependentOnRight: firstRightUnorderedDependency?.name,
                 },
                 node: right.node,
                 fix: (fixer: TSESLint.RuleFixer) =>

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -7,6 +7,8 @@ import {
   sortNodesByDependencies,
   nodeDependsOn,
 } from '../utils/sort-nodes-by-dependencies'
+import { hasPartitionComment } from '../utils/is-partition-comment'
+import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
@@ -16,8 +18,6 @@ import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { getCommentsBefore } from '../utils/get-comments-before'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 
 type MESSAGE_ID = 'unexpectedEnumsDependencyOrder' | 'unexpectedEnumsOrder'
 

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -4,8 +4,8 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 import type { CompareOptions } from '../utils/compare'
 
 import {
+  getFirstUnorderedDependency,
   sortNodesByDependencies,
-  nodeDependsOn,
 } from '../utils/sort-nodes-by-dependencies'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
@@ -94,7 +94,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     messages: {
       unexpectedEnumsOrder: 'Expected "{{right}}" to come before "{{left}}".',
       unexpectedEnumsDependencyOrder:
-        'Expected dependency "{{right}}" to come before "{{left}}".',
+        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
     },
   },
   defaultOptions: [
@@ -250,14 +250,18 @@ export default createEslintRule<Options, MESSAGE_ID>({
             let indexOfLeft = sortedNodes.indexOf(left)
             let indexOfRight = sortedNodes.indexOf(right)
             if (indexOfLeft > indexOfRight) {
-              let leftDependsOnRight = nodeDependsOn(left, right)
+              let firstNodeDependentOnRight = getFirstUnorderedDependency(
+                right,
+                nodes,
+              )
               context.report({
-                messageId: leftDependsOnRight
+                messageId: firstNodeDependentOnRight
                   ? 'unexpectedEnumsDependencyOrder'
                   : 'unexpectedEnumsOrder',
                 data: {
                   left: toSingleLine(left.name),
                   right: toSingleLine(right.name),
+                  nodeDependentOnRight: firstNodeDependentOnRight?.name,
                 },
                 node: right.node,
                 fix: fixer =>

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -4,7 +4,7 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 import type { CompareOptions } from '../utils/compare'
 
 import {
-  getFirstUnorderedDependency,
+  getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -250,18 +250,17 @@ export default createEslintRule<Options, MESSAGE_ID>({
             let indexOfLeft = sortedNodes.indexOf(left)
             let indexOfRight = sortedNodes.indexOf(right)
             if (indexOfLeft > indexOfRight) {
-              let firstNodeDependentOnRight = getFirstUnorderedDependency(
-                right,
-                nodes,
-              )
+              let firstUnorderedNodeDependentOnRight =
+                getFirstUnorderedNodeDependentOn(right, nodes)
               context.report({
-                messageId: firstNodeDependentOnRight
+                messageId: firstUnorderedNodeDependentOnRight
                   ? 'unexpectedEnumsDependencyOrder'
                   : 'unexpectedEnumsOrder',
                 data: {
                   left: toSingleLine(left.name),
                   right: toSingleLine(right.name),
-                  nodeDependentOnRight: firstNodeDependentOnRight?.name,
+                  nodeDependentOnRight:
+                    firstUnorderedNodeDependentOnRight?.name,
                 },
                 node: right.node,
                 fix: fixer =>

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -5,9 +5,11 @@ import { minimatch } from 'minimatch'
 
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
-import { nodeDependsOn } from '../utils/sort-nodes-by-dependencies'
+import {
+  sortNodesByDependencies,
+  nodeDependsOn,
+} from '../utils/sort-nodes-by-dependencies'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
-import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -472,12 +474,17 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 })
               let leftNum = getGroupNumber(options.groups, left)
               let rightNum = getGroupNumber(options.groups, right)
-              context.report({
-                messageId: leftDependsOnRight
-                  ? 'unexpectedObjectsDependencyOrder'
-                  : leftNum !== rightNum
+              let messageId: MESSAGE_ID
+              if (leftDependsOnRight) {
+                messageId = 'unexpectedObjectsDependencyOrder'
+              } else {
+                messageId =
+                  leftNum !== rightNum
                     ? 'unexpectedObjectsGroupOrder'
-                    : 'unexpectedObjectsOrder',
+                    : 'unexpectedObjectsOrder'
+              }
+              context.report({
+                messageId,
                 data: {
                   left: toSingleLine(left.name),
                   leftGroup: left.group,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -6,7 +6,7 @@ import { minimatch } from 'minimatch'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
-  getFirstUnorderedDependency,
+  getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
@@ -465,10 +465,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
             let indexOfRight = sortedNodes.indexOf(right)
 
             if (indexOfLeft > indexOfRight) {
-              let firstNodeDependentOnRight = getFirstUnorderedDependency(
-                right,
-                nodes,
-              )
+              let firstUnorderedNodeDependentOnRight =
+                getFirstUnorderedNodeDependentOn(right, nodes)
               let fix:
                 | ((fixer: TSESLint.RuleFixer) => TSESLint.RuleFix[])
                 | undefined = fixer =>
@@ -478,7 +476,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               let leftNum = getGroupNumber(options.groups, left)
               let rightNum = getGroupNumber(options.groups, right)
               let messageId: MESSAGE_ID
-              if (firstNodeDependentOnRight) {
+              if (firstUnorderedNodeDependentOnRight) {
                 messageId = 'unexpectedObjectsDependencyOrder'
               } else {
                 messageId =
@@ -493,7 +491,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   leftGroup: left.group,
                   right: toSingleLine(right.name),
                   rightGroup: right.group,
-                  nodeDependentOnRight: firstNodeDependentOnRight?.name,
+                  nodeDependentOnRight:
+                    firstUnorderedNodeDependentOnRight?.name,
                 },
                 node: right.node,
                 fix,

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -3,8 +3,8 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
+  getFirstUnorderedDependency,
   sortNodesByDependencies,
-  nodeDependsOn,
 } from '../utils/sort-nodes-by-dependencies'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
@@ -64,7 +64,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       unexpectedVariableDeclarationsOrder:
         'Expected "{{right}}" to come before "{{left}}".',
       unexpectedVariableDeclarationsDependencyOrder:
-        'Expected dependency "{{right}}" to come before "{{left}}".',
+        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
     },
   },
   defaultOptions: [
@@ -202,14 +202,18 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let indexOfLeft = sortedNodes.indexOf(left)
           let indexOfRight = sortedNodes.indexOf(right)
           if (indexOfLeft > indexOfRight) {
-            let leftDependsOnRight = nodeDependsOn(left, right)
+            let firstNodeDependentOnRight = getFirstUnorderedDependency(
+              right,
+              nodes,
+            )
             context.report({
-              messageId: leftDependsOnRight
+              messageId: firstNodeDependentOnRight
                 ? 'unexpectedVariableDeclarationsDependencyOrder'
                 : 'unexpectedVariableDeclarationsOrder',
               data: {
                 left: toSingleLine(left.name),
                 right: toSingleLine(right.name),
+                nodeDependentOnRight: firstNodeDependentOnRight?.name,
               },
               node: right.node,
               fix: fixer => makeFixes(fixer, nodes, sortedNodes, sourceCode),

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -2,7 +2,10 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
-import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
+import {
+  sortNodesByDependencies,
+  nodeDependsOn,
+} from '../utils/sort-nodes-by-dependencies'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
@@ -13,7 +16,9 @@ import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
-type MESSAGE_ID = 'unexpectedVariableDeclarationsOrder'
+type MESSAGE_ID =
+  | 'unexpectedVariableDeclarationsDependencyOrder'
+  | 'unexpectedVariableDeclarationsOrder'
 
 type Options = [
   Partial<{
@@ -58,6 +63,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
     messages: {
       unexpectedVariableDeclarationsOrder:
         'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedVariableDeclarationsDependencyOrder:
+        'Expected dependency "{{right}}" to come before "{{left}}".',
     },
   },
   defaultOptions: [
@@ -195,8 +202,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let indexOfLeft = sortedNodes.indexOf(left)
           let indexOfRight = sortedNodes.indexOf(right)
           if (indexOfLeft > indexOfRight) {
+            let leftDependsOnRight = nodeDependsOn(left, right)
             context.report({
-              messageId: 'unexpectedVariableDeclarationsOrder',
+              messageId: leftDependsOnRight
+                ? 'unexpectedVariableDeclarationsDependencyOrder'
+                : 'unexpectedVariableDeclarationsOrder',
               data: {
                 left: toSingleLine(left.name),
                 right: toSingleLine(right.name),

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
-  getFirstUnorderedDependency,
+  getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -202,18 +202,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let indexOfLeft = sortedNodes.indexOf(left)
           let indexOfRight = sortedNodes.indexOf(right)
           if (indexOfLeft > indexOfRight) {
-            let firstNodeDependentOnRight = getFirstUnorderedDependency(
-              right,
-              nodes,
-            )
+            let firstUnorderedNodeDependentOnRight =
+              getFirstUnorderedNodeDependentOn(right, nodes)
             context.report({
-              messageId: firstNodeDependentOnRight
+              messageId: firstUnorderedNodeDependentOnRight
                 ? 'unexpectedVariableDeclarationsDependencyOrder'
                 : 'unexpectedVariableDeclarationsOrder',
               data: {
                 left: toSingleLine(left.name),
                 right: toSingleLine(right.name),
-                nodeDependentOnRight: firstNodeDependentOnRight?.name,
+                nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
               },
               node: right.node,
               fix: fixer => makeFixes(fixer, nodes, sortedNodes, sourceCode),

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -2453,10 +2453,10 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesDependencyOrder',
                 data: {
                   left: 'aaa',
-                  right: 'b',
+                  dependency: 'b',
                 },
               },
             ],
@@ -2920,24 +2920,31 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesDependencyOrder',
                   data: {
                     left: 'e',
-                    right: 'd',
+                    dependency: 'c',
                   },
                 },
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesDependencyOrder',
                   data: {
                     left: 'd',
-                    right: 'a',
+                    dependency: 'b',
                   },
                 },
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    left: 'b',
+                    dependency: 'z',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
                   data: {
                     left: 'c',
-                    right: 'z',
+                    dependency: 'z',
                   },
                 },
               ],
@@ -2963,6 +2970,13 @@ describe(ruleName, () => {
                 },
               ],
               errors: [
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    left: 'a',
+                    dependency: 'c',
+                  },
+                },
                 {
                   messageId: 'unexpectedClassesOrder',
                   data: {
@@ -3631,10 +3645,24 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    left: 'a',
+                    dependency: 'c',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
                   data: {
                     left: 'b',
-                    right: 'c',
+                    dependency: 'c',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    dependency: 'c',
+                    left: 'b',
                   },
                 },
                 {
@@ -3683,10 +3711,17 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesDependencyOrder',
                   data: {
+                    dependency: 'e',
                     left: 'b',
-                    right: 'a',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    left: 'e',
+                    dependency: 'g',
                   },
                 },
                 {
@@ -3797,10 +3832,10 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesDependencyOrder',
                   data: {
+                    dependency: 'left',
                     left: 'aaa',
-                    right: 'left',
                   },
                 },
               ],
@@ -4827,10 +4862,10 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesDependencyOrder',
                 data: {
                   left: 'aaa',
-                  right: 'b',
+                  dependency: 'b',
                 },
               },
             ],
@@ -5003,10 +5038,10 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedClassesOrder',
+                messageId: 'unexpectedClassesDependencyOrder',
                 data: {
+                  dependency: 'left',
                   left: 'aaa',
-                  right: 'left',
                 },
               },
             ],

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -2455,8 +2455,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesDependencyOrder',
                 data: {
-                  left: 'aaa',
-                  dependency: 'b',
+                  right: 'b',
+                  nodeDependentOnRight: 'aaa',
                 },
               },
             ],
@@ -2920,31 +2920,38 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesDependencyOrder',
+                  messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'e',
-                    dependency: 'c',
+                    right: 'd',
                   },
                 },
                 {
-                  messageId: 'unexpectedClassesDependencyOrder',
+                  messageId: 'unexpectedClassesOrder',
                   data: {
                     left: 'd',
-                    dependency: 'b',
+                    right: 'a',
                   },
                 },
                 {
                   messageId: 'unexpectedClassesDependencyOrder',
                   data: {
-                    left: 'b',
-                    dependency: 'z',
+                    right: 'b',
+                    nodeDependentOnRight: 'd',
                   },
                 },
                 {
                   messageId: 'unexpectedClassesDependencyOrder',
                   data: {
-                    left: 'c',
-                    dependency: 'z',
+                    right: 'c',
+                    nodeDependentOnRight: 'e',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    right: 'z',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],
@@ -2973,15 +2980,8 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedClassesDependencyOrder',
                   data: {
-                    left: 'a',
-                    dependency: 'c',
-                  },
-                },
-                {
-                  messageId: 'unexpectedClassesOrder',
-                  data: {
-                    left: 'b',
                     right: 'c',
+                    nodeDependentOnRight: 'a',
                   },
                 },
               ],
@@ -3647,29 +3647,15 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedClassesDependencyOrder',
                   data: {
-                    left: 'a',
-                    dependency: 'c',
-                  },
-                },
-                {
-                  messageId: 'unexpectedClassesDependencyOrder',
-                  data: {
-                    left: 'b',
-                    dependency: 'c',
-                  },
-                },
-                {
-                  messageId: 'unexpectedClassesDependencyOrder',
-                  data: {
-                    dependency: 'c',
-                    left: 'b',
-                  },
-                },
-                {
-                  messageId: 'unexpectedClassesOrder',
-                  data: {
-                    left: 'c',
                     right: 'c',
+                    nodeDependentOnRight: 'b',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    right: 'c',
+                    nodeDependentOnRight: 'a',
                   },
                 },
               ],
@@ -3711,24 +3697,24 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesDependencyOrder',
-                  data: {
-                    dependency: 'e',
-                    left: 'b',
-                  },
-                },
-                {
-                  messageId: 'unexpectedClassesDependencyOrder',
-                  data: {
-                    left: 'e',
-                    dependency: 'g',
-                  },
-                },
-                {
                   messageId: 'unexpectedClassesOrder',
                   data: {
-                    left: 'f',
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    right: 'e',
+                    nodeDependentOnRight: 'b',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
                     right: 'g',
+                    nodeDependentOnRight: 'e',
                   },
                 },
               ],
@@ -3834,8 +3820,15 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedClassesDependencyOrder',
                   data: {
-                    dependency: 'left',
-                    left: 'aaa',
+                    right: 'left',
+                    nodeDependentOnRight: 'aaa',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    right: 'right',
+                    nodeDependentOnRight: 'aaa',
                   },
                 },
               ],
@@ -4864,8 +4857,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesDependencyOrder',
                 data: {
-                  left: 'aaa',
-                  dependency: 'b',
+                  right: 'b',
+                  nodeDependentOnRight: 'aaa',
                 },
               },
             ],
@@ -5040,8 +5033,15 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedClassesDependencyOrder',
                 data: {
-                  dependency: 'left',
-                  left: 'aaa',
+                  right: 'left',
+                  nodeDependentOnRight: 'aaa',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesDependencyOrder',
+                data: {
+                  right: 'right',
+                  nodeDependentOnRight: 'aaa',
                 },
               },
             ],

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1850,10 +1850,10 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedEnumsOrder',
+                messageId: 'unexpectedEnumsDependencyOrder',
                 data: {
-                  left: 'B',
                   right: 'C',
+                  nodeDependentOnRight: 'A',
                 },
               },
             ],
@@ -1924,10 +1924,10 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'unexpectedEnumsOrder',
+                messageId: 'unexpectedEnumsDependencyOrder',
                 data: {
-                  left: 'E',
                   right: 'F',
+                  nodeDependentOnRight: 'B',
                 },
               },
             ],

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -511,7 +511,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
                     left: 'b',
                     right: 'c',
@@ -543,7 +543,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
                     left: 'c',
                     right: 'b',
@@ -580,7 +580,7 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
                     left: 'b',
                     right: 'c',
@@ -612,7 +612,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
                     left: 'b',
                     right: 'c',
@@ -644,7 +644,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
                     left: 'b',
                     right: 'c',
@@ -1916,7 +1916,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'b',
                   right: 'c',
@@ -1948,7 +1948,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'c',
                   right: 'b',
@@ -1985,7 +1985,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'b',
                   right: 'c',
@@ -2017,7 +2017,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'b',
                   right: 'c',
@@ -2049,7 +2049,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'b',
                   right: 'c',
@@ -2751,7 +2751,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'b',
                   right: 'c',
@@ -2783,7 +2783,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'c',
                   right: 'b',
@@ -2820,7 +2820,7 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'b',
                   right: 'c',
@@ -2852,7 +2852,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedObjectsOrder',
+                messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
                   left: 'b',
                   right: 'c',

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -513,8 +513,8 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'c',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],
@@ -545,8 +545,8 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'c',
                     right: 'b',
+                    nodeDependentOnRight: 'c',
                   },
                 },
               ],
@@ -582,8 +582,8 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'c',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],
@@ -614,8 +614,8 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'c',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],
@@ -646,8 +646,8 @@ describe(ruleName, () => {
                 {
                   messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'c',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],
@@ -674,10 +674,10 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'c',
+                    nodeDependentOnRight: 'a',
                   },
                 },
               ],
@@ -1158,10 +1158,10 @@ describe(ruleName, () => {
                   },
                 },
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'e',
                     right: 'f',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],
@@ -1918,8 +1918,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'b',
                   right: 'c',
+                  nodeDependentOnRight: 'b',
                 },
               },
             ],
@@ -1950,8 +1950,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'c',
                   right: 'b',
+                  nodeDependentOnRight: 'c',
                 },
               },
             ],
@@ -1987,8 +1987,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'b',
                   right: 'c',
+                  nodeDependentOnRight: 'b',
                 },
               },
             ],
@@ -2019,8 +2019,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'b',
                   right: 'c',
+                  nodeDependentOnRight: 'b',
                 },
               },
             ],
@@ -2051,8 +2051,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'b',
                   right: 'c',
+                  nodeDependentOnRight: 'b',
                 },
               },
             ],
@@ -2753,8 +2753,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'b',
                   right: 'c',
+                  nodeDependentOnRight: 'b',
                 },
               },
             ],
@@ -2785,8 +2785,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'c',
                   right: 'b',
+                  nodeDependentOnRight: 'c',
                 },
               },
             ],
@@ -2822,8 +2822,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'b',
                   right: 'c',
+                  nodeDependentOnRight: 'b',
                 },
               },
             ],
@@ -2854,8 +2854,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedObjectsDependencyOrder',
                 data: {
-                  left: 'b',
                   right: 'c',
+                  nodeDependentOnRight: 'b',
                 },
               },
             ],

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -794,8 +794,8 @@ describe(ruleName, () => {
               {
                 messageId: 'unexpectedVariableDeclarationsOrder',
                 data: {
-                  right: 'bb',
-                  nodeDependentOnRight: 'aaa',
+                  left: 'b',
+                  right: 'a',
                 },
               },
             ],

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -185,7 +185,10 @@ describe(ruleName, () => {
               errors: [
                 {
                   messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                  data: { left: 'aaa', right: 'bb' },
+                  data: {
+                    right: 'bb',
+                    nodeDependentOnRight: 'aaa',
+                  },
                 },
               ],
             },
@@ -204,7 +207,10 @@ describe(ruleName, () => {
               errors: [
                 {
                   messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                  data: { left: 'b', right: 'a' },
+                  data: {
+                    right: 'a',
+                    nodeDependentOnRight: 'b',
+                  },
                 },
               ],
             },
@@ -223,7 +229,10 @@ describe(ruleName, () => {
               errors: [
                 {
                   messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                  data: { left: 'y', right: 'x' },
+                  data: {
+                    right: 'x',
+                    nodeDependentOnRight: 'y',
+                  },
                 },
               ],
             },
@@ -242,7 +251,10 @@ describe(ruleName, () => {
               errors: [
                 {
                   messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                  data: { left: 'sum', right: 'arr' },
+                  data: {
+                    right: 'arr',
+                    nodeDependentOnRight: 'sum',
+                  },
                 },
               ],
             },
@@ -261,7 +273,10 @@ describe(ruleName, () => {
               errors: [
                 {
                   messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                  data: { left: 'value', right: 'getValue' },
+                  data: {
+                    right: 'getValue',
+                    nodeDependentOnRight: 'value',
+                  },
                 },
               ],
             },
@@ -279,8 +294,11 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                  data: { left: 'b', right: 'c' },
+                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+                  data: {
+                    right: 'c',
+                    nodeDependentOnRight: 'a',
+                  },
                 },
               ],
             },
@@ -775,7 +793,10 @@ describe(ruleName, () => {
             errors: [
               {
                 messageId: 'unexpectedVariableDeclarationsOrder',
-                data: { left: 'b', right: 'a' },
+                data: {
+                  right: 'bb',
+                  nodeDependentOnRight: 'aaa',
+                },
               },
             ],
           },
@@ -794,7 +815,10 @@ describe(ruleName, () => {
             errors: [
               {
                 messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                data: { left: 'aaa', right: 'bb' },
+                data: {
+                  right: 'bb',
+                  nodeDependentOnRight: 'aaa',
+                },
               },
             ],
           },
@@ -813,7 +837,10 @@ describe(ruleName, () => {
             errors: [
               {
                 messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                data: { left: 'b', right: 'a' },
+                data: {
+                  right: 'a',
+                  nodeDependentOnRight: 'b',
+                },
               },
             ],
           },
@@ -832,7 +859,10 @@ describe(ruleName, () => {
             errors: [
               {
                 messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                data: { left: 'y', right: 'x' },
+                data: {
+                  right: 'x',
+                  nodeDependentOnRight: 'y',
+                },
               },
             ],
           },
@@ -851,7 +881,10 @@ describe(ruleName, () => {
             errors: [
               {
                 messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                data: { left: 'sum', right: 'arr' },
+                data: {
+                  right: 'arr',
+                  nodeDependentOnRight: 'sum',
+                },
               },
             ],
           },
@@ -870,7 +903,10 @@ describe(ruleName, () => {
             errors: [
               {
                 messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                data: { left: 'value', right: 'getValue' },
+                data: {
+                  right: 'getValue',
+                  nodeDependentOnRight: 'value',
+                },
               },
             ],
           },
@@ -908,8 +944,11 @@ describe(ruleName, () => {
                 data: { left: 'c', right: 'd' },
               },
               {
-                messageId: 'unexpectedVariableDeclarationsOrder',
-                data: { left: 'e', right: 'f' },
+                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+                data: {
+                  right: 'f',
+                  nodeDependentOnRight: 'b',
+                },
               },
             ],
           },

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -184,7 +184,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedVariableDeclarationsOrder',
+                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                   data: { left: 'aaa', right: 'bb' },
                 },
               ],
@@ -203,7 +203,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedVariableDeclarationsOrder',
+                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                   data: { left: 'b', right: 'a' },
                 },
               ],
@@ -222,7 +222,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedVariableDeclarationsOrder',
+                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                   data: { left: 'y', right: 'x' },
                 },
               ],
@@ -241,7 +241,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedVariableDeclarationsOrder',
+                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                   data: { left: 'sum', right: 'arr' },
                 },
               ],
@@ -260,7 +260,7 @@ describe(ruleName, () => {
               options: [options],
               errors: [
                 {
-                  messageId: 'unexpectedVariableDeclarationsOrder',
+                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                   data: { left: 'value', right: 'getValue' },
                 },
               ],
@@ -793,7 +793,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedVariableDeclarationsOrder',
+                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                 data: { left: 'aaa', right: 'bb' },
               },
             ],
@@ -812,7 +812,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedVariableDeclarationsOrder',
+                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                 data: { left: 'b', right: 'a' },
               },
             ],
@@ -831,7 +831,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedVariableDeclarationsOrder',
+                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                 data: { left: 'y', right: 'x' },
               },
             ],
@@ -850,7 +850,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedVariableDeclarationsOrder',
+                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                 data: { left: 'sum', right: 'arr' },
               },
             ],
@@ -869,7 +869,7 @@ describe(ruleName, () => {
             options: [options],
             errors: [
               {
-                messageId: 'unexpectedVariableDeclarationsOrder',
+                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
                 data: { left: 'value', right: 'getValue' },
               },
             ],

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -49,24 +49,25 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
   return result
 }
 
+/**
+ * Returns the first node that is dependent on the given node, but is not
+ * ordered before it
+ */
 export let getFirstUnorderedDependency = (
   node: SortingNodeWithDependencies,
   currentlyOrderedNodes: SortingNodeWithDependencies[],
-): SortingNodeWithDependencies | null => {
-  let firstNodeDependentOnNode = currentlyOrderedNodes.find(
+): SortingNodeWithDependencies | undefined => {
+  let nodesDependentOnNode = currentlyOrderedNodes.filter(
     currentlyOrderedNode =>
       currentlyOrderedNode.dependencies.includes(
         node.dependencyName ?? node.name,
       ),
   )
-  if (firstNodeDependentOnNode) {
+  return nodesDependentOnNode.find(firstNodeDependentOnNode => {
     let currentIndexOfNode = currentlyOrderedNodes.indexOf(node)
     let currentIndexOfFirstNodeDependentOnNode = currentlyOrderedNodes.indexOf(
       firstNodeDependentOnNode,
     )
-    if (currentIndexOfFirstNodeDependentOnNode < currentIndexOfNode) {
-      return firstNodeDependentOnNode
-    }
-  }
-  return null
+    return currentIndexOfFirstNodeDependentOnNode < currentIndexOfNode
+  })
 }

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -53,7 +53,7 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
  * Returns the first node that is dependent on the given node, but is not
  * ordered before it
  */
-export let getFirstUnorderedDependency = (
+export let getFirstUnorderedNodeDependentOn = (
   node: SortingNodeWithDependencies,
   currentlyOrderedNodes: SortingNodeWithDependencies[],
 ): SortingNodeWithDependencies | undefined => {


### PR DESCRIPTION
Resolves #270.

Adds a new error for each rule that is impacted by dependency order:
- [x] `sort-classes`: `unexpectedClassesDependencyOrder`
- [x] `sort-enums`: `unexpectedEnumsDependencyOrder'` 
- [x] `sort-objects`: `unexpectedObjectsDependencyOrder` 
- [x] `sort-variable-declarations`: `unexpectedVariableDeclarationsDependencyOrder` 

Code 
```ts
class Class {

  a = { // A very complex object depending on `static z`
         // ...
         attribute: Class.z,
         // ...
         }
  
   // [...] Many other members

  someMethod() {
     // ...
 }

  static z = 0
}
```

#### Before for `z`

![image](https://github.com/user-attachments/assets/9c20491c-2b8b-40a3-83df-8f6f9550e0fc)


#### After for `z`

![image](https://github.com/user-attachments/assets/21307c1e-0a2a-47e6-9082-a31b5110911f)
