### PR TITLE
feat(sort-named-imports): Adds `partitionByComment` and `partitionByNewLine`

### DIFF
--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -145,6 +145,44 @@ Allows you to group named imports by their kind, determining whether value impor
 - `values-first` — Group all value imports before type imports.
 - `types-first` — Group all type imports before value imports.
 
+### partitionByComment
+
+<sub>default: `false`</sub>
+
+Allows you to use comments to separate the members of named imports into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
+
+- `true` — All comments will be treated as delimiters, creating partitions.
+-	`false` — Comments will not be used as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of named imports if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+import {
+     // Group 1
+    Drone,
+    Keyboard,
+    Mouse,
+    Smartphone,
+
+    // Group 2
+    Laptop,
+    Monitor,
+    Smartwatch,
+    Tablet,
+
+    // Group 3
+    Headphones,
+    Router,
+} from './devices'
+```
+
+
 ## Usage
 
 <CodeTabs
@@ -168,6 +206,8 @@ Allows you to group named imports by their kind, determining whether value impor
                   ignoreAlias: false,
                   ignoreCase: true,
                   groupKind: 'mixed',
+                  partitionByNewLine: false,
+                  partitionByComment: false,
                 },
               ],
             },
@@ -193,6 +233,8 @@ Allows you to group named imports by their kind, determining whether value impor
                 ignoreAlias: false,
                 ignoreCase: true,
                 groupKind: 'mixed',
+                partitionByNewLine: false,
+                partitionByComment: false,
               },
             ],
           },

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -1,6 +1,9 @@
 import type { SortingNode } from '../typings'
 
+import { hasPartitionComment } from '../utils/is-partition-comment'
+import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
+import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -18,6 +21,8 @@ type Options = [
   Partial<{
     groupKind: 'values-first' | 'types-first' | 'mixed'
     type: 'alphabetical' | 'line-length' | 'natural'
+    partitionByComment: string[] | boolean | string
+    partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreAlias: boolean
     ignoreCase: boolean
@@ -61,6 +66,29 @@ export default createEslintRule<Options, MESSAGE_ID>({
             enum: ['mixed', 'values-first', 'types-first'],
             type: 'string',
           },
+          partitionByComment: {
+            description:
+              'Allows you to use comments to separate the named imports members into logical groups.',
+            anyOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'string',
+              },
+            ],
+          },
+          partitionByNewLine: {
+            description:
+              'Allows to use spaces to separate the nodes into logical groups.',
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
@@ -76,6 +104,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
       order: 'asc',
       ignoreAlias: false,
       ignoreCase: true,
+      partitionByNewLine: false,
+      partitionByComment: false,
       groupKind: 'mixed',
     },
   ],
@@ -93,12 +123,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreAlias: false,
           groupKind: 'mixed',
           ignoreCase: true,
+          partitionByNewLine: false,
+          partitionByComment: false,
           order: 'asc',
         } as const)
 
         let sourceCode = getSourceCode(context)
+        let partitionComment = options.partitionByComment
 
-        let nodes: SortingNode[] = specifiers.map(specifier => {
+        let formattedMembers: SortingNode[][] = [[]]
+        for (let specifier of specifiers) {
           let group: undefined | 'value' | 'type'
           let { name } = specifier.local
 
@@ -115,13 +149,29 @@ export default createEslintRule<Options, MESSAGE_ID>({
             group = 'value'
           }
 
-          return {
+          let lastSortingNode = formattedMembers.at(-1)?.at(-1)
+          let sortingNode: SortingNode = {
             size: rangeToDiff(specifier.range),
             node: specifier,
             group,
             name,
           }
-        })
+
+          if (
+            (partitionComment &&
+              hasPartitionComment(
+                partitionComment,
+                getCommentsBefore(specifier, sourceCode),
+              )) ||
+            (options.partitionByNewLine &&
+              lastSortingNode &&
+              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+          ) {
+            formattedMembers.push([])
+          }
+
+          formattedMembers.at(-1)!.push(sortingNode)
+        }
 
         let shouldGroupByKind = options.groupKind !== 'mixed'
         let groupKindOrder =
@@ -129,33 +179,37 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ? ['value', 'type']
             : ['type', 'value']
 
-        pairwise(nodes, (left, right) => {
-          let leftNum = getGroupNumber(groupKindOrder, left)
-          let rightNum = getGroupNumber(groupKindOrder, right)
+        for (let nodes of formattedMembers) {
+          pairwise(nodes, (left, right) => {
+            let leftNum = getGroupNumber(groupKindOrder, left)
+            let rightNum = getGroupNumber(groupKindOrder, right)
+            if (
+              (shouldGroupByKind && leftNum > rightNum) ||
+              ((!shouldGroupByKind || leftNum === rightNum) &&
+                isPositive(compare(left, right, options)))
+            ) {
+              let sortedNodes = shouldGroupByKind
+                ? groupKindOrder
+                    .map(group => nodes.filter(n => n.group === group))
+                    .map(groupedNodes => sortNodes(groupedNodes, options))
+                    .flat()
+                : sortNodes(nodes, options)
 
-          if (
-            (shouldGroupByKind && leftNum > rightNum) ||
-            ((!shouldGroupByKind || leftNum === rightNum) &&
-              isPositive(compare(left, right, options)))
-          ) {
-            let sortedNodes = shouldGroupByKind
-              ? groupKindOrder
-                  .map(group => nodes.filter(n => n.group === group))
-                  .map(groupedNodes => sortNodes(groupedNodes, options))
-                  .flat()
-              : sortNodes(nodes, options)
-
-            context.report({
-              messageId: 'unexpectedNamedImportsOrder',
-              data: {
-                left: left.name,
-                right: right.name,
-              },
-              node: right.node,
-              fix: fixer => makeFixes(fixer, nodes, sortedNodes, sourceCode),
-            })
-          }
-        })
+              context.report({
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: left.name,
+                  right: right.name,
+                },
+                node: right.node,
+                fix: fixer =>
+                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                    partitionComment,
+                  }),
+              })
+            }
+          })
+        }
       }
     },
   }),


### PR DESCRIPTION
### Description

Adds these two options to `sort-array-includes` and `sort-sets`.

### What is the purpose of this pull request?

- [x] New Feature
