### PR TITLE
feat: add locales option for all rules

### DIFF
--- a/docs/content/guide/getting-started.mdx
+++ b/docs/content/guide/getting-started.mdx
@@ -145,6 +145,7 @@ In settings you can set the following options:
 - `ignoreCase` — Ignore case when sorting.
 - `ignorePattern` — Ignore sorting for elements that match the pattern.
 - `specialCharacters` — Control whether special characters should be kept, trimmed or removed before sorting. Values can be `'keep'`, `'trim'` or `'remove'`.
+- `locales` - The locales of sorting. Values can be a string with a BCP 47 language tag, or an array of such strings. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
 - `partitionByComment` — Partition the sorted elements by comments. Values can be `true`, `false` or regexp pattern.
 - `partitionByNewLine` — Partition the sorted elements by new lines. Values can be `true` or `false`.
 

--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -157,6 +157,16 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
 
 ### groupKind
 

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -192,6 +192,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-decorators.mdx
+++ b/docs/content/rules/sort-decorators.mdx
@@ -186,6 +186,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -122,6 +122,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### sortByValue
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -116,6 +116,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-heritage-clauses.mdx
+++ b/docs/content/rules/sort-heritage-clauses.mdx
@@ -99,6 +99,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### groups
 
 <sub>

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -155,6 +155,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### internalPattern
 
 <sub>default: `['^~/.*']`</sub>

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -171,6 +171,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### ignorePattern
 
 <sub>default: `[]`</sub>

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -112,6 +112,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -172,6 +172,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### ignorePattern
 
 <sub>default: `[]`</sub>

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -117,6 +117,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -135,6 +135,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### groupKind
 
 <sub>default: `'mixed'`</sub>

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -136,6 +136,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### ignoreAlias
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -133,6 +133,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -191,6 +191,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -163,6 +163,16 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
 
 ### groupKind
 

--- a/docs/content/rules/sort-switch-case.mdx
+++ b/docs/content/rules/sort-switch-case.mdx
@@ -184,6 +184,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ## Usage
 
 <CodeTabs

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -132,6 +132,17 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
+
 ### partitionByComment
 
 <sub>default: `false`</sub>

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -116,6 +116,16 @@ Controls whether special characters should be trimmed, removed or kept before so
 - `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
 - `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
 
+### locales
+
+<sub>default: `'en-US'`</sub>
+
+Specifies the sorting locales. See [String.prototype.localeCompare() - locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales).
+
+- `string` — A BCP 47 language tag (e.g. `'en'`, `'en-US'`, `'zh-CN'`).
+- `string[]` — An array of BCP 47 language tags.
+
+**Note:** Only effective when `type` is `alphabetical`.
 
 ### partitionByComment
 

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -8,6 +8,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -35,6 +36,7 @@ export type Options = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -49,6 +51,7 @@ export const defaultOptions: Required<Options[0]> = {
   order: 'asc',
   partitionByComment: false,
   partitionByNewLine: false,
+  locales: 'en-US',
 }
 
 export let jsonSchema: JSONSchema4 = {
@@ -56,6 +59,7 @@ export let jsonSchema: JSONSchema4 = {
   properties: {
     type: typeJsonSchema,
     order: orderJsonSchema,
+    locales: localesJsonSchema,
     ignoreCase: ignoreCaseJsonSchema,
     specialCharacters: specialCharactersJsonSchema,
     groupKind: {

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -250,6 +250,7 @@ export const getCompareOptions = (
         : options.order,
     specialCharacters: options.specialCharacters,
     ignoreCase: options.ignoreCase,
+    locales: options.locales,
   }
 }
 

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -12,6 +12,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -82,6 +83,7 @@ const defaultOptions: Required<SortClassesOptions[0]> = {
   specialCharacters: 'keep',
   customGroups: [],
   order: 'asc',
+  locales: 'en-US',
 }
 
 export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
@@ -98,6 +100,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -189,6 +189,7 @@ export type SortClassesOptions = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     customGroups: CustomGroup[]
     groups: (Group[] | Group)[]
     order: 'desc' | 'asc'

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -8,6 +8,7 @@ import {
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -38,6 +39,7 @@ export type Options<T extends string[]> = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     sortOnParameters: boolean
     sortOnProperties: boolean
@@ -64,6 +66,7 @@ const defaultOptions: Required<Options<string[]>[0]> = {
   sortOnAccessors: true,
   sortOnProperties: true,
   sortOnParameters: true,
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
@@ -80,6 +83,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           sortOnClasses: {

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -7,6 +7,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -34,6 +35,7 @@ export type Options = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     forceNumericSort: boolean
     order: 'desc' | 'asc'
@@ -51,6 +53,7 @@ const defaultOptions: Required<Options[0]> = {
   order: 'asc',
   sortByValue: false,
   forceNumericSort: false,
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -67,6 +70,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           sortByValue: {
@@ -217,6 +221,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           order: options.order,
           ignoreCase: options.ignoreCase,
           specialCharacters: options.specialCharacters,
+          locales: options.locales,
           // Get the enum value rather than the name if needed
           nodeValueGetter:
             options.sortByValue || (isNumericEnum && options.forceNumericSort)

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -6,6 +6,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -29,6 +30,7 @@ type Options = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -47,6 +49,7 @@ const defaultOptions: Required<Options[0]> = {
   partitionByComment: false,
   partitionByNewLine: false,
   groupKind: 'mixed',
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -63,6 +66,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -7,6 +7,7 @@ import {
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -35,6 +36,7 @@ export type Options<T extends string[]> = [
     customGroups: { [key in T[number]]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -48,6 +50,7 @@ const defaultOptions: Required<Options<string[]>[0]> = {
   customGroups: {},
   order: 'asc',
   groups: [],
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
@@ -64,6 +67,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           groups: groupsJsonSchema,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -7,6 +7,7 @@ import type { SortingNode } from '../typings'
 import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -64,6 +65,7 @@ export type Options<T extends string[]> = [
     type: 'alphabetical' | 'line-length' | 'natural'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     environment: 'node' | 'bun'
     internalPattern: string[]
@@ -93,6 +95,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           internalPattern: {
@@ -207,6 +210,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       ],
       customGroups: { type: {}, value: {} },
       environment: 'node',
+      locales: 'en-US',
     },
   ],
   create: context => {
@@ -234,6 +238,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         ignoreCase: true,
         specialCharacters: 'keep',
         order: 'asc',
+        locales: 'en-US',
       } as const),
     )
 

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -5,6 +5,7 @@ import {
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -45,6 +46,7 @@ export type Options<T extends string[]> = [
     partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     partitionByNewLine: boolean
     ignorePattern: string[]
@@ -65,6 +67,7 @@ const defaultOptions: Required<Options<string[]>[0]> = {
   customGroups: {},
   order: 'asc',
   groups: [],
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
@@ -81,6 +84,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignorePattern: {

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -4,6 +4,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -54,6 +55,7 @@ type Options = [
     partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group[] | Group)[]
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
@@ -70,6 +72,7 @@ const defaultOptions: Required<Options[0]> = {
   partitionByComment: false,
   partitionByNewLine: false,
   groups: [],
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -86,6 +89,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           groups: groupsJsonSchema,

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -6,6 +6,7 @@ import {
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -36,6 +37,7 @@ type Options<T extends string[]> = [
     customGroups: { [key in T[number]]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     ignorePattern: string[]
     order: 'desc' | 'asc'
@@ -51,6 +53,7 @@ const defaultOptions: Required<Options<string[]>[0]> = {
   customGroups: {},
   order: 'asc',
   groups: [],
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
@@ -67,6 +70,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignorePattern: {

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -6,6 +6,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -31,6 +32,7 @@ type Options = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -44,6 +46,7 @@ const defaultOptions: Required<Options[0]> = {
   specialCharacters: 'keep',
   partitionByComment: false,
   partitionByNewLine: false,
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -60,6 +63,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -4,6 +4,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -30,6 +31,7 @@ type Options = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -44,6 +46,7 @@ const defaultOptions: Required<Options[0]> = {
   partitionByNewLine: false,
   partitionByComment: false,
   groupKind: 'mixed',
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -60,6 +63,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           groupKind: {

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -4,6 +4,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -30,6 +31,7 @@ type Options = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreAlias: boolean
@@ -46,6 +48,7 @@ const defaultOptions: Required<Options[0]> = {
   partitionByNewLine: false,
   partitionByComment: false,
   order: 'asc',
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -62,6 +65,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignoreAlias: {

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -7,6 +7,7 @@ import {
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -46,6 +47,7 @@ type Options<T extends string[]> = [
     partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
@@ -66,6 +68,7 @@ const defaultOptions: Required<Options<string[]>[0]> = {
   customGroups: {},
   order: 'asc',
   groups: [],
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
@@ -82,6 +85,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -7,6 +7,7 @@ import {
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -51,6 +52,7 @@ type Options = [
     partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group[] | Group)[]
     partitionByNewLine: boolean
     styledComponents: boolean
@@ -74,6 +76,7 @@ const defaultOptions: Required<Options[0]> = {
   customGroups: {},
   order: 'asc',
   groups: [],
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -90,6 +93,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -6,6 +6,7 @@ import type { SortingNode } from '../typings'
 import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -26,6 +27,7 @@ type Options = [
   Partial<{
     type: 'alphabetical' | 'line-length' | 'natural'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -40,6 +42,7 @@ const defaultOptions: Required<Options[0]> = {
   ignoreCase: true,
   specialCharacters: 'keep',
   order: 'asc',
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -56,6 +59,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
         },

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -4,6 +4,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
@@ -54,6 +55,7 @@ type Options = [
     partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     groups: (Group[] | Group)[]
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
@@ -70,6 +72,7 @@ const defaultOptions: Required<Options[0]> = {
   newlinesBetween: 'ignore',
   partitionByNewLine: false,
   partitionByComment: false,
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -86,6 +89,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           groups: groupsJsonSchema,

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -6,6 +6,7 @@ import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
+  localesJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -35,6 +36,7 @@ type Options = [
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
+    locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -48,6 +50,7 @@ const defaultOptions: Required<Options[0]> = {
   partitionByNewLine: false,
   partitionByComment: false,
   order: 'asc',
+  locales: 'en-US',
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
@@ -64,6 +67,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           type: typeJsonSchema,
           order: orderJsonSchema,
+          locales: localesJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {

--- a/test/get-settings.test.ts
+++ b/test/get-settings.test.ts
@@ -27,6 +27,7 @@ describe('get-settings', () => {
       ignoreCase: true,
       order: 'asc',
       type: 'alphabetical',
+      locales: 'en-US',
     }
     expect(() => {
       getSettings({

--- a/test/sort-array-includes.test.ts
+++ b/test/sort-array-includes.test.ts
@@ -689,6 +689,25 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+            [
+              '你好',
+              '世界',
+              'a',
+              'A',
+              'b',
+              'B'
+            ].includes(value)
+          `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): sorts inline elements correctly`,
       rule,

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -4064,6 +4064,30 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+            class Class {
+              你好 = '你好'
+
+              世界 = '世界'
+
+              a = 'a'
+
+              A = 'A'
+
+              b = 'b'
+
+              B = 'B'
+            }
+          `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     describe(`${ruleName}(${type}): sorts inline elements correctly`, () => {
       describe(`${ruleName}(${type}): methods`, () => {
         describe(`${ruleName}(${type}): non-abstract methods`, () => {

--- a/test/sort-decorators.test.ts
+++ b/test/sort-decorators.test.ts
@@ -1014,6 +1014,58 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+
+            @你好
+            @世界
+            @a
+            @A
+            @b
+            @B
+            class Class {
+
+              @你好
+              @世界
+              @a
+              @A
+              @b
+              @B
+              property
+
+              @你好
+              @世界
+              @a
+              @A
+              @b
+              @B
+              accessor field
+
+              @你好
+              @世界
+              @a
+              @A
+              @b
+              @B
+              method(
+                @你好
+                @世界
+                @a
+                @A
+                @b
+                @B
+                parameter) {}
+
+            }
+          `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -584,6 +584,25 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              enum Enum {
+                你好 = '你好',
+                世界 = '世界',
+                a = 'a',
+                A = 'A',
+                b = 'b',
+                B = 'B',
+              }
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): sorts inline elements correctly`,
       rule,

--- a/test/sort-exports.test.ts
+++ b/test/sort-exports.test.ts
@@ -516,6 +516,23 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              export { 你好 } from '你好'
+              export { 世界 } from '世界'
+              export { a } from 'a'
+              export { A } from 'A'
+              export { b } from 'b'
+              export { B } from 'B'
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): sorts inline elements correctly`,
       rule,

--- a/test/sort-heritage-clauses.test.ts
+++ b/test/sort-heritage-clauses.test.ts
@@ -335,6 +335,25 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              interface MyInterface extends
+                你好,
+                世界,
+                a,
+                A,
+                b,
+                B {
+              }
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): sorts inline elements correctly`,
       rule,

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -1921,6 +1921,23 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              import '你好'
+              import '世界'
+              import 'a'
+              import 'A'
+              import 'b'
+              import 'B'
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     describe(`${ruleName}: newlinesBetween`, () => {
       ruleTester.run(
         `${ruleName}(${type}): removes newlines when never`,

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -1026,6 +1026,25 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              interface MyInterface {
+                你好: string
+                世界: string
+                a: string
+                A: string
+                b: string
+                B: string
+              }
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
       valid: [
         {

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -745,6 +745,24 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              type T =
+                你好 &
+                世界 &
+                a &
+                A &
+                b &
+                B
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     describe(`${ruleName}: newlinesBetween`, () => {
       ruleTester.run(
         `${ruleName}(${type}): removes newlines when never`,

--- a/test/sort-jsx-props.test.ts
+++ b/test/sort-jsx-props.test.ts
@@ -571,6 +571,25 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              <Component
+                你好
+                世界
+                a
+                A
+                b
+                B
+              />
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-maps.test.ts
+++ b/test/sort-maps.test.ts
@@ -512,6 +512,25 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              new Map([
+                [你好, '你好'],
+                [世界, '世界'],
+                [a, 'a'],
+                [A, 'A'],
+                [b, 'b'],
+                [B, 'B'],
+              ])
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-named-exports.test.ts
+++ b/test/sort-named-exports.test.ts
@@ -425,6 +425,18 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              export { 你好, 世界, a, A, b, B }
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(`${ruleName}(${type}): works with arbitrary names`, rule, {
       valid: [
         {

--- a/test/sort-named-imports.test.ts
+++ b/test/sort-named-imports.test.ts
@@ -647,6 +647,18 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              import { 你好, 世界, a, A, b, B } from 'module'
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(`${ruleName}(${type}): works with arbitrary names`, rule, {
       valid: [
         {

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -855,6 +855,25 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              type Type = {
+                你好: string
+                世界: string
+                a: string
+                A: string
+                b: string
+                B: string
+              }
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
       valid: [
         {

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1616,6 +1616,25 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              let obj = {
+                你好 = '你好',
+                世界 = '世界',
+                a = 'a',
+                A = 'A',
+                b = 'b',
+                B = 'B',
+              }
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): allows to set groups for sorting`,
       rule,

--- a/test/sort-sets.test.ts
+++ b/test/sort-sets.test.ts
@@ -636,6 +636,25 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              new Set([
+                '你好',
+                '世界',
+                'a',
+                'A',
+                'b',
+                'B',
+              ])
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): sorts inline elements correctly`,
       rule,

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -851,6 +851,26 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              switch (x) {
+                case '你好':
+                case '世界':
+                case 'a':
+                case 'A':
+                case 'b':
+                case 'B':
+                  break;
+              }
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): sorts inline elements correctly`,
       rule,

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -748,6 +748,24 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              type T =
+                你好 |
+                世界 |
+                a |
+                A |
+                b |
+                B
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     describe(`${ruleName}: newlinesBetween`, () => {
       ruleTester.run(
         `${ruleName}(${type}): removes newlines when never`,

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -915,6 +915,24 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
+      valid: [
+        {
+          code: dedent`
+              const
+                你好 = '你好',
+                世界 = '世界',
+                a = 'a',
+                A = 'A',
+                b = 'b',
+                B = 'B'
+            `,
+          options: [{ ...options, locales: 'zh-CN' }],
+        },
+      ],
+      invalid: [],
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): sorts inline elements correctly`,
       rule,

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -13,6 +13,21 @@ export let orderJsonSchema: JSONSchema4 = {
   type: 'string',
 }
 
+export let localesJsonSchema: JSONSchema4 = {
+  oneOf: [
+    {
+      type: 'string',
+    },
+    {
+      items: {
+        type: 'string',
+      },
+      type: 'array',
+    },
+  ],
+  description: 'Specifies the sorting locales.',
+}
+
 export let ignoreCaseJsonSchema: JSONSchema4 = {
   description: 'Controls whether sorting should be case-sensitive or not.',
   type: 'boolean',

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -12,6 +12,7 @@ interface BaseCompareOptions {
 
 interface AlphabeticalCompareOptions extends BaseCompareOptions {
   specialCharacters: 'remove' | 'trim' | 'keep'
+  locales: NonNullable<Intl.LocalesArgument>
   type: 'alphabetical'
   ignoreCase: boolean
 }
@@ -50,6 +51,7 @@ export let compare = (
     sortingFunction = (aNode, bNode) =>
       formatString(nodeValueGetter(aNode)).localeCompare(
         formatString(nodeValueGetter(bNode)),
+        options.locales,
       )
   } else if (options.type === 'natural') {
     let prepareNumeric = (string: string) => {

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -4,6 +4,7 @@ export type Settings = Partial<{
   type: 'alphabetical' | 'line-length' | 'natural'
   partitionByComment: string[] | boolean | string
   specialCharacters: 'remove' | 'trim' | 'keep'
+  locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
   ignorePattern: string[]
   order: 'desc' | 'asc'
@@ -24,6 +25,7 @@ export let getSettings = (
       'specialCharacters',
       'ignorePattern',
       'ignoreCase',
+      'locales',
       'order',
       'type',
     ]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

My colleague and I encountered differences when using the sort-objects rule.

After troubleshooting, we found that the discrepancies occurred during the **localeCompare** process. My VSCode display language is **English**, while my colleague's VSCode display language is **Simplified Chinese**.

A simple reproduction example:

**1. add test.ts**
```
const locale = new Intl.DateTimeFormat().resolvedOptions().locale;
console.log('locale', locale);

const result = 'CPO'.localeCompare('运营商');
console.log('"CPO" localeCompare "运营商" result', result);
```

**2. vscode config display language Simplified Chinese, run test.ts in vscode terminal**
output:
```
locale zh-CN
"CPO" localeCompare "运营商" result 1
```

**3. vscode config display language English, run test.ts in vscode terminal**
output:
```
locale en-US
"CPO" localeCompare "运营商" result -1
```

**4. run test.ts in system terminal, not vscode terminal**
output:
```
locale zh-CN
"CPO" localeCompare "运营商" result 1
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

**I'm not sure if it's reasonable to use the locale from the operating environment.**

My perspective is: when I use sort-objects, I want it to return the same order in any environment. Therefore, I added a fixed locales parameter of `en-US`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
