### PR TITLE
fix(sort-classes): fixes runtime error related to dependencies

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -267,16 +267,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           let dependencies: string[] = []
 
           let checkNode = (nodeValue: TSESTree.Node) => {
-            /**
-             * No need to check the body of functions and arrow functions
-             */
-            if (
-              nodeValue.type === 'ArrowFunctionExpression' ||
-              nodeValue.type === 'FunctionExpression'
-            ) {
-              return
-            }
-
             if (
               nodeValue.type === 'MemberExpression' &&
               (nodeValue.object.type === 'ThisExpression' ||

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -2681,7 +2681,7 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
-        `${ruleName}(${type}) detects function expression dependencies`,
+        `${ruleName}(${type}) detects function property dependencies`,
         rule,
         {
           valid: [
@@ -2796,6 +2796,22 @@ describe(ruleName, () => {
                     return 1
                   }
                   static a = [1].map(Class.b)
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  groups: [['property', 'method']],
+                },
+              ],
+            },
+            {
+              code: dedent`
+                class Class {
+                  querystring = createQueryString();
+                  state = createState((set) => {
+                      set('query', this.queryString.value);
+                   });
                 }
               `,
               options: [
@@ -2834,13 +2850,13 @@ describe(ruleName, () => {
             {
               code: dedent`
                 class Class {
+                  static z = true;
                   static {
                     const method = () => {
                       return (Class.z || true) && (false || this.z);
                     };
                     method();
                   }
-                  static z = true;
                 }
               `,
               options: [


### PR DESCRIPTION
Fixes #300 .

### Description

Fixes possible runtime errors due to function body dependencies not being considered when passing callback functions in property assignments. Issue possibly affects `static` block as well in some cases. One test affected had to be updated.

### What is the purpose of this pull request?

- [x] Bug fix
