### PR TITLE
feat(sort-imports): Improves side-effect handling behavior

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -6,9 +6,9 @@ import { builtinModules } from 'node:module'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { getOptionsWithCleanGroups } from '../utils/get-options-with-clean-groups'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
-import { cleanGroupsOption } from '../utils/clean-groups-option'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -246,7 +246,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     let settings = getSettings(context.settings)
 
     let userOptions = context.options.at(0)
-    let options = cleanGroupsOption(
+    let options = getOptionsWithCleanGroups(
       complete(userOptions, settings, {
         groups: [
           'type',

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -267,23 +267,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     } as const)
 
     let sourceCode = getSourceCode(context)
-    let hasUnknownGroup = false
-
-    for (let group of options.groups) {
-      if (Array.isArray(group)) {
-        for (let subGroup of group) {
-          if (subGroup === 'unknown') {
-            hasUnknownGroup = true
-          }
-        }
-      } else if (group === 'unknown') {
-        hasUnknownGroup = true
-      }
-    }
-
-    if (!hasUnknownGroup) {
-      options.groups = [...options.groups, 'unknown']
-    }
 
     validateGroupsConfiguration(
       options.groups,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -6,7 +6,9 @@ import { builtinModules } from 'node:module'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
+import { cleanGroupsOption } from '../utils/clean-groups-option'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -14,15 +16,13 @@ import { getSourceCode } from '../utils/get-source-code'
 import { getNodeRange } from '../utils/get-node-range'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { useGroups } from '../utils/use-groups'
-import { sortNodes } from '../utils/sort-nodes'
+import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
-import { compare } from '../utils/compare'
 import { matches } from '../utils/matches'
 
-type MESSAGE_ID =
+export type MESSAGE_ID =
   | 'missedSpacingBetweenImports'
   | 'unexpectedImportsGroupOrder'
   | 'extraSpacingBetweenImports'
@@ -49,7 +49,7 @@ type Group<T extends string[]> =
   | 'style'
   | 'type'
 
-type Options<T extends string[]> = [
+export type Options<T extends string[]> = [
   Partial<{
     customGroups: {
       value?: { [key in T[number]]: string[] | string }
@@ -68,6 +68,10 @@ type Options<T extends string[]> = [
     ignoreCase: boolean
   }>,
 ]
+
+interface SortImportsSortingNode extends SortingNode {
+  isIgnored: boolean
+}
 
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: 'sort-imports',
@@ -241,32 +245,32 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
 
-    let defaultOptions = context.options.at(0)
-    let options = complete(defaultOptions, settings, {
-      groups: [
-        'type',
-        ['builtin', 'external'],
-        'internal-type',
-        'internal',
-        ['parent-type', 'sibling-type', 'index-type'],
-        ['parent', 'sibling', 'index'],
-        'object',
-        'unknown',
-      ],
-      matcher: 'minimatch',
-      customGroups: { type: {}, value: {} },
-      internalPattern:
-        defaultOptions?.matcher === 'regex' ? ['^~/.*'] : ['~/**'],
-      newlinesBetween: 'always',
-      sortSideEffects: false,
-      type: 'alphabetical',
-      environment: 'node',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      order: 'asc',
-    } as const)
-
-    let sourceCode = getSourceCode(context)
+    let userOptions = context.options.at(0)
+    let options = cleanGroupsOption(
+      complete(userOptions, settings, {
+        groups: [
+          'type',
+          ['builtin', 'external'],
+          'internal-type',
+          'internal',
+          ['parent-type', 'sibling-type', 'index-type'],
+          ['parent', 'sibling', 'index'],
+          'object',
+          'unknown',
+        ],
+        matcher: 'minimatch',
+        customGroups: { type: {}, value: {} },
+        internalPattern:
+          userOptions?.matcher === 'regex' ? ['^~/.*'] : ['~/**'],
+        newlinesBetween: 'always',
+        sortSideEffects: false,
+        type: 'alphabetical',
+        environment: 'node',
+        ignoreCase: true,
+        specialCharacters: 'keep',
+        order: 'asc',
+      } as const),
+    )
 
     validateGroupsConfiguration(
       options.groups,
@@ -296,7 +300,41 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       ],
     )
 
-    let nodes: SortingNode[] = []
+    let isSideEffectOnlyGroup = (
+      group: undefined | string[] | string,
+    ): boolean => {
+      if (!group) {
+        return false
+      }
+      if (typeof group === 'string') {
+        return group === 'side-effect' || group === 'side-effect-style'
+      }
+
+      return group.every(isSideEffectOnlyGroup)
+    }
+
+    // Ensure that if `sortSideEffects: false`, no side effect group is in a
+    // nested group with non-side-effect groups.
+    if (!options.sortSideEffects) {
+      let hasInvalidGroup = options.groups
+        .filter(group => Array.isArray(group))
+        .some(
+          nestedGroup =>
+            !isSideEffectOnlyGroup(nestedGroup) &&
+            nestedGroup.some(
+              subGroup =>
+                subGroup === 'side-effect' || subGroup === 'side-effect-style',
+            ),
+        )
+      if (hasInvalidGroup) {
+        throw new Error(
+          "Side effect groups cannot be nested with non side effect groups when 'sortSideEffects' is 'false'.",
+        )
+      }
+    }
+
+    let sourceCode = getSourceCode(context)
+    let nodes: SortImportsSortingNode[] = []
 
     let isSideEffectImport = (node: TSESTree.Node) =>
       node.type === 'ImportDeclaration' &&
@@ -304,16 +342,40 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       /* Avoid matching on named imports without specifiers */
       !/}\s*from\s+/.test(sourceCode.getText(node))
 
-    let computeGroup = (
+    let isStyle = (value: string) =>
+      ['.less', '.scss', '.sass', '.styl', '.pcss', '.css', '.sss'].some(
+        extension => value.endsWith(extension),
+      )
+
+    let hasMultipleImportDeclarations = (
+      node: TSESTree.ImportDeclaration,
+    ): boolean => node.specifiers.length > 1
+
+    let flatGroups = options.groups.flat()
+    let shouldRegroupSideEffectNodes = flatGroups.includes('side-effect')
+    let shouldRegroupSideEffectStyleNodes =
+      flatGroups.includes('side-effect-style')
+    let registerNode = (
       node:
         | TSESTree.TSImportEqualsDeclaration
         | TSESTree.VariableDeclaration
         | TSESTree.ImportDeclaration,
-    ): Group<string[]> => {
-      let isStyle = (value: string) =>
-        ['.less', '.scss', '.sass', '.styl', '.pcss', '.css', '.sss'].some(
-          extension => value.endsWith(extension),
-        )
+    ) => {
+      let name: string
+
+      if (node.type === 'ImportDeclaration') {
+        name = node.source.value
+      } else if (node.type === 'TSImportEqualsDeclaration') {
+        if (node.moduleReference.type === 'TSExternalModuleReference') {
+          name = `${node.moduleReference.expression.value}`
+        } else {
+          name = sourceCode.text.slice(...node.moduleReference.range)
+        }
+      } else {
+        let decl = node.declarations[0].init as TSESTree.CallExpression
+        let { value } = decl.arguments[0] as TSESTree.Literal
+        name = value!.toString()
+      }
 
       let isIndex = (value: string) =>
         [
@@ -395,6 +457,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         defineGroup('type')
       }
 
+      let isSideEffect = isSideEffectImport(node)
+      let isStyleSideEffect = false
       if (
         node.type === 'ImportDeclaration' ||
         node.type === 'VariableDeclaration'
@@ -407,18 +471,20 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           let declValue = (decl.arguments[0] as TSESTree.Literal).value
           value = declValue!.toString()
         }
+        let isStyleValue = isStyle(value)
+        isStyleSideEffect = isSideEffect && isStyleValue
 
         setCustomGroups(options.customGroups.value, value)
 
-        if (isSideEffectImport(node) && isStyle(value)) {
+        if (isStyleSideEffect) {
           defineGroup('side-effect-style')
         }
 
-        if (isSideEffectImport(node)) {
+        if (isSideEffect) {
           defineGroup('side-effect')
         }
 
-        if (isStyle(value)) {
+        if (isStyleValue) {
           defineGroup('style')
         }
 
@@ -447,39 +513,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         }
       }
 
-      return getGroup()
-    }
-
-    let hasMultipleImportDeclarations = (
-      node: TSESTree.ImportDeclaration,
-    ): boolean => node.specifiers.length > 1
-
-    let registerNode = (
-      node:
-        | TSESTree.TSImportEqualsDeclaration
-        | TSESTree.VariableDeclaration
-        | TSESTree.ImportDeclaration,
-    ) => {
-      let name: string
-
-      if (node.type === 'ImportDeclaration') {
-        name = node.source.value
-      } else if (node.type === 'TSImportEqualsDeclaration') {
-        if (node.moduleReference.type === 'TSExternalModuleReference') {
-          name = `${node.moduleReference.expression.value}`
-        } else {
-          name = sourceCode.text.slice(...node.moduleReference.range)
-        }
-      } else {
-        let decl = node.declarations[0].init as TSESTree.CallExpression
-        let { value } = decl.arguments[0] as TSESTree.Literal
-        name = value!.toString()
-      }
-
       nodes.push({
         size: rangeToDiff(node.range),
-        group: computeGroup(node),
+        group: getGroup(),
         node,
+        isIgnored:
+          !options.sortSideEffects &&
+          isSideEffect &&
+          !shouldRegroupSideEffectNodes &&
+          (!isStyleSideEffect || !shouldRegroupSideEffectStyleNodes),
         name,
         ...(options.type === 'line-length' &&
           options.maxLineLength && {
@@ -506,182 +548,80 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
       'Program:exit': () => {
         let hasContentBetweenNodes = (
-          left: SortingNode,
-          right: SortingNode,
+          left: SortImportsSortingNode,
+          right: SortImportsSortingNode,
         ): boolean =>
           getCommentsBefore(right.node, sourceCode).length > 0 ||
           !!sourceCode.getTokensBetween(left.node, right.node, {
             includeComments: false,
           }).length
 
-        let fix = (
-          fixer: TSESLint.RuleFixer,
-          nodesToFix: SortingNode[],
-        ): TSESLint.RuleFix[] => {
-          let fixes: TSESLint.RuleFix[] = []
-
-          let grouped: {
-            [key: string]: SortingNode[]
-          } = {}
-
-          for (let node of nodesToFix) {
-            let groupNum = getGroupNumber(options.groups, node)
-
-            if (!(groupNum in grouped)) {
-              grouped[groupNum] = [node]
-            } else if (
-              !options.sortSideEffects &&
-              isSideEffectImport(node.node)
-            ) {
-              grouped[groupNum] = [...grouped[groupNum], node]
-            } else {
-              grouped[groupNum] = sortNodes(
-                [...grouped[groupNum], node],
-                options,
-              )
-            }
-          }
-
-          let formatted = Object.keys(grouped)
-            .sort((a, b) => Number(a) - Number(b))
-            .reduce(
-              (accumulator: SortingNode[], group: string) => [
-                ...accumulator,
-                ...grouped[group],
-              ],
-              [],
-            )
-
-          for (let max = formatted.length, i = 0; i < max; i++) {
-            let node = formatted.at(i)!
-
-            fixes.push(
-              fixer.replaceTextRange(
-                getNodeRange(nodesToFix.at(i)!.node, sourceCode, options),
-                sourceCode.text.slice(
-                  ...getNodeRange(node.node, sourceCode, options),
-                ),
-              ),
-            )
-
-            if (options.newlinesBetween !== 'ignore') {
-              let nextNode = formatted.at(i + 1)
-
-              if (nextNode) {
-                let linesBetweenImports = getLinesBetween(
-                  sourceCode,
-                  nodesToFix.at(i)!,
-                  nodesToFix.at(i + 1)!,
-                )
-
-                if (
-                  (options.newlinesBetween === 'always' &&
-                    getGroupNumber(options.groups, node) ===
-                      getGroupNumber(options.groups, nextNode) &&
-                    linesBetweenImports !== 0) ||
-                  (options.newlinesBetween === 'never' &&
-                    linesBetweenImports > 0)
-                ) {
-                  fixes.push(
-                    fixer.removeRange([
-                      getNodeRange(
-                        nodesToFix.at(i)!.node,
-                        sourceCode,
-                        options,
-                      ).at(1)!,
-                      getNodeRange(
-                        nodesToFix.at(i + 1)!.node,
-                        sourceCode,
-                        options,
-                      ).at(0)! - 1,
-                    ]),
-                  )
-                }
-
-                if (
-                  options.newlinesBetween === 'always' &&
-                  getGroupNumber(options.groups, node) !==
-                    getGroupNumber(options.groups, nextNode) &&
-                  linesBetweenImports > 1
-                ) {
-                  fixes.push(
-                    fixer.replaceTextRange(
-                      [
-                        getNodeRange(
-                          nodesToFix.at(i)!.node,
-                          sourceCode,
-                          options,
-                        ).at(1)!,
-                        getNodeRange(
-                          nodesToFix.at(i + 1)!.node,
-                          sourceCode,
-                          options,
-                        ).at(0)! - 1,
-                      ],
-                      '\n',
-                    ),
-                  )
-                }
-
-                if (
-                  options.newlinesBetween === 'always' &&
-                  getGroupNumber(options.groups, node) !==
-                    getGroupNumber(options.groups, nextNode) &&
-                  linesBetweenImports === 0
-                ) {
-                  fixes.push(
-                    fixer.insertTextAfterRange(
-                      getNodeRange(nodesToFix.at(i)!.node, sourceCode, options),
-                      '\n',
-                    ),
-                  )
-                }
-              }
-            }
-          }
-
-          return fixes
-        }
-
-        let splittedNodes: SortingNode[][] = [[]]
+        let splitNodes: SortImportsSortingNode[][] = [[]]
 
         for (let node of nodes) {
-          let lastNode = splittedNodes.at(-1)?.at(-1)
+          let lastNode = splitNodes.at(-1)?.at(-1)
 
           if (lastNode && hasContentBetweenNodes(lastNode, node)) {
-            splittedNodes.push([node])
+            splitNodes.push([node])
           } else {
-            splittedNodes.at(-1)!.push(node)
+            splitNodes.at(-1)!.push(node)
           }
         }
 
-        for (let nodeList of splittedNodes) {
+        for (let nodeList of splitNodes) {
+          let sortedNodes = sortNodesByGroups(nodeList, options, {
+            isNodeIgnored: node => node.isIgnored,
+            getGroupCompareOptions: groupNumber => {
+              if (options.sortSideEffects) {
+                return options
+              }
+              let group = options.groups[groupNumber]
+              return isSideEffectOnlyGroup(group) ? null : options
+            },
+          })
           pairwise(nodeList, (left, right) => {
             let leftNum = getGroupNumber(options.groups, left)
             let rightNum = getGroupNumber(options.groups, right)
+
+            let indexOfLeft = sortedNodes.indexOf(left)
+            let indexOfRight = sortedNodes.indexOf(right)
+
+            let messageIds: MESSAGE_ID[] = []
+
+            if (indexOfLeft > indexOfRight) {
+              messageIds.push(
+                leftNum !== rightNum
+                  ? 'unexpectedImportsGroupOrder'
+                  : 'unexpectedImportsOrder',
+              )
+            }
 
             let numberOfEmptyLinesBetween = getLinesBetween(
               sourceCode,
               left,
               right,
             )
-
             if (
-              !(
-                !options.sortSideEffects &&
-                isSideEffectImport(left.node) &&
-                isSideEffectImport(right.node)
-              ) &&
-              !hasContentBetweenNodes(left, right) &&
-              (leftNum > rightNum ||
-                (leftNum === rightNum &&
-                  isPositive(compare(left, right, options))))
+              options.newlinesBetween === 'never' &&
+              numberOfEmptyLinesBetween > 0
             ) {
+              messageIds.push('extraSpacingBetweenImports')
+            }
+
+            if (options.newlinesBetween === 'always') {
+              if (leftNum < rightNum && numberOfEmptyLinesBetween === 0) {
+                messageIds.push('missedSpacingBetweenImports')
+              } else if (
+                numberOfEmptyLinesBetween > 1 ||
+                (leftNum === rightNum && numberOfEmptyLinesBetween > 0)
+              ) {
+                messageIds.push('extraSpacingBetweenImports')
+              }
+            }
+
+            for (let messageId of messageIds) {
               context.report({
-                messageId:
-                  leftNum !== rightNum
-                    ? 'unexpectedImportsGroupOrder'
-                    : 'unexpectedImportsOrder',
+                messageId,
                 data: {
                   left: left.name,
                   leftGroup: left.group,
@@ -689,50 +629,79 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   rightGroup: right.group,
                 },
                 node: right.node,
-                fix: fixer => fix(fixer, nodeList),
-              })
-            }
+                fix: fixer => {
+                  let newlinesFixes: TSESLint.RuleFix[] = []
 
-            if (
-              options.newlinesBetween === 'never' &&
-              numberOfEmptyLinesBetween > 0
-            ) {
-              context.report({
-                messageId: 'extraSpacingBetweenImports',
-                data: {
-                  left: left.name,
-                  right: right.name,
+                  for (let max = sortedNodes.length, i = 0; i < max; i++) {
+                    let node = sortedNodes.at(i)!
+                    let nextNode = sortedNodes.at(i + 1)
+
+                    if (options.newlinesBetween === 'ignore' || !nextNode) {
+                      continue
+                    }
+
+                    let nodeGroupNumber = getGroupNumber(options.groups, node)
+                    let nextNodeGroupNumber = getGroupNumber(
+                      options.groups,
+                      nextNode,
+                    )
+                    let currentNodeRange = getNodeRange(
+                      nodeList.at(i)!.node,
+                      sourceCode,
+                      options,
+                    )
+                    let nextNodeRange =
+                      getNodeRange(
+                        nodeList.at(i + 1)!.node,
+                        sourceCode,
+                        options,
+                      ).at(0)! - 1
+
+                    let linesBetweenImports = getLinesBetween(
+                      sourceCode,
+                      nodeList.at(i)!,
+                      nodeList.at(i + 1)!,
+                    )
+
+                    if (
+                      (options.newlinesBetween === 'always' &&
+                        nodeGroupNumber === nextNodeGroupNumber &&
+                        linesBetweenImports !== 0) ||
+                      (options.newlinesBetween === 'never' &&
+                        linesBetweenImports > 0)
+                    ) {
+                      newlinesFixes.push(
+                        fixer.removeRange([
+                          currentNodeRange.at(1)!,
+                          nextNodeRange,
+                        ]),
+                      )
+                    }
+                    if (
+                      options.newlinesBetween === 'always' &&
+                      nodeGroupNumber !== nextNodeGroupNumber
+                    ) {
+                      if (linesBetweenImports > 1) {
+                        newlinesFixes.push(
+                          fixer.replaceTextRange(
+                            [currentNodeRange.at(1)!, nextNodeRange],
+                            '\n',
+                          ),
+                        )
+                      } else if (linesBetweenImports === 0) {
+                        newlinesFixes.push(
+                          fixer.insertTextAfterRange(currentNodeRange, '\n'),
+                        )
+                      }
+                    }
+                  }
+
+                  return [
+                    ...makeFixes(fixer, nodeList, sortedNodes, sourceCode),
+                    ...newlinesFixes,
+                  ]
                 },
-                node: right.node,
-                fix: fixer => fix(fixer, nodeList),
               })
-            }
-
-            if (options.newlinesBetween === 'always') {
-              if (leftNum < rightNum && numberOfEmptyLinesBetween === 0) {
-                context.report({
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: left.name,
-                    right: right.name,
-                  },
-                  node: right.node,
-                  fix: fixer => fix(fixer, nodeList),
-                })
-              } else if (
-                numberOfEmptyLinesBetween > 1 ||
-                (leftNum === rightNum && numberOfEmptyLinesBetween > 0)
-              ) {
-                context.report({
-                  messageId: 'extraSpacingBetweenImports',
-                  data: {
-                    left: left.name,
-                    right: right.name,
-                  },
-                  node: right.node,
-                  fix: fixer => fix(fixer, nodeList),
-                })
-              }
             }
           })
         }

--- a/test/clean-groups-option.test.ts
+++ b/test/clean-groups-option.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { cleanGroupsOption } from '../utils/clean-groups-option'
+
+describe('clean-groups-option', () => {
+  it('cleans the groups option', () => {
+    expect(
+      cleanGroupsOption({
+        groups: [
+          'predefinedGroup',
+          [],
+          ['customGroup', 'group1'],
+          ['singleGroup'],
+          'group2',
+        ],
+      }),
+    ).toStrictEqual({
+      groups: [
+        'predefinedGroup',
+        ['customGroup', 'group1'],
+        'singleGroup',
+        'group2',
+      ],
+    })
+  })
+})

--- a/test/clean-groups-option.test.ts
+++ b/test/clean-groups-option.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { cleanGroupsOption } from '../utils/clean-groups-option'
+import { getOptionsWithCleanGroups } from '../utils/get-options-with-clean-groups'
 
-describe('clean-groups-option', () => {
-  it('cleans the groups option', () => {
+describe('get-options-with-cleaned-groups', () => {
+  it('get options with cleaned groups', () => {
     expect(
-      cleanGroupsOption({
+      getOptionsWithCleanGroups({
         groups: [
           'predefinedGroup',
           [],

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -159,9 +159,9 @@ describe(ruleName, () => {
 
             import a from '.'
             import h from '../../h'
+            import './style.css'
             import { j } from '../j'
             import { K, L, M } from '../k'
-            import './style.css'
           `,
           options: [
             {
@@ -250,13 +250,6 @@ describe(ruleName, () => {
               data: {
                 left: 't',
                 right: './style.css',
-              },
-            },
-            {
-              messageId: 'unexpectedImportsOrder',
-              data: {
-                left: './style.css',
-                right: '../j',
               },
             },
           ],
@@ -2068,9 +2061,9 @@ describe(ruleName, () => {
 
             import a from '.'
             import h from '../../h'
+            import './style.css'
             import { j } from '../j'
             import { K, L, M } from '../k'
-            import './style.css'
           `,
           options: [
             {
@@ -2159,13 +2152,6 @@ describe(ruleName, () => {
               data: {
                 left: 't',
                 right: './style.css',
-              },
-            },
-            {
-              messageId: 'unexpectedImportsOrder',
-              data: {
-                left: './style.css',
-                right: '../j',
               },
             },
           ],
@@ -3606,8 +3592,8 @@ describe(ruleName, () => {
 
             import { K, L, M } from '../k'
             import { j } from '../j'
-            import h from '../../h'
             import './style.css'
+            import h from '../../h'
             import a from '.'
           `,
           options: [
@@ -5280,6 +5266,15 @@ describe(ruleName, () => {
                 data: {
                   left: '~/hooks/useClient',
                   right: '~/data',
+                },
+              },
+              {
+                messageId: 'unexpectedImportsGroupOrder',
+                data: {
+                  left: '~/data',
+                  leftGroup: 'side-effect',
+                  right: '~/css/globals.css',
+                  rightGroup: 'side-effect-style',
                 },
               },
             ],

--- a/utils/clean-groups-option.ts
+++ b/utils/clean-groups-option.ts
@@ -1,0 +1,15 @@
+interface GroupOptions {
+  groups: (string[] | string)[]
+}
+
+export const cleanGroupsOption = <T extends GroupOptions>(options: T): T => ({
+  ...options,
+  groups: options.groups
+    .filter(group => group.length > 0)
+    .map(group =>
+      typeof group === 'string' ? group : getCleanedNestedGroups(group),
+    ),
+})
+
+const getCleanedNestedGroups = (nestedGroup: string[]): string[] | string =>
+  nestedGroup.length === 1 ? nestedGroup[0] : nestedGroup

--- a/utils/get-options-with-clean-groups.ts
+++ b/utils/get-options-with-clean-groups.ts
@@ -2,7 +2,9 @@ interface GroupOptions {
   groups: (string[] | string)[]
 }
 
-export const cleanGroupsOption = <T extends GroupOptions>(options: T): T => ({
+export const getOptionsWithCleanGroups = <T extends GroupOptions>(
+  options: T,
+): T => ({
   ...options,
   groups: options.groups
     .filter(group => group.length > 0)

--- a/utils/sort-nodes-by-groups.ts
+++ b/utils/sort-nodes-by-groups.ts
@@ -8,26 +8,57 @@ interface GroupOptions {
   groups: (string[] | string)[]
 }
 
+interface ExtraOptions<T extends SortingNode> {
+  /**
+   * If not provided, `options` will be used. If function returns null, nodes
+   * will not be sorted within the group.
+   */
+  getGroupCompareOptions?: (groupNumber: number) => CompareOptions | null
+  isNodeIgnored?: (node: T) => boolean
+}
+
 export let sortNodesByGroups = <T extends SortingNode>(
   nodes: T[],
   options: CompareOptions & GroupOptions,
+  extraOptions?: ExtraOptions<T>,
 ): T[] => {
-  let nodesByGroupNumber: {
+  let nodesByNonIgnoredGroupNumber: {
     [key: number]: T[]
   } = {}
-  for (let sortingNode of nodes.values()) {
+  let ignoredNodeIndices: number[] = []
+  for (let [index, sortingNode] of nodes.entries()) {
+    if (extraOptions?.isNodeIgnored?.(sortingNode)) {
+      ignoredNodeIndices.push(index)
+      continue
+    }
     let groupNum = getGroupNumber(options.groups, sortingNode)
-    nodesByGroupNumber[groupNum] = nodesByGroupNumber[groupNum] ?? []
-    nodesByGroupNumber[groupNum].push(sortingNode)
+    nodesByNonIgnoredGroupNumber[groupNum] =
+      nodesByNonIgnoredGroupNumber[groupNum] ?? []
+    nodesByNonIgnoredGroupNumber[groupNum].push(sortingNode)
   }
 
   let sortedNodes: T[] = []
-  for (let groupNumber of Object.keys(nodesByGroupNumber).sort(
+  for (let groupNumber of Object.keys(nodesByNonIgnoredGroupNumber).sort(
     (a, b) => Number(a) - Number(b),
   )) {
+    let compareOptions = extraOptions?.getGroupCompareOptions
+      ? extraOptions.getGroupCompareOptions(Number(groupNumber))
+      : options
+    if (!compareOptions) {
+      sortedNodes.push(...nodesByNonIgnoredGroupNumber[Number(groupNumber)])
+      continue
+    }
     sortedNodes.push(
-      ...sortNodes(nodesByGroupNumber[Number(groupNumber)], options),
+      ...sortNodes(
+        nodesByNonIgnoredGroupNumber[Number(groupNumber)],
+        compareOptions,
+      ),
     )
+  }
+
+  // Add ignored nodes at the same position as they were before linting
+  for (let ignoredIndex of ignoredNodeIndices) {
+    sortedNodes.splice(ignoredIndex, 0, nodes[ignoredIndex])
   }
 
   return sortedNodes


### PR DESCRIPTION
Fixes #311
Fixes #315 
Fixes #316

Most of the new lines added come from tests. Some code had to be moved around, but there is not that much added code in the end, especially since the functions doing the heavy work already existed for other rules.

### Description

This PR fixes three related issues at the same time: some code was refactored to follow the same logic that the other rules use.

## #311 - Side effects do not stay in place with `sortSideEffects: false`

In the current code, side effect imports do not actually stay in place: when a side effect import is encountered, they are put at the end of the group they belong. If for that same group a non-side effect import is encountered, that group is sorted, making the previous step go to waste!

Sorting or not sorting side effects is actually a little bit more complex than it seems: it depends on the user's `groups` option, which is used for two things: sorting and regrouping elements.

Here are some examples to illustrate:

#### Example 1

```
{
    "groups": ["side-effect", "internal", "side-effect-style"],
    "sortSideEffects": false
}
```
Can be translated: to: Put side effects imports first, internal import in the middle and side effect style imports at the end. Pretty straightforward. However, do **not** change the order of `side-effect` and `side-effect-style` elements within these groups.

#### Example 2

```
{
    "groups": [["side-effect", "side-effect-style"], "internal"],
    "sortSideEffects": false
}
```
This is equivalent to 
```
{
    "groups": ["side-effect", "internal"],
    "sortSideEffects": false
}
```
Because side effect style imports are side effect imports: all side effects are regrouped together at the start but not sorted.

#### Example 3

```
{
    "groups": ["unknown"],
    "sortSideEffects": false
}
```

Can be translated: to: Do not touch any side effect import (as `side-effect` and `side-effect-style` are not present)!

#### Example 4

```
{
    "groups": [["side-effect", "internal], "unknown"],
    "sortSideEffects": false
}
```

This configuration is invalid : the user is asking to regroup and sort side effect and internal imports together, but side effect imports should not be sorted.

#### What this PR does

This PR does the following:

- Checks that the user is not entering an invalid configuration: one where `side-effect` or `side-effect-style` are entered in a nested group with a non-side effect group, and with `sortSideEffects: false`. In that case, the following error is thrown: `Side effect groups cannot be nested with non side effect groups when 'sortSideEffects' is false.`.
- Allows users to regroup side effect/side effect style imports together, and not change their sort within that group.
- Allows side effect not to be touched at all, if `side-effect` is not present in the `groups` option, for example.

#### Impacted tests

There are 3 tests (duplicated in the `natural`/`line-length` test sections) that have been changed: because side effect imports are now truly staying in place, and not put at the end of the group they belong. 

You can find here the changes to those tests in this commit: [`089a944` (#312)](https://github.com/azat-io/eslint-plugin-perfectionist/pull/312/commits/089a944b77caf367aacee6a41d5a88fc1fa3541b).

## #315 / #316 - False positive error report with `sortSideEffects: false` / Side effect grouping errors not reported

The issue mainly comes from the fact that the way errors are detected is not based on the expected sort. This PR makes sure that this is the case, with a logic identical to other rules.


## Additional changes

- This rule now uses `makeFixes`, reducing code duplication: `makeFixes` is used to fix order errors. Newline errors are still handled within this rule "manually".
- Improves `sortNodesByGroups` to handle groups that should not be sorted (`side-effect`-like groups), and nodes that should be ignored/should remain at their place.
- This rule now uses `sortNodesByGroups`, further reducing code duplication.
- Makes `sort-classes` use `sortNodesByGroups` as well, reducing code duplication.

- [x] Bug fix
