### PR TITLE
fix(sort-switch-case): fixes expressions being ignored

### DIFF
--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -93,7 +93,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
       let sourceCode = getSourceCode(context)
 
-      let isDiscriminantIdentifier = node.discriminant.type === 'Identifier'
+      let isDiscriminantTrue =
+        node.discriminant.type === 'Literal' && node.discriminant.value === true
       let isCasesHasBreak = node.cases
         .filter(caseNode => caseNode.test !== null)
         .every(
@@ -107,7 +108,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ),
         )
 
-      if (isDiscriminantIdentifier && isCasesHasBreak) {
+      if (!isDiscriminantTrue && isCasesHasBreak) {
         let nodes = node.cases.map<SortSwitchCaseSortingNode>(
           (caseNode: TSESTree.SwitchCase) => {
             let name: string

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -52,6 +52,46 @@ describe(ruleName, () => {
           {
             code: dedent`
               function func(name) {
+                switch(<any> myFunc(a! + b?.c as any)) {
+                  case 'bb':
+                    return 'b'
+                  case 'aaa':
+                    return 'a'
+                  case 'c':
+                    return 'c'
+                  default:
+                    return 'x'
+                }
+              }
+            `,
+            output: dedent`
+              function func(name) {
+                switch(<any> myFunc(a! + b?.c as any)) {
+                  case 'aaa':
+                    return 'a'
+                  case 'bb':
+                    return 'b'
+                  case 'c':
+                    return 'c'
+                  default:
+                    return 'x'
+                }
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'bb',
+                  right: 'aaa',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              function func(name) {
                 switch(name) {
                   case 'bb':
                     return 'b'
@@ -1867,12 +1907,9 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
-    ruleTester.run(
-      `${ruleName}: not works if discriminant is not literal`,
-      rule,
-      {
-        valid: [
-          dedent`
+    ruleTester.run(`${ruleName}: not works if discriminant is true`, rule, {
+      valid: [
+        dedent`
             switch (true) {
               case name === 'bb':
                 return 'b'
@@ -1884,10 +1921,9 @@ describe(ruleName, () => {
                 return 'x'
             }
           `,
-        ],
-        invalid: [],
-      },
-    )
+      ],
+      invalid: [],
+    })
   })
 
   ruleTester.run(`${ruleName}: default should be last`, rule, {


### PR DESCRIPTION
Fixes #326 

### Description

This PR makes sure that `switch(true)` is still disabled, but enables other expressions to be entered.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
