### PR TITLE
feat(sort-classes)!: removes support for old `customGroups` API

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -14,6 +14,7 @@ keywords:
 ---
 
 import CodeExample from '../../components/CodeExample.svelte'
+import Important from '../../components/Important.astro'
 import CodeTabs from '../../components/CodeTabs.svelte'
 import { dedent } from 'ts-dedent'
 
@@ -471,6 +472,34 @@ abstract class Example extends BaseExample {
 ```
 
 ### customGroups
+
+<Important title="ℹ️ Migrating from the old API">
+Support for the object-based `customGroups` option has been removed.
+
+Migrating from the old to the current API is easy:
+
+Old API:
+```ts
+{
+  "key1": "value1",
+  "key2": "value2"
+}
+```
+
+Current API:
+```ts
+[
+  {
+    "groupName": "key1",
+    "elementNamePattern": "value1"
+  },
+  {
+    "groupName": "key2",
+    "elementNamePattern": "value2"
+  }
+]
+```
+</Important>
 
 <sub>
   type: `Array<CustomGroupDefinition | CustomGroupBlockDefinition>`

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -473,7 +473,7 @@ abstract class Example extends BaseExample {
 
 ### customGroups
 
-<Important title="ℹ️ Migrating from the old API">
+<Important title="Migrating from the old API">
 Support for the object-based `customGroups` option has been removed.
 
 Migrating from the old to the current API is easy:

--- a/rules/sort-classes-utils.ts
+++ b/rules/sort-classes-utils.ts
@@ -239,7 +239,7 @@ export const getCompareOptions = (
 ): CompareOptions | null => {
   let group = options.groups[groupNumber]
   let customGroup =
-    typeof group === 'string' && Array.isArray(options.customGroups)
+    typeof group === 'string'
       ? options.customGroups.find(g => group === g.groupName)
       : null
   if (customGroup?.type === 'unsorted') {
@@ -260,9 +260,9 @@ export let validateGroupsConfiguration = (
   groups: Required<SortClassesOptions[0]>['groups'],
   customGroups: Required<SortClassesOptions[0]>['customGroups'],
 ): void => {
-  let availableCustomGroupNames = Array.isArray(customGroups)
-    ? customGroups.map(customGroup => customGroup.groupName)
-    : Object.keys(customGroups)
+  let availableCustomGroupNames = customGroups.map(
+    customGroup => customGroup.groupName,
+  )
   let invalidGroups = groups
     .flat()
     .filter(

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -144,62 +144,41 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           },
           customGroups: {
             description: 'Specifies custom groups.',
-            oneOf: [
-              {
-                type: 'object',
-                additionalProperties: {
-                  oneOf: [
-                    {
-                      type: 'string',
-                    },
-                    {
+            type: 'array',
+            items: {
+              oneOf: [
+                {
+                  description: 'Custom group block.',
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    ...customGroupNameJsonSchema,
+                    ...customGroupSortJsonSchema,
+                    anyOf: {
                       type: 'array',
                       items: {
-                        type: 'string',
-                      },
-                    },
-                  ],
-                },
-              },
-              {
-                type: 'array',
-                items: {
-                  description: 'Advanced custom groups.',
-                  oneOf: [
-                    {
-                      description: 'Custom group block.',
-                      type: 'object',
-                      additionalProperties: false,
-                      properties: {
-                        ...customGroupNameJsonSchema,
-                        ...customGroupSortJsonSchema,
-                        anyOf: {
-                          type: 'array',
-                          items: {
-                            description: 'Custom group.',
-                            type: 'object',
-                            additionalProperties: false,
-                            properties: {
-                              ...singleCustomGroupJsonSchema,
-                            },
-                          },
+                        description: 'Custom group.',
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                          ...singleCustomGroupJsonSchema,
                         },
                       },
                     },
-                    {
-                      description: 'Custom group.',
-                      type: 'object',
-                      additionalProperties: false,
-                      properties: {
-                        ...customGroupNameJsonSchema,
-                        ...customGroupSortJsonSchema,
-                        ...singleCustomGroupJsonSchema,
-                      },
-                    },
-                  ],
+                  },
                 },
-              },
-            ],
+                {
+                  description: 'Custom group.',
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    ...customGroupNameJsonSchema,
+                    ...customGroupSortJsonSchema,
+                    ...singleCustomGroupJsonSchema,
+                  },
+                },
+              ],
+            },
           },
         },
         additionalProperties: false,
@@ -393,7 +372,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             let name: string
             let dependencies: string[] = []
-            let { getGroup, defineGroup, setCustomGroups } = useGroups(options)
+            let { getGroup, defineGroup } = useGroups(options)
 
             if (member.type === 'StaticBlock') {
               name = 'static'
@@ -591,32 +570,24 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               defineGroup(officialGroup)
             }
 
-            if (Array.isArray(options.customGroups)) {
-              // New API
-              for (let customGroup of options.customGroups) {
-                if (
-                  customGroupMatches({
-                    customGroup,
-                    elementName: name,
-                    elementValue: memberValue,
-                    modifiers,
-                    selectors,
-                    decorators,
-                    matcher: options.matcher,
-                  })
-                ) {
-                  defineGroup(customGroup.groupName, true)
-                  // If the custom group is not referenced in the `groups` option, it will be ignored
-                  if (getGroup() === customGroup.groupName) {
-                    break
-                  }
+            for (let customGroup of options.customGroups) {
+              if (
+                customGroupMatches({
+                  customGroup,
+                  elementName: name,
+                  elementValue: memberValue,
+                  modifiers,
+                  selectors,
+                  decorators,
+                  matcher: options.matcher,
+                })
+              ) {
+                defineGroup(customGroup.groupName, true)
+                // If the custom group is not referenced in the `groups` option, it will be ignored
+                if (getGroup() === customGroup.groupName) {
+                  break
                 }
               }
-            } else {
-              // Old API
-              setCustomGroups(options.customGroups, name, {
-                override: true,
-              })
             }
 
             // Members belonging to the same overload signature group should have the same size in order to keep line-length sorting between them consistent.

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -186,11 +186,11 @@ export type CustomGroup = (
 
 export type SortClassesOptions = [
   Partial<{
-    customGroups: { [key: string]: string[] | string } | CustomGroup[]
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     matcher: 'minimatch' | 'regex'
+    customGroups: CustomGroup[]
     groups: (Group[] | Group)[]
     order: 'desc' | 'asc'
     ignoreCase: boolean

--- a/test/sort-classes-utils.test.ts
+++ b/test/sort-classes-utils.test.ts
@@ -67,7 +67,7 @@ describe('sort-classes-utils', () => {
       ).toBeUndefined()
     })
 
-    it('allows custom groups with the new API', () => {
+    it('allows custom groups', () => {
       expect(
         validateGroupsConfiguration(
           ['static-property', 'myCustomGroup'],
@@ -92,7 +92,7 @@ describe('sort-classes-utils', () => {
       ).toThrow('Duplicated group(s): static-property')
     })
 
-    it('throws an error if invalid groups are provided with the new API', () => {
+    it('throws an error if invalid groups are provided', () => {
       expect(() =>
         validateGroupsConfiguration(
           ['static-property', 'myCustomGroup', ''],
@@ -102,22 +102,6 @@ describe('sort-classes-utils', () => {
             },
           ],
         ),
-      ).toThrow('Invalid group(s): myCustomGroup')
-    })
-
-    it('allows groups with the old API', () => {
-      expect(
-        validateGroupsConfiguration(['static-property', 'myCustomGroup'], {
-          myCustomGroup: 'foo',
-        }),
-      ).toBeUndefined()
-    })
-
-    it('throws an error if invalid custom groups are provided with the old API', () => {
-      expect(() =>
-        validateGroupsConfiguration(['static-property', 'myCustomGroup'], {
-          myCustomGroupNotReferenced: 'foo',
-        }),
       ).toThrow('Invalid group(s): myCustomGroup')
     })
   })

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -6074,10 +6074,16 @@ describe(ruleName, () => {
           options: [
             {
               ...options,
-              customGroups: {
-                'my-first-group': 'customFirst*',
-                'my-last-group': 'customLast*',
-              },
+              customGroups: [
+                {
+                  groupName: 'my-first-group',
+                  elementNamePattern: 'customFirst*',
+                },
+                {
+                  groupName: 'my-last-group',
+                  elementNamePattern: 'customLast*',
+                },
+              ],
               groups: [
                 'my-first-group',
                 'decorated-accessor-property',
@@ -6765,37 +6771,7 @@ describe(ruleName, () => {
     })
 
     ruleTester.run(
-      `${ruleName}: allows to use regex matcher for element names in custom groups with old API`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              class Class {
-                iHaveFooInMyName: string
-                meTooIHaveFoo: string
-                a: string
-                b: string
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-                matcher: 'regex',
-                groups: ['unknown', 'elementsWithoutFoo'],
-                customGroups: {
-                  elementsWithoutFoo: '^(?!.*Foo).*$',
-                },
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: allows to use regex matcher for element names in custom groups with new API`,
+      `${ruleName}: allows to use regex matcher for element names in custom groups`,
       rule,
       {
         valid: [
@@ -6828,7 +6804,7 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
-      `${ruleName}: allows to use regex matcher for element values in custom groups with new API`,
+      `${ruleName}: allows to use regex matcher for element values in custom groups`,
       rule,
       {
         valid: [
@@ -6861,7 +6837,7 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
-      `${ruleName}: allows to use regex matcher for decorator names in custom groups with new API`,
+      `${ruleName}: allows to use regex matcher for decorator names in custom groups`,
       rule,
       {
         valid: [


### PR DESCRIPTION
### Description

`sort-classes`'s `customGroups` option currently supports:
- an object (old API): like other rules, each key is the group's name, and its value the pattern to match the value of the class's member.
- an array (new API) with more options.

Migrating from the old to the new API is very straightforward.

Old API:
```ts
{
  "key1": "value1",
  "key2": "value2"
}
```

New API:
```ts
[
  {
    "groupName": "key1",
    "elementNamePattern": "value1"
  },
  {
    "groupName": "key2",
    "elementNamePattern": "value2"
  }
]
```

This PR removes support for the old API and the code associated and adds a section to the documentation to help users who have not yet switched to the new API to migrate.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Documentation update
- [x] Other
