### PR TITLE
feat(multiple rules): Do not sort unknown elements if unknown is not referenced in groups

### DIFF
--- a/docs/content/rules/sort-astro-attributes.mdx
+++ b/docs/content/rules/sort-astro-attributes.mdx
@@ -138,7 +138,14 @@ Controls whether sorting should be case-sensitive or not.
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of Astro attribute groups for sorting. Groups help organize attributes into categories, prioritizing them during sorting. Multiple groups can be combined to achieve the desired sorting order.
 
@@ -149,7 +156,7 @@ Predefined Groups:
 - `'multiline'` — Attributes with multiline values.
 -	`'shorthand'` — Shorthand attributes, which are used without a value, typically for boolean props.
 -	`'astro-shorthand'` — Astro shorthand attributes, where the attribute name and value are the same.
-- `'unknown'` — Attributes that don’t fit into any other group.
+- `'unknown'` — Attributes that don’t fit into any other group. If the `unknown` group is not specified in `groups`, the attributes will remain in their original order.
 
 Example:
 
@@ -246,7 +253,7 @@ In order to start using this rule, you need to install additional dependency:
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
-                  groups: [],
+                  groups: ['unknown'],
                   customGroups: {},
                 },
               ],
@@ -277,7 +284,7 @@ In order to start using this rule, you need to install additional dependency:
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
-                groups: [],
+                groups: ['unknown'],
                 customGroups: {},
               },
             ],

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -205,7 +205,14 @@ Specifies how optional and required members should be ordered in TypeScript inte
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of interface member groups for sorting. Groups help organize members into categories, making your interfaces more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
 
@@ -214,7 +221,7 @@ There are predefined group: `'multiline'`.
 Predefined Groups:
 
 - `'multiline'` — Members with multiline definitions, such as methods or properties with complex types.
-- `'unknown'` — Interface members that don’t fit into any other group.
+- `'unknown'` — Interface members that don’t fit into any other group. If the `unknown` group is not specified in `groups`, the members will remain in their original order.
 
 ### customGroups
 
@@ -263,7 +270,7 @@ Example:
                   ignorePattern: [],
                   partitionByNewLine: false,
                   optionalityOrder: 'ignore',
-                  groups: [],
+                  groups: ['unknown'],
                   customGroups: {},
                 },
               ],
@@ -291,7 +298,7 @@ Example:
                 ignorePattern: [],
                 partitionByNewLine: false,
                 optionalityOrder: 'ignore',
-                groups: [],
+                groups: ['unknown'],
                 customGroups: {},
               },
             ],

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -124,7 +124,7 @@ Predefined Groups:
 - `'tuple`' — Tuple types.
 - `'union`' — Union types.
 - `'nullish`' — Nullish types (`null` or `undefined`).
-- `'unknown`' — Types that don’t fit into any other group.
+- `'unknown'` — Types that don’t fit into any other group. If the `unknown` group is not specified in `groups`, the types will remain in their original order.
 
 Example:
 

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -172,7 +172,14 @@ You can specify their names or a glob pattern to ignore, for example: `'Table*'`
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of JSX props groups for sorting. Groups help organize props into categories, making your components more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
 
@@ -182,7 +189,7 @@ Predefined Groups:
 
 - `'multiline'` — Props with multiline values.
 - `'shorthand'` — Shorthand props, which are used without a value, typically for boolean props.
-- `'unknown'` — Props that don’t fit into any other group.
+- `'unknown'` — Props that don’t fit into any other group. If the `unknown` group is not specified in `groups`, the props will remain in their original order.
 
 ### customGroups
 
@@ -228,7 +235,7 @@ Example:
                   order: 'asc',
                   ignoreCase: true,
                   ignorePattern: [],
-                  groups: [],
+                  groups: ['unknown'],
                   customGroups: {},
                 },
               ],
@@ -254,7 +261,7 @@ Example:
                 order: 'asc',
                 ignoreCase: true,
                 ignorePattern: [],
-                groups: [],
+                groups: ['unknown'],
                 customGroups: {},
               },
             ],

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -162,7 +162,14 @@ Allows you to group type object keys by their kind, determining whether required
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of type properties groups for sorting. Groups help organize properties into categories, making your type definitions more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
 
@@ -171,7 +178,7 @@ There are predefined group: `'multiline'`.
 Predefined Group:
 
 - `'multiline'` — Properties with multiline definitions, such as methods or complex type declarations.
-- `'unknown'` — Properties that don’t fit into any other group.
+- `'unknown'` — Properties that don’t fit into any other group. If the `unknown` group is not specified in `groups`, the properties will remain in their original order.
 
 ### customGroups
 
@@ -216,7 +223,7 @@ Example:
                   order: 'asc',
                   ignoreCase: true,
                   partitionByNewLine: false,
-                  groups: [],
+                  groups: ['unknown'],
                   customGroups: {},
                 },
               ],
@@ -242,7 +249,7 @@ Example:
                 order: 'asc',
                 ignoreCase: true,
                 partitionByNewLine: false,
-                groups: [],
+                groups: ['unknown'],
                 customGroups: {},
               },
             ],

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -240,11 +240,20 @@ Allows you to sort only objects that are part of a destructuring pattern. When s
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of object keys groups for sorting. Groups help organize object keys into categories, making your objects more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
 
-There are no predefined groups. You must use this with the `customGroups` option.
+Predefined Groups:
+
+- `'unknown'` — Properties that don’t fit into any custom group you may enter. If the `unknown` group is not specified in `groups`, the properties will remain in their original order.
 
 ### customGroups
 
@@ -290,7 +299,7 @@ You can define your own groups for object keys using custom glob patterns for ma
                   styledComponents: true,
                   ignorePattern: [],
                   customIgnore: [],
-                  groups: [],
+                  groups: ['unknown'],
                   customGroups: {},
                 },
               ],
@@ -320,7 +329,7 @@ You can define your own groups for object keys using custom glob patterns for ma
                 styledComponents: true,
                 ignorePattern: [],
                 customIgnore: [],
-                groups: [],
+                groups: ['unknown'],
                 customGroups: {},
               },
             ],

--- a/docs/content/rules/sort-svelte-attributes.mdx
+++ b/docs/content/rules/sort-svelte-attributes.mdx
@@ -133,7 +133,14 @@ Controls whether sorting should be case-sensitive or not.
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of Svelte attribute groups for sorting. Groups help organize attributes into categories, making your components more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
 
@@ -144,7 +151,7 @@ Predefined Groups:
 - `'multiline'` — Attributes whose length exceeds one line, such as event handlers or functions.
 - `'shorthand'` — Shorthand attributes, which are used without a value, typically for boolean props.
 - `'svelte-shorthand'` — Svelte’s shorthand for replacing `name={name}` with `{name}`.
-- `'unknown'` — Svelte attributes that don’t fit into any other group.
+- `'unknown'` — Svelte attributes that don’t fit into any other group. If the `unknown` group is not specified in `groups`, the attributes will remain in their original order.
 
 Example:
 
@@ -250,7 +257,7 @@ In order to start using this rule, you need to install additional dependency:
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
-                  groups: [],
+                  groups: ['unknown'],
                   customGroups: {},
                 },
               ],
@@ -281,7 +288,7 @@ In order to start using this rule, you need to install additional dependency:
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
-                groups: [],
+                groups: ['unknown'],
                 customGroups: {},
               },
             ],

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -124,7 +124,14 @@ Controls whether sorting should be case-sensitive or not.
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of union type groups for sorting. Groups help organize types into categories, making your type definitions more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
 
@@ -144,7 +151,7 @@ Predefined Groups:
 - `'tuple`' — Tuple types.
 - `'union`' — Union types.
 - `'nullish`' — Nullish types (`null` or `undefined`).
-- `'unknown`' — Types that don’t fit into any group entered by the user.
+- `'unknown`' — Types that don’t fit into any group entered by the user. If the `unknown` group is not specified in `groups`, the types will remain in their original order.
 
 Example using all predefined groups:
 
@@ -243,7 +250,7 @@ groups: [
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
-                  groups: [],
+                  groups: ['unknown'],
                 },
               ],
             },
@@ -267,7 +274,7 @@ groups: [
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
-                groups: [],
+                groups: ['unknown'],
               },
             ],
           },

--- a/docs/content/rules/sort-vue-attributes.mdx
+++ b/docs/content/rules/sort-vue-attributes.mdx
@@ -167,7 +167,14 @@ Controls whether sorting should be case-sensitive or not.
 
 ### groups
 
-<sub>default: `[]`</sub>
+<sub>
+  default:
+  ```
+  [
+    'unknown',
+  ]
+  ```
+</sub>
 
 Allows you to specify a list of Vue attribute groups for sorting. Groups help organize attributes into categories, making your components more readable and maintainable. Multiple groups can be combined to achieve the desired sorting order.
 
@@ -177,7 +184,7 @@ Predefined Groups:
 
 - `'multiline'` — Attributes with multiline values, such as event handlers or functions.
 - `'shorthand'` — Shorthand attributes, which are used without a value, typically for boolean props.
-- `'unknown'` — Vue attributes that don’t fit into any other group.
+- `'unknown'` — Vue attributes that don’t fit into any other group. If the `unknown` group is not specified in `groups`, the attributes will remain in their original order.
 
 ### customGroups
 
@@ -258,7 +265,7 @@ In order to start using this rule, you need to install additional dependency:
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
-                  groups: [],
+                  groups: ['unknown'],
                   customGroups: {},
                 },
               ],
@@ -289,7 +296,7 @@ In order to start using this rule, you need to install additional dependency:
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
-                groups: [],
+                groups: ['unknown'],
                 customGroups: {},
               },
             ],

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -5,18 +5,16 @@ import { minimatch } from 'minimatch'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
-import { sortNodes } from '../utils/sort-nodes'
 import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID = 'unexpectedJSXPropsGroupOrder' | 'unexpectedJSXPropsOrder'
 
@@ -124,7 +122,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       order: 'asc',
       ignoreCase: true,
       ignorePattern: [],
-      groups: [],
+      groups: ['unknown'],
       customGroups: {},
     },
   ],
@@ -139,7 +137,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           ignoreCase: true,
           customGroups: {},
           order: 'asc',
-          groups: [],
+          groups: ['unknown'],
         } as const)
 
         validateGroupsConfiguration(
@@ -203,15 +201,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           )
 
           for (let nodes of parts) {
+            let sortedNodes = sortNodesByGroups(nodes, options)
             pairwise(nodes, (left, right) => {
-              let leftNum = getGroupNumber(options.groups, left)
-              let rightNum = getGroupNumber(options.groups, right)
-
-              if (
-                leftNum > rightNum ||
-                (leftNum === rightNum &&
-                  isPositive(compare(left, right, options)))
-              ) {
+              let indexOfLeft = sortedNodes.indexOf(left)
+              let indexOfRight = sortedNodes.indexOf(right)
+              if (indexOfLeft > indexOfRight) {
+                let leftNum = getGroupNumber(options.groups, left)
+                let rightNum = getGroupNumber(options.groups, right)
                 context.report({
                   messageId:
                     leftNum !== rightNum
@@ -224,34 +220,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     rightGroup: right.group,
                   },
                   node: right.node,
-                  fix: fixer => {
-                    let grouped: {
-                      [key: string]: SortingNode[]
-                    } = {}
-
-                    for (let currentNode of nodes) {
-                      let groupNum = getGroupNumber(options.groups, currentNode)
-
-                      if (!(groupNum in grouped)) {
-                        grouped[groupNum] = [currentNode]
-                      } else {
-                        grouped[groupNum] = sortNodes(
-                          [...grouped[groupNum], currentNode],
-                          options,
-                        )
-                      }
-                    }
-
-                    let sortedNodes: SortingNode[] = []
-
-                    for (let group of Object.keys(grouped).sort(
-                      (a, b) => Number(a) - Number(b),
-                    )) {
-                      sortedNodes.push(...sortNodes(grouped[group], options))
-                    }
-
-                    return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-                  },
+                  fix: fixer =>
+                    makeFixes(fixer, nodes, sortedNodes, sourceCode),
                 })
               }
             })

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -10,13 +11,10 @@ import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
-import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID =
   | 'unexpectedObjectTypesGroupOrder'
@@ -126,7 +124,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       ignoreCase: true,
       partitionByNewLine: false,
       groupKind: 'mixed',
-      groups: [],
+      groups: ['unknown'],
       customGroups: {},
     },
   ],
@@ -142,7 +140,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           ignoreCase: true,
           customGroups: {},
           order: 'asc',
-          groups: [],
+          groups: ['unknown'],
         } as const)
 
         validateGroupsConfiguration(
@@ -228,58 +226,43 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           )
 
         for (let nodes of formattedMembers) {
+          let groupedByKind
+          if (options.groupKind !== 'mixed') {
+            groupedByKind = nodes.reduce<SortingNode<TSESTree.TypeElement>[][]>(
+              (accumulator, currentNode) => {
+                let requiredIndex =
+                  options.groupKind === 'required-first' ? 0 : 1
+                let optionalIndex =
+                  options.groupKind === 'required-first' ? 1 : 0
+
+                if (
+                  'optional' in currentNode.node &&
+                  currentNode.node.optional
+                ) {
+                  accumulator[optionalIndex].push(currentNode)
+                } else {
+                  accumulator[requiredIndex].push(currentNode)
+                }
+                return accumulator
+              },
+              [[], []],
+            )
+          } else {
+            groupedByKind = [nodes]
+          }
+
+          let sortedNodes: SortingNode[] = []
+
+          for (let nodesByKind of groupedByKind) {
+            sortedNodes.push(...sortNodesByGroups(nodesByKind, options))
+          }
+
           pairwise(nodes, (left, right) => {
-            let leftNum = getGroupNumber(options.groups, left)
-            let rightNum = getGroupNumber(options.groups, right)
-
-            let getIsOptionalValue = (nodeValue: TSESTree.TypeElement) => {
-              if (
-                nodeValue.type === 'TSCallSignatureDeclaration' ||
-                nodeValue.type === 'TSConstructSignatureDeclaration' ||
-                nodeValue.type === 'TSIndexSignature'
-              ) {
-                return false
-              }
-              return nodeValue.optional
-            }
-
-            let isLeftOptional = getIsOptionalValue(left.node)
-            let isRightOptional = getIsOptionalValue(right.node)
-
-            let compareValue
-            if (
-              options.groupKind === 'optional-first' &&
-              isLeftOptional &&
-              !isRightOptional
-            ) {
-              compareValue = false
-            } else if (
-              options.groupKind === 'optional-first' &&
-              !isLeftOptional &&
-              isRightOptional
-            ) {
-              compareValue = true
-            } else if (
-              options.groupKind === 'required-first' &&
-              !isLeftOptional &&
-              isRightOptional
-            ) {
-              compareValue = false
-            } else if (
-              options.groupKind === 'required-first' &&
-              isLeftOptional &&
-              !isRightOptional
-            ) {
-              compareValue = true
-            } else if (leftNum > rightNum) {
-              compareValue = true
-            } else if (leftNum === rightNum) {
-              compareValue = isPositive(compare(left, right, options))
-            } else {
-              compareValue = false
-            }
-
-            if (compareValue) {
+            let indexOfLeft = sortedNodes.indexOf(left)
+            let indexOfRight = sortedNodes.indexOf(right)
+            if (indexOfLeft > indexOfRight) {
+              let leftNum = getGroupNumber(options.groups, left)
+              let rightNum = getGroupNumber(options.groups, right)
               context.report({
                 messageId:
                   leftNum !== rightNum
@@ -292,60 +275,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   rightGroup: right.group,
                 },
                 node: right.node,
-                fix: fixer => {
-                  let groupedByKind
-                  if (options.groupKind !== 'mixed') {
-                    groupedByKind = nodes.reduce<
-                      SortingNode<TSESTree.TypeElement>[][]
-                    >(
-                      (accumulator, currentNode) => {
-                        let requiredIndex =
-                          options.groupKind === 'required-first' ? 0 : 1
-                        let optionalIndex =
-                          options.groupKind === 'required-first' ? 1 : 0
-
-                        if (getIsOptionalValue(currentNode.node)) {
-                          accumulator[optionalIndex].push(currentNode)
-                        } else {
-                          accumulator[requiredIndex].push(currentNode)
-                        }
-                        return accumulator
-                      },
-                      [[], []],
-                    )
-                  } else {
-                    groupedByKind = [nodes]
-                  }
-
-                  let sortedNodes: SortingNode[] = []
-
-                  for (let nodesByKind of groupedByKind) {
-                    let grouped: {
-                      [key: string]: SortingNode[]
-                    } = {}
-
-                    for (let currentNode of nodesByKind) {
-                      let groupNum = getGroupNumber(options.groups, currentNode)
-
-                      if (!(groupNum in grouped)) {
-                        grouped[groupNum] = [currentNode]
-                      } else {
-                        grouped[groupNum] = sortNodes(
-                          [...grouped[groupNum], currentNode],
-                          options,
-                        )
-                      }
-                    }
-
-                    for (let group of Object.keys(grouped).sort(
-                      (a, b) => Number(a) - Number(b),
-                    )) {
-                      sortedNodes.push(...sortNodes(grouped[group], options))
-                    }
-                  }
-
-                  return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-                },
+                fix: fixer => makeFixes(fixer, nodes, sortedNodes, sourceCode),
               })
             }
           })

--- a/rules/sort-svelte-attributes.ts
+++ b/rules/sort-svelte-attributes.ts
@@ -6,18 +6,16 @@ import path from 'node:path'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
-import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID =
   | 'unexpectedSvelteAttributesGroupOrder'
@@ -118,7 +116,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
-      groups: [],
+      groups: ['unknown'],
       customGroups: {},
     },
   ],
@@ -137,7 +135,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             ignoreCase: true,
             customGroups: {},
             order: 'asc',
-            groups: [],
+            groups: ['unknown'],
           } as const)
 
           validateGroupsConfiguration(
@@ -202,15 +200,14 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           )
 
           for (let nodes of parts) {
-            pairwise(nodes, (left, right) => {
-              let leftNum = getGroupNumber(options.groups, left)
-              let rightNum = getGroupNumber(options.groups, right)
+            let sortedNodes = sortNodesByGroups(nodes, options)
 
-              if (
-                leftNum > rightNum ||
-                (leftNum === rightNum &&
-                  isPositive(compare(left, right, options)))
-              ) {
+            pairwise(nodes, (left, right) => {
+              let indexOfLeft = sortedNodes.indexOf(left)
+              let indexOfRight = sortedNodes.indexOf(right)
+              if (indexOfLeft > indexOfRight) {
+                let leftNum = getGroupNumber(options.groups, left)
+                let rightNum = getGroupNumber(options.groups, right)
                 context.report({
                   messageId:
                     leftNum !== rightNum
@@ -223,34 +220,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     rightGroup: right.group,
                   },
                   node: right.node,
-                  fix: fixer => {
-                    let grouped: {
-                      [key: string]: SortingNode[]
-                    } = {}
-
-                    for (let currentNode of nodes) {
-                      let groupNum = getGroupNumber(options.groups, currentNode)
-
-                      if (!(groupNum in grouped)) {
-                        grouped[groupNum] = [currentNode]
-                      } else {
-                        grouped[groupNum] = sortNodes(
-                          [...grouped[groupNum], currentNode],
-                          options,
-                        )
-                      }
-                    }
-
-                    let sortedNodes: SortingNode[] = []
-
-                    for (let group of Object.keys(grouped).sort(
-                      (a, b) => Number(a) - Number(b),
-                    )) {
-                      sortedNodes.push(...sortNodes(grouped[group], options))
-                    }
-
-                    return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-                  },
+                  fix: fixer =>
+                    makeFixes(fixer, nodes, sortedNodes, sourceCode),
                 })
               }
             })

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -1,19 +1,17 @@
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
-import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID = 'unexpectedUnionTypesGroupOrder' | 'unexpectedUnionTypesOrder'
 
@@ -102,7 +100,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
-      groups: [],
+      groups: ['unknown'],
     },
   ],
   create: context => ({
@@ -113,7 +111,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         type: 'alphabetical',
         ignoreCase: true,
         order: 'asc',
-        groups: [],
+        groups: ['unknown'],
       } as const)
 
       validateGroupsConfiguration(
@@ -208,14 +206,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
         }
       })
 
-      pairwise(nodes, (left, right) => {
-        let leftNum = getGroupNumber(options.groups, left)
-        let rightNum = getGroupNumber(options.groups, right)
+      let sortedNodes = sortNodesByGroups(nodes, options)
 
-        if (
-          leftNum > rightNum ||
-          (leftNum === rightNum && isPositive(compare(left, right, options)))
-        ) {
+      pairwise(nodes, (left, right) => {
+        let indexOfLeft = sortedNodes.indexOf(left)
+        let indexOfRight = sortedNodes.indexOf(right)
+        if (indexOfLeft > indexOfRight) {
+          let leftNum = getGroupNumber(options.groups, left)
+          let rightNum = getGroupNumber(options.groups, right)
           context.report({
             messageId:
               leftNum !== rightNum
@@ -228,34 +226,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               rightGroup: right.group,
             },
             node: right.node,
-            fix: fixer => {
-              let grouped: {
-                [key: string]: SortingNode[]
-              } = {}
-
-              for (let currentNode of nodes) {
-                let groupNum = getGroupNumber(options.groups, currentNode)
-
-                if (!(groupNum in grouped)) {
-                  grouped[groupNum] = [currentNode]
-                } else {
-                  grouped[groupNum] = sortNodes(
-                    [...grouped[groupNum], currentNode],
-                    options,
-                  )
-                }
-              }
-
-              let sortedNodes: SortingNode[] = []
-
-              for (let group of Object.keys(grouped).sort(
-                (a, b) => Number(a) - Number(b),
-              )) {
-                sortedNodes.push(...sortNodes(grouped[group], options))
-              }
-
-              return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-            },
+            fix: fixer => makeFixes(fixer, nodes, sortedNodes, sourceCode),
           })
         }
       })

--- a/rules/sort-vue-attributes.ts
+++ b/rules/sort-vue-attributes.ts
@@ -6,17 +6,15 @@ import path from 'node:path'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
-import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID =
   | 'unexpectedVueAttributesGroupOrder'
@@ -116,7 +114,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
-      groups: [],
+      groups: ['unknown'],
       customGroups: {},
     },
   ],
@@ -149,7 +147,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             ignoreCase: true,
             customGroups: {},
             order: 'asc',
-            groups: [],
+            groups: ['unknown'],
           } as const)
 
           validateGroupsConfiguration(
@@ -206,15 +204,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           )
 
           for (let nodes of parts) {
+            let sortedNodes = sortNodesByGroups(nodes, options)
             pairwise(nodes, (left, right) => {
-              let leftNum = getGroupNumber(options.groups, left)
-              let rightNum = getGroupNumber(options.groups, right)
-
-              if (
-                leftNum > rightNum ||
-                (leftNum === rightNum &&
-                  isPositive(compare(left, right, options)))
-              ) {
+              let indexOfLeft = sortedNodes.indexOf(left)
+              let indexOfRight = sortedNodes.indexOf(right)
+              if (indexOfLeft > indexOfRight) {
+                let leftNum = getGroupNumber(options.groups, left)
+                let rightNum = getGroupNumber(options.groups, right)
                 context.report({
                   messageId:
                     leftNum !== rightNum
@@ -226,36 +222,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     right: right.name,
                     rightGroup: right.group,
                   },
-                  // @ts-ignore
                   node: right.node,
-                  fix: fixer => {
-                    let grouped: {
-                      [key: string]: SortingNode[]
-                    } = {}
-
-                    for (let currentNode of nodes) {
-                      let groupNum = getGroupNumber(options.groups, currentNode)
-
-                      if (!(groupNum in grouped)) {
-                        grouped[groupNum] = [currentNode]
-                      } else {
-                        grouped[groupNum] = sortNodes(
-                          [...grouped[groupNum], currentNode],
-                          options,
-                        )
-                      }
-                    }
-
-                    let sortedNodes: SortingNode[] = []
-
-                    for (let group of Object.keys(grouped).sort(
-                      (a, b) => Number(a) - Number(b),
-                    )) {
-                      sortedNodes.push(...sortNodes(grouped[group], options))
-                    }
-
-                    return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-                  },
+                  fix: fixer =>
+                    makeFixes(fixer, nodes, sortedNodes, sourceCode),
                 })
               }
             })

--- a/test/sort-astro-attributes.test.ts
+++ b/test/sort-astro-attributes.test.ts
@@ -1405,5 +1405,38 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file.astro',
+            code: dedent`
+              ---
+                import Component from '../file.astro'
+
+                let d = 'd'
+              ---
+              <Component
+                eee="e"
+                {b}
+                a="a"
+                c
+                dd="d"
+              />
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['astro-shorthand', 'shorthand'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -2314,5 +2314,64 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface Interface {
+                a: string
+                dX: string
+                b: string
+                cX: string
+                e: string
+              }
+            `,
+            output: dedent`
+              interface Interface {
+                a: string
+                cX: string
+                b: string
+                dX: string
+                e: string
+              }
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['attributesEndingWithX'],
+                customGroups: {
+                  attributesEndingWithX: '*X',
+                },
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesGroupOrder',
+                data: {
+                  left: 'dX',
+                  leftGroup: 'attributesEndingWithX',
+                  right: 'b',
+                  rightGroup: 'unknown',
+                },
+              },
+              {
+                messageId: 'unexpectedInterfacePropertiesGroupOrder',
+                data: {
+                  left: 'b',
+                  leftGroup: 'unknown',
+                  right: 'cX',
+                  rightGroup: 'attributesEndingWithX',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 })

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -1243,5 +1243,49 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              type Type = 0 & D & 1 & C & 2
+            `,
+            output: dedent`
+              type Type = 0 & C & 1 & D & 2
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['named'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedIntersectionTypesGroupOrder',
+                data: {
+                  left: 'D',
+                  leftGroup: 'named',
+                  right: '1',
+                  rightGroup: 'unknown',
+                },
+              },
+              {
+                messageId: 'unexpectedIntersectionTypesGroupOrder',
+                data: {
+                  left: '1',
+                  leftGroup: 'unknown',
+                  right: 'C',
+                  rightGroup: 'named',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 })

--- a/test/sort-jsx-props.test.ts
+++ b/test/sort-jsx-props.test.ts
@@ -1544,5 +1544,61 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              <Element
+                eee="e"
+                c
+                a="a"
+                b
+                dd="d"
+              />
+            `,
+            output: dedent`
+              <Element
+                eee="e"
+                b
+                a="a"
+                c
+                dd="d"
+              />
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['shorthand'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedJSXPropsGroupOrder',
+                data: {
+                  left: 'c',
+                  leftGroup: 'shorthand',
+                  right: 'a',
+                  rightGroup: 'unknown',
+                },
+              },
+              {
+                messageId: 'unexpectedJSXPropsGroupOrder',
+                data: {
+                  left: 'a',
+                  leftGroup: 'unknown',
+                  right: 'b',
+                  rightGroup: 'shorthand',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 })

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -1854,5 +1854,64 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              type Type = {
+                a: string
+                dX: string
+                b: string
+                cX: string
+                e: string
+              }
+            `,
+            output: dedent`
+              type Type = {
+                a: string
+                cX: string
+                b: string
+                dX: string
+                e: string
+              }
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['attributesEndingWithX'],
+                customGroups: {
+                  attributesEndingWithX: '*X',
+                },
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedObjectTypesGroupOrder',
+                data: {
+                  left: 'dX',
+                  leftGroup: 'attributesEndingWithX',
+                  right: 'b',
+                  rightGroup: 'unknown',
+                },
+              },
+              {
+                messageId: 'unexpectedObjectTypesGroupOrder',
+                data: {
+                  left: 'b',
+                  leftGroup: 'unknown',
+                  right: 'cX',
+                  rightGroup: 'attributesEndingWithX',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 })

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -3728,6 +3728,65 @@ describe(ruleName, () => {
           },
         ],
       })
+
+      ruleTester.run(
+        `${ruleName}: should ignore unknown group if not referenced in groups`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              let obj = {
+                a: 0,
+                dX: 0,
+                b: 0,
+                cX: 0,
+                e: 0,
+              }
+            `,
+              output: dedent`
+              let obj = {
+                a: 0,
+                cX: 0,
+                b: 0,
+                dX: 0,
+                e: 0,
+              }
+            `,
+              options: [
+                {
+                  type: 'alphabetical',
+                  groups: ['attributesEndingWithX'],
+                  customGroups: {
+                    attributesEndingWithX: '*X',
+                  },
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedObjectsGroupOrder',
+                  data: {
+                    left: 'dX',
+                    leftGroup: 'attributesEndingWithX',
+                    right: 'b',
+                    rightGroup: 'unknown',
+                  },
+                },
+                {
+                  messageId: 'unexpectedObjectsGroupOrder',
+                  data: {
+                    left: 'b',
+                    leftGroup: 'unknown',
+                    right: 'cX',
+                    rightGroup: 'attributesEndingWithX',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
     })
   })
 })

--- a/test/sort-svelte-attributes.test.ts
+++ b/test/sort-svelte-attributes.test.ts
@@ -1430,5 +1430,33 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'filename.svelte',
+            code: dedent`
+              <Component
+                eee="e"
+                {b}
+                a="a"
+                c
+                dd="d"
+              />
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['svelte-shorthand', 'shorthand'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -1275,5 +1275,49 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              type Type = 0 | D | 1 | C | 2
+            `,
+            output: dedent`
+              type Type = 0 | C | 1 | D | 2
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['named'],
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedUnionTypesGroupOrder',
+                data: {
+                  left: 'D',
+                  leftGroup: 'named',
+                  right: '1',
+                  rightGroup: 'unknown',
+                },
+              },
+              {
+                messageId: 'unexpectedUnionTypesGroupOrder',
+                data: {
+                  left: '1',
+                  leftGroup: 'unknown',
+                  right: 'C',
+                  rightGroup: 'named',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 })

--- a/test/sort-vue-attributes.test.ts
+++ b/test/sort-vue-attributes.test.ts
@@ -949,5 +949,33 @@ describe(ruleName, () => {
         invalid: [],
       })
     })
+
+    ruleTester.run(
+      `${ruleName}: should ignore unknown group if not referenced in groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file.vue',
+            code: dedent`
+              <component
+                eee="e"
+                {b}
+                a="a"
+                c
+                dd="d"
+              />
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                groups: ['shorthand'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/utils/sort-nodes-by-groups.ts
+++ b/utils/sort-nodes-by-groups.ts
@@ -1,0 +1,44 @@
+import type { CompareOptions } from './compare'
+import type { SortingNode } from '../typings'
+
+import { getGroupNumber } from './get-group-number'
+import { sortNodes } from './sort-nodes'
+
+interface GroupOptions {
+  groups: (string[] | string)[]
+}
+
+export let sortNodesByGroups = <T extends SortingNode>(
+  nodes: T[],
+  options: CompareOptions & GroupOptions,
+): T[] => {
+  let nodesByNonIgnoredGroupNumber: {
+    [key: number]: T[]
+  } = {}
+  let ignoredNodeIndices: number[] = []
+  for (let [index, sortingNode] of nodes.entries()) {
+    let groupNum = getGroupNumber(options.groups, sortingNode)
+    if (groupNum === options.groups.length) {
+      ignoredNodeIndices.push(index)
+      continue
+    }
+    nodesByNonIgnoredGroupNumber[groupNum] =
+      nodesByNonIgnoredGroupNumber[groupNum] ?? []
+    nodesByNonIgnoredGroupNumber[groupNum].push(sortingNode)
+  }
+
+  let sortedNodes: T[] = []
+  for (let groupNumber of Object.keys(nodesByNonIgnoredGroupNumber).sort(
+    (a, b) => Number(a) - Number(b),
+  )) {
+    sortedNodes.push(
+      ...sortNodes(nodesByNonIgnoredGroupNumber[Number(groupNumber)], options),
+    )
+  }
+
+  // Add ignored nodes at the same position as they were before linting
+  for (let ignoredIndex of ignoredNodeIndices) {
+    sortedNodes.splice(ignoredIndex, 0, nodes[ignoredIndex])
+  }
+  return sortedNodes
+}


### PR DESCRIPTION
### Description

The large majority of the actual code added involves documentation and tests.

Extends #220 to other rules that handle the `unknown` group.

When the `unknown` group is not entered by the user in the `groups` option, `unknown` group members will not be sorted and will remain where they are rather than go at the very bottom.

- [x] `sort-astro-attributes`
- [x] `sort-interfaces`
- [x] `sort-intersection-types`
- [x] `sort-jsx-props`
- [x] `sort-object-types`
- [x] `sort-objects`
- [x] `sort-svelte-attributes`
- [x] `sort-union-types`
- [x] `sort-vue-attributes`

The `sort-imports` rule takes into account other complex elements such as newline separation, making it very different than other rules. Left for another PR if needed.


Rules that had a default group configuration equal to `[]` now have `['unknown']` (otherwise, they would not sort anything by default).

Because all those rules rely on the same code to sort groups, a `sortNodesByGroups` function has been extracted, greatly reducing the amount of duplicate code.

No existing unit test was impacted.

- [x] Add tests

### What is the purpose of this pull request?

- [x] New Feature