### PR TITLE
feat(multiple-rules): #138: Adds `matcher` option

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -197,6 +197,15 @@ if ([
   }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-astro-attributes.mdx
+++ b/docs/content/rules/sort-astro-attributes.mdx
@@ -189,6 +189,15 @@ Example:
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `customGroups` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 In order to start using this rule, you need to install additional dependency:

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -557,6 +557,15 @@ Example:
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `internalPattern` and `customGroups` options.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -164,6 +164,15 @@ enum Enum {
 }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -144,6 +144,14 @@ Allows you to group exports by their kind, determining whether value exports sho
 - `values-first` — Group all value exports before type exports.
 - `types-first` — Group all type exports before value exports.
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
 
 ## Usage
 

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -291,6 +291,7 @@ Example:
 +  },                               // [!code ++]
  }
 ```
+
 ### matcher
 
 <sub>default: `'minimatch'`</sub>

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -147,7 +147,7 @@ Controls whether sorting should be case-sensitive or not.
 
 ### internalPattern
 
-<sub>default: `['~/**']`</sub>
+<sub>default: `['~/**']` for `minimatch` matcher, `['^~/.*']` for `regex` matcher</sub>
 
 Allows you to specify a pattern for identifying internal imports. This is useful for distinguishing your own modules from external dependencies.
 
@@ -291,6 +291,14 @@ Example:
 +  },                               // [!code ++]
  }
 ```
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `internalPattern` and `customGroups` options.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
 
 ### environment
 
@@ -319,6 +327,7 @@ Specifies which environment’s built-in modules should be recognized. If you ar
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
+                  matcher: 'minimatch',
                   internalPattern: ['~/**'],
                   newlinesBetween: 'always',
                   maxLineLength: undefined,
@@ -357,6 +366,7 @@ Specifies which environment’s built-in modules should be recognized. If you ar
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
+                matcher: 'minimatch',
                 internalPattern: ['~/**'],
                 newlinesBetween: 'always',
                 maxLineLength: undefined,

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -249,6 +249,14 @@ Example:
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` and `customGroups` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
 
 ## Usage
 

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -190,6 +190,15 @@ type Example =
   & undefined;
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -206,6 +206,15 @@ Example:
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `customGroups` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -144,6 +144,15 @@ new Map([
   ])
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -172,6 +172,15 @@ export {
 } from './devices'
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -205,6 +205,15 @@ Example:
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `internalPattern` and `customGroups` options.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -265,6 +265,15 @@ You can define your own groups for object keys using custom glob patterns for ma
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `internalPattern` and `customGroups` options.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -201,6 +201,15 @@ let items = new Set([
   ])
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-svelte-attributes.mdx
+++ b/docs/content/rules/sort-svelte-attributes.mdx
@@ -193,6 +193,15 @@ Example:
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `customGroups` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 In order to start using this rule, you need to install additional dependency:

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -253,6 +253,15 @@ groups: [
 ],
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -138,6 +138,15 @@ const
   ford = "Ford"
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `partitionByComment` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-vue-attributes.mdx
+++ b/docs/content/rules/sort-vue-attributes.mdx
@@ -201,6 +201,15 @@ Example:
  }
 ```
 
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `customGroups` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
 ## Usage
 
 In order to start using this rule, you need to install additional dependency:

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -27,6 +27,7 @@ export type Options = [
     groupKind: 'literals-first' | 'spreads-first' | 'mixed'
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -46,6 +47,11 @@ export let jsonSchema: JSONSchema4 = {
         'Determines whether the sorted items should be in ascending or descending order.',
       type: 'string',
       enum: ['asc', 'desc'],
+    },
+    matcher: {
+      description: 'Specifies the string matcher.',
+      type: 'string',
+      enum: ['minimatch', 'regex'],
     },
     ignoreCase: {
       description: 'Controls whether sorting should be case-sensitive or not.',
@@ -102,6 +108,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       groupKind: 'literals-first',
       partitionByComment: false,
       partitionByNewLine: false,
@@ -137,6 +144,7 @@ export let sortArray = <MessageIds extends string>(
       groupKind: 'literals-first',
       type: 'alphabetical',
       ignoreCase: true,
+      matcher: 'minimatch',
       order: 'asc',
       partitionByComment: false,
       partitionByNewLine: false,
@@ -171,6 +179,7 @@ export let sortArray = <MessageIds extends string>(
               hasPartitionComment(
                 partitionComment,
                 getCommentsBefore(element, sourceCode),
+                options.matcher,
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
@@ -221,9 +230,7 @@ export let sortArray = <MessageIds extends string>(
                       .flat()
                   : sortNodes(nodes, options)
 
-              return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                partitionComment,
-              })
+              return makeFixes(fixer, nodes, sortedNodes, sourceCode, options)
             },
           })
         }

--- a/rules/sort-astro-attributes.ts
+++ b/rules/sort-astro-attributes.ts
@@ -33,6 +33,7 @@ type Options<T extends string[]> = [
     customGroups: { [key in T[number]]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
     groups: (Group<T>[] | Group<T>)[]
+    matcher: 'minimatch' | 'regex'
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -60,6 +61,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -116,6 +122,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       groups: [],
       customGroups: {},
     },
@@ -136,6 +143,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           let options = complete(context.options.at(0), settings, {
             type: 'alphabetical',
             ignoreCase: true,
+            matcher: 'minimatch',
             customGroups: {},
             order: 'asc',
             groups: [],
@@ -161,9 +169,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   ? attribute.name.name
                   : sourceCode.text.slice(...attribute.name.range)
 
-              let { getGroup, defineGroup, setCustomGroups } = useGroups(
-                options.groups,
-              )
+              let { getGroup, defineGroup, setCustomGroups } =
+                useGroups(options)
 
               setCustomGroups(options.customGroups, name)
 

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -1,7 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/utils'
 
-import { minimatch } from 'minimatch'
-
 import type {
   SortClassesOptions,
   SingleCustomGroup,
@@ -11,8 +9,11 @@ import type {
 } from './sort-classes.types'
 import type { CompareOptions } from '../utils/compare'
 
+import { matches } from '../utils/matches'
+
 interface CustomGroupMatchesProps {
   customGroup: SingleCustomGroup | CustomGroupBlock
+  matcher: 'minimatch' | 'regex'
   selectors: Selector[]
   modifiers: Modifier[]
   decorators: string[]
@@ -184,12 +185,10 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
     'elementNamePattern' in props.customGroup &&
     props.customGroup.elementNamePattern
   ) {
-    let matchesElementNamePattern: boolean = minimatch(
+    let matchesElementNamePattern: boolean = matches(
       props.elementName,
       props.customGroup.elementNamePattern,
-      {
-        nocomment: true,
-      },
+      props.matcher,
     )
     if (!matchesElementNamePattern) {
       return false
@@ -202,10 +201,7 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
   ) {
     let decoratorPattern = props.customGroup.decoratorNamePattern
     let matchesDecoratorNamePattern: boolean = props.decorators.some(
-      decorator =>
-        minimatch(decorator, decoratorPattern, {
-          nocomment: true,
-        }),
+      decorator => matches(decorator, decoratorPattern, props.matcher),
     )
     if (!matchesDecoratorNamePattern) {
       return false

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -65,6 +65,11 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             type: 'string',
             enum: ['asc', 'desc'],
           },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
+          },
           ignoreCase: {
             description:
               'Controls whether sorting should be case-sensitive or not.',
@@ -181,6 +186,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       partitionByComment: false,
       groups: [
         'index-signature',
@@ -221,6 +227,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             ['get-method', 'set-method'],
             'unknown',
           ],
+          matcher: 'minimatch',
           partitionByComment: false,
           type: 'alphabetical',
           ignoreCase: true,
@@ -377,16 +384,18 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             if (
               options.partitionByComment &&
-              hasPartitionComment(options.partitionByComment, comments)
+              hasPartitionComment(
+                options.partitionByComment,
+                comments,
+                options.matcher,
+              )
             ) {
               accumulator.push([])
             }
 
             let name: string
             let dependencies: string[] = []
-            let { getGroup, defineGroup, setCustomGroups } = useGroups(
-              options.groups,
-            )
+            let { getGroup, defineGroup, setCustomGroups } = useGroups(options)
 
             if (member.type === 'StaticBlock') {
               name = 'static'
@@ -589,6 +598,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                     modifiers,
                     selectors,
                     decorators,
+                    matcher: options.matcher,
                   })
                 ) {
                   defineGroup(customGroup.groupName, true)
@@ -709,9 +719,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               },
               node: right.node,
               fix: (fixer: TSESLint.RuleFixer) =>
-                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                  partitionComment: options.partitionByComment,
-                }),
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
             })
           }
         })

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -188,6 +188,7 @@ export type SortClassesOptions = [
     customGroups: { [key: string]: string[] | string } | CustomGroup[]
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     groups: (Group[] | Group)[]
     order: 'desc' | 'asc'
     ignoreCase: boolean

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -26,6 +26,7 @@ export type Options = [
   Partial<{
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     forceNumericSort: boolean
     order: 'desc' | 'asc'
@@ -56,6 +57,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -109,6 +115,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       sortByValue: false,
       partitionByComment: false,
       partitionByNewLine: false,
@@ -132,6 +139,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           partitionByComment: false,
           partitionByNewLine: false,
           type: 'alphabetical',
+          matcher: 'minimatch',
           ignoreCase: true,
           order: 'asc',
           sortByValue: false,
@@ -213,6 +221,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 hasPartitionComment(
                   partitionComment,
                   getCommentsBefore(member, sourceCode),
+                  options.matcher,
                 )) ||
               (options.partitionByNewLine &&
                 lastSortingNode &&
@@ -277,9 +286,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               },
               node: right.node,
               fix: fixer =>
-                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                  partitionComment,
-                }),
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
             })
           }
         })

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -21,6 +21,7 @@ type Options = [
     groupKind: 'values-first' | 'types-first' | 'mixed'
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -53,6 +54,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -100,6 +106,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       partitionByComment: false,
       partitionByNewLine: false,
       groupKind: 'mixed',
@@ -112,6 +119,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       ignoreCase: true,
       order: 'asc',
+      matcher: 'minimatch',
       partitionByComment: false,
       partitionByNewLine: false,
       groupKind: 'mixed',
@@ -138,6 +146,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           hasPartitionComment(
             partitionComment,
             getCommentsBefore(node, sourceCode),
+            options.matcher,
           )) ||
         (options.partitionByNewLine &&
           lastNode &&
@@ -194,9 +203,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 },
                 node: right.node,
                 fix: fixer =>
-                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                    partitionComment,
-                  }),
+                  makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
               })
             }
           })

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -233,7 +233,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
 
-    let options = complete(context.options.at(0), settings, {
+    let defaultOptions = context.options.at(0)
+    let options = complete(defaultOptions, settings, {
       groups: [
         'type',
         ['builtin', 'external'],
@@ -246,7 +247,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       ],
       matcher: 'minimatch',
       customGroups: { type: {}, value: {} },
-      internalPattern: ['~/**'],
+      internalPattern:
+        defaultOptions?.matcher === 'regex' ? ['^~/.*'] : ['~/**'],
       newlinesBetween: 'always',
       sortSideEffects: false,
       type: 'alphabetical',

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -338,10 +338,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
       let isSibling = (value: string) => value.startsWith('./')
 
-      let { getGroup, defineGroup, setCustomGroups } = useGroups(
-        options.groups,
-        options.matcher,
-      )
+      let { getGroup, defineGroup, setCustomGroups } = useGroups(options)
 
       let isInternal = (value: string) =>
         options.internalPattern.length &&
@@ -568,8 +565,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
             fixes.push(
               fixer.replaceTextRange(
-                getNodeRange(nodesToFix.at(i)!.node, sourceCode),
-                sourceCode.text.slice(...getNodeRange(node.node, sourceCode)),
+                getNodeRange(nodesToFix.at(i)!.node, sourceCode, options),
+                sourceCode.text.slice(
+                  ...getNodeRange(node.node, sourceCode, options),
+                ),
               ),
             )
 
@@ -593,10 +592,16 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 ) {
                   fixes.push(
                     fixer.removeRange([
-                      getNodeRange(nodesToFix.at(i)!.node, sourceCode).at(1)!,
-                      getNodeRange(nodesToFix.at(i + 1)!.node, sourceCode).at(
-                        0,
-                      )! - 1,
+                      getNodeRange(
+                        nodesToFix.at(i)!.node,
+                        sourceCode,
+                        options,
+                      ).at(1)!,
+                      getNodeRange(
+                        nodesToFix.at(i + 1)!.node,
+                        sourceCode,
+                        options,
+                      ).at(0)! - 1,
                     ]),
                   )
                 }
@@ -610,10 +615,16 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   fixes.push(
                     fixer.replaceTextRange(
                       [
-                        getNodeRange(nodesToFix.at(i)!.node, sourceCode).at(1)!,
-                        getNodeRange(nodesToFix.at(i + 1)!.node, sourceCode).at(
-                          0,
-                        )! - 1,
+                        getNodeRange(
+                          nodesToFix.at(i)!.node,
+                          sourceCode,
+                          options,
+                        ).at(1)!,
+                        getNodeRange(
+                          nodesToFix.at(i + 1)!.node,
+                          sourceCode,
+                          options,
+                        ).at(0)! - 1,
                       ],
                       '\n',
                     ),
@@ -628,7 +639,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 ) {
                   fixes.push(
                     fixer.insertTextAfterRange(
-                      getNodeRange(nodesToFix.at(i)!.node, sourceCode),
+                      getNodeRange(nodesToFix.at(i)!.node, sourceCode, options),
                       '\n',
                     ),
                   )

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -39,6 +39,7 @@ type Options = [
   Partial<{
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     groups: (Group[] | Group)[]
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
@@ -68,6 +69,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -130,6 +136,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       partitionByNewLine: false,
       partitionByComment: false,
       groups: [],
@@ -143,6 +150,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         type: 'alphabetical',
         ignoreCase: true,
         order: 'asc',
+        matcher: 'minimatch',
         partitionByComment: false,
         partitionByNewLine: false,
         groups: [],
@@ -173,7 +181,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
       let formattedMembers: SortingNode[][] = node.types.reduce(
         (accumulator: SortingNode[][], type) => {
-          let { getGroup, defineGroup } = useGroups(options.groups)
+          let { getGroup, defineGroup } = useGroups(options)
 
           switch (type.type) {
             case 'TSConditionalType':
@@ -246,6 +254,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               hasPartitionComment(
                 partitionComment,
                 getCommentsBefore(type, sourceCode),
+                options.matcher,
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
@@ -282,9 +291,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               },
               node: right.node,
               fix: fixer =>
-                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                  partitionComment,
-                }),
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
             })
           }
         })

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -23,6 +23,7 @@ type Options = [
   Partial<{
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -51,6 +52,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -94,6 +100,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       partitionByComment: false,
       partitionByNewLine: false,
     },
@@ -115,6 +122,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'alphabetical',
             ignoreCase: true,
             order: 'asc',
+            matcher: 'minimatch',
             partitionByComment: false,
             partitionByNewLine: false,
           } as const)
@@ -168,6 +176,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   hasPartitionComment(
                     partitionComment,
                     getCommentsBefore(element, sourceCode),
+                    options.matcher,
                   )) ||
                 (options.partitionByNewLine &&
                   lastSortingNode &&
@@ -195,9 +204,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                         nodes,
                         sortNodes(nodes, options),
                         sourceCode,
-                        {
-                          partitionComment,
-                        },
+                        options,
                       ),
                   })
                 }

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -22,6 +22,7 @@ type Options = [
     groupKind: 'values-first' | 'types-first' | 'mixed'
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -50,6 +51,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -98,6 +104,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       partitionByNewLine: false,
       partitionByComment: false,
       groupKind: 'mixed',
@@ -112,6 +119,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           type: 'alphabetical',
           groupKind: 'mixed',
           ignoreCase: true,
+          matcher: 'minimatch',
           partitionByNewLine: false,
           partitionByComment: false,
           order: 'asc',
@@ -141,6 +149,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               hasPartitionComment(
                 partitionComment,
                 getCommentsBefore(specifier, sourceCode),
+                options.matcher,
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
@@ -183,9 +192,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 },
                 node: right.node,
                 fix: fixer =>
-                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                    partitionComment,
-                  }),
+                  makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
               })
             }
           })

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -22,6 +22,7 @@ type Options = [
     groupKind: 'values-first' | 'types-first' | 'mixed'
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreAlias: boolean
@@ -51,6 +52,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -123,6 +129,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreAlias: false,
           groupKind: 'mixed',
           ignoreCase: true,
+          matcher: 'minimatch',
           partitionByNewLine: false,
           partitionByComment: false,
           order: 'asc',
@@ -162,6 +169,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               hasPartitionComment(
                 partitionComment,
                 getCommentsBefore(specifier, sourceCode),
+                options.matcher,
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
@@ -203,9 +211,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 },
                 node: right.node,
                 fix: fixer =>
-                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                    partitionComment,
-                  }),
+                  makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
               })
             }
           })

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -31,6 +31,7 @@ type Options<T extends string[]> = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     groups: (Group<T>[] | Group<T>)[]
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -61,6 +62,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -145,6 +151,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       partitionByComment: false,
       partitionByNewLine: false,
       groupKind: 'mixed',
@@ -162,6 +169,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           partitionByNewLine: false,
           type: 'alphabetical',
           groupKind: 'mixed',
+          matcher: 'minimatch',
           ignoreCase: true,
           customGroups: {},
           order: 'asc',
@@ -187,9 +195,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               )
               let lastSortingNode = accumulator.at(-1)?.at(-1)
 
-              let { getGroup, defineGroup, setCustomGroups } = useGroups(
-                options.groups,
-              )
+              let { getGroup, defineGroup, setCustomGroups } =
+                useGroups(options)
 
               let formatName = (value: string): string =>
                 value.replace(/([,;])$/, '')
@@ -239,6 +246,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   hasPartitionComment(
                     partitionComment,
                     getCommentsBefore(member, sourceCode),
+                    options.matcher,
                   )) ||
                 (options.partitionByNewLine &&
                   lastSortingNode &&
@@ -305,9 +313,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 },
                 node: right.node,
                 fix: fixer =>
-                  makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                    partitionComment,
-                  }),
+                  makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
               })
             }
           })

--- a/rules/sort-sets.ts
+++ b/rules/sort-sets.ts
@@ -23,6 +23,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       groupKind: 'literals-first',
     },
   ],

--- a/rules/sort-svelte-attributes.ts
+++ b/rules/sort-svelte-attributes.ts
@@ -33,6 +33,7 @@ type Options<T extends string[]> = [
     customGroups: { [key in T[number]]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
     groups: (Group<T>[] | Group<T>)[]
+    matcher: 'minimatch' | 'regex'
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -60,6 +61,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -116,6 +122,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       groups: [],
       customGroups: {},
     },
@@ -134,6 +141,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             type: 'alphabetical',
             ignoreCase: true,
             customGroups: {},
+            matcher: 'minimatch',
             order: 'asc',
             groups: [],
           } as const)
@@ -155,9 +163,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
               let name: string
 
-              let { getGroup, defineGroup, setCustomGroups } = useGroups(
-                options.groups,
-              )
+              let { getGroup, defineGroup, setCustomGroups } =
+                useGroups(options)
 
               if (attribute.key.type === 'SvelteSpecialDirectiveKey') {
                 name = sourceCode.text.slice(...attribute.key.range)

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -27,6 +27,7 @@ type Options = [
   Partial<{
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -55,6 +56,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -100,6 +106,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       partitionByComment: false,
       partitionByNewLine: false,
     },
@@ -113,6 +120,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           type: 'alphabetical',
           ignoreCase: true,
           partitionByNewLine: false,
+          matcher: 'minimatch',
           partitionByComment: false,
           order: 'asc',
         } as const)
@@ -233,6 +241,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 hasPartitionComment(
                   partitionComment,
                   getCommentsBefore(declaration, sourceCode),
+                  options.matcher,
                 )) ||
               (options.partitionByNewLine &&
                 lastSortingNode &&
@@ -269,9 +278,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               },
               node: right.node,
               fix: fixer =>
-                makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                  partitionComment,
-                }),
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
             })
           }
         })

--- a/rules/sort-vue-attributes.ts
+++ b/rules/sort-vue-attributes.ts
@@ -31,6 +31,7 @@ type Options<T extends string[]> = [
     customGroups: { [key in T[number]]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
     groups: (Group<T>[] | Group<T>)[]
+    matcher: 'minimatch' | 'regex'
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -58,6 +59,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               'Determines whether the sorted items should be in ascending or descending order.',
             type: 'string',
             enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
           },
           ignoreCase: {
             description:
@@ -114,6 +120,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      matcher: 'minimatch',
       groups: [],
       customGroups: {},
     },
@@ -146,6 +153,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             type: 'alphabetical',
             ignoreCase: true,
             customGroups: {},
+            matcher: 'minimatch',
             order: 'asc',
             groups: [],
           } as const)
@@ -168,9 +176,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
               let name: string
 
-              let { getGroup, defineGroup, setCustomGroups } = useGroups(
-                options.groups,
-              )
+              let { getGroup, defineGroup, setCustomGroups } =
+                useGroups(options)
 
               if (
                 typeof attribute.key.name === 'string' &&

--- a/test/sort-array-includes.test.ts
+++ b/test/sort-array-includes.test.ts
@@ -616,6 +616,30 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(`${ruleName}(${type}): allows to use regex matcher`, rule, {
+      valid: [
+        {
+          code: dedent`
+              [
+                'e',
+                'f',
+                // I am a partition comment because I don't have f o o
+                'a',
+                'b',
+              ].includes(value)
+            `,
+          options: [
+            {
+              ...options,
+              matcher: 'regex',
+              partitionByComment: ['^(?!.*foo).*$'],
+            },
+          ],
+        },
+      ],
+      invalid: [],
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-astro-attributes.test.ts
+++ b/test/sort-astro-attributes.test.ts
@@ -465,6 +465,40 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file.astro',
+            code: dedent`
+            ---
+              import Component from '~/file.astro'
+            ---
+            <Component
+              iHaveFooInMyName="iHaveFooInMyName"
+              meTooIHaveFoo="meTooIHaveFoo"
+              a="a"
+              b="b"
+            />
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: {
+                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -399,6 +399,34 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              enum Enum {
+                E = 'E',
+                F = 'F',
+                // I am a partition comment because I don't have f o o
+                A = 'A',
+                B = 'B',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                partitionByComment: ['^(?!.*foo).*$'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
     ruleTester.run(`${ruleName}: sort enum values correctly`, rule, {
       valid: [],
       invalid: [

--- a/test/sort-exports.test.ts
+++ b/test/sort-exports.test.ts
@@ -346,6 +346,32 @@ describe(ruleName, () => {
       )
     })
 
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              export * from './e'
+              export * from './f'
+              // I am a partition comment because I don't have f o o
+              export * from './a'
+              export * from './b'
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                partitionByComment: ['^(?!.*foo).*$'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
     ruleTester.run(`${ruleName}(${type}): sorts by group kind`, rule, {
       valid: [],
       invalid: [

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -5172,5 +5172,114 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    describe(`${ruleName}: allows to use regex matcher`, () => {
+      let options = {
+        type: 'alphabetical',
+        ignoreCase: true,
+        order: 'asc',
+        matcher: 'regex',
+      } as const
+
+      ruleTester.run(
+        `${ruleName}: uses default internalPattern for regex`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                import type { T } from 't'
+
+                import { a1, a2, a3 } from 'a'
+
+                import { b1, b2 } from '~/b'
+                import { c1, c2, c3 } from '~/c'
+
+                import { e1, e2, e3 } from '../../e'
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: ['type', 'external', 'internal', 'parent'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: allows to use regex matcher for custom groups`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                import type { T } from 't'
+
+                import { i18n } from "../../../../../Basics/Language";
+                import { i18n } from "../../../Basics/Language";
+
+                import { b1, b2 } from '~/b'
+                import { c1, c2, c3 } from '~/c'
+              `,
+              options: [
+                {
+                  ...options,
+                  customGroups: {
+                    value: {
+                      primary: '^(?:\\.\\.\\/)+Basics\\/Language$',
+                    },
+                  },
+                  groups: ['type', 'primary', 'unknown'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: allows hash symbol in internal pattern`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              import type { T } from 'a'
+
+              import { a } from 'a'
+
+              import type { S } from '#b'
+
+              import { b1, b2 } from '#b'
+              import c from '#c'
+
+              import { d } from '../d'
+            `,
+              options: [
+                {
+                  ...options,
+                  internalPattern: ['^#.*$'],
+                  groups: [
+                    'type',
+                    ['builtin', 'external'],
+                    'internal-type',
+                    'internal',
+                    ['parent-type', 'sibling-type', 'index-type'],
+                    ['parent', 'sibling', 'index'],
+                    'object',
+                    'unknown',
+                  ],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
   })
 })

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -579,6 +579,36 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              interface Interface {
+                  iHaveFooInMyName: string
+                  meTooIHaveFoo: string
+                  a: string
+                  b: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: {
+                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
+    ruleTester.run(
       `${ruleName}(${type}): allows to use new line as partition`,
       rule,
       {
@@ -916,6 +946,34 @@ describe(ruleName, () => {
             ],
           },
         ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              interface MyInterface {
+                e: string,
+                f: string,
+                // I am a partition comment because I don't have f o o
+                a: string,
+                b: string,
+              }
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                partitionByComment: ['^(?!.*foo).*$'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
       },
     )
   })

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -610,6 +610,33 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              type T =
+                E &
+                F &
+                // I am a partition comment because I don't have f o o
+                A &
+                B
+            `,
+              options: [
+                {
+                  ...options,
+                  matcher: 'regex',
+                  partitionByComment: ['^(?!.*foo).*$'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
     })
   })
 

--- a/test/sort-jsx-props.test.ts
+++ b/test/sort-jsx-props.test.ts
@@ -493,6 +493,36 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+            <Element
+              iHaveFooInMyName="iHaveFooInMyName"
+              meTooIHaveFoo="meTooIHaveFoo"
+              a="a"
+              b="b"
+            />
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: {
+                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-maps.test.ts
+++ b/test/sort-maps.test.ts
@@ -439,6 +439,34 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex matcher`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              new Map([
+                ['e', 'e'],
+                ['f', 'f'],
+                // I am a partition comment because I don't have f o o
+                ['a', 'a'],
+                ['b', 'b'],
+              ])
+            `,
+              options: [
+                {
+                  ...options,
+                  matcher: 'regex',
+                  partitionByComment: ['^(?!.*foo).*$'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
     })
   })
 

--- a/test/sort-named-exports.test.ts
+++ b/test/sort-named-exports.test.ts
@@ -354,6 +354,34 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              export {
+                E,
+                F,
+                // I am a partition comment because I don't have f o o
+                A,
+                B,
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  matcher: 'regex',
+                  partitionByComment: ['^(?!.*foo).*$'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
     })
   })
 

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -366,6 +366,36 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              type T = {
+                iHaveFooInMyName: string
+                meTooIHaveFoo: string
+                a: string
+                b: string
+              }
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: {
+                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
+    ruleTester.run(
       `${ruleName}(${type}): allows to use in class methods`,
       rule,
       {
@@ -624,6 +654,34 @@ describe(ruleName, () => {
               ],
             },
           ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              type Type = {
+                e: string
+                f: string
+                // I am a partition comment because I don't have f o o
+                a: string
+                b: string
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  matcher: 'regex',
+                  partitionByComment: ['^(?!.*foo).*$'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
         },
       )
     })

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -322,6 +322,36 @@ describe(ruleName, () => {
     })
 
     ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+            let Obj = {
+              iHaveFooInMyName: string,
+              meTooIHaveFoo: string,
+              a: string,
+              b: string,
+            }
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: {
+                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
+    ruleTester.run(
       `${ruleName}(${type}): sorts with comments on the same line`,
       rule,
       {
@@ -1432,6 +1462,34 @@ describe(ruleName, () => {
             ],
           },
         ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              let obj = {
+                e = 'e',
+                f = 'f',
+                // I am a partition comment because I don't have f o o
+                a = 'a',
+                b = 'b',
+              }
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                partitionByComment: ['^(?!.*foo).*$'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
       },
     )
 

--- a/test/sort-sets.test.ts
+++ b/test/sort-sets.test.ts
@@ -562,6 +562,34 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex matcher`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              new Set([
+                'e',
+                'f',
+                // I am a partition comment because I don't have f o o
+                'a',
+                'b',
+              ])
+            `,
+              options: [
+                {
+                  ...options,
+                  matcher: 'regex',
+                  partitionByComment: ['^(?!.*foo).*$'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
     })
   })
 

--- a/test/sort-svelte-attributes.test.ts
+++ b/test/sort-svelte-attributes.test.ts
@@ -471,6 +471,41 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file.svelte',
+            code: dedent`
+            <script>
+              import Component from '~/file.svelte'
+            </script>
+
+            <Component
+              iHaveFooInMyName="iHaveFooInMyName"
+              meTooIHaveFoo="meTooIHaveFoo"
+              a="a"
+              b="b"
+            />
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: {
+                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -613,6 +613,33 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex matcher for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              type T =
+                E |
+                F |
+                // I am a partition comment because I don't have f o o
+                A |
+                B
+            `,
+              options: [
+                {
+                  ...options,
+                  matcher: 'regex',
+                  partitionByComment: ['^(?!.*foo).*$'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
     })
   })
 

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -844,6 +844,33 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex matcher`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              const
+                e = 'e',
+                f = 'f',
+                // I am a partition comment because I don't have f o o
+                a = 'a',
+                b = 'b'
+            `,
+              options: [
+                {
+                  ...options,
+                  matcher: 'regex',
+                  partitionByComment: ['^(?!.*foo).*$'],
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
     })
   })
 

--- a/test/sort-vue-attributes.test.ts
+++ b/test/sort-vue-attributes.test.ts
@@ -308,6 +308,39 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use regex matcher for custom groups`,
+      rule,
+      {
+        valid: [
+          {
+            filename: 'file.vue',
+            code: dedent`
+              <template>
+                <component
+                  iHaveFooInMyName="iHaveFooInMyName"
+                  meTooIHaveFoo="meTooIHaveFoo"
+                  a="a"
+                  b="b"
+                ></component>
+              </template>
+            `,
+            options: [
+              {
+                ...options,
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: {
+                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                },
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -10,7 +10,8 @@ export let getNodeRange = (
   node: TSESTree.Node,
   sourceCode: TSESLint.SourceCode,
   additionalOptions?: {
-    partitionComment?: string[] | boolean | string
+    partitionByComment?: string[] | boolean | string
+    matcher?: 'minimatch' | 'regex'
   },
 ): TSESTree.Range => {
   let start = node.range.at(0)!
@@ -44,14 +45,21 @@ export let getNodeRange = (
     }
   }
   let comments = getCommentsBefore(node, sourceCode)
-  let partitionComment = additionalOptions?.partitionComment ?? false
+  let partitionComment = additionalOptions?.partitionByComment ?? false
+  let partitionCommentMatcher = additionalOptions?.matcher ?? 'minimatch'
 
   // Iterate on all comments starting from the bottom until we reach the last
   // of the comments, a newline between comments, or a partition comment
   let relevantTopComment: TSESTree.Comment | undefined
   for (let i = comments.length - 1; i >= 0; i--) {
     let comment = comments[i]
-    if (isPartitionComment(partitionComment, comment.value)) {
+    if (
+      isPartitionComment(
+        partitionComment,
+        comment.value,
+        partitionCommentMatcher,
+      )
+    ) {
       break
     }
     // Check for newlines between comments or between the first comment and

--- a/utils/is-partition-comment.ts
+++ b/utils/is-partition-comment.ts
@@ -1,25 +1,25 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import { minimatch } from 'minimatch'
+import { matches } from './matches'
 
 export let isPartitionComment = (
   partitionComment: string[] | boolean | string,
   comment: string,
+  matcher: 'minimatch' | 'regex',
 ) =>
   (Array.isArray(partitionComment) &&
     partitionComment.some(pattern =>
-      minimatch(comment.trim(), pattern, {
-        nocomment: true,
-      }),
+      matches(comment.trim(), pattern, matcher),
     )) ||
   (typeof partitionComment === 'string' &&
-    minimatch(comment.trim(), partitionComment, {
-      nocomment: true,
-    })) ||
+    matches(comment.trim(), partitionComment, matcher)) ||
   partitionComment === true
 
 export let hasPartitionComment = (
   partitionComment: string[] | boolean | string,
   comments: TSESTree.Comment[],
+  matcher: 'minimatch' | 'regex',
 ): boolean =>
-  comments.some(comment => isPartitionComment(partitionComment, comment.value))
+  comments.some(comment =>
+    isPartitionComment(partitionComment, comment.value, matcher),
+  )

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -12,7 +12,8 @@ export let makeFixes = (
   sortedNodes: SortingNode[],
   source: TSESLint.SourceCode,
   additionalOptions?: {
-    partitionComment?: string[] | boolean | string
+    partitionByComment: string[] | boolean | string
+    matcher: 'minimatch' | 'regex'
   },
 ) => {
   let fixes: TSESLint.RuleFix[] = []

--- a/utils/matches.ts
+++ b/utils/matches.ts
@@ -1,0 +1,17 @@
+import { minimatch } from 'minimatch'
+
+export let matches = (
+  value: string,
+  pattern: string,
+  type: 'minimatch' | 'regex',
+) => {
+  switch (type) {
+    case 'regex':
+      return new RegExp(pattern).test(value)
+    case 'minimatch':
+    default:
+      return minimatch(value, pattern, {
+        nocomment: true,
+      })
+  }
+}

--- a/utils/use-groups.ts
+++ b/utils/use-groups.ts
@@ -1,9 +1,11 @@
 import { matches } from './matches'
 
-export let useGroups = (
-  groups: (string[] | string)[],
-  matcher: 'minimatch' | 'regex' = 'minimatch',
-) => {
+interface UseGroupProps {
+  matcher: 'minimatch' | 'regex'
+  groups: (string[] | string)[]
+}
+
+export let useGroups = ({ matcher, groups }: UseGroupProps) => {
   let group: undefined | string
   // For lookup performance
   let groupsSet = new Set(groups.flat())

--- a/utils/use-groups.ts
+++ b/utils/use-groups.ts
@@ -1,6 +1,9 @@
-import { minimatch } from 'minimatch'
+import { matches } from './matches'
 
-export let useGroups = (groups: (string[] | string)[]) => {
+export let useGroups = (
+  groups: (string[] | string)[],
+  matcher: 'minimatch' | 'regex' = 'minimatch',
+) => {
   let group: undefined | string
   // For lookup performance
   let groupsSet = new Set(groups.flat())
@@ -24,21 +27,12 @@ export let useGroups = (groups: (string[] | string)[]) => {
       for (let [key, pattern] of Object.entries(customGroups)) {
         if (
           Array.isArray(pattern) &&
-          pattern.some(patternValue =>
-            minimatch(name, patternValue, {
-              nocomment: true,
-            }),
-          )
+          pattern.some(patternValue => matches(name, patternValue, matcher))
         ) {
           defineGroup(key, params.override)
         }
 
-        if (
-          typeof pattern === 'string' &&
-          minimatch(name, pattern, {
-            nocomment: true,
-          })
-        ) {
+        if (typeof pattern === 'string' && matches(name, pattern, matcher)) {
           defineGroup(key, params.override)
         }
       }


### PR DESCRIPTION
Resolves #138 .

### Description

This PR adds the following to all rules supporting `customGroups` or `partitionByComment`:
- A `matcher: 'minimatch' | 'regex'` option (by default `minimatch`) that dictates what matcher is used for pattern matching for both the `internalPattern` and `customGroups` options.
- For `sort-imports`, the default `ignorePattern` option will be `['^~/.*']` if the matcher is `regex`.

Don't be afraid of the number of line changes, most are tests and documentation.

Rules affected:
- [x] `sort-array-includes`
- [x] `sort-astro-attributes`
- [x] `sort-classes`
- [x] `sort-enums`
- [x] `sort-exports`
- [x] `sort-imports`
- [x] `sort-interfaces`
- [x] `sort-interesection-types`
- [x] `sort-jsx-props`
- [x] `sort-maps`
- [x] `sort-named-exports`
- [x] `sort-object-types`
- [x] `sort-objects`
- [x] `sort-sets`
- [x] `sort-svelte-attributes`
- [x] `sort-union-types`
- [x] `sort-variable-declarations`
- [x] `sort-vue-attributes`

### Important note

- Entering an invalid RegExp expression will throw an error when a node is evaluated.
- Regex options are not supported: the regex string (`"xxxx"` and not `/xxxx/`) must be entered for serialization reasons.

### What is the purpose of this pull request?

- [x] New Feature