### PR TITLE
fix(all-rules): Ignores whitespaces in node names

### DIFF
--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -1439,5 +1439,19 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(`${ruleName}: should ignore whitespaces`, rule, {
+      valid: [
+        {
+          code: dedent`
+            type T =
+            { a: string } &
+            {  b: string }
+          `,
+          options: [{}],
+        },
+      ],
+      invalid: [],
+    })
   })
 })

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -1471,5 +1471,19 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(`${ruleName}: should ignore whitespaces`, rule, {
+      valid: [
+        {
+          code: dedent`
+            type T =
+            { a: string } |
+            {  b: string }
+          `,
+          options: [{}],
+        },
+      ],
+      invalid: [],
+    })
   })
 })

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -37,24 +37,11 @@ export let compare = (
 ): number => {
   let orderCoefficient = options.order === 'asc' ? 1 : -1
   let sortingFunction: (a: SortingNode, b: SortingNode) => number
-
-  let formatString: (value: string) => string
-  if (options.type === 'line-length') {
-    formatString = (string: string) => string
-  } else {
-    formatString = (value: string) => {
-      let valueToCompare = value
-      if (options.ignoreCase) {
-        valueToCompare = valueToCompare.toLowerCase()
-      }
-      return valueToCompare.replaceAll(/\s/g, '')
-    }
-  }
-
   let nodeValueGetter =
     options.nodeValueGetter ?? ((node: SortingNode) => node.name)
 
   if (options.type === 'alphabetical') {
+    let formatString = getFormatStringFunc(!!options.ignoreCase)
     sortingFunction = (aNode, bNode) =>
       formatString(nodeValueGetter(aNode)).localeCompare(
         formatString(nodeValueGetter(bNode)),
@@ -67,11 +54,13 @@ export let compare = (
       }
       return string
     }
-    sortingFunction = (aNode, bNode) =>
-      naturalCompare(
+    sortingFunction = (aNode, bNode) => {
+      let formatString = getFormatStringFunc(!!options.ignoreCase)
+      return naturalCompare(
         prepareNumeric(formatString(nodeValueGetter(aNode))),
         prepareNumeric(formatString(nodeValueGetter(bNode))),
       )
+    }
   } else {
     sortingFunction = (aNode, bNode) => {
       let aSize = aNode.size
@@ -97,4 +86,12 @@ export let compare = (
   }
 
   return orderCoefficient * sortingFunction(a, b)
+}
+
+let getFormatStringFunc = (ignoreCase: boolean) => (value: string) => {
+  let valueToCompare = value
+  if (ignoreCase) {
+    valueToCompare = valueToCompare.toLowerCase()
+  }
+  return valueToCompare.replaceAll(/\s/g, '')
 }

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -38,10 +38,18 @@ export let compare = (
   let orderCoefficient = options.order === 'asc' ? 1 : -1
   let sortingFunction: (a: SortingNode, b: SortingNode) => number
 
-  let formatString =
-    options.type === 'line-length' || !options.ignoreCase
-      ? (string: string) => string
-      : (string: string) => string.toLowerCase()
+  let formatString: (value: string) => string
+  if (options.type === 'line-length') {
+    formatString = (string: string) => string
+  } else {
+    formatString = (value: string) => {
+      let valueToCompare = value
+      if (options.ignoreCase) {
+        valueToCompare = valueToCompare.toLowerCase()
+      }
+      return valueToCompare.replaceAll(/\s/g, '')
+    }
+  }
 
   let nodeValueGetter =
     options.nodeValueGetter ?? ((node: SortingNode) => node.name)


### PR DESCRIPTION
Resolves #181 .

### Description

Today with the `alphabetical` or `natural` sort, the following code is valid

```ts
type T =
{ a: string } &
{ b: string }
```

but this one is not:

```ts
type T =
{ a: string } &
{  b: string }
```

The issue lies in the fact that `{  b` is "lower" than `{ a` because of the whitespace before `b`.
Giving the possibility for users to ignore whitespaces can solve this issue.  

### Changes

This PR changes the following:
- [x] All whitespace-like characters (including `\n`) will be ignored in node names.
- [x] Add tests. Refactored `compare` file to reach 100% code coverage.

### What is the purpose of this pull request?

- [x] New Feature
