### PR TITLE
feat(sort-classes): Throw an error when a group entered in config does not exist/is duplicated

### DIFF
--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -9,6 +9,7 @@ import type {
 } from './sort-classes.types'
 import type { CompareOptions } from '../utils/compare'
 
+import { validateNoDuplicatedGroups } from '../utils/validate-groups-configuration'
 import { allModifiers, allSelectors } from './sort-classes.types'
 import { matches } from '../utils/matches'
 
@@ -271,6 +272,7 @@ export let validateGroupsConfiguration = (
   if (invalidGroups.length) {
     throw new Error('Invalid group(s): ' + invalidGroups.join(', '))
   }
+  validateNoDuplicatedGroups(groups)
 }
 
 const isPredefinedGroup = (input: string): boolean => {
@@ -294,6 +296,6 @@ const isPredefinedGroup = (input: string): boolean => {
   let modifiers = input.split('-').slice(0, isTwoWordSelectorValid ? -2 : -1)
   return (
     new Set(modifiers).size === modifiers.length &&
-    !modifiers.some(modifier => !allModifiers.includes(modifier as Modifier))
+    modifiers.every(modifier => allModifiers.includes(modifier as Modifier))
   )
 }

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -9,6 +9,7 @@ import type {
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
+  validateGroupsConfiguration,
   getOverloadSignatureGroups,
   generateOfficialGroups,
   customGroupMatches,
@@ -242,6 +243,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           customGroups: [],
           order: 'asc',
         } as const)
+
+        validateGroupsConfiguration(options.groups, options.customGroups)
 
         let sourceCode = getSourceCode(context)
         let className = node.parent.id?.name

--- a/test/sort-classes-utils.test.ts
+++ b/test/sort-classes-utils.test.ts
@@ -51,7 +51,7 @@ describe('sort-classes-utils', () => {
   })
 
   describe('validateGroupsConfiguration', () => {
-    it('should allow predefined groups', () => {
+    it('allows predefined groups', () => {
       let allModifierCombinationPermutations =
         getAllNonEmptyCombinations(allModifiers)
       let allPredefinedGroups = allSelectors
@@ -67,7 +67,7 @@ describe('sort-classes-utils', () => {
       ).toBeUndefined()
     })
 
-    it('should allow custom groups with new API', () => {
+    it('allows custom groups with the new API', () => {
       expect(
         validateGroupsConfiguration(
           ['static-property', 'myCustomGroup'],
@@ -80,13 +80,19 @@ describe('sort-classes-utils', () => {
       ).toBeUndefined()
     })
 
-    it('should not allow predefined groups with duplicate modifiers', () => {
+    it('throws an error with predefined groups with duplicate modifiers', () => {
       expect(() =>
         validateGroupsConfiguration(['static-static-property'], []),
       ).toThrow('Invalid group(s): static-static-property')
     })
 
-    it('should not allow invalid groups with new API', () => {
+    it('throws an error if a duplicate group is provided', () => {
+      expect(() =>
+        validateGroupsConfiguration(['static-property', 'static-property'], []),
+      ).toThrow('Duplicated group(s): static-property')
+    })
+
+    it('throws an error if invalid groups are provided with the new API', () => {
       expect(() =>
         validateGroupsConfiguration(
           ['static-property', 'myCustomGroup', ''],
@@ -99,7 +105,7 @@ describe('sort-classes-utils', () => {
       ).toThrow('Invalid group(s): myCustomGroup')
     })
 
-    it('should allow groups with old API', () => {
+    it('allows groups with the old API', () => {
       expect(
         validateGroupsConfiguration(['static-property', 'myCustomGroup'], {
           myCustomGroup: 'foo',
@@ -107,7 +113,7 @@ describe('sort-classes-utils', () => {
       ).toBeUndefined()
     })
 
-    it('should not allow invalid custom groups with old API', () => {
+    it('throws an error if invalid custom groups are provided with the old API', () => {
       expect(() =>
         validateGroupsConfiguration(['static-property', 'myCustomGroup'], {
           myCustomGroupNotReferenced: 'foo',

--- a/test/validate-groups-configuration.test.ts
+++ b/test/validate-groups-configuration.test.ts
@@ -21,4 +21,14 @@ describe('validate-groups-configuration', () => {
       )
     }).toThrow('Invalid group(s): invalidGroup1, invalidGroup2')
   })
+
+  it('throws an error when a duplicate group is provided', () => {
+    expect(() => {
+      validateGroupsConfiguration(
+        ['predefinedGroup', 'predefinedGroup'],
+        ['predefinedGroup'],
+        [],
+      )
+    }).toThrow('Duplicated group(s): predefinedGroup')
+  })
 })

--- a/utils/validate-groups-configuration.ts
+++ b/utils/validate-groups-configuration.ts
@@ -1,3 +1,9 @@
+/**
+ * Throws an error if one of the following conditions is met:
+ * - One or more groups specified in `groups` are not predefined nor specified
+ * in `customGroups`
+ * - A group is specified in `groups` more than once
+ */
 export let validateGroupsConfiguration = (
   groups: (string[] | string)[],
   allowedPredefinedGroups: string[],
@@ -12,5 +18,21 @@ export let validateGroupsConfiguration = (
     .filter(group => !allowedGroupsSet.has(group))
   if (invalidGroups.length) {
     throw new Error('Invalid group(s): ' + invalidGroups.join(', '))
+  }
+  validateNoDuplicatedGroups(groups)
+}
+
+/**
+ * Throws an error if a group is specified more than once
+ */
+export let validateNoDuplicatedGroups = (
+  groups: (string[] | string)[],
+): void => {
+  let flattenGroups = groups.flat()
+  let duplicatedGroups = flattenGroups.filter(
+    (group, index) => flattenGroups.indexOf(group) !== index,
+  )
+  if (duplicatedGroups.length) {
+    throw new Error('Duplicated group(s): ' + duplicatedGroups.join(', '))
   }
 }


### PR DESCRIPTION
Continuation of https://github.com/azat-io/eslint-plugin-perfectionist/pull/232 to solve https://github.com/azat-io/eslint-plugin-perfectionist/issues/214.

### Description

Groups that are not part of predefined groups nor entered as custom groups have no reason to exist in the groups attribute. `sort-classes` was the only remaining rule not to have this feature, because predefined groups are computed differently.

- [x] Makes `sort-classes` throw an error if a group entered in `groups` is not a predefined nor custom custom.
- [x] For all rules, also checks that no group is entered more than once in `groups`. 

![Screenshot 2024-10-09 at 08 27 13](https://github.com/user-attachments/assets/03538ef7-e2e4-4de8-b49c-e8d82adf2015)

### What is the purpose of this pull request?

- [x] New Feature
