### PR TITLE
feat(#272): `sort-exports`: adds `partitionByNewline`

### DIFF
--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -106,6 +106,23 @@ Controls whether sorting should be case-sensitive or not.
 - `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
 - `false` — Consider case when sorting (e.g., “A” comes before “a”).
 
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the exports if there is an empty line between them. This can be useful for keeping logically separated groups of exports in their defined order.
+
+```js
+// Group 1
+export * from "./atoms";
+export * from "./organisms";
+export * from "./shared";
+
+// Group 2
+export { Named } from './folder';
+export { AnotherNamed } from './second-folder';
+```
+
 ## Usage
 
 <CodeTabs
@@ -127,6 +144,7 @@ Controls whether sorting should be case-sensitive or not.
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
+                  partitionByNewLine: false,
                 },
               ],
             },
@@ -150,6 +168,7 @@ Controls whether sorting should be case-sensitive or not.
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
+                partitionByNewLine: false,
               },
             ],
           },

--- a/test/sort-exports.test.ts
+++ b/test/sort-exports.test.ts
@@ -158,6 +158,56 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use new line as partition`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              export * from "./organisms";
+              export * from "./atoms";
+              export * from "./shared";
+
+              export { AnotherNamed } from './second-folder';
+              export { Named } from './folder';
+            `,
+            output: dedent`
+              export * from "./atoms";
+              export * from "./organisms";
+              export * from "./shared";
+
+              export { Named } from './folder';
+              export { AnotherNamed } from './second-folder';
+            `,
+            options: [
+              {
+                ...options,
+                partitionByNewLine: true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: './organisms',
+                  right: './atoms',
+                },
+              },
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: './second-folder',
+                  right: './folder',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {
@@ -302,6 +352,56 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use new line as partition`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              export * from "./organisms";
+              export * from "./atoms";
+              export * from "./shared";
+
+              export { AnotherNamed } from './second-folder';
+              export { Named } from './folder';
+            `,
+            output: dedent`
+              export * from "./atoms";
+              export * from "./organisms";
+              export * from "./shared";
+
+              export { Named } from './folder';
+              export { AnotherNamed } from './second-folder';
+            `,
+            options: [
+              {
+                ...options,
+                partitionByNewLine: true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: './organisms',
+                  right: './atoms',
+                },
+              },
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: './second-folder',
+                  right: './folder',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by line length`, () => {


### PR DESCRIPTION
### Description

Resolves #272: Adds a `partitionByNewline` option (default to `false`).

### What is the purpose of this pull request?

- [x] New Feature
- [x] Documentation update
