### PR TITLE
fix(sort-classes): #275: partitionByComment/partitionByLine takes precedence over dependencies

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -688,42 +688,40 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             leftNum === options.groups.length ||
             rightNum === options.groups.length
 
-            let indexOfLeft = sortedNodes.indexOf(left)
-            let indexOfRight = sortedNodes.indexOf(right)
-            let firstUnorderedNodeDependentOnRight =
-              getFirstUnorderedNodeDependentOn(right, nodes)
-            if (
-              firstUnorderedNodeDependentOnRight ||
-              (!isLeftOrRightIgnored && indexOfLeft > indexOfRight)
-            ) {
-              let messageId: MESSAGE_ID
-              if (firstUnorderedNodeDependentOnRight) {
-                messageId = 'unexpectedClassesDependencyOrder'
-              } else {
-                messageId =
-                  leftNum !== rightNum
-                    ? 'unexpectedClassesGroupOrder'
-                    : 'unexpectedClassesOrder'
-              }
-              context.report({
-                messageId,
-                data: {
-                  left: toSingleLine(left.name),
-                  leftGroup: left.group,
-                  right: toSingleLine(right.name),
-                  rightGroup: right.group,
-                  nodeDependentOnRight:
-                    firstUnorderedNodeDependentOnRight?.name,
-                },
-                node: right.node,
-                fix: (fixer: TSESLint.RuleFixer) =>
-                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                    partitionComment: options.partitionByComment,
-                  }),
-              })
+          let indexOfLeft = sortedNodes.indexOf(left)
+          let indexOfRight = sortedNodes.indexOf(right)
+          let firstUnorderedNodeDependentOnRight =
+            getFirstUnorderedNodeDependentOn(right, nodes)
+          if (
+            firstUnorderedNodeDependentOnRight ||
+            (!isLeftOrRightIgnored && indexOfLeft > indexOfRight)
+          ) {
+            let messageId: MESSAGE_ID
+            if (firstUnorderedNodeDependentOnRight) {
+              messageId = 'unexpectedClassesDependencyOrder'
+            } else {
+              messageId =
+                leftNum !== rightNum
+                  ? 'unexpectedClassesGroupOrder'
+                  : 'unexpectedClassesOrder'
             }
-          })
-        }
+            context.report({
+              messageId,
+              data: {
+                left: toSingleLine(left.name),
+                leftGroup: left.group,
+                right: toSingleLine(right.name),
+                rightGroup: right.group,
+                nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
+              },
+              node: right.node,
+              fix: (fixer: TSESLint.RuleFixer) =>
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                  partitionComment: options.partitionByComment,
+                }),
+            })
+          }
+        })
       }
     },
   }),

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -634,6 +634,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           [[]],
         )
 
+        let sortedNodes: SortingNodeWithDependencies[] = []
         for (let nodes of formattedNodes) {
           let nodesByNonIgnoredGroupNumber: {
             [key: number]: SortingNodeWithDependencies[]
@@ -650,7 +651,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             nodesByNonIgnoredGroupNumber[groupNum].push(sortingNode)
           }
 
-          let sortedNodes: SortingNodeWithDependencies[] = []
           for (let groupNumber of Object.keys(
             nodesByNonIgnoredGroupNumber,
           ).sort((a, b) => Number(a) - Number(b))) {
@@ -674,17 +674,19 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           for (let ignoredIndex of ignoredNodeIndices) {
             sortedNodes.splice(ignoredIndex, 0, nodes[ignoredIndex])
           }
+        }
 
-          sortedNodes = sortNodesByDependencies(sortedNodes)
+        sortedNodes = sortNodesByDependencies(sortedNodes)
+        let nodes = formattedNodes.flat()
 
-          pairwise(nodes, (left, right) => {
-            let leftNum = getGroupNumber(options.groups, left)
-            let rightNum = getGroupNumber(options.groups, right)
-            // Ignore nodes belonging to `unknown` group when that group is not referenced in the
-            // `groups` option.
-            let isLeftOrRightIgnored =
-              leftNum === options.groups.length ||
-              rightNum === options.groups.length
+        pairwise(nodes, (left, right) => {
+          let leftNum = getGroupNumber(options.groups, left)
+          let rightNum = getGroupNumber(options.groups, right)
+          // Ignore nodes belonging to `unknown` group when that group is not referenced in the
+          // `groups` option.
+          let isLeftOrRightIgnored =
+            leftNum === options.groups.length ||
+            rightNum === options.groups.length
 
             let indexOfLeft = sortedNodes.indexOf(left)
             let indexOfRight = sortedNodes.indexOf(right)

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -242,6 +242,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 }
               : undefined,
         }
+        let sortedNodes = sortNodesByDependencies(
+          formattedMembers
+            .map(nodes => sortNodes(nodes, compareOptions))
+            .flat(),
+        )
+        let nodes = formattedMembers.flat()
         for (let nodes of formattedMembers) {
           let sortedNodes = sortNodesByDependencies(
             sortNodes(nodes, compareOptions),

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -248,35 +248,29 @@ export default createEslintRule<Options, MESSAGE_ID>({
             .flat(),
         )
         let nodes = formattedMembers.flat()
-        for (let nodes of formattedMembers) {
-          let sortedNodes = sortNodesByDependencies(
-            sortNodes(nodes, compareOptions),
-          )
-          pairwise(nodes, (left, right) => {
-            let indexOfLeft = sortedNodes.indexOf(left)
-            let indexOfRight = sortedNodes.indexOf(right)
-            if (indexOfLeft > indexOfRight) {
-              let firstUnorderedNodeDependentOnRight =
-                getFirstUnorderedNodeDependentOn(right, nodes)
-              context.report({
-                messageId: firstUnorderedNodeDependentOnRight
-                  ? 'unexpectedEnumsDependencyOrder'
-                  : 'unexpectedEnumsOrder',
-                data: {
-                  left: toSingleLine(left.name),
-                  right: toSingleLine(right.name),
-                  nodeDependentOnRight:
-                    firstUnorderedNodeDependentOnRight?.name,
-                },
-                node: right.node,
-                fix: fixer =>
-                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                    partitionComment,
-                  }),
-              })
-            }
-          })
-        }
+        pairwise(nodes, (left, right) => {
+          let indexOfLeft = sortedNodes.indexOf(left)
+          let indexOfRight = sortedNodes.indexOf(right)
+          if (indexOfLeft > indexOfRight) {
+            let firstUnorderedNodeDependentOnRight =
+              getFirstUnorderedNodeDependentOn(right, nodes)
+            context.report({
+              messageId: firstUnorderedNodeDependentOnRight
+                ? 'unexpectedEnumsDependencyOrder'
+                : 'unexpectedEnumsOrder',
+              data: {
+                left: toSingleLine(left.name),
+                right: toSingleLine(right.name),
+                nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
+              },
+              node: right.node,
+              fix: fixer =>
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                  partitionComment,
+                }),
+            })
+          }
+        })
       }
     },
   }),

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -435,7 +435,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             [[]],
           )
 
-        for (let nodes of formatProperties(node.properties)) {
+        let sortedNodes: SortingNodeWithDependencies[] = []
+
+        let formattedNodes = formatProperties(node.properties)
+        for (let nodes of formattedNodes) {
           let grouped: {
             [key: string]: SortingNodeWithDependencies[]
           } = {}
@@ -450,15 +453,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             }
           }
 
-          let sortedNodes: SortingNodeWithDependencies[] = []
-
           for (let group of Object.keys(grouped).sort(
             (a, b) => Number(a) - Number(b),
           )) {
             sortedNodes.push(...sortNodes(grouped[group], options))
           }
+        }
 
-          sortedNodes = sortNodesByDependencies(sortedNodes)
+        sortedNodes = sortNodesByDependencies(sortedNodes)
+        let nodes = formattedNodes.flat()
 
           pairwise(nodes, (left, right) => {
             let indexOfLeft = sortedNodes.indexOf(left)

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -463,46 +463,44 @@ export default createEslintRule<Options, MESSAGE_ID>({
         sortedNodes = sortNodesByDependencies(sortedNodes)
         let nodes = formattedNodes.flat()
 
-          pairwise(nodes, (left, right) => {
-            let indexOfLeft = sortedNodes.indexOf(left)
-            let indexOfRight = sortedNodes.indexOf(right)
+        pairwise(nodes, (left, right) => {
+          let indexOfLeft = sortedNodes.indexOf(left)
+          let indexOfRight = sortedNodes.indexOf(right)
 
-            if (indexOfLeft > indexOfRight) {
-              let firstUnorderedNodeDependentOnRight =
-                getFirstUnorderedNodeDependentOn(right, nodes)
-              let fix:
-                | ((fixer: TSESLint.RuleFixer) => TSESLint.RuleFix[])
-                | undefined = fixer =>
-                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                  partitionComment: options.partitionByComment,
-                })
-              let leftNum = getGroupNumber(options.groups, left)
-              let rightNum = getGroupNumber(options.groups, right)
-              let messageId: MESSAGE_ID
-              if (firstUnorderedNodeDependentOnRight) {
-                messageId = 'unexpectedObjectsDependencyOrder'
-              } else {
-                messageId =
-                  leftNum !== rightNum
-                    ? 'unexpectedObjectsGroupOrder'
-                    : 'unexpectedObjectsOrder'
-              }
-              context.report({
-                messageId,
-                data: {
-                  left: toSingleLine(left.name),
-                  leftGroup: left.group,
-                  right: toSingleLine(right.name),
-                  rightGroup: right.group,
-                  nodeDependentOnRight:
-                    firstUnorderedNodeDependentOnRight?.name,
-                },
-                node: right.node,
-                fix,
+          if (indexOfLeft > indexOfRight) {
+            let firstUnorderedNodeDependentOnRight =
+              getFirstUnorderedNodeDependentOn(right, nodes)
+            let fix:
+              | ((fixer: TSESLint.RuleFixer) => TSESLint.RuleFix[])
+              | undefined = fixer =>
+              makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                partitionComment: options.partitionByComment,
               })
+            let leftNum = getGroupNumber(options.groups, left)
+            let rightNum = getGroupNumber(options.groups, right)
+            let messageId: MESSAGE_ID
+            if (firstUnorderedNodeDependentOnRight) {
+              messageId = 'unexpectedObjectsDependencyOrder'
+            } else {
+              messageId =
+                leftNum !== rightNum
+                  ? 'unexpectedObjectsGroupOrder'
+                  : 'unexpectedObjectsOrder'
             }
-          })
-        }
+            context.report({
+              messageId,
+              data: {
+                left: toSingleLine(left.name),
+                leftGroup: left.group,
+                right: toSingleLine(right.name),
+                rightGroup: right.group,
+                nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
+              },
+              node: right.node,
+              fix,
+            })
+          }
+        })
       }
     }
 

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3779,6 +3779,47 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                class Class {
+                  b = this.a
+                  // Part1
+                  a
+                }
+              `,
+              output: dedent`
+                class Class {
+                  a
+                  // Part1
+                  b = this.a
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: 'Part*',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}): works with left and right dependencies`,
         rule,
         {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3807,10 +3807,10 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedClassesOrder',
+                  messageId: 'unexpectedClassesDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'a',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1964,10 +1964,10 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedEnumsOrder',
+                  messageId: 'unexpectedEnumsDependencyOrder',
                   data: {
-                    left: 'B',
                     right: 'A',
+                    nodeDependentOnRight: 'B',
                   },
                 },
               ],

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1934,6 +1934,47 @@ describe(ruleName, () => {
           },
         ],
       })
+
+      ruleTester.run(
+        `${ruleName}: prioritizes dependencies over partitionByComment`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              enum Enum {
+                B = A,
+                // Part: 1
+                A = 'A',
+              }
+            `,
+              output: dedent`
+              enum Enum {
+                A = 'A',
+                // Part: 1
+                B = A,
+              }
+            `,
+              options: [
+                {
+                  type: 'alphabetical',
+                  partitionByComment: 'Part**',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedEnumsOrder',
+                  data: {
+                    left: 'B',
+                    right: 'A',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
     })
 
     describe('handles complex comment cases', () => {

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1236,10 +1236,10 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'a',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],
@@ -1281,10 +1281,10 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'unexpectedObjectsOrder',
+                  messageId: 'unexpectedObjectsDependencyOrder',
                   data: {
-                    left: 'b',
                     right: 'a',
+                    nodeDependentOnRight: 'b',
                   },
                 },
               ],

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1202,6 +1202,51 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              let Func = ({
+                b = a,
+                // Part: 1
+                a = 0,
+              }) => {
+                // ...
+              }
+            `,
+              output: dedent`
+                let Func = ({
+                  a = 0,
+                  // Part: 1
+                  b = a,
+                }) => {
+                  // ...
+                }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: 'Part**',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedObjectsOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
     })
 
     ruleTester.run(

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1247,6 +1247,51 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              let Func = ({
+                b = a,
+
+                a = 0,
+              }) => {
+                // ...
+              }
+            `,
+              output: dedent`
+                let Func = ({
+                  a = 0,
+
+                  b = a,
+                }) => {
+                  // ...
+                }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByNewLine: true,
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedObjectsOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
     })
 
     ruleTester.run(


### PR DESCRIPTION
Fixes #275 for `sort-classes`, `sort-objects` and `sort-enums`.

The problem comes from the fact that the dependency check is done within each "block" partitioned by comments/line, rather than globally across the whole class/object/enum.

There is very little code change in reality! A large code block has been moved out of a `for` block; so the new indent generates a lot of line changes.

Note: the following code

```ts
class Class {
    b = this.a
    // Part1
    a
}
```

Will get sorted into

```ts
class Class {
    a
    // Part1
    b = this.a
}
```

This means that `b` is now part of the partitioned group defined by `Part1`! Ideally, we would want to get

```ts
class Class {
    a
    b = this.a
    // Part1
}
```

or

```ts
class Class {
    // Part1
    a
    b = this.a
}
```

Unfortunately, the current sorting implementation permutates elements between each others, which is why `a` gets permuted with `b`, and partition comments are never moved around.

This applies for `sort-objects` and `sort-enums` as well.

The current fix should do the job for now.

- [x] Bug fix