### PR TITLE
fix(sort-classes): #268: ignored nodes prevent their adjacent node from triggering linting

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -682,11 +682,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
         pairwise(nodes, (left, right) => {
           let leftNum = getGroupNumber(options.groups, left)
           let rightNum = getGroupNumber(options.groups, right)
-          // Ignore nodes belonging to `unknown` group when that group is not referenced in the
-          // `groups` option.
-          let isLeftOrRightIgnored =
-            leftNum === options.groups.length ||
-            rightNum === options.groups.length
 
           let indexOfLeft = sortedNodes.indexOf(left)
           let indexOfRight = sortedNodes.indexOf(right)
@@ -694,7 +689,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             getFirstUnorderedNodeDependentOn(right, nodes)
           if (
             firstUnorderedNodeDependentOnRight ||
-            (!isLeftOrRightIgnored && indexOfLeft > indexOfRight)
+            indexOfLeft > indexOfRight
           ) {
             let messageId: MESSAGE_ID
             if (firstUnorderedNodeDependentOnRight) {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3923,6 +3923,77 @@ describe(ruleName, () => {
                 rightGroup: 'private-method',
               },
             },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'z',
+                leftGroup: 'private-method',
+                right: 'method3',
+                rightGroup: 'unknown',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method3',
+                leftGroup: 'unknown',
+                right: 'y',
+                rightGroup: 'private-method',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method1',
+                leftGroup: 'unknown',
+                right: 'x',
+                rightGroup: 'private-method',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+              class Class {
+                b
+                someMethod() {
+                }
+                a
+              }
+            `,
+          output: dedent`
+              class Class {
+                a
+                someMethod() {
+                }
+                b
+              }
+            `,
+          options: [
+            {
+              ...options,
+              groups: ['property'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'b',
+                leftGroup: 'property',
+                right: 'someMethod',
+                rightGroup: 'unknown',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'someMethod',
+                leftGroup: 'unknown',
+                right: 'a',
+                rightGroup: 'property',
+              },
+            },
           ],
         },
       ],
@@ -5135,6 +5206,77 @@ describe(ruleName, () => {
                 rightGroup: 'private-method',
               },
             },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'z',
+                leftGroup: 'private-method',
+                right: 'method3',
+                rightGroup: 'unknown',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method3',
+                leftGroup: 'unknown',
+                right: 'y',
+                rightGroup: 'private-method',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method1',
+                leftGroup: 'unknown',
+                right: 'x',
+                rightGroup: 'private-method',
+              },
+            },
+          ],
+        },
+        {
+          code: dedent`
+              class Class {
+                b
+                someMethod() {
+                }
+                a
+              }
+            `,
+          output: dedent`
+              class Class {
+                a
+                someMethod() {
+                }
+                b
+              }
+            `,
+          options: [
+            {
+              ...options,
+              groups: ['property'],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'b',
+                leftGroup: 'property',
+                right: 'someMethod',
+                rightGroup: 'unknown',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'someMethod',
+                leftGroup: 'unknown',
+                right: 'a',
+                rightGroup: 'property',
+              },
+            },
           ],
         },
       ],
@@ -5967,6 +6109,24 @@ describe(ruleName, () => {
                 left: 'i',
                 leftGroup: 'property',
                 right: 'z',
+                rightGroup: 'private-method',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method3',
+                leftGroup: 'unknown',
+                right: 'y',
+                rightGroup: 'private-method',
+              },
+            },
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'method1',
+                leftGroup: 'unknown',
+                right: 'x',
                 rightGroup: 'private-method',
               },
             },


### PR DESCRIPTION
### Description

Fixes #268.

When implementing the notion of ignored `unknown` group, ignored nodes were set to avoid creating linting errors: it's a bit counter-intuitive to tell the user that an ignored node should be before or after another node if it's supposed to be ignored.

Because linting errors are based on adjacent nodes comparison, classes that **only** have errors between ignored nodes and their adjacent nodes will not raise any error, and thus not trigger linting.

In practice, this likely shouldn't happen often and is fixed as soon as another error is detected in the class, as it will trigger linting and correctly sort it, so I don't believe this is a big issue (I detected it by accident while trying something else).

Custom groups with the `unsorted` sort type are unrelated to this issue. Only cases where a node has the `unknown` group may trigger this behavior.

This PR removes the checks that prevented errors from being raised between an ignored node and its adjacent nodes.

Because those ignored nodes now create ESLint error messages, a test had to be updated as it would now display more errors than before.

#### Possible improvements for another PR

```ts
class Class {
    b

    method() {
    }

    a
}
```

This PR will make the following errors appear:
- on `method`: `Expected "method" (unknown) to come before "b" (property)`
- on `a`: `Expected "a" (property) to come before "method" (unknown)`

The ideal message should appear only on `a` and say `Expected "a" to come before "b"`.
The reasoning behind is that if we compute that a node N1 needs to be placed before an adjacent ignored node NI, then there is at least one other node N2 before NI that should be placed after N1.


### What is the purpose of this pull request?

- [x] Bug fix
