### PR TITLE
feat: add `specialCharacters` and `matcher` to settings

### DIFF
--- a/docs/content/guide/getting-started.mdx
+++ b/docs/content/guide/getting-started.mdx
@@ -144,8 +144,10 @@ In settings you can set the following options:
 - `order` — The order of sorting. Possible values are `'asc'` and `'desc'`.
 - `ignoreCase` — Ignore case when sorting.
 - `ignorePattern` — Ignore sorting for elements that match the pattern.
+- `specialCharacters` — Control whether special characters should be kept, trimmed or removed before sorting. Values can be `'keep'`, `'trim'` or `'remove'`.
 - `partitionByComment` — Partition the sorted elements by comments. Values can be `true`, `false` or glob pattern string.
 - `partitionByNewLine` — Partition the sorted elements by new lines. Values can be `true` or `false`.
+- `matcher` — Determine the matcher used for patterns in options such as `partitionByComment`. Values can be `minimatch` or `regex`.
 
 Example:
 

--- a/test/get-settings.test.ts
+++ b/test/get-settings.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Settings } from '../utils/get-settings'
+
+import { getSettings } from '../utils/get-settings'
+
+describe('get-settings', () => {
+  it('throws an error when an invalid setting is provided', () => {
+    expect(() => {
+      getSettings({
+        perfectionist: {
+          invalidOption1: 'value',
+          invalidOption2: 'value',
+        },
+      })
+    }).toThrow(
+      'Invalid Perfectionist setting(s): invalidOption1, invalidOption2',
+    )
+  })
+
+  it('accepts official settings provided', () => {
+    let allowedOptions: { [key in keyof Required<Settings>]: Settings[key] } = {
+      partitionByComment: 'value',
+      partitionByNewLine: true,
+      specialCharacters: 'keep',
+      ignorePattern: [],
+      ignoreCase: true,
+      matcher: 'regex',
+      order: 'asc',
+      type: 'alphabetical',
+    }
+    expect(() => {
+      getSettings({
+        perfectionist: allowedOptions,
+      })
+    }).not.toThrow()
+  })
+})

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -3,6 +3,8 @@ import type { TSESLint } from '@typescript-eslint/utils'
 export type Settings = Partial<{
   type: 'alphabetical' | 'line-length' | 'natural'
   partitionByComment: string[] | boolean | string
+  specialCharacters: 'remove' | 'trim' | 'keep'
+  matcher: 'minimatch' | 'regex'
   partitionByNewLine: boolean
   ignorePattern: string[]
   order: 'desc' | 'asc'
@@ -16,34 +18,31 @@ export let getSettings = (
     return {}
   }
 
-  let validateOptions = (object: Record<string, unknown>) => {
-    let allowedOptions = [
+  let getInvalidOptions = (object: Record<string, unknown>) => {
+    let allowedOptions: (keyof Settings)[] = [
       'partitionByComment',
       'partitionByNewLine',
+      'specialCharacters',
       'ignorePattern',
       'ignoreCase',
+      'matcher',
       'order',
       'type',
     ]
 
-    let keys = Object.keys(object)
-    for (let key of keys) {
-      /* c8 ignore start */
-      if (!allowedOptions.includes(key)) {
-        return false
-      }
-      /* c8 ignore end */
-    }
-    return true
+    return Object.keys(object).filter(
+      key => !allowedOptions.includes(key as keyof Settings),
+    )
   }
 
   let perfectionistSettings = settings.perfectionist as Record<string, unknown>
 
-  /* c8 ignore start */
-  if (!validateOptions(perfectionistSettings)) {
-    throw new Error('Invalid Perfectionist settings')
+  let invalidOptions = getInvalidOptions(perfectionistSettings)
+  if (invalidOptions.length) {
+    throw new Error(
+      'Invalid Perfectionist setting(s): ' + invalidOptions.join(', '),
+    )
   }
-  /* c8 ignore end */
 
   return settings.perfectionist as Settings
 }


### PR DESCRIPTION
### Changes

- Adds `specialCharacters` and `matcher` to global settings, as all rules allow them.
- Adds tests and ensure 100% coverage.
- Improves the error in case of invalid settings: displays the invalid settings provided.
- Updates docs.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature
- [x] Documentation update
