### PR TITLE
feat: new rule: `sort-heritage-clauses`

### DIFF
--- a/docs/content/rules/sort-heritage-clauses.mdx
+++ b/docs/content/rules/sort-heritage-clauses.mdx
@@ -1,0 +1,249 @@
+---
+title: sort-heritage-clauses
+description: Enforce sorting of heritage clauses for improved readability and maintainability. Use this ESLint rule to keep your heritage clauses well-organized
+shortDescription: Enforce sorted heritage clauses
+keywords:
+  - eslint
+  - sort heritage clauses
+  - sort implements
+  - sort extends
+  - eslint rule
+  - coding standards
+  - code quality
+  - javascript linting
+  - typescript heritage clauses sorting
+---
+
+import CodeExample from '../../components/CodeExample.svelte'
+import Important from '../../components/Important.astro'
+import CodeTabs from '../../components/CodeTabs.svelte'
+import { dedent } from 'ts-dedent'
+
+Enforce sorted heritage clauses.
+
+This rule detects instances where heritage clauses are not sorted and raises linting errors, encouraging developers to arrange elements in the desired order.
+
+## Try it out
+
+<CodeExample
+  alphabetical={dedent`
+    interface Interface extends Logged, Pausable, StartupService {
+     // ...
+    }
+
+    class Class implements Logged, Pausable, StartupService {
+     // ...
+    }
+  `}
+  lineLength={dedent`
+    interface Interface extends StartupService, Pausable, Logged {
+     // ...
+    }
+
+    class Class implements StartupService, Pausable, Logged {
+     // ...
+    }
+  `}
+  initial={dedent`
+    interface Interface extends StartupService, Logged, Pausable {
+     // ...
+    }
+
+    class Class implements StartupService, Logged, Pausable {
+     // ...
+    }
+  `}
+  client:load
+  lang="tsx"
+/>
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+### type
+
+<sub>default: `'alphabetical'`</sub>
+
+Specifies the sorting method.
+
+- `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”).
+- `'natural'` — Sort items in a natural order (e.g., “item2” < “item10”).
+- `'line-length'` — Sort items by the length of the code line (shorter lines first).
+
+### order
+
+<sub>default: `'asc'`</sub>
+
+Determines whether the sorted items should be in ascending or descending order.
+
+- `'asc'` — Sort items in ascending order (A to Z, 1 to 9).
+- `'desc'` — Sort items in descending order (Z to A, 9 to 1).
+
+### ignoreCase
+
+<sub>default: `true`</sub>
+
+Controls whether sorting should be case-sensitive or not.
+
+- `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
+- `false` — Consider case when sorting (e.g., “A” comes before “a”).
+
+### specialCharacters
+
+<sub>default: `keep`</sub>
+
+Controls whether special characters should be trimmed, removed or kept before sorting.
+
+- `'keep'` — Keep special characters when sorting (e.g., “_a” comes before “a”).
+- `'trim'` — Trim special characters when sorting alphabetically or naturally (e.g., “_a” and “a” are the same).
+- `'remove'` — Remove special characters when sorting (e.g., “/a/b” and “ab” are the same).
+
+### groups
+
+<sub>
+  type: `Array<string | string[]>`
+</sub>
+<sub>default: `[]`</sub>
+
+Allows you to specify a list of heritage clause groups for sorting.
+
+Predefined groups:
+
+- `'unknown'` — Heritage Clauses that don’t fit into any group specified in the `groups` option.
+
+If the `unknown` group is not specified in the `groups` option, it will automatically be added to the end of the list.
+
+Each heritage clause will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
+The order of items in the `groups` option determines how groups are ordered.
+
+Within a given group, members will be sorted according to the `type`, `order`, `ignoreCase`, etc. options.
+
+Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
+All members of the groups in the array will be sorted together as if they were part of a single group.
+
+### customGroups
+
+<sub>
+  type: `{ [groupName: string]: string | string[] }`
+</sub>
+<sub>default: `{}`</sub>
+
+You can define your own groups and use custom glob patterns or regex to match specific heritage clauses.
+
+Use the `matcher` option to specify the pattern matching method.
+
+Each key of `customGroups` represents a group name which you can then use in the `groups` option. The value for each key can either be of type:
+- `string` — A heritage clause's name matching the value will be marked as part of the group referenced by the key.
+- `string[]` — A heritage clause's name matching any of the values of the array will be marked as part of the group referenced by the key.
+The order of values in the array does not matter.
+
+Custom group matching takes precedence over predefined group matching.
+
+#### Example:
+
+Put the `WithId` clause before anything else:
+
+```ts
+interface Interface extends WithId, Logged, StartupService {
+ // ...
+}
+```
+
+`groups` and `customGroups` configuration:
+
+```js
+ {
+   groups: [
+     'withIdInterface',           // [!code ++]
+     'unknown'
+   ],
++  customGroups: {                // [!code ++]
++    withIdInterface: 'WithId'   // [!code ++]
++  }                              // [!code ++]
+ }
+```
+
+### matcher
+
+<sub>default: `'minimatch'`</sub>
+
+Determines the matcher used for patterns in the `customGroups` option.
+
+- `'minimatch'` — Use the [minimatch](https://github.com/isaacs/minimatch) library for pattern matching.
+- `'regex'` — Use regular expressions for pattern matching.
+
+## Usage
+
+<CodeTabs
+  code={[
+    {
+      source: dedent`
+        // eslint.config.js
+        import perfectionist from 'eslint-plugin-perfectionist'
+
+        export default [
+          {
+            plugins: {
+              perfectionist,
+            },
+            rules: {
+              'perfectionist/sort-heritage-clauses': [
+                'error',
+                {
+                  type: 'alphabetical',
+                  order: 'asc',
+                  ignoreCase: true,
+                  specialCharacters: 'keep',
+                  matcher: 'minimatch',
+                  groups: [],
+                  customGroups: {}
+                },
+              ],
+            },
+          },
+        ]
+      `,
+      name: 'Flat Config',
+      value: 'flat',
+    },
+    {
+      source: dedent`
+        // .eslintrc.js
+        module.exports = {
+          plugins: [
+            'perfectionist',
+          ],
+          rules: {
+            'perfectionist/sort-heritage-clauses': [
+              'error',
+              {
+                type: 'alphabetical',
+                order: 'asc',
+                ignoreCase: true,
+                specialCharacters: 'keep',
+                matcher: 'minimatch',
+                groups: [],
+                customGroups: {}
+              },
+            ],
+          },
+        }
+      `,
+      name: 'Legacy Config',
+      value: 'legacy',
+    },
+  ]}
+  type="config-type"
+  client:load
+  lang="ts"
+/>
+
+## Version
+
+This rule was introduced in [v4.0.0](https://github.com/azat-io/eslint-plugin-perfectionist/releases/tag/v4.0.0).
+
+## Resources
+
+- [Rule source](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/rules/sort-heritage-clauses.ts)
+- [Test source](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/test/sort-heritage-clauses.test.ts)

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import type {
 
 import sortVariableDeclarations from './rules/sort-variable-declarations'
 import sortIntersectionTypes from './rules/sort-intersection-types'
+import sortHeritageClauses from './rules/sort-heritage-clauses'
 import sortArrayIncludes from './rules/sort-array-includes'
 import sortNamedImports from './rules/sort-named-imports'
 import sortNamedExports from './rules/sort-named-exports'
@@ -37,6 +38,7 @@ let plugin = {
   rules: {
     'sort-variable-declarations': sortVariableDeclarations,
     'sort-intersection-types': sortIntersectionTypes,
+    'sort-heritage-clauses': sortHeritageClauses,
     'sort-array-includes': sortArrayIncludes,
     'sort-named-imports': sortNamedImports,
     'sort-named-exports': sortNamedExports,

--- a/readme.md
+++ b/readme.md
@@ -172,26 +172,27 @@ module.exports = {
 
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                                     | Description                                 | 🔧  |
-| :--------------------------------------------------------------------------------------- | :------------------------------------------ | :-- |
-| [sort-array-includes](https://perfectionist.dev/rules/sort-array-includes)               | Enforce sorted arrays before include method | 🔧  |
-| [sort-classes](https://perfectionist.dev/rules/sort-classes)                             | Enforce sorted classes                      | 🔧  |
-| [sort-decorators](https://perfectionist.dev/rules/sort-decorators)                       | Enforce sorted decorators                   | 🔧  |
-| [sort-enums](https://perfectionist.dev/rules/sort-enums)                                 | Enforce sorted TypeScript enums             | 🔧  |
-| [sort-exports](https://perfectionist.dev/rules/sort-exports)                             | Enforce sorted exports                      | 🔧  |
-| [sort-imports](https://perfectionist.dev/rules/sort-imports)                             | Enforce sorted imports                      | 🔧  |
-| [sort-interfaces](https://perfectionist.dev/rules/sort-interfaces)                       | Enforce sorted interface properties         | 🔧  |
-| [sort-intersection-types](https://perfectionist.dev/rules/sort-intersection-types)       | Enforce sorted intersection types           | 🔧  |
-| [sort-jsx-props](https://perfectionist.dev/rules/sort-jsx-props)                         | Enforce sorted JSX props                    | 🔧  |
-| [sort-maps](https://perfectionist.dev/rules/sort-maps)                                   | Enforce sorted Map elements                 | 🔧  |
-| [sort-named-exports](https://perfectionist.dev/rules/sort-named-exports)                 | Enforce sorted named exports                | 🔧  |
-| [sort-named-imports](https://perfectionist.dev/rules/sort-named-imports)                 | Enforce sorted named imports                | 🔧  |
-| [sort-object-types](https://perfectionist.dev/rules/sort-object-types)                   | Enforce sorted object types                 | 🔧  |
-| [sort-objects](https://perfectionist.dev/rules/sort-objects)                             | Enforce sorted objects                      | 🔧  |
-| [sort-sets](https://perfectionist.dev/rules/sort-sets)                                   | Enforce sorted Set elements                 | 🔧  |
-| [sort-switch-case](https://perfectionist.dev/rules/sort-switch-case)                     | Enforce sorted switch case statements       | 🔧  |
-| [sort-union-types](https://perfectionist.dev/rules/sort-union-types)                     | Enforce sorted union types                  | 🔧  |
-| [sort-variable-declarations](https://perfectionist.dev/rules/sort-variable-declarations) | Enforce sorted variable declarations        | 🔧  |
+| Name                                                                                     | Description                                   | 🔧  |
+| :--------------------------------------------------------------------------------------- | :-------------------------------------------- | :-- |
+| [sort-array-includes](https://perfectionist.dev/rules/sort-array-includes)               | Enforce sorted arrays before include method   | 🔧  |
+| [sort-classes](https://perfectionist.dev/rules/sort-classes)                             | Enforce sorted classes                        | 🔧  |
+| [sort-decorators](https://perfectionist.dev/rules/sort-decorators)                       | Enforce sorted decorators                     | 🔧  |
+| [sort-enums](https://perfectionist.dev/rules/sort-enums)                                 | Enforce sorted TypeScript enums               | 🔧  |
+| [sort-exports](https://perfectionist.dev/rules/sort-exports)                             | Enforce sorted exports                        | 🔧  |
+| [sort-heritage-clauses](https://perfectionist.dev/rules/sort-heritage-clauses)           | Enforce sorted `implements`/`extends` clauses | 🔧  |
+| [sort-imports](https://perfectionist.dev/rules/sort-imports)                             | Enforce sorted imports                        | 🔧  |
+| [sort-interfaces](https://perfectionist.dev/rules/sort-interfaces)                       | Enforce sorted interface properties           | 🔧  |
+| [sort-intersection-types](https://perfectionist.dev/rules/sort-intersection-types)       | Enforce sorted intersection types             | 🔧  |
+| [sort-jsx-props](https://perfectionist.dev/rules/sort-jsx-props)                         | Enforce sorted JSX props                      | 🔧  |
+| [sort-maps](https://perfectionist.dev/rules/sort-maps)                                   | Enforce sorted Map elements                   | 🔧  |
+| [sort-named-exports](https://perfectionist.dev/rules/sort-named-exports)                 | Enforce sorted named exports                  | 🔧  |
+| [sort-named-imports](https://perfectionist.dev/rules/sort-named-imports)                 | Enforce sorted named imports                  | 🔧  |
+| [sort-object-types](https://perfectionist.dev/rules/sort-object-types)                   | Enforce sorted object types                   | 🔧  |
+| [sort-objects](https://perfectionist.dev/rules/sort-objects)                             | Enforce sorted objects                        | 🔧  |
+| [sort-sets](https://perfectionist.dev/rules/sort-sets)                                   | Enforce sorted Set elements                   | 🔧  |
+| [sort-switch-case](https://perfectionist.dev/rules/sort-switch-case)                     | Enforce sorted switch case statements         | 🔧  |
+| [sort-union-types](https://perfectionist.dev/rules/sort-union-types)                     | Enforce sorted union types                    | 🔧  |
+| [sort-variable-declarations](https://perfectionist.dev/rules/sort-variable-declarations) | Enforce sorted variable declarations          | 🔧  |
 
 <!-- end auto-generated rules list -->
 

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -1,0 +1,227 @@
+import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
+import type { TSESTree } from '@typescript-eslint/types'
+
+import type { SortingNode } from '../typings'
+
+import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
+import { createEslintRule } from '../utils/create-eslint-rule'
+import { getGroupNumber } from '../utils/get-group-number'
+import { getSourceCode } from '../utils/get-source-code'
+import { toSingleLine } from '../utils/to-single-line'
+import { rangeToDiff } from '../utils/range-to-diff'
+import { getSettings } from '../utils/get-settings'
+import { useGroups } from '../utils/use-groups'
+import { makeFixes } from '../utils/make-fixes'
+import { complete } from '../utils/complete'
+import { pairwise } from '../utils/pairwise'
+
+type MESSAGE_ID =
+  | 'unexpectedHeritageClausesGroupOrder'
+  | 'unexpectedHeritageClausesOrder'
+
+type Group<T extends string[]> = 'unknown' | T[number]
+
+export type Options<T extends string[]> = [
+  Partial<{
+    customGroups: { [key in T[number]]: string[] | string }
+    type: 'alphabetical' | 'line-length' | 'natural'
+    specialCharacters: 'remove' | 'trim' | 'keep'
+    groups: (Group<T>[] | Group<T>)[]
+    matcher: 'minimatch' | 'regex'
+    order: 'desc' | 'asc'
+    ignoreCase: boolean
+  }>,
+]
+
+export default createEslintRule<Options<string[]>, MESSAGE_ID>({
+  name: 'sort-heritage-clauses',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Enforce sorted heritage clauses.',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          type: {
+            description: 'Specifies the sorting method.',
+            type: 'string',
+            enum: ['alphabetical', 'natural', 'line-length'],
+          },
+          order: {
+            description:
+              'Determines whether the sorted items should be in ascending or descending order.',
+            type: 'string',
+            enum: ['asc', 'desc'],
+          },
+          matcher: {
+            description: 'Specifies the string matcher.',
+            type: 'string',
+            enum: ['minimatch', 'regex'],
+          },
+          ignoreCase: {
+            description:
+              'Controls whether sorting should be case-sensitive or not.',
+            type: 'boolean',
+          },
+          specialCharacters: {
+            description:
+              'Controls how special characters should be handled before sorting.',
+            type: 'string',
+            enum: ['remove', 'trim', 'keep'],
+          },
+          groups: {
+            description: 'Specifies the order of the groups.',
+            type: 'array',
+            items: {
+              oneOf: [
+                {
+                  type: 'string',
+                },
+                {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+              ],
+            },
+          },
+          customGroups: {
+            description: 'Specifies custom groups.',
+            type: 'object',
+            additionalProperties: {
+              oneOf: [
+                {
+                  type: 'string',
+                },
+                {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+              ],
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      unexpectedHeritageClausesGroupOrder:
+        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+      unexpectedHeritageClausesOrder:
+        'Expected "{{right}}" to come before "{{left}}".',
+    },
+  },
+  defaultOptions: [
+    {
+      type: 'alphabetical',
+      order: 'asc',
+      ignoreCase: true,
+      specialCharacters: 'keep',
+      matcher: 'minimatch',
+      groups: [],
+      customGroups: {},
+    },
+  ],
+  create: context => {
+    let settings = getSettings(context.settings)
+
+    let options = complete(context.options.at(0), settings, {
+      type: 'alphabetical',
+      matcher: 'minimatch',
+      ignoreCase: true,
+      specialCharacters: 'keep',
+      customGroups: {},
+      order: 'asc',
+      groups: [],
+    } as const)
+
+    validateGroupsConfiguration(
+      options.groups,
+      ['unknown'],
+      Object.keys(options.customGroups),
+    )
+
+    return {
+      ClassDeclaration: declaration =>
+        sortHeritageClauses(context, options, declaration.implements),
+      TSInterfaceDeclaration: declaration =>
+        sortHeritageClauses(context, options, declaration.extends),
+    }
+  },
+})
+
+const sortHeritageClauses = (
+  context: Readonly<RuleContext<MESSAGE_ID, Options<string[]>>>,
+  options: Required<Options<string[]>[0]>,
+  heritageClauses:
+    | TSESTree.TSInterfaceHeritage[]
+    | TSESTree.TSClassImplements[],
+) => {
+  if (heritageClauses.length < 2) {
+    return
+  }
+  let sourceCode = getSourceCode(context)
+
+  let formattedNodes: SortingNode[] = heritageClauses.map(heritageClause => {
+    let name = getHeritageClauseExpressionName(heritageClause.expression)
+
+    let { getGroup, setCustomGroups } = useGroups(options)
+    setCustomGroups(options.customGroups, name)
+
+    return {
+      size: rangeToDiff(heritageClause.range),
+      node: heritageClause,
+      group: getGroup(),
+      name,
+    }
+  })
+
+  let sortedNodes = sortNodesByGroups(formattedNodes, options)
+  pairwise(formattedNodes, (left, right) => {
+    let indexOfLeft = sortedNodes.indexOf(left)
+    let indexOfRight = sortedNodes.indexOf(right)
+    if (indexOfLeft <= indexOfRight) {
+      return
+    }
+    let leftNum = getGroupNumber(options.groups, left)
+    let rightNum = getGroupNumber(options.groups, right)
+    context.report({
+      messageId:
+        leftNum !== rightNum
+          ? 'unexpectedHeritageClausesGroupOrder'
+          : 'unexpectedHeritageClausesOrder',
+      data: {
+        left: toSingleLine(left.name),
+        leftGroup: left.group,
+        right: toSingleLine(right.name),
+        rightGroup: right.group,
+      },
+      node: right.node,
+      fix: fixer => makeFixes(fixer, formattedNodes, sortedNodes, sourceCode),
+    })
+  })
+}
+
+const getHeritageClauseExpressionName = (
+  expression: TSESTree.PrivateIdentifier | TSESTree.Expression,
+) => {
+  if (expression.type === 'Identifier') {
+    return expression.name
+  }
+  if ('property' in expression) {
+    return getHeritageClauseExpressionName(expression.property)
+    /* c8 ignore start - should never throw */
+  }
+  throw new Error(
+    'Unexpected heritage clause expression. Please report this issue ' +
+      'here: https://github.com/azat-io/eslint-plugin-perfectionist/issues',
+  )
+  /* c8 ignore end */
+}


### PR DESCRIPTION
### Description

This PR adds a `sort-heritage-clauses` (feel free to suggest another name if you find a better one) that allows users to sort classes `implements` and interfaces `extends` clauses.

Example:

```ts
interface Interface extends Loggable, Pausable, Startable {
 // ...
}
```

```ts
class Class implements Loggable, Pausable, Startable {
 // ...
}
```

### Options

```ts
{
    customGroups: { [key in T[number]]: string[] | string }
    type: 'alphabetical' | 'line-length' | 'natural'
    specialCharacters: 'remove' | 'trim' | 'keep'
    groups: (Group<T>[] | Group<T>)[]
    matcher: 'minimatch' | 'regex'
    order: 'desc' | 'asc'
    ignoreCase: boolean
}
```

There is only one predefined group: `unknown`.

I don't believe that `partitionByNewline` and `partitionByComment` have relevant use cases here.

- [x] Add tests.
- [x] Update documentation.

### What is the purpose of this pull request?

- [x] New Feature
- [x] Documentation update