### PR TITLE
feat(sort-objects-types): adds `partitionByComment`

### DIFF
--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -123,11 +123,22 @@ Controls whether sorting should be case-sensitive or not.
 - `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
 - `false` — Consider case when sorting (e.g., “A” comes before “a”).
 
+### partitionByComment
+
+<sub>default: `false`</sub>
+
+Allows you to use comments to separate the members of types into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
+
+- `true` — All comments will be treated as delimiters, creating partitions.
+- `false` — Comments will not be used as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
 ### partitionByNewLine
 
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an interface if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+When `true`, the rule will not sort the members of an object if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 type User = {
@@ -215,6 +226,7 @@ Example:
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
+                  partitionByComment: false,
                   partitionByNewLine: false,
                   groups: [],
                   customGroups: {},
@@ -241,6 +253,7 @@ Example:
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
+                partitionByComment: false,
                 partitionByNewLine: false,
                 groups: [],
                 customGroups: {},

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -3,8 +3,8 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
-import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -257,7 +257,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         for (let nodes of formattedMembers) {
           let groupedByKind
           if (options.groupKind !== 'mixed') {
-            groupedByKind = nodes.reduce<SortingNode<TSESTree.TypeElement>[][]>(
+            groupedByKind = nodes.reduce<SortObjectTypesSortingNode[][]>(
               (accumulator, currentNode) => {
                 let requiredIndex =
                   options.groupKind === 'required-first' ? 0 : 1
@@ -280,7 +280,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             groupedByKind = [nodes]
           }
 
-          let sortedNodes: SortingNode[] = []
+          let sortedNodes: SortObjectTypesSortingNode[] = []
 
           for (let nodesByKind of groupedByKind) {
             sortedNodes.push(...sortNodesByGroups(nodesByKind, options))
@@ -304,7 +304,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   rightGroup: right.group,
                 },
                 node: right.node,
-                fix: fixer => makeFixes(fixer, nodes, sortedNodes, sourceCode),
+                fix: fixer =>
+                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                    partitionComment,
+                  }),
               })
             }
           })


### PR DESCRIPTION
### Description

Adds this option to `sort-object-types`.

### What is the purpose of this pull request?

- [x] New Feature
