### PR TITLE
feat(sort-imports): reduces the amount of newline-related errors thrown

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -609,11 +609,17 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             }
 
             if (options.newlinesBetween === 'always') {
-              if (leftNum < rightNum && numberOfEmptyLinesBetween === 0) {
+              if (
+                leftNum < rightNum &&
+                numberOfEmptyLinesBetween === 0 &&
+                indexOfLeft === indexOfRight - 1
+              ) {
                 messageIds.push('missedSpacingBetweenImports')
               } else if (
                 numberOfEmptyLinesBetween > 1 ||
-                (leftNum === rightNum && numberOfEmptyLinesBetween > 0)
+                (leftNum === rightNum &&
+                  indexOfLeft === indexOfRight - 1 &&
+                  numberOfEmptyLinesBetween > 0)
               ) {
                 messageIds.push('extraSpacingBetweenImports')
               }

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -198,33 +198,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: '~/i',
-                right: './d',
-              },
-            },
-            {
               messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './d',
                 leftGroup: 'sibling-type',
                 right: 'fs',
                 rightGroup: 'builtin',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: 'fs',
-                right: '~/c',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: '../f',
-                right: '../../h',
               },
             },
             {
@@ -243,13 +222,6 @@ describe(ruleName, () => {
                 leftGroup: 'index',
                 right: 't',
                 rightGroup: 'type',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: 't',
-                right: './style.css',
               },
             },
           ],
@@ -1030,20 +1002,6 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'extraSpacingBetweenImports',
-                data: {
-                  left: 't',
-                  right: '@a/a1',
-                },
-              },
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '@a/a2',
-                  right: '@b/b1',
-                },
-              },
-              {
                 messageId: 'missedSpacingBetweenImports',
                 data: {
                   left: '@b/b3',
@@ -1177,13 +1135,6 @@ describe(ruleName, () => {
               },
             ],
             errors: [
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '#b',
-                  right: '#c',
-                },
-              },
               {
                 messageId: 'unexpectedImportsOrder',
                 data: {
@@ -1392,21 +1343,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: 'fs',
-                  right: '~/c',
-                },
-              },
-              {
                 messageId: 'unexpectedImportsOrder',
-                data: {
-                  left: '../../h',
-                  right: '.',
-                },
-              },
-              {
-                messageId: 'extraSpacingBetweenImports',
                 data: {
                   left: '../../h',
                   right: '.',
@@ -1499,13 +1436,6 @@ describe(ruleName, () => {
                 data: {
                   left: 'e',
                   right: 'aaaa',
-                },
-              },
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: 'aaaa',
-                  right: '../d',
                 },
               },
             ],
@@ -1636,13 +1566,6 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: './z-side-effect.scss',
-                    right: './b',
-                  },
-                },
-                {
                   messageId: 'unexpectedImportsGroupOrder',
                   data: {
                     left: './b',
@@ -1697,13 +1620,6 @@ describe(ruleName, () => {
                 },
               ],
               errors: [
-                {
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: './z-side-effect.scss',
-                    right: './b',
-                  },
-                },
                 {
                   messageId: 'unexpectedImportsGroupOrder',
                   data: {
@@ -1760,13 +1676,6 @@ describe(ruleName, () => {
               ],
               errors: [
                 {
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: './z-side-effect.scss',
-                    right: './b',
-                  },
-                },
-                {
                   messageId: 'unexpectedImportsGroupOrder',
                   data: {
                     left: './b',
@@ -1776,26 +1685,12 @@ describe(ruleName, () => {
                   },
                 },
                 {
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: './b-side-effect',
-                    right: './g-side-effect.css',
-                  },
-                },
-                {
                   messageId: 'unexpectedImportsGroupOrder',
                   data: {
                     left: './g-side-effect.css',
                     leftGroup: 'side-effect-style',
                     right: './a-side-effect',
                     rightGroup: 'side-effect',
-                  },
-                },
-                {
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: './a-side-effect',
-                    right: './a',
                   },
                 },
               ],
@@ -1847,26 +1742,12 @@ describe(ruleName, () => {
                   },
                 },
                 {
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: './b-side-effect.scss',
-                    right: './g-side-effect',
-                  },
-                },
-                {
                   messageId: 'unexpectedImportsGroupOrder',
                   data: {
                     left: './g-side-effect',
                     leftGroup: 'unknown',
                     right: './a-side-effect.css',
                     rightGroup: 'side-effect-style',
-                  },
-                },
-                {
-                  messageId: 'missedSpacingBetweenImports',
-                  data: {
-                    left: './a-side-effect.css',
-                    right: './a',
                   },
                 },
               ],
@@ -2100,33 +1981,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: '~/i',
-                right: './d',
-              },
-            },
-            {
               messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './d',
                 leftGroup: 'sibling-type',
                 right: 'fs',
                 rightGroup: 'builtin',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: 'fs',
-                right: '~/c',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: '../f',
-                right: '../../h',
               },
             },
             {
@@ -2145,13 +2005,6 @@ describe(ruleName, () => {
                 leftGroup: 'index',
                 right: 't',
                 rightGroup: 'type',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: 't',
-                right: './style.css',
               },
             },
           ],
@@ -2932,20 +2785,6 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'extraSpacingBetweenImports',
-                data: {
-                  left: 't',
-                  right: '@a/a1',
-                },
-              },
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '@a/a2',
-                  right: '@b/b1',
-                },
-              },
-              {
                 messageId: 'missedSpacingBetweenImports',
                 data: {
                   left: '@b/b3',
@@ -3079,13 +2918,6 @@ describe(ruleName, () => {
               },
             ],
             errors: [
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '#b',
-                  right: '#c',
-                },
-              },
               {
                 messageId: 'unexpectedImportsOrder',
                 data: {
@@ -3294,21 +3126,7 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: 'fs',
-                  right: '~/c',
-                },
-              },
-              {
                 messageId: 'unexpectedImportsOrder',
-                data: {
-                  left: '../../h',
-                  right: '.',
-                },
-              },
-              {
-                messageId: 'extraSpacingBetweenImports',
                 data: {
                   left: '../../h',
                   right: '.',
@@ -3401,13 +3219,6 @@ describe(ruleName, () => {
                 data: {
                   left: 'e',
                   right: 'aaaa',
-                },
-              },
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: 'aaaa',
-                  right: '../d',
                 },
               },
             ],
@@ -3624,26 +3435,12 @@ describe(ruleName, () => {
               },
             },
             {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: '~/i',
-                right: './d',
-              },
-            },
-            {
               messageId: 'unexpectedImportsGroupOrder',
               data: {
                 left: './d',
                 leftGroup: 'sibling-type',
                 right: 'fs',
                 rightGroup: 'builtin',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: 'fs',
-                right: '~/c',
               },
             },
             {
@@ -3658,13 +3455,6 @@ describe(ruleName, () => {
               data: {
                 left: '.',
                 right: '../f',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: '../f',
-                right: '../../h',
               },
             },
             {
@@ -3683,13 +3473,6 @@ describe(ruleName, () => {
                 leftGroup: 'index',
                 right: 't',
                 rightGroup: 'type',
-              },
-            },
-            {
-              messageId: 'missedSpacingBetweenImports',
-              data: {
-                left: 't',
-                right: './style.css',
               },
             },
             {
@@ -4595,13 +4378,6 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '#b',
-                  right: '#c',
-                },
-              },
-              {
                 messageId: 'unexpectedImportsOrder',
                 data: {
                   left: '#c',
@@ -4884,13 +4660,6 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: 'fs',
-                  right: '~/c',
-                },
-              },
-              {
                 messageId: 'unexpectedImportsOrder',
                 data: {
                   left: '~/c',
@@ -5005,13 +4774,6 @@ describe(ruleName, () => {
                 data: {
                   left: 'e',
                   right: 'aaaa',
-                },
-              },
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: 'aaaa',
-                  right: '../d',
                 },
               },
             ],
@@ -5262,13 +5024,6 @@ describe(ruleName, () => {
             ],
             errors: [
               {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '~/hooks/useClient',
-                  right: '~/data',
-                },
-              },
-              {
                 messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/data',
@@ -5469,26 +5224,12 @@ describe(ruleName, () => {
                 },
               },
               {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '~/stores/userStore.ts',
-                  right: '~/utils/dateTime.ts',
-                },
-              },
-              {
                 messageId: 'unexpectedImportsGroupOrder',
                 data: {
                   left: '~/composable/useFetch.ts',
                   leftGroup: 'composable',
                   right: '~/stores/cartStore.ts',
                   rightGroup: 'stores',
-                },
-              },
-              {
-                messageId: 'missedSpacingBetweenImports',
-                data: {
-                  left: '~/stores/cartStore.ts',
-                  right: '~/composable/useDebounce.ts',
                 },
               },
             ],


### PR DESCRIPTION
Resolves #322

### Description

There are two types of newline-related errors thrown:
- `extraSpacingBetweenImports`: when a newline needs to be removed.
- `missedSpacingBetweenImports`: when a newline needs to be added.

`extraSpacingBetweenImports` can be thrown when `options.newlinesBetween` is `never` or `always`.

This PR **only** affects the `always` option.

The current issue is that newline-related errors are thrown when comparing the **current** code, not the **expected** one (see example in the issue).

```ts
import a1 from "./a"
import a2 from "a"
import b1 from "./b"
import b2 from "b"
import c1 from "./c"
import c2 from "c"
import d1 from "./d"
import d2 from "d"
```
might throw 3 `Missed spacing between` errors, even through the sorted result will be

```ts
import a2 from "a"
import b2 from "b"
import c2 from "c"
import d2 from "d"

import a1 from "./a"
import b1 from "./b"
import c1 from "./c"
import d1 from "./d"
```

The actual newline required is between `d` and `./a`, but those are not correctly sorted by default, so there is no reason for the user to know that at this moment.

### What this PR does

When the `options.newlinesBetween` is `always`:
- `missedSpacingBetweenImports` will be thrown **ONLY** if the two nodes are correctly sorted.
- `extraSpacingBetweenImports` will be thrown if either:
  - There are at least 2 newlines between the nodes being compared: this error needs to be addressed but the user even if those nodes are unordered (unchanged with today's version).
  - If there is one newline between the nodes being compared **AND** the two nodes are correctly sorted.

### Tests affected

- Many expected thrown newline errors have had to be removed.
- No test code input has been changed.
- No test code output has been affected.

### What is the purpose of this pull request?

- [x] Bug fix
