### PR TITLE
feat(multiple-rules): adds `newlinesBetween`

### DIFF
--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -214,6 +214,18 @@ interface User {
 
 Each group of members (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between interface groups.
+
+- `ignore` — Do not report errors related to new lines between interface groups.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed between interface members.
+
+This options is only applicable when `partitionByNewLine` is `false`.
+
 ### groupKind
 
 <sub>default: `'mixed'`</sub>
@@ -363,6 +375,7 @@ Determines the matcher used for patterns in the `partitionByComment`, `ignorePat
                   specialCharacters: 'keep',
                   ignorePattern: [],
                   partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   optionalityOrder: 'ignore',
                   matcher: 'minimatch',
                   groups: [],
@@ -393,6 +406,7 @@ Determines the matcher used for patterns in the `partitionByComment`, `ignorePat
                 specialCharacters: 'keep',
                 ignorePattern: [],
                 partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 optionalityOrder: 'ignore',
                 matcher: 'minimatch',
                 groups: [],

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -145,6 +145,18 @@ type Employee =
 
 Each group of intersection types (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between intersection type groups.
+
+- `ignore` — Do not report errors related to new lines between intersection type groups.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed in intersection types.
+
+This options is only applicable when `partitionByNewLine` is `false`.
+
 ### groups
 
 <sub>
@@ -294,8 +306,9 @@ Determines the matcher used for patterns in the `partitionByComment` option.
                   order: 'asc',
                   ignoreCase: true,
                   specialCharacters: 'keep',
+                  partitionByComment: false,
                   partitionByNewLine: false,
-                  partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   matcher: 'minimatch',
                   groups: [],
                 },
@@ -322,8 +335,9 @@ Determines the matcher used for patterns in the `partitionByComment` option.
                 order: 'asc',
                 ignoreCase: true,
                 specialCharacters: 'keep',
-                partitionByNewLine: false,
                 partitionByComment: false,
+                partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 matcher: 'minimatch',
                 groups: [],
               },

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -171,6 +171,18 @@ type User = {
 
 Each group of members (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between object type groups.
+
+- `ignore` — Do not report errors related to new lines between object type groups.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed in object types.
+
+This options is only applicable when `partitionByNewLine` is `false`.
+
 ### groupKind
 
 <sub>default: `'mixed'`</sub>
@@ -320,6 +332,7 @@ Determines the matcher used for patterns in the `partitionByComment` and `custom
                   specialCharacters: 'keep',
                   partitionByComment: false,
                   partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   matcher: 'minimatch',
                   groups: [],
                   customGroups: {},
@@ -349,6 +362,7 @@ Determines the matcher used for patterns in the `partitionByComment` and `custom
                 specialCharacters: 'keep',
                 partitionByComment: false,
                 partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 matcher: 'minimatch',
                 groups: [],
                 customGroups: {},

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -226,6 +226,18 @@ const user = {
 
 Each group of keys (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between object groups.
+
+- `ignore` — Do not report errors related to new lines between object groups.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed in objects.
+
+This options is only applicable when `partitionByNewLine` is `false`.
+
 ### styledComponents
 
 <sub>default: `true`</sub>
@@ -362,6 +374,7 @@ Determines the matcher used for patterns in the `partitionByComment`, `ignorePat
                   specialCharacters: 'keep',
                   partitionByComment: false,
                   partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   styledComponents: true,
                   ignorePattern: [],
                   matcher: 'minimatch',
@@ -393,6 +406,7 @@ Determines the matcher used for patterns in the `partitionByComment`, `ignorePat
                 specialCharacters: 'keep',
                 partitionByComment: false,
                 partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 styledComponents: true,
                 ignorePattern: [],
                 matcher: 'minimatch',

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -165,6 +165,18 @@ type CarBrand =
 
 Each group of union types (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between union type groups.
+
+- `ignore` — Do not report errors related to new lines between union type groups.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed in union types.
+
+This options is only applicable when `partitionByNewLine` is `false`.
+
 ### groups
 
 <sub>
@@ -314,8 +326,9 @@ Determines the matcher used for patterns in the `partitionByComment` option.
                   order: 'asc',
                   ignoreCase: true,
                   specialCharacters: 'keep',
-                  partitionByNewLine: false,
                   partitionByComment: false,
+                  partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   matcher: 'minimatch',
                   groups: [],
                 },
@@ -342,8 +355,9 @@ Determines the matcher used for patterns in the `partitionByComment` option.
                 order: 'asc',
                 ignoreCase: true,
                 specialCharacters: 'keep',
-                partitionByNewLine: false,
                 partitionByComment: false,
+                partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 matcher: 'minimatch',
                 groups: [],
               },

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -1920,6 +1920,146 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                  import { A } from 'a'
+
+
+                 import y from '~/y'
+                import z from '~/z'
+
+                    import b from '~/b'
+                `,
+              output: dedent`
+                  import { A } from 'a'
+                 import b from '~/b'
+                import y from '~/y'
+                    import z from '~/z'
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'never',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenImports',
+                  data: {
+                    left: 'a',
+                    right: '~/y',
+                  },
+                },
+                {
+                  messageId: 'unexpectedImportsOrder',
+                  data: {
+                    left: '~/z',
+                    right: '~/b',
+                  },
+                },
+                {
+                  messageId: 'extraSpacingBetweenImports',
+                  data: {
+                    left: '~/z',
+                    right: '~/b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                  import c from 'c';    import a from '~/a'
+                `,
+              output: dedent`
+                  import c from 'c';    
+
+                  import a from '~/a'
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'always',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'missedSpacingBetweenImports',
+                  data: {
+                    left: 'c',
+                    right: '~/a',
+                  },
+                },
+              ],
+            },
+            {
+              code: dedent`
+                  import { A } from 'a'
+
+
+                 import c from '~/c'
+                import b from '~/b'
+
+                    import d from '~/d'
+                `,
+              output: dedent`
+                  import { A } from 'a'
+
+                 import b from '~/b'
+                import c from '~/c'
+                    import d from '~/d'
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'always',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenImports',
+                  data: {
+                    left: 'a',
+                    right: '~/c',
+                  },
+                },
+                {
+                  messageId: 'unexpectedImportsOrder',
+                  data: {
+                    left: '~/c',
+                    right: '~/b',
+                  },
+                },
+                {
+                  messageId: 'extraSpacingBetweenImports',
+                  data: {
+                    left: '~/b',
+                    right: '~/d',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -691,6 +691,127 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                type T =
+                  (() => null)
+
+
+                 & Y
+                & Z
+
+                    & B
+              `,
+              output: dedent`
+                type T =
+                  (() => null)
+                 & B
+                & Y
+                    & Z
+              `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'never',
+                  groups: ['function', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenIntersectionTypes',
+                  data: {
+                    left: '() => null',
+                    right: 'Y',
+                  },
+                },
+                {
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                  data: {
+                    left: 'Z',
+                    right: 'B',
+                  },
+                },
+                {
+                  messageId: 'extraSpacingBetweenIntersectionTypes',
+                  data: {
+                    left: 'Z',
+                    right: 'B',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                type T =
+                  (() => null)
+
+
+                 & Z
+                & Y
+                    & "A"
+              `,
+              output: dedent`
+                type T =
+                  (() => null)
+
+                 & Y
+                & Z
+
+                    & "A"
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'always',
+                  groups: ['function', 'unknown', 'literal'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenIntersectionTypes',
+                  data: {
+                    left: '() => null',
+                    right: 'Z',
+                  },
+                },
+                {
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                  data: {
+                    left: 'Z',
+                    right: 'Y',
+                  },
+                },
+                {
+                  messageId: 'missedSpacingBetweenIntersectionTypes',
+                  data: {
+                    left: 'Y',
+                    right: '"A"',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -889,6 +889,135 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                type Type = {
+                  a: () => null,
+
+
+                 y: "y",
+                z: "z",
+
+                    b: "b",
+                }
+              `,
+              output: dedent`
+                type Type = {
+                  a: () => null,
+                 b: "b",
+                y: "y",
+                    z: "z",
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'never',
+                  groups: ['method', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenObjectTypeMembers',
+                  data: {
+                    left: 'a',
+                    right: 'y',
+                  },
+                },
+                {
+                  messageId: 'unexpectedObjectTypesOrder',
+                  data: {
+                    left: 'z',
+                    right: 'b',
+                  },
+                },
+                {
+                  messageId: 'extraSpacingBetweenObjectTypeMembers',
+                  data: {
+                    left: 'z',
+                    right: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                type Type = {
+                  a: () => null,
+
+
+                 z: "z",
+                y: "y",
+                    b: {
+                      // Newline stuff
+                    },
+                }
+              `,
+              output: dedent`
+                type Type = {
+                  a: () => null,
+
+                 y: "y",
+                z: "z",
+
+                    b: {
+                      // Newline stuff
+                    },
+                }
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'always',
+                  groups: ['method', 'unknown', 'multiline'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenObjectTypeMembers',
+                  data: {
+                    left: 'a',
+                    right: 'z',
+                  },
+                },
+                {
+                  messageId: 'unexpectedObjectTypesOrder',
+                  data: {
+                    left: 'z',
+                    right: 'y',
+                  },
+                },
+                {
+                  messageId: 'missedSpacingBetweenObjectTypeMembers',
+                  data: {
+                    left: 'y',
+                    right: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -332,7 +332,7 @@ describe(ruleName, () => {
               iHaveFooInMyName: string,
               meTooIHaveFoo: string,
               a: string,
-              b: string,
+              b: "b",
             }
             `,
             options: [
@@ -1646,6 +1646,135 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                let Obj = {
+                  a: () => null,
+
+
+                 y: "y",
+                z: "z",
+
+                    b: "b",
+                }
+              `,
+              output: dedent`
+                let Obj = {
+                  a: () => null,
+                 b: "b",
+                y: "y",
+                    z: "z",
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'never',
+                  groups: ['method', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenObjectMembers',
+                  data: {
+                    left: 'a',
+                    right: 'y',
+                  },
+                },
+                {
+                  messageId: 'unexpectedObjectsOrder',
+                  data: {
+                    left: 'z',
+                    right: 'b',
+                  },
+                },
+                {
+                  messageId: 'extraSpacingBetweenObjectMembers',
+                  data: {
+                    left: 'z',
+                    right: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                let Obj = {
+                  a: () => null,
+
+
+                 z: "z",
+                y: "y",
+                    b: {
+                      // Newline stuff
+                    },
+                }
+              `,
+              output: dedent`
+                let Obj = {
+                  a: () => null,
+
+                 y: "y",
+                z: "z",
+
+                    b: {
+                      // Newline stuff
+                    },
+                }
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'always',
+                  groups: ['method', 'unknown', 'multiline'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenObjectMembers',
+                  data: {
+                    left: 'a',
+                    right: 'z',
+                  },
+                },
+                {
+                  messageId: 'unexpectedObjectsOrder',
+                  data: {
+                    left: 'z',
+                    right: 'y',
+                  },
+                },
+                {
+                  messageId: 'missedSpacingBetweenObjectMembers',
+                  data: {
+                    left: 'y',
+                    right: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -694,6 +694,127 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                type T =
+                  (() => null)
+
+
+                 | Y
+                | Z
+
+                    | B
+              `,
+              output: dedent`
+                type T =
+                  (() => null)
+                 | B
+                | Y
+                    | Z
+              `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'never',
+                  groups: ['function', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenUnionTypes',
+                  data: {
+                    left: '() => null',
+                    right: 'Y',
+                  },
+                },
+                {
+                  messageId: 'unexpectedUnionTypesOrder',
+                  data: {
+                    left: 'Z',
+                    right: 'B',
+                  },
+                },
+                {
+                  messageId: 'extraSpacingBetweenUnionTypes',
+                  data: {
+                    left: 'Z',
+                    right: 'B',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                type T =
+                  (() => null)
+
+
+                 | Z
+                | Y
+                    | "A"
+              `,
+              output: dedent`
+                type T =
+                  (() => null)
+
+                 | Y
+                | Z
+
+                    | "A"
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'always',
+                  groups: ['function', 'unknown', 'literal'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenUnionTypes',
+                  data: {
+                    left: '() => null',
+                    right: 'Z',
+                  },
+                },
+                {
+                  messageId: 'unexpectedUnionTypesOrder',
+                  data: {
+                    left: 'Z',
+                    right: 'Y',
+                  },
+                },
+                {
+                  messageId: 'missedSpacingBetweenUnionTypes',
+                  data: {
+                    left: 'Y',
+                    right: '"A"',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/validate-newlines-and-partition-configuration.test.ts
+++ b/test/validate-newlines-and-partition-configuration.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
+
+describe('validate-newlines-and-partition-configuration', () => {
+  let partitionByCommentValues: (string[] | boolean | string)[] = [
+    true,
+    'partitionComment',
+    ['partition1', 'partition2'],
+  ]
+
+  it("throws an error when 'partitionComment' is enabled and 'newlinesBetween' is not 'ignore'", () => {
+    let newlinesBetweenValues = ['always', 'never'] as const
+
+    for (let newlinesBetween of newlinesBetweenValues) {
+      for (let partitionByComment of partitionByCommentValues) {
+        expect(() => {
+          validateNewlinesAndPartitionConfiguration({
+            newlinesBetween,
+            partitionByNewLine: partitionByComment,
+          })
+        }).toThrow(
+          "The 'partitionByNewLine' and 'newlinesBetween' options cannot be used together",
+        )
+      }
+    }
+  })
+
+  it("allows 'partitionComment' when 'newlinesBetween' is 'ignore'", () => {
+    for (let partitionByComment of partitionByCommentValues) {
+      expect(() => {
+        validateNewlinesAndPartitionConfiguration({
+          newlinesBetween: 'ignore',
+          partitionByNewLine: partitionByComment,
+        })
+      }).not.toThrow()
+    }
+  })
+
+  it("allows 'newlinesBetween' when 'partitionByComment' is 'false'", () => {
+    let newlinesBetweenValues = ['always', 'never', 'ignore'] as const
+
+    for (let newlinesBetween of newlinesBetweenValues) {
+      expect(() => {
+        validateNewlinesAndPartitionConfiguration({
+          newlinesBetween,
+          partitionByNewLine: false,
+        })
+      }).not.toThrow()
+    }
+  })
+})

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -1,0 +1,51 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { SortingNode } from '../typings'
+
+import { getLinesBetween } from './get-lines-between'
+
+interface Options {
+  newlinesBetween: 'ignore' | 'always' | 'never'
+}
+
+interface Props<T extends string> {
+  sourceCode: TSESLint.SourceCode
+  missedSpacingError: T
+  extraSpacingError: T
+  right: SortingNode
+  left: SortingNode
+  rightNum: number
+  options: Options
+  leftNum: number
+}
+
+export let getNewlinesErrors = <T extends string>({
+  missedSpacingError,
+  extraSpacingError,
+  sourceCode,
+  rightNum,
+  leftNum,
+  options,
+  right,
+  left,
+}: Props<T>) => {
+  let errors: T[] = []
+
+  let numberOfEmptyLinesBetween = getLinesBetween(sourceCode, left, right)
+  if (options.newlinesBetween === 'never' && numberOfEmptyLinesBetween > 0) {
+    errors.push(extraSpacingError)
+  }
+
+  if (options.newlinesBetween === 'always') {
+    if (leftNum < rightNum && numberOfEmptyLinesBetween === 0) {
+      errors.push(missedSpacingError)
+    } else if (
+      numberOfEmptyLinesBetween > 1 ||
+      (leftNum === rightNum && numberOfEmptyLinesBetween > 0)
+    ) {
+      errors.push(extraSpacingError)
+    }
+  }
+
+  return errors
+}

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -1,0 +1,95 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { SortingNode } from '../typings'
+
+import { getLinesBetween } from './get-lines-between'
+import { getGroupNumber } from './get-group-number'
+import { getNodeRange } from './get-node-range'
+
+export const makeNewlinesFixes = (
+  fixer: TSESLint.RuleFixer,
+  nodes: SortingNode[],
+  sortedNodes: SortingNode[],
+  source: TSESLint.SourceCode,
+  options: {
+    newlinesBetween: 'ignore' | 'always' | 'never'
+    groups: (string[] | string)[]
+  },
+) => {
+  let fixes: TSESLint.RuleFix[] = []
+
+  for (let max = sortedNodes.length, i = 0; i < max; i++) {
+    let sortingNode = sortedNodes.at(i)!
+    let nextSortingNode = sortedNodes.at(i + 1)
+
+    if (options.newlinesBetween === 'ignore' || !nextSortingNode) {
+      continue
+    }
+
+    let nodeGroupNumber = getGroupNumber(options.groups, sortingNode)
+    let nextNodeGroupNumber = getGroupNumber(options.groups, nextSortingNode)
+    let currentNodeRange = getNodeRange(nodes.at(i)!.node, source)
+    let nextNodeRangeStart = getNodeRange(nodes.at(i + 1)!.node, source).at(0)!
+    let rangeToReplace: [number, number] = [
+      currentNodeRange.at(1)!,
+      nextNodeRangeStart,
+    ]
+    let textBetweenNodes = source.text.slice(
+      currentNodeRange.at(1),
+      nextNodeRangeStart,
+    )
+
+    let linesBetweenMembers = getLinesBetween(
+      source,
+      nodes.at(i)!,
+      nodes.at(i + 1)!,
+    )
+
+    let rangeReplacement: undefined | string
+    if (
+      (options.newlinesBetween === 'always' &&
+        nodeGroupNumber === nextNodeGroupNumber &&
+        linesBetweenMembers !== 0) ||
+      (options.newlinesBetween === 'never' && linesBetweenMembers > 0)
+    ) {
+      rangeReplacement = getStringWithoutInvalidNewlines(textBetweenNodes)
+    }
+
+    if (
+      options.newlinesBetween === 'always' &&
+      nodeGroupNumber !== nextNodeGroupNumber &&
+      linesBetweenMembers !== 1
+    ) {
+      rangeReplacement = addNewlineBeforeFirstNewline(
+        linesBetweenMembers > 1
+          ? getStringWithoutInvalidNewlines(textBetweenNodes)
+          : textBetweenNodes,
+      )
+      let isOnSameLine =
+        linesBetweenMembers === 0 &&
+        nodes.at(i)!.node.loc.end.line === nodes.at(i + 1)!.node.loc.start.line
+      if (isOnSameLine) {
+        rangeReplacement = addNewlineBeforeFirstNewline(rangeReplacement)
+      }
+    }
+
+    if (rangeReplacement) {
+      fixes.push(fixer.replaceTextRange(rangeToReplace, rangeReplacement))
+    }
+  }
+
+  return fixes
+}
+
+const getStringWithoutInvalidNewlines = (value: string) =>
+  value.replaceAll(/\n+\s*\n+/g, '\n').replaceAll(/\n+/g, '\n')
+
+const addNewlineBeforeFirstNewline = (value: string) => {
+  let firstNewlineIndex = value.indexOf('\n')
+  if (firstNewlineIndex === -1) {
+    return value + '\n'
+  }
+  return (
+    value.slice(0, firstNewlineIndex) + '\n' + value.slice(firstNewlineIndex)
+  )
+}

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -53,10 +53,12 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
  * Returns the first node that is dependent on the given node, but is not
  * ordered before it
  */
-export let getFirstUnorderedNodeDependentOn = (
-  node: SortingNodeWithDependencies,
-  currentlyOrderedNodes: SortingNodeWithDependencies[],
-): SortingNodeWithDependencies | undefined => {
+export let getFirstUnorderedNodeDependentOn = <
+  T extends SortingNodeWithDependencies,
+>(
+  node: T,
+  currentlyOrderedNodes: T[],
+): undefined | T => {
   let nodesDependentOnNode = currentlyOrderedNodes.filter(
     currentlyOrderedNode =>
       currentlyOrderedNode.dependencies.includes(

--- a/utils/validate-newlines-and-partition-configuration.ts
+++ b/utils/validate-newlines-and-partition-configuration.ts
@@ -1,0 +1,15 @@
+interface Options {
+  partitionByNewLine: string[] | boolean | string
+  newlinesBetween: 'ignore' | 'always' | 'never'
+}
+
+export const validateNewlinesAndPartitionConfiguration = ({
+  partitionByNewLine,
+  newlinesBetween,
+}: Options): void => {
+  if (!!partitionByNewLine && newlinesBetween !== 'ignore') {
+    throw new Error(
+      "The 'partitionByNewLine' and 'newlinesBetween' options cannot be used together",
+    )
+  }
+}


### PR DESCRIPTION
Resolves #146
Fixes #329

### Description

This PR aims to extend the `newlinesBetween` option of `sort-imports` to other rules.

Affected rules:
- [x] `sort-interfaces`
- [x] `sort-object-types`
- [x] `sort-objects`
- [x] `sort-union-types`
- [x] `sort-intersection-types`

### Compatibility with `partitionByNewline`

`partitionByNewLine` and `newlinesBetween` are incompatible:

Only one option at a time can be active.

An error if thrown otherwise: `The 'partitionByNewLine' and 'newlinesBetween' options cannot be used together`

### What is the purpose of this pull request?

- [x] New Feature
- [x] Documentation update