### PR TITLE
feat(sort-array-includes + sort-sets): Adds `partitionByComment` and `partitionByNewLine`

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -158,6 +158,44 @@ Allows you to group array elements by their kind, determining whether spread val
 - `literals-first` — Group all literal values before spread values.
 - `spread-first` — Group all spread values before literal values.
 
+### partitionByComment
+
+<sub>default: `false`</sub>
+
+Allows you to use comments to separate the members of arrays into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
+
+- `true` — All comments will be treated as delimiters, creating partitions.
+-	`false` — Comments will not be used as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of an array if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+if ([
+     // Group 1
+    'Drone',
+    'Keyboard',
+    'Mouse',
+    'Smartphone',
+
+    // Group 2
+    'Laptop',
+    'Monitor',
+    'Smartwatch',
+    'Tablet',
+
+    // Group 3
+    'Headphones',
+    'Router',
+  ].includes(product.name)) {
+    return 'Electronics'
+  }
+```
 
 ## Usage
 
@@ -181,6 +219,7 @@ Allows you to group array elements by their kind, determining whether spread val
                   order: 'asc',
                   ignoreCase: true,
                   groupKind: 'literals-first',
+                  partitionByNewLine: false,
                 },
               ],
             },
@@ -205,6 +244,7 @@ Allows you to group array elements by their kind, determining whether spread val
                 order: 'asc',
                 ignoreCase: true,
                 groupKind: 'literals-first',
+                partitionByNewLine: false,
               },
             ],
           },

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -164,6 +164,42 @@ Allows you to group set elements by their kind, determining whether spread value
 - `literals-first` — Group all literal values before spread values.
 - `spread-first` — Group all spread values before literal values.
 
+### partitionByComment
+
+<sub>default: `false`</sub>
+
+Allows you to use comments to separate the members of enums into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
+
+- `true` — All comments will be treated as delimiters, creating partitions.
+-	`false` — Comments will not be used as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of a set if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+let items = new Set([
+     // Group 1
+    'Drone',
+    'Keyboard',
+    'Mouse',
+    'Smartphone',
+
+    // Group 2
+    'Laptop',
+    'Monitor',
+    'Smartwatch',
+    'Tablet',
+
+    // Group 3
+    'Headphones',
+    'Router',
+  ])
+```
 
 ## Usage
 


### PR DESCRIPTION
### Description

Adds these two options to `sort-array-includes` and `sort-sets`.

### What is the purpose of this pull request?

- [x] New Feature
