### PR TITLE
feat(sort-variable-declarations): Adds `partitionByComment` and `partitionByNewLine`

### DIFF
--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -106,6 +106,38 @@ Controls whether sorting should be case-sensitive or not.
 - `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
 - `false` — Consider case when sorting (e.g., “A” comes before “a”).
 
+
+### partitionByComment
+
+<sub>default: `false`</sub>
+
+Allows you to use comments to separate the members of variable declarations into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
+
+- `true` — All comments will be treated as delimiters, creating partitions.
+-	`false` — Comments will not be used as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of a variable declaration if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+const
+  // Group 1
+  fiat = "Fiat",
+  honda = "Honda",
+
+  // Group 2
+  ferrari = "Ferrari",
+
+  // Group 3
+  chevrolet = "Chevrolet",
+  ford = "Ford"
+```
+
 ## Usage
 
 <CodeTabs
@@ -127,6 +159,8 @@ Controls whether sorting should be case-sensitive or not.
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
+                  partitionByNewLine: false,
+                  partitionByComment: false,
                 },
               ],
             },
@@ -150,6 +184,8 @@ Controls whether sorting should be case-sensitive or not.
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
+                partitionByNewLine: false,
+                partitionByComment: false,
               },
             ],
           },


### PR DESCRIPTION
### Description

Adds these two options to `sort-variable-declarations`.

### What is the purpose of this pull request?

- [x] New Feature
