### PR TITLE
feat(sort maps): Adds `partitionByNewLine` and `partitionByComment`

### DIFF
--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -107,6 +107,43 @@ Controls whether sorting should be case-sensitive or not.
 - `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
 - `false` — Consider case when sorting (e.g., “A” comes before “a”).
 
+### partitionByComment
+
+<sub>default: `false`</sub>
+
+Allows you to use comments to separate the members of maps into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
+
+- `true` — All comments will be treated as delimiters, creating partitions.
+-	`false` — Comments will not be used as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of a map if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+new Map([
+     // Group 1
+    ['Drone', 0],
+    ['Keyboard', 1],
+    ['Mouse', 3],
+    ['Smartphone', 4],
+
+    // Group 2
+    ['Laptop', 5],
+    ['Monitor', 6],
+    ['Smartwatch', 7],
+    ['Tablet', 8],
+
+    // Group 3
+    ['Headphones', 9],
+    ['Router', 10],
+  ])
+```
+
 ## Usage
 
 <CodeTabs
@@ -128,6 +165,8 @@ Controls whether sorting should be case-sensitive or not.
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
+                  partitionByNewLine: false,
+                  partitionByComment: false,
                 },
               ],
             },
@@ -151,6 +190,8 @@ Controls whether sorting should be case-sensitive or not.
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
+                partitionByNewLine: false,
+                partitionByComment: false,
               },
             ],
           },


### PR DESCRIPTION
### Description

Adds these two options to `sort-maps`.

### What is the purpose of this pull request?

- [x] New Feature
