### PR TITLE
refactor(multiple-rules): adds `sort-nodes-by-groups` function to reduce code duplication

### DIFF
--- a/rules/sort-astro-attributes.ts
+++ b/rules/sort-astro-attributes.ts
@@ -6,18 +6,16 @@ import path from 'node:path'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
-import { sortNodes } from '../utils/sort-nodes'
 import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
-import { compare } from '../utils/compare'
 
 type Group<T extends string[]> =
   | 'astro-shorthand'
@@ -195,15 +193,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           )
 
           for (let nodes of parts) {
+            let sortedNodes = sortNodesByGroups(nodes, options)
             pairwise(nodes, (left, right) => {
-              let leftNum = getGroupNumber(options.groups, left)
-              let rightNum = getGroupNumber(options.groups, right)
-
-              if (
-                leftNum > rightNum ||
-                (leftNum === rightNum &&
-                  isPositive(compare(left, right, options)))
-              ) {
+              let indexOfLeft = sortedNodes.indexOf(left)
+              let indexOfRight = sortedNodes.indexOf(right)
+              if (indexOfLeft > indexOfRight) {
+                let leftNum = getGroupNumber(options.groups, left)
+                let rightNum = getGroupNumber(options.groups, right)
                 context.report({
                   messageId:
                     leftNum !== rightNum
@@ -216,34 +212,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     rightGroup: right.group,
                   },
                   node: right.node,
-                  fix: fixer => {
-                    let grouped: {
-                      [key: string]: SortingNode[]
-                    } = {}
-
-                    for (let currentNode of nodes) {
-                      let groupNum = getGroupNumber(options.groups, currentNode)
-
-                      if (!(groupNum in grouped)) {
-                        grouped[groupNum] = [currentNode]
-                      } else {
-                        grouped[groupNum] = sortNodes(
-                          [...grouped[groupNum], currentNode],
-                          options,
-                        )
-                      }
-                    }
-
-                    let sortedNodes: SortingNode[] = []
-
-                    for (let group of Object.keys(grouped).sort(
-                      (a, b) => Number(a) - Number(b),
-                    )) {
-                      sortedNodes.push(...sortNodes(grouped[group], options))
-                    }
-
-                    return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-                  },
+                  fix: fixer =>
+                    makeFixes(fixer, nodes, sortedNodes, sourceCode),
                 })
               }
             })

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -4,6 +4,7 @@ import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { isMemberOptional } from '../utils/is-member-optional'
@@ -13,13 +14,10 @@ import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
-import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID =
   | 'unexpectedInterfacePropertiesGroupOrder'
@@ -233,9 +231,16 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 name = sourceCode.text.slice(element.range.at(0), endIndex)
               }
 
-              let elementSortingNode = {
+              setCustomGroups(options.customGroups, name)
+
+              if (element.loc.start.line !== element.loc.end.line) {
+                defineGroup('multiline')
+              }
+
+              let elementSortingNode: SortingNode = {
                 size: rangeToDiff(element.range),
                 node: element,
+                group: getGroup(),
                 name,
               }
 
@@ -252,97 +257,44 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 accumulator.push([])
               }
 
-              setCustomGroups(options.customGroups, name)
-
-              if (element.loc.start.line !== element.loc.end.line) {
-                defineGroup('multiline')
-              }
-
-              accumulator.at(-1)!.push({
-                ...elementSortingNode,
-                group: getGroup(),
-              })
+              accumulator.at(-1)!.push(elementSortingNode)
 
               return accumulator
             },
             [[]],
           )
 
-          let toSorted = (nodes: SortingNode[]) => {
-            let grouped: {
-              [key: string]: SortingNode[]
-            } = {}
-
-            for (let currentNode of nodes) {
-              let groupNum = getGroupNumber(options.groups, currentNode)
-
-              if (!(groupNum in grouped)) {
-                grouped[groupNum] = [currentNode]
-              } else {
-                grouped[groupNum] = sortNodes(
-                  [...grouped[groupNum], currentNode],
-                  options,
-                )
-              }
-            }
-
-            let sortedNodes: SortingNode[] = []
-
-            for (let group of Object.keys(grouped).sort(
-              (a, b) => Number(a) - Number(b),
-            )) {
-              sortedNodes.push(...sortNodes(grouped[group], options))
-            }
-
-            return sortedNodes
-          }
-
-          let checkGroupSort = (left: SortingNode, right: SortingNode) => {
-            let leftNum = getGroupNumber(options.groups, left)
-            let rightNum = getGroupNumber(options.groups, right)
-
-            return (
-              leftNum > rightNum ||
-              (leftNum === rightNum &&
-                isPositive(compare(left, right, options)))
-            )
-          }
-
           let { groupKind } = options
 
-          let checkOrder = (
-            members: SortingNode[],
-            left: SortingNode,
-            right: SortingNode,
-            iteration: number,
-          ) => {
-            if (groupKind === 'mixed') {
-              return checkGroupSort(left, right)
-            }
-
-            let switchIndex = members.findIndex(
-              (_, i) =>
-                i &&
-                isMemberOptional(members[i - 1].node) !==
-                  isMemberOptional(members[i].node),
-            )
-
-            if (iteration < switchIndex && iteration + 1 !== switchIndex) {
-              return checkGroupSort(left, right)
-            }
-
-            if (isMemberOptional(left.node) !== isMemberOptional(right.node)) {
-              return (
-                isMemberOptional(left.node) !== (groupKind === 'optional-first')
-              )
-            }
-
-            return checkGroupSort(left, right)
-          }
-
           for (let nodes of formattedMembers) {
-            pairwise(nodes, (left, right, iteration) => {
-              if (checkOrder(nodes, left, right, iteration)) {
+            let sortedNodes: SortingNode[]
+
+            if (groupKind !== 'mixed') {
+              let optionalNodes = nodes.filter(member =>
+                isMemberOptional(member.node),
+              )
+              let requiredNodes = nodes.filter(
+                member => !isMemberOptional(member.node),
+              )
+
+              sortedNodes =
+                groupKind === 'optional-first'
+                  ? [
+                      ...sortNodesByGroups(optionalNodes, options),
+                      ...sortNodesByGroups(requiredNodes, options),
+                    ]
+                  : [
+                      ...sortNodesByGroups(requiredNodes, options),
+                      ...sortNodesByGroups(optionalNodes, options),
+                    ]
+            } else {
+              sortedNodes = sortNodesByGroups(nodes, options)
+            }
+
+            pairwise(nodes, (left, right) => {
+              let indexOfLeft = sortedNodes.indexOf(left)
+              let indexOfRight = sortedNodes.indexOf(right)
+              if (indexOfLeft > indexOfRight) {
                 let leftNum = getGroupNumber(options.groups, left)
                 let rightNum = getGroupNumber(options.groups, right)
                 context.report({
@@ -357,35 +309,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     rightGroup: right.group,
                   },
                   node: right.node,
-                  fix: fixer => {
-                    let sortedNodes
-
-                    if (groupKind !== 'mixed') {
-                      let optionalNodes = nodes.filter(member =>
-                        isMemberOptional(member.node),
-                      )
-                      let requiredNodes = nodes.filter(
-                        member => !isMemberOptional(member.node),
-                      )
-
-                      sortedNodes =
-                        groupKind === 'optional-first'
-                          ? [
-                              ...toSorted(optionalNodes),
-                              ...toSorted(requiredNodes),
-                            ]
-                          : [
-                              ...toSorted(requiredNodes),
-                              ...toSorted(optionalNodes),
-                            ]
-                    } else {
-                      sortedNodes = toSorted(nodes)
-                    }
-
-                    return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                  fix: fixer =>
+                    makeFixes(fixer, nodes, sortedNodes, sourceCode, {
                       partitionComment,
-                    })
-                  },
+                    }),
                 })
               }
             })

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -2,6 +2,7 @@ import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -10,13 +11,10 @@ import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
-import { sortNodes } from '../utils/sort-nodes'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID =
   | 'unexpectedIntersectionTypesGroupOrder'
@@ -264,14 +262,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
       )
 
       for (let nodes of formattedMembers) {
+        let sortedNodes = sortNodesByGroups(nodes, options)
         pairwise(nodes, (left, right) => {
-          let leftNum = getGroupNumber(options.groups, left)
-          let rightNum = getGroupNumber(options.groups, right)
-
-          if (
-            leftNum > rightNum ||
-            (leftNum === rightNum && isPositive(compare(left, right, options)))
-          ) {
+          let indexOfLeft = sortedNodes.indexOf(left)
+          let indexOfRight = sortedNodes.indexOf(right)
+          if (indexOfLeft > indexOfRight) {
+            let leftNum = getGroupNumber(options.groups, left)
+            let rightNum = getGroupNumber(options.groups, right)
             context.report({
               messageId:
                 leftNum !== rightNum
@@ -284,36 +281,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 rightGroup: right.group,
               },
               node: right.node,
-              fix: fixer => {
-                let grouped: {
-                  [key: string]: SortingNode[]
-                } = {}
-
-                for (let currentNode of nodes) {
-                  let groupNum = getGroupNumber(options.groups, currentNode)
-
-                  if (!(groupNum in grouped)) {
-                    grouped[groupNum] = [currentNode]
-                  } else {
-                    grouped[groupNum] = sortNodes(
-                      [...grouped[groupNum], currentNode],
-                      options,
-                    )
-                  }
-                }
-
-                let sortedNodes: SortingNode[] = []
-
-                for (let group of Object.keys(grouped).sort(
-                  (a, b) => Number(a) - Number(b),
-                )) {
-                  sortedNodes.push(...sortNodes(grouped[group], options))
-                }
-
-                return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+              fix: fixer =>
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
                   partitionComment,
-                })
-              },
+                }),
             })
           }
         })

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -5,18 +5,16 @@ import { minimatch } from 'minimatch'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
-import { sortNodes } from '../utils/sort-nodes'
 import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID = 'unexpectedJSXPropsGroupOrder' | 'unexpectedJSXPropsOrder'
 
@@ -203,15 +201,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           )
 
           for (let nodes of parts) {
+            let sortedNodes = sortNodesByGroups(nodes, options)
             pairwise(nodes, (left, right) => {
-              let leftNum = getGroupNumber(options.groups, left)
-              let rightNum = getGroupNumber(options.groups, right)
-
-              if (
-                leftNum > rightNum ||
-                (leftNum === rightNum &&
-                  isPositive(compare(left, right, options)))
-              ) {
+              let indexOfLeft = sortedNodes.indexOf(left)
+              let indexOfRight = sortedNodes.indexOf(right)
+              if (indexOfLeft > indexOfRight) {
+                let leftNum = getGroupNumber(options.groups, left)
+                let rightNum = getGroupNumber(options.groups, right)
                 context.report({
                   messageId:
                     leftNum !== rightNum
@@ -224,34 +220,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     rightGroup: right.group,
                   },
                   node: right.node,
-                  fix: fixer => {
-                    let grouped: {
-                      [key: string]: SortingNode[]
-                    } = {}
-
-                    for (let currentNode of nodes) {
-                      let groupNum = getGroupNumber(options.groups, currentNode)
-
-                      if (!(groupNum in grouped)) {
-                        grouped[groupNum] = [currentNode]
-                      } else {
-                        grouped[groupNum] = sortNodes(
-                          [...grouped[groupNum], currentNode],
-                          options,
-                        )
-                      }
-                    }
-
-                    let sortedNodes: SortingNode[] = []
-
-                    for (let group of Object.keys(grouped).sort(
-                      (a, b) => Number(a) - Number(b),
-                    )) {
-                      sortedNodes.push(...sortNodes(grouped[group], options))
-                    }
-
-                    return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-                  },
+                  fix: fixer =>
+                    makeFixes(fixer, nodes, sortedNodes, sourceCode),
                 })
               }
             })

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -11,6 +11,7 @@ import {
 } from '../utils/sort-nodes-by-dependencies'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -22,7 +23,6 @@ import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
-import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
@@ -435,34 +435,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
             [[]],
           )
 
-        let sortedNodes: SortingNodeWithDependencies[] = []
-
-        let formattedNodes = formatProperties(node.properties)
-        for (let nodes of formattedNodes) {
-          let grouped: {
-            [key: string]: SortingNodeWithDependencies[]
-          } = {}
-
-          for (let currentNode of nodes) {
-            let groupNum = getGroupNumber(options.groups, currentNode)
-
-            if (!(groupNum in grouped)) {
-              grouped[groupNum] = [currentNode]
-            } else {
-              grouped[groupNum].push(currentNode)
-            }
-          }
-
-          for (let group of Object.keys(grouped).sort(
-            (a, b) => Number(a) - Number(b),
-          )) {
-            sortedNodes.push(...sortNodes(grouped[group], options))
-          }
-        }
-
-        sortedNodes = sortNodesByDependencies(sortedNodes)
-        let nodes = formattedNodes.flat()
-
+        let formattedMembers = formatProperties(node.properties)
+        let sortedNodes = sortNodesByDependencies(
+          formattedMembers
+            .map(nodes => sortNodesByGroups(nodes, options))
+            .flat(),
+        )
+        let nodes = formattedMembers.flat()
         pairwise(nodes, (left, right) => {
           let indexOfLeft = sortedNodes.indexOf(left)
           let indexOfRight = sortedNodes.indexOf(right)
@@ -470,12 +449,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
           if (indexOfLeft > indexOfRight) {
             let firstUnorderedNodeDependentOnRight =
               getFirstUnorderedNodeDependentOn(right, nodes)
-            let fix:
-              | ((fixer: TSESLint.RuleFixer) => TSESLint.RuleFix[])
-              | undefined = fixer =>
-              makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                partitionComment: options.partitionByComment,
-              })
             let leftNum = getGroupNumber(options.groups, left)
             let rightNum = getGroupNumber(options.groups, right)
             let messageId: MESSAGE_ID
@@ -497,7 +470,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
               },
               node: right.node,
-              fix,
+              fix: (fixer: TSESLint.RuleFixer) =>
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                  partitionComment: options.partitionByComment,
+                }),
             })
           }
         })

--- a/rules/sort-svelte-attributes.ts
+++ b/rules/sort-svelte-attributes.ts
@@ -6,18 +6,16 @@ import path from 'node:path'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
-import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 
 type MESSAGE_ID =
   | 'unexpectedSvelteAttributesGroupOrder'
@@ -202,15 +200,14 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           )
 
           for (let nodes of parts) {
-            pairwise(nodes, (left, right) => {
-              let leftNum = getGroupNumber(options.groups, left)
-              let rightNum = getGroupNumber(options.groups, right)
+            let sortedNodes = sortNodesByGroups(nodes, options)
 
-              if (
-                leftNum > rightNum ||
-                (leftNum === rightNum &&
-                  isPositive(compare(left, right, options)))
-              ) {
+            pairwise(nodes, (left, right) => {
+              let indexOfLeft = sortedNodes.indexOf(left)
+              let indexOfRight = sortedNodes.indexOf(right)
+              if (indexOfLeft > indexOfRight) {
+                let leftNum = getGroupNumber(options.groups, left)
+                let rightNum = getGroupNumber(options.groups, right)
                 context.report({
                   messageId:
                     leftNum !== rightNum
@@ -223,34 +220,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     rightGroup: right.group,
                   },
                   node: right.node,
-                  fix: fixer => {
-                    let grouped: {
-                      [key: string]: SortingNode[]
-                    } = {}
-
-                    for (let currentNode of nodes) {
-                      let groupNum = getGroupNumber(options.groups, currentNode)
-
-                      if (!(groupNum in grouped)) {
-                        grouped[groupNum] = [currentNode]
-                      } else {
-                        grouped[groupNum] = sortNodes(
-                          [...grouped[groupNum], currentNode],
-                          options,
-                        )
-                      }
-                    }
-
-                    let sortedNodes: SortingNode[] = []
-
-                    for (let group of Object.keys(grouped).sort(
-                      (a, b) => Number(a) - Number(b),
-                    )) {
-                      sortedNodes.push(...sortNodes(grouped[group], options))
-                    }
-
-                    return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-                  },
+                  fix: fixer =>
+                    makeFixes(fixer, nodes, sortedNodes, sourceCode),
                 })
               }
             })

--- a/utils/sort-nodes-by-groups.ts
+++ b/utils/sort-nodes-by-groups.ts
@@ -1,0 +1,34 @@
+import type { CompareOptions } from './compare'
+import type { SortingNode } from '../typings'
+
+import { getGroupNumber } from './get-group-number'
+import { sortNodes } from './sort-nodes'
+
+interface GroupOptions {
+  groups: (string[] | string)[]
+}
+
+export let sortNodesByGroups = <T extends SortingNode>(
+  nodes: T[],
+  options: CompareOptions & GroupOptions,
+): T[] => {
+  let nodesByGroupNumber: {
+    [key: number]: T[]
+  } = {}
+  for (let sortingNode of nodes.values()) {
+    let groupNum = getGroupNumber(options.groups, sortingNode)
+    nodesByGroupNumber[groupNum] = nodesByGroupNumber[groupNum] ?? []
+    nodesByGroupNumber[groupNum].push(sortingNode)
+  }
+
+  let sortedNodes: T[] = []
+  for (let groupNumber of Object.keys(nodesByGroupNumber).sort(
+    (a, b) => Number(a) - Number(b),
+  )) {
+    sortedNodes.push(
+      ...sortNodes(nodesByGroupNumber[Number(groupNumber)], options),
+    )
+  }
+
+  return sortedNodes
+}


### PR DESCRIPTION
### Description

All rules handling groups (with the exception of `sort-classes` with a new CustomGroup API) do the same thing when it comes to sorting nodes by groups. This PR refactor codes to reduce code duplication for those rules.

### What is the purpose of this pull request?

- [x] Other

