### PR TITLE
feat(sort-enums): adds `partitionByNewLine`

### DIFF
--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -140,7 +140,29 @@ Allows you to use comments to separate the members of enums into logical groups.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.
-- string — A glob pattern to specify which comments should act as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of an enum if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+enum Enum {
+  // Group 1
+  C = 'C',
+  D = 'D',
+
+  // Group 2
+  B = 'B',
+
+  // Group 3
+  A = 'A',
+  E = 'E',
+}
+```
 
 ## Usage
 
@@ -164,7 +186,9 @@ Allows you to use comments to separate the members of enums into logical groups.
                   order: 'asc',
                   ignoreCase: true,
                   partitionByComment: false,
-                  sortByValue: false
+                  partitionByNewLine: false,
+                  sortByValue: false,
+                  forceNumericSort: false
                 },
               ],
             },
@@ -189,6 +213,7 @@ Allows you to use comments to separate the members of enums into logical groups.
                 order: 'asc',
                 ignoreCase: true,
                 partitionByComment: false,
+                partitionByNewLine: false,
                 sortByValue: false,
                 forceNumericSort: false
               },

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1977,12 +1977,15 @@ describe(ruleName, () => {
       )
     })
 
-    describe('handles complex comment cases', () => {
-      ruleTester.run(`keeps comments associated to their node`, rule, {
-        valid: [],
-        invalid: [
-          {
-            code: dedent`
+    describe(`${ruleName}: handles complex comment cases`, () => {
+      ruleTester.run(
+        `${ruleName}: keeps comments associated to their node`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
               enum Enum {
                 // Ignore this comment
 
@@ -2002,7 +2005,7 @@ describe(ruleName, () => {
                 A = 'A',
               }
             `,
-            output: dedent`
+              output: dedent`
               enum Enum {
                 // Ignore this comment
 
@@ -2022,25 +2025,26 @@ describe(ruleName, () => {
                 B = 'B',
               }
             `,
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-            errors: [
-              {
-                messageId: 'unexpectedEnumsOrder',
-                data: {
-                  left: 'B',
-                  right: 'A',
+              options: [
+                {
+                  type: 'alphabetical',
                 },
-              },
-            ],
-          },
-        ],
-      })
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedEnumsOrder',
+                  data: {
+                    left: 'B',
+                    right: 'A',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
 
-      ruleTester.run(`handles partition comments`, rule, {
+      ruleTester.run(`${ruleName}: handles partition comments`, rule, {
         valid: [],
         invalid: [
           {
@@ -2119,6 +2123,58 @@ describe(ruleName, () => {
           },
         ],
       })
+    })
+
+    ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            enum Enum {
+              D = 'D',
+              C = 'C',
+
+              B = 'B',
+
+              E = 'E',
+              A = 'A',
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              C = 'C',
+              D = 'D',
+
+              B = 'B',
+
+              A = 'A',
+              E = 'E',
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+              partitionByNewLine: true,
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'D',
+                right: 'C',
+              },
+            },
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'E',
+                right: 'A',
+              },
+            },
+          ],
+        },
+      ],
     })
   })
 })


### PR DESCRIPTION
### Description

Adds this option to `sort-enums`.

No test was changed, `${ruleName}:` was added in places where it was missing and re-indented some lines.

### What is the purpose of this pull request?

- [x] New Feature
