### PR TITLE
feat(sort-classes): adds `elementValuePattern` filter for properties

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -481,6 +481,7 @@ interface CustomGroupDefinition {
   selector?: string
   modifiers?: string[]
   elementNamePattern?: string
+  elementValuePattern?: string
   decoratorNamePattern?: string
 }
 ```
@@ -497,6 +498,7 @@ interface CustomGroupBlockDefinition {
       selector?: string
       modifiers?: string[]
       elementNamePattern?: string
+      elementValuePattern?: string
       decoratorNamePattern?: string
   }>
 }
@@ -510,6 +512,7 @@ A class member will match a `CustomGroupBlockDefinition` group if it matches all
 - `selector`: Filter on the `selector` of the element.
 - `modifiers`: Filter on the `modifiers` of the element. (All the modifiers of the element must be present in that list)
 - `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
+- `elementValuePattern`: Only for non-function properties. If entered, will check that the value of the property matches the pattern entered.
 - `decoratorNamePattern`: If entered, will check that at least one `decorator` matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -13,6 +13,7 @@ import { matches } from '../utils/matches'
 
 interface CustomGroupMatchesProps {
   customGroup: SingleCustomGroup | CustomGroupBlock
+  elementValue: undefined | string
   matcher: 'minimatch' | 'regex'
   selectors: Selector[]
   modifiers: Modifier[]
@@ -191,6 +192,20 @@ export const customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
       props.matcher,
     )
     if (!matchesElementNamePattern) {
+      return false
+    }
+  }
+
+  if (
+    'elementValuePattern' in props.customGroup &&
+    props.customGroup.elementValuePattern
+  ) {
+    let matchesElementValuePattern: boolean = matches(
+      props.elementValue ?? '',
+      props.customGroup.elementValuePattern,
+      props.matcher,
+    )
+    if (!matchesElementValuePattern) {
       return false
     }
   }

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -430,6 +430,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               }
             }
 
+            let memberValue: undefined | string
             let modifiers: Modifier[] = []
             let selectors: Selector[] = []
             if (
@@ -570,6 +571,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                 selectors.push('function-property')
               }
 
+              if (!isFunctionProperty && member.value) {
+                memberValue = sourceCode.getText(member.value)
+              }
+
               selectors.push('property')
 
               if (
@@ -595,6 +600,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
                   customGroupMatches({
                     customGroup,
                     elementName: name,
+                    elementValue: memberValue,
                     modifiers,
                     selectors,
                     decorators,
@@ -621,7 +627,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               .find(overloadSignatures => overloadSignatures.includes(member))
               ?.at(-1)
 
-            let value: SortingNodeWithDependencies = {
+            let sortingNode: SortingNodeWithDependencies = {
               size: overloadSignatureGroupMember
                 ? rangeToDiff(overloadSignatureGroupMember.range)
                 : rangeToDiff(member.range),
@@ -635,7 +641,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               ),
             }
 
-            accumulator.at(-1)!.push(value)
+            accumulator.at(-1)!.push(sortingNode)
 
             return accumulator
           },

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -156,6 +156,7 @@ interface BaseSingleCustomGroup<T extends Selector> {
 
 type AdvancedSingleCustomGroup<T extends Selector> = {
   decoratorNamePattern?: string
+  elementValuePattern?: string
   elementNamePattern?: string
 } & BaseSingleCustomGroup<T>
 
@@ -260,6 +261,10 @@ export const singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   },
   elementNamePattern: {
     description: 'Element name pattern filter.',
+    type: 'string',
+  },
+  elementValuePattern: {
+    description: 'Element value pattern filter for properties.',
     type: 'string',
   },
   decoratorNamePattern: {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -6259,6 +6259,58 @@ describe(ruleName, () => {
       ],
     })
 
+    ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              class Class {
+                a = computed(A)
+                b = inject(B)
+                y = inject(Y)
+                z = computed(Z)
+                c() {}
+              }
+            `,
+          output: dedent`
+              class Class {
+                a = computed(A)
+                z = computed(Z)
+                b = inject(B)
+                y = inject(Y)
+                c() {}
+              }
+            `,
+          options: [
+            {
+              groups: ['computed', 'inject', 'unknown'],
+              customGroups: [
+                {
+                  groupName: 'inject',
+                  elementValuePattern: 'inject*',
+                },
+                {
+                  groupName: 'computed',
+                  elementValuePattern: 'computed*',
+                },
+              ],
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedClassesGroupOrder',
+              data: {
+                left: 'y',
+                leftGroup: 'inject',
+                right: 'z',
+                rightGroup: 'computed',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
     ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
       valid: [],
       invalid: [
@@ -6700,6 +6752,39 @@ describe(ruleName, () => {
                   {
                     groupName: 'elementsWithoutFoo',
                     elementNamePattern: '^(?!.*Foo).*$',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}: allows to use regex matcher for element values in custom groups with new API`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              class Class {
+                x = "iHaveFooInMyName"
+                z = "MeTooIHaveFoo"
+                a = "a"
+                b = "b"
+              }
+            `,
+            options: [
+              {
+                type: 'alphabetical',
+                matcher: 'regex',
+                groups: ['unknown', 'elementsWithoutFoo'],
+                customGroups: [
+                  {
+                    groupName: 'elementsWithoutFoo',
+                    elementValuePattern: '^(?!.*Foo).*$',
                   },
                 ],
               },


### PR DESCRIPTION
### Description

Resolves #298 

### Changes

Adds a `elementValuePattern` option for custom groups, allowing users to match **non-function property** values.

- [x] Add tests
- [x] Update documentation 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature
- [x] Documentation update
