### PR TITLE
fix: Improve ending commas/semicolon behavior

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -178,7 +178,7 @@ export let sortArray = <MessageIds extends string>(
             name:
               element.type === 'Literal'
                 ? `${element.value}`
-                : sourceCode.text.slice(...element.range),
+                : sourceCode.getText(element),
             size: rangeToDiff(element, sourceCode),
             node: element,
             group,

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -179,7 +179,7 @@ export let sortArray = <MessageIds extends string>(
               element.type === 'Literal'
                 ? `${element.value}`
                 : sourceCode.text.slice(...element.range),
-            size: rangeToDiff(element.range),
+            size: rangeToDiff(element, sourceCode),
             node: element,
             group,
           }

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -608,7 +608,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               node: member,
               dependencies,
               name,
-              requiresEndingSemicolonWhenInline: requiresEndingSemicolon,
+              addSafetySemicolonWhenInline: requiresEndingSemicolon,
               dependencyName: getDependencyName(
                 name,
                 modifiers.includes('static'),

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -384,7 +384,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             } else if (member.key.type === 'Identifier') {
               ;({ name } = member.key)
             } else {
-              name = sourceCode.text.slice(...member.key.range)
+              name = sourceCode.getText(member.key)
             }
 
             let isPrivateHash =

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -602,8 +602,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             let sortingNode: SortingNodeWithDependencies = {
               size: overloadSignatureGroupMember
-                ? rangeToDiff(overloadSignatureGroupMember.range)
-                : rangeToDiff(member.range),
+                ? rangeToDiff(overloadSignatureGroupMember, sourceCode)
+                : rangeToDiff(member, sourceCode),
               group: getGroup(),
               node: member,
               dependencies,

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -410,7 +410,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             let memberValue: undefined | string
             let modifiers: Modifier[] = []
             let selectors: Selector[] = []
-            let requiresEndingSemicolon: boolean = true
+            let addSafetySemicolonWhenInline: boolean = true
             if (
               member.type === 'MethodDefinition' ||
               member.type === 'TSAbstractMethodDefinition'
@@ -426,7 +426,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               if (member.type === 'TSAbstractMethodDefinition') {
                 modifiers.push('abstract')
               } else {
-                requiresEndingSemicolon = false
+                addSafetySemicolonWhenInline = false
               }
 
               if (decorated) {
@@ -472,7 +472,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
               selectors.push('index-signature')
             } else if (member.type === 'StaticBlock') {
-              requiresEndingSemicolon = false
+              addSafetySemicolonWhenInline = false
 
               selectors.push('static-block')
 
@@ -608,7 +608,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               node: member,
               dependencies,
               name,
-              addSafetySemicolonWhenInline: requiresEndingSemicolon,
+              addSafetySemicolonWhenInline,
               dependencyName: getDependencyName(
                 name,
                 modifiers.includes('static'),

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -410,6 +410,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             let memberValue: undefined | string
             let modifiers: Modifier[] = []
             let selectors: Selector[] = []
+            let requiresEndingSemicolon: boolean = true
             if (
               member.type === 'MethodDefinition' ||
               member.type === 'TSAbstractMethodDefinition'
@@ -424,6 +425,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               }
               if (member.type === 'TSAbstractMethodDefinition') {
                 modifiers.push('abstract')
+              } else {
+                requiresEndingSemicolon = false
               }
 
               if (decorated) {
@@ -469,6 +472,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
               selectors.push('index-signature')
             } else if (member.type === 'StaticBlock') {
+              requiresEndingSemicolon = false
+
               selectors.push('static-block')
 
               dependencies = extractDependencies(member, true)
@@ -502,7 +507,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               selectors.push('accessor-property')
             } else {
               // Member is necessarily a Property
-
               // Similarly to above for methods, prioritize 'static', 'declare', 'decorated', 'abstract', 'override' and 'readonly'
               // over accessibility modifiers
               if (member.static) {
@@ -604,6 +608,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               node: member,
               dependencies,
               name,
+              requiresEndingSemicolonWhenInline: requiresEndingSemicolon,
               dependencyName: getDependencyName(
                 name,
                 modifiers.includes('static'),

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -279,7 +279,7 @@ let sortDecorators = (
       setCustomGroups(options.customGroups, name)
 
       let sortingNode: SortDecoratorsSortingNode = {
-        size: rangeToDiff(decorator.range),
+        size: rangeToDiff(decorator, sourceCode),
         node: decorator,
         group: getGroup(),
         name,

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -222,7 +222,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               name:
                 member.id.type === 'Literal'
                   ? `${member.id.value}`
-                  : `${sourceCode.text.slice(...member.id.range)}`,
+                  : `${sourceCode.getText(member.id)}`,
             }
 
             if (

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -216,7 +216,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             }
             let lastSortingNode = accumulator.at(-1)?.at(-1)
             let sortingNode: SortingNodeWithDependencies = {
-              size: rangeToDiff(member.range),
+              size: rangeToDiff(member, sourceCode),
               node: member,
               dependencies,
               name:

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -148,7 +148,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         size: rangeToDiff(node, sourceCode),
         name: node.source.value,
         node,
-        requiresEndingSemicolonWhenInline: true,
+        addSafetySemicolonWhenInline: true,
       }
       let lastNode = parts.at(-1)?.at(-1)
       if (

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -148,6 +148,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         size: rangeToDiff(node.range),
         name: node.source.value,
         node,
+        requiresEndingSemicolonWhenInline: true,
       }
       let lastNode = parts.at(-1)?.at(-1)
       if (

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -145,7 +145,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         | TSESTree.ExportAllDeclaration,
     ) => {
       let sortingNode: SortExportsSortingNode = {
-        size: rangeToDiff(node.range),
+        size: rangeToDiff(node, sourceCode),
         name: node.source.value,
         node,
         requiresEndingSemicolonWhenInline: true,

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -176,7 +176,7 @@ const sortHeritageClauses = (
     setCustomGroups(options.customGroups, name)
 
     return {
-      size: rangeToDiff(heritageClause.range),
+      size: rangeToDiff(heritageClause, sourceCode),
       node: heritageClause,
       group: getGroup(),
       name,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -516,7 +516,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         size: rangeToDiff(node, sourceCode),
         group: getGroup(),
         node,
-        requiresEndingSemicolonWhenInline: true,
+        addSafetySemicolonWhenInline: true,
         isIgnored:
           !options.sortSideEffects &&
           isSideEffect &&

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -368,7 +368,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         if (node.moduleReference.type === 'TSExternalModuleReference') {
           name = `${node.moduleReference.expression.value}`
         } else {
-          name = sourceCode.text.slice(...node.moduleReference.range)
+          name = sourceCode.getText(node.moduleReference)
         }
       } else {
         let decl = node.declarations[0].init as TSESTree.CallExpression

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -513,7 +513,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       }
 
       nodes.push({
-        size: rangeToDiff(node.range),
+        size: rangeToDiff(node, sourceCode),
         group: getGroup(),
         node,
         requiresEndingSemicolonWhenInline: true,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -516,6 +516,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         size: rangeToDiff(node.range),
         group: getGroup(),
         node,
+        requiresEndingSemicolonWhenInline: true,
         isIgnored:
           !options.sortSideEffects &&
           isSideEffect &&

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -281,7 +281,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 node: element,
                 group: getGroup(),
                 name,
-                requiresEndingSemicolonWhenInline: true,
+                addSafetySemicolonWhenInline: true,
               }
 
               if (

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -281,6 +281,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 node: element,
                 group: getGroup(),
                 name,
+                requiresEndingSemicolonWhenInline: true,
               }
 
               if (

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -277,7 +277,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               }
 
               let elementSortingNode: SortingNode = {
-                size: rangeToDiff(element.range),
+                size: rangeToDiff(element, sourceCode),
                 node: element,
                 group: getGroup(),
                 name,

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -271,7 +271,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let lastSortingNode = accumulator.at(-1)?.at(-1)
           let sortingNode: SortingNode = {
             name: sourceCode.text.slice(...type.range),
-            size: rangeToDiff(type.range),
+            size: rangeToDiff(type, sourceCode),
             group: getGroup(),
             node: type,
           }

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -270,7 +270,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
           let lastSortingNode = accumulator.at(-1)?.at(-1)
           let sortingNode: SortingNode = {
-            name: sourceCode.text.slice(...type.range),
+            name: sourceCode.getText(type),
             size: rangeToDiff(type, sourceCode),
             group: getGroup(),
             node: type,

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -202,10 +202,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               }
 
               let jsxNode = {
-                size: rangeToDiff(attribute.range),
+                size: rangeToDiff(attribute, sourceCode),
                 group: getGroup(),
                 node: attribute,
                 name,
+                requiresEndingSemicolonOrCommaWhenInline: true,
               }
 
               accumulator.at(-1)!.push(jsxNode)

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -166,7 +166,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
         let shouldIgnore = false
         if (options.ignorePattern.length) {
-          let tagName = sourceCode.text.slice(...node.openingElement.name.range)
+          let tagName = sourceCode.getText(node.openingElement.name)
           shouldIgnore = options.ignorePattern.some(pattern =>
             matches(tagName, pattern, options.matcher),
           )

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -167,10 +167,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 } else if (left.type === 'Literal') {
                   name = left.raw
                 } else {
-                  name = sourceCode.text.slice(...left.range)
+                  name = sourceCode.getText(left)
                 }
               } else {
-                name = sourceCode.text.slice(...element.range)
+                name = sourceCode.getText(element)
               }
 
               let lastSortingNode = formattedMembers.at(-1)?.at(-1)

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -175,7 +175,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
               let lastSortingNode = formattedMembers.at(-1)?.at(-1)
               let sortingNode: SortingNode = {
-                size: rangeToDiff(element.range),
+                size: rangeToDiff(element, sourceCode),
                 node: element,
                 name,
               }

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -156,7 +156,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
           let lastSortingNode = formattedMembers.at(-1)?.at(-1)
           let sortingNode: SortingNode = {
-            size: rangeToDiff(specifier.range),
+            size: rangeToDiff(specifier, sourceCode),
             node: specifier,
             group,
             name,

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -171,7 +171,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
           let lastSortingNode = formattedMembers.at(-1)?.at(-1)
           let sortingNode: SortingNode = {
-            size: rangeToDiff(specifier.range),
+            size: rangeToDiff(specifier, sourceCode),
             node: specifier,
             group,
             name,

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -217,10 +217,6 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           node.members.reduce(
             (accumulator: SortObjectTypesSortingNode[][], member) => {
               let name: string
-              let raw = sourceCode.text.slice(
-                member.range.at(0),
-                member.range.at(1),
-              )
               let lastSortingNode = accumulator.at(-1)?.at(-1)
 
               let { getGroup, defineGroup, setCustomGroups } =
@@ -268,11 +264,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 defineGroup('multiline')
               }
 
-              let endsWithComma = raw.endsWith(';') || raw.endsWith(',')
-              let endSize = endsWithComma ? 1 : 0
-
               let sortingNode: SortObjectTypesSortingNode = {
-                size: rangeToDiff(member.range) - endSize,
+                size: rangeToDiff(member, sourceCode),
                 group: getGroup(),
                 node: member,
                 name,

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -269,7 +269,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 group: getGroup(),
                 node: member,
                 name,
-                requiresEndingSemicolonWhenInline: true,
+                addSafetySemicolonWhenInline: true,
               }
 
               if (

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -276,6 +276,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 group: getGroup(),
                 node: member,
                 name,
+                requiresEndingSemicolonWhenInline: true,
               }
 
               if (

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -416,7 +416,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               } else if (prop.key.type === 'Literal') {
                 name = `${prop.key.value}`
               } else {
-                name = sourceCode.text.slice(...prop.key.range)
+                name = sourceCode.getText(prop.key)
               }
 
               if (prop.value.type === 'AssignmentPattern') {

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -437,7 +437,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               }
 
               let propSortingNode: SortingNodeWithDependencies = {
-                size: rangeToDiff(prop.range),
+                size: rangeToDiff(prop, sourceCode),
                 node: prop,
                 group: getGroup(),
                 dependencies,

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -119,7 +119,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               name = 'default'
               isDefaultClause = true
             } else {
-              name = sourceCode.text.slice(...caseNode.test.range)
+              name = sourceCode.getText(caseNode.test)
             }
 
             return {

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -126,7 +126,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               size: rangeToDiff(caseNode.test ?? caseNode, sourceCode),
               node: caseNode,
               isDefaultClause,
-              requiresEndingSemicolonWhenInline: true,
+              addSafetySemicolonWhenInline: true,
               name,
             }
           },

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -123,7 +123,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             }
 
             return {
-              size: rangeToDiff(caseNode.test?.range ?? caseNode.range),
+              size: rangeToDiff(caseNode.test ?? caseNode, sourceCode),
               node: caseNode,
               isDefaultClause,
               requiresEndingSemicolonWhenInline: true,

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -126,6 +126,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               size: rangeToDiff(caseNode.test?.range ?? caseNode.range),
               node: caseNode,
               isDefaultClause,
+              requiresEndingSemicolonWhenInline: true,
               name,
             }
           },

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -271,7 +271,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let lastSortingNode = accumulator.at(-1)?.at(-1)
           let sortingNode: SortingNode = {
             name: sourceCode.text.slice(...type.range),
-            size: rangeToDiff(type.range),
+            size: rangeToDiff(type, sourceCode),
             group: getGroup(),
             node: type,
           }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -270,7 +270,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
           let lastSortingNode = accumulator.at(-1)?.at(-1)
           let sortingNode: SortingNode = {
-            name: sourceCode.text.slice(...type.range),
+            name: sourceCode.getText(type),
             size: rangeToDiff(type, sourceCode),
             group: getGroup(),
             node: type,

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -240,7 +240,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
             let lastSortingNode = accumulator.at(-1)?.at(-1)
             let sortingNode: SortingNodeWithDependencies = {
-              size: rangeToDiff(declaration.range),
+              size: rangeToDiff(declaration, sourceCode),
               node: declaration,
               dependencies,
               name,

--- a/test/sort-array-includes.test.ts
+++ b/test/sort-array-includes.test.ts
@@ -689,6 +689,60 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              [
+                b, a
+              ].includes(value)
+            `,
+            output: dedent`
+              [
+                a, b
+              ].includes(value)
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedArrayIncludesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              [
+                b, a,
+              ].includes(value)
+            `,
+            output: dedent`
+              [
+                a, b,
+              ].includes(value)
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedArrayIncludesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -4063,6 +4063,340 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    describe(`${ruleName}(${type}): sorts inline elements correctly`, () => {
+      describe(`${ruleName}(${type}): methods`, () => {
+        describe(`${ruleName}(${type}): non-abstract methods`, () => {
+          ruleTester.run(
+            `${ruleName}(${type}): sorts inline non-abstract methods correctly`,
+            rule,
+            {
+              valid: [],
+              invalid: [
+                {
+                  code: dedent`
+                  class Class {
+                    b(){} a(){}
+                  }
+                `,
+                  output: dedent`
+                  class Class {
+                    a(){} b(){}
+                  }
+                `,
+                  options: [options],
+                  errors: [
+                    {
+                      messageId: 'unexpectedClassesOrder',
+                      data: {
+                        left: 'b',
+                        right: 'a',
+                      },
+                    },
+                  ],
+                },
+                {
+                  code: dedent`
+                  class Class {
+                    b(){} a(){};
+                  }
+                `,
+                  output: dedent`
+                  class Class {
+                    a(){} b(){};
+                  }
+                `,
+                  options: [options],
+                  errors: [
+                    {
+                      messageId: 'unexpectedClassesOrder',
+                      data: {
+                        left: 'b',
+                        right: 'a',
+                      },
+                    },
+                  ],
+                },
+                {
+                  code: dedent`
+                  class Class {
+                    b(){}; a(){}
+                  }
+                `,
+                  output: dedent`
+                  class Class {
+                    a(){}; b(){}
+                  }
+                `,
+                  options: [options],
+                  errors: [
+                    {
+                      messageId: 'unexpectedClassesOrder',
+                      data: {
+                        left: 'b',
+                        right: 'a',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          )
+        })
+
+        describe(`${ruleName}(${type}): abstract methods`, () => {
+          ruleTester.run(
+            `${ruleName}(${type}): sorts inline abstract methods correctly`,
+            rule,
+            {
+              valid: [],
+              invalid: [
+                {
+                  code: dedent`
+                  abstract class Class {
+                    abstract b(); abstract a()
+                  }
+                `,
+                  output: dedent`
+                  abstract class Class {
+                    abstract a(); abstract b();
+                  }
+                `,
+                  options: [options],
+                  errors: [
+                    {
+                      messageId: 'unexpectedClassesOrder',
+                      data: {
+                        left: 'b',
+                        right: 'a',
+                      },
+                    },
+                  ],
+                },
+                {
+                  code: dedent`
+                  abstract class Class {
+                    abstract b(); abstract a();
+                  }
+                `,
+                  output: dedent`
+                  abstract class Class {
+                    abstract a(); abstract b();
+                  }
+                `,
+                  options: [options],
+                  errors: [
+                    {
+                      messageId: 'unexpectedClassesOrder',
+                      data: {
+                        left: 'b',
+                        right: 'a',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          )
+        })
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): sorts inline properties correctly`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                  class Class {
+                    b; a
+                  }
+                `,
+              output: dedent`
+                  class Class {
+                    a; b;
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+            {
+              code: dedent`
+                  class Class {
+                    b; a;
+                  }
+                `,
+              output: dedent`
+                  class Class {
+                    a; b;
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): sorts inline accessors correctly`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                  class Class {
+                    accessor b; accessor a
+                  }
+                `,
+              output: dedent`
+                  class Class {
+                    accessor a; accessor b;
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+            {
+              code: dedent`
+                  class Class {
+                    accessor b; accessor a;
+                  }
+                `,
+              output: dedent`
+                  class Class {
+                    accessor a; accessor b;
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): sorts inline index-signatures correctly`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                  class Class {
+                    [key: string]: string; [key: number]: string
+                  }
+                `,
+              output: dedent`
+                  class Class {
+                    [key: number]: string; [key: string]: string;
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: '[key: string]',
+                    right: '[key: number]',
+                  },
+                },
+              ],
+            },
+            {
+              code: dedent`
+                  class Class {
+                    [key: string]: string; [key: number]: string;
+                  }
+                `,
+              output: dedent`
+                  class Class {
+                    [key: number]: string; [key: string]: string;
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: '[key: string]',
+                    right: '[key: number]',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): sorts inline static-block correctly`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                  class Class {
+                    a; static {}
+                  }
+                `,
+              output: dedent`
+                  class Class {
+                    static {} a;
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesGroupOrder',
+                  data: {
+                    left: 'a',
+                    leftGroup: 'property',
+                    right: 'static',
+                    rightGroup: 'static-block',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -584,6 +584,60 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              enum Enum {
+                B = "B", A = "A"
+              }
+            `,
+            output: dedent`
+              enum Enum {
+                A = "A", B = "B"
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedEnumsOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              enum Enum {
+                B = "B", A = "A",
+              }
+            `,
+            output: dedent`
+              enum Enum {
+                A = "A", B = "B",
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedEnumsOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-exports.test.ts
+++ b/test/sort-exports.test.ts
@@ -516,6 +516,52 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              export { b } from "b"; export { a } from "a"
+            `,
+            output: dedent`
+              export { a } from "a"; export { b } from "b";
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export { b } from "b"; export { a } from "a";
+            `,
+            output: dedent`
+              export { a } from "a"; export { b } from "b";
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedExportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-heritage-clauses.test.ts
+++ b/test/sort-heritage-clauses.test.ts
@@ -335,6 +335,60 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface Interface extends
+                B, A
+              {}
+            `,
+            output: dedent`
+              interface Interface extends
+                A, B
+              {}
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedHeritageClausesOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              class Class implements
+                B, A
+              {}
+            `,
+            output: dedent`
+              class Class implements
+                A, B
+              {}
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedHeritageClausesOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -2060,6 +2060,52 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              import { b } from "b"; import { a } from "a"
+            `,
+            output: dedent`
+              import { a } from "a"; import { b } from "b";
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedImportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import { b } from "b"; import { a } from "a";
+            `,
+            output: dedent`
+              import { a } from "a"; import { b } from "b";
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedImportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -1178,6 +1178,82 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              interface Interface {
+                b: string, a: string
+              }
+            `,
+            output: dedent`
+              interface Interface {
+                a: string; b: string,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              interface Interface {
+                b: string, a: string;
+              }
+            `,
+            output: dedent`
+              interface Interface {
+                a: string; b: string,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              interface Interface {
+                b: string, a: string,
+              }
+            `,
+            output: dedent`
+              interface Interface {
+                a: string, b: string,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedInterfacePropertiesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-intersection-types.test.ts
+++ b/test/sort-intersection-types.test.ts
@@ -866,6 +866,56 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              type T =
+                & B & A
+            `,
+            output: dedent`
+              type T =
+                & A & B
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedIntersectionTypesOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              type T =
+                B & A
+            `,
+            output: dedent`
+              type T =
+                A & B
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedIntersectionTypesOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-named-exports.test.ts
+++ b/test/sort-named-exports.test.ts
@@ -456,6 +456,60 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              export {
+                b, a
+              }
+            `,
+            output: dedent`
+              export {
+                a, b
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              export {
+                b, a,
+              }
+            `,
+            output: dedent`
+              export {
+                a, b,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedNamedExportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-named-imports.test.ts
+++ b/test/sort-named-imports.test.ts
@@ -687,6 +687,60 @@ describe(ruleName, () => {
         },
       ],
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              import {
+                b, a
+              } from 'module'
+            `,
+            output: dedent`
+              import {
+                a, b
+              } from 'module'
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              import {
+                b, a,
+              } from 'module'
+            `,
+            output: dedent`
+              import {
+                a, b,
+              } from 'module'
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedNamedImportsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -1007,6 +1007,82 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              type Type = {
+                b: string, a: string
+              }
+            `,
+            output: dedent`
+              type Type = {
+                a: string; b: string,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedObjectTypesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              type Type = {
+                b: string, a: string;
+              }
+            `,
+            output: dedent`
+              type Type = {
+                a: string; b: string,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedObjectTypesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              type Type = {
+                b: string, a: string,
+              }
+            `,
+            output: dedent`
+              type Type = {
+                a: string, b: string,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedObjectTypesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -252,7 +252,7 @@ describe(ruleName, () => {
             func<{ b: 'b'; a: 'aa' }>(/* ... */)
           `,
           output: dedent`
-            func<{ a: 'aa'; b: 'b' }>(/* ... */)
+            func<{ a: 'aa'; b: 'b'; }>(/* ... */)
           `,
           options: [options],
           errors: [
@@ -310,17 +310,6 @@ describe(ruleName, () => {
               }
             `,
             output: [
-              dedent`
-                type Type = {
-                  b: 'bb'
-                  a: 'aaa'
-                  c: 'c'
-                  d: {
-                    f: 'f'
-                    e: 'ee'
-                  }
-                }
-              `,
               dedent`
                 type Type = {
                   b: 'bb'
@@ -1256,7 +1245,7 @@ describe(ruleName, () => {
             func<{ b: 'b'; a: 'aa' }>(/* ... */)
           `,
           output: dedent`
-            func<{ a: 'aa'; b: 'b' }>(/* ... */)
+            func<{ a: 'aa'; b: 'b'; }>(/* ... */)
           `,
           options: [options],
           errors: [
@@ -1314,17 +1303,6 @@ describe(ruleName, () => {
               }
             `,
             output: [
-              dedent`
-                type Type = {
-                  b: 'bb'
-                  a: 'aaa'
-                  c: 'c'
-                  d: {
-                    f: 'f'
-                    e: 'ee'
-                  }
-                }
-              `,
               dedent`
                 type Type = {
                   b: 'bb'
@@ -1850,7 +1828,7 @@ describe(ruleName, () => {
             func<{ b: 'b'; a: 'aa' }>(/* ... */)
           `,
           output: dedent`
-            func<{ a: 'aa'; b: 'b' }>(/* ... */)
+            func<{ a: 'aa'; b: 'b'; }>(/* ... */)
           `,
           options: [options],
           errors: [
@@ -1908,17 +1886,6 @@ describe(ruleName, () => {
               }
             `,
             output: [
-              dedent`
-                type Type = {
-                  b: 'bb'
-                  a: 'aaa'
-                  c: 'c'
-                  d: {
-                    f: 'f'
-                    e: 'ee'
-                  }
-                }
-              `,
               dedent`
                 type Type = {
                   b: 'bb'

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1775,6 +1775,60 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              let obj = {
+                b: string, a: string
+              }
+            `,
+            output: dedent`
+              let obj = {
+                a: string, b: string
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              let obj = {
+                b: string, a: string,
+              }
+            `,
+            output: dedent`
+              let obj = {
+                a: string, b: string,
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-sets.test.ts
+++ b/test/sort-sets.test.ts
@@ -640,6 +640,60 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              new Set([
+                b, a
+              ])
+            `,
+            output: dedent`
+              new Set([
+                a, b
+              ])
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSetsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              new Set([
+                b, a,
+              ])
+            `,
+            output: dedent`
+              new Set([
+                a, b,
+              ])
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSetsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -705,6 +705,104 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              switch (x) {
+                case "b": break; case "a": break
+              }
+            `,
+            output: dedent`
+              switch (x) {
+                case "a": break; case "b": break;
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              switch (x) {
+                case "b": break; case "a": break;
+              }
+            `,
+            output: dedent`
+              switch (x) {
+                case "a": break; case "b": break;
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              switch (x) {
+                case "b": { break } case "a": { break }
+              }
+            `,
+            output: dedent`
+              switch (x) {
+                case "a": { break }; case "b": { break }
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              switch (x) {
+                case "b": { break } case "a": { break };
+              }
+            `,
+            output: dedent`
+              switch (x) {
+                case "a": { break }; case "b": { break }
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -869,6 +869,56 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              type T =
+                | B | A
+            `,
+            output: dedent`
+              type T =
+                | A | B
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedUnionTypesOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              type T =
+                B | A
+            `,
+            output: dedent`
+              type T =
+                A | B
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedUnionTypesOrder',
+                data: {
+                  left: 'B',
+                  right: 'A',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -919,6 +919,56 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): sorts inline elements correctly`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              const
+                b = 'b', a = 'a'
+            `,
+            output: dedent`
+              const
+                a = 'a', b = 'b'
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedVariableDeclarationsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+          {
+            code: dedent`
+              const
+                b = 'b', a = 'a',
+            `,
+            output: dedent`
+              const
+                a = 'a', b = 'b',
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedVariableDeclarationsOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,8 +1,8 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
 export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
-  requiresEndingSemicolonWhenInline?: boolean
   hasMultipleImportDeclarations?: boolean
+  addSafetySemicolonWhenInline?: boolean
   group?: string
   name: string
   size: number

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
 export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
+  requiresEndingSemicolonWhenInline?: boolean
   hasMultipleImportDeclarations?: boolean
   group?: string
   name: string

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -17,8 +17,6 @@ export let getNodeRange = (
   let start = node.range.at(0)!
   let end = node.range.at(1)!
 
-  let raw = sourceCode.text.slice(start, end)
-
   if (ASTUtils.isParenthesized(node, sourceCode)) {
     let bodyOpeningParen = sourceCode.getTokenBefore(
       node,
@@ -34,16 +32,6 @@ export let getNodeRange = (
     end = bodyClosingParen.range.at(1)!
   }
 
-  if (raw.endsWith(';') || raw.endsWith(',')) {
-    let tokensAfter = sourceCode.getTokensAfter(node, {
-      includeComments: true,
-      count: 2,
-    })
-
-    if (node.loc.start.line === tokensAfter.at(1)?.loc.start.line) {
-      end -= 1
-    }
-  }
   let comments = getCommentsBefore(node, sourceCode)
   let partitionComment = additionalOptions?.partitionByComment ?? false
   let partitionCommentMatcher = additionalOptions?.matcher ?? 'minimatch'

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -40,7 +40,7 @@ export let makeFixes = (
       if (
         !sortedNodeText.endsWith(';') &&
         !sortedNodeText.endsWith(',') &&
-        sortedSortingNode.requiresEndingSemicolonWhenInline &&
+        sortedSortingNode.addSafetySemicolonWhenInline &&
         nextToken &&
         node.loc.start.line === nextToken.loc.start.line &&
         nextToken.value !== ';' &&

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -10,7 +10,7 @@ export let makeFixes = (
   fixer: TSESLint.RuleFixer,
   nodes: SortingNode[],
   sortedNodes: SortingNode[],
-  source: TSESLint.SourceCode,
+  sourceCode: TSESLint.SourceCode,
   additionalOptions?: {
     partitionByComment: string[] | boolean | string
     matcher: 'minimatch' | 'regex'
@@ -22,21 +22,44 @@ export let makeFixes = (
     nodes.at(0)?.node.loc.start.line === nodes.at(-1)?.node.loc.end.line
 
   for (let max = nodes.length, i = 0; i < max; i++) {
-    let { node } = nodes.at(i)!
+    let sortingNode = nodes.at(i)!
+    let sortedSortingNode = sortedNodes.at(i)!
+    let { node } = sortingNode
+    let { node: sortedNode } = sortedSortingNode
 
-    fixes.push(
-      fixer.replaceTextRange(
-        getNodeRange(node, source, additionalOptions),
-        source.text.slice(
-          ...getNodeRange(sortedNodes.at(i)!.node, source, additionalOptions),
+    if (node !== sortedNode) {
+      let sortedNodeCode = sourceCode.text.slice(
+        ...getNodeRange(sortedNode, sourceCode, additionalOptions),
+      )
+      let sortedNodeText = sourceCode.getText(sortedNode)
+      let tokensAfter = sourceCode.getTokensAfter(node, {
+        includeComments: false,
+        count: 1,
+      })
+      let nextToken = tokensAfter.at(0)
+      if (
+        !sortedNodeText.endsWith(';') &&
+        !sortedNodeText.endsWith(',') &&
+        sortedSortingNode.requiresEndingSemicolonWhenInline &&
+        nextToken &&
+        node.loc.start.line === nextToken.loc.start.line &&
+        nextToken.value !== ';' &&
+        nextToken.value !== ','
+      ) {
+        sortedNodeCode += ';'
+      }
+      fixes.push(
+        fixer.replaceTextRange(
+          getNodeRange(node, sourceCode, additionalOptions),
+          sortedNodeCode,
         ),
-      ),
-    )
+      )
+    }
 
-    let commentAfter = getCommentAfter(sortedNodes.at(i)!.node, source)
+    let commentAfter = getCommentAfter(sortedNodes.at(i)!.node, sourceCode)
 
     if (commentAfter && !isSingleline) {
-      let tokenBefore = source.getTokenBefore(commentAfter)
+      let tokenBefore = sourceCode.getTokenBefore(commentAfter)
 
       let range: TSESTree.Range = [
         tokenBefore!.range.at(1)!,
@@ -45,14 +68,14 @@ export let makeFixes = (
 
       fixes.push(fixer.replaceTextRange(range, ''))
 
-      let tokenAfterNode = source.getTokenAfter(node)
+      let tokenAfterNode = sourceCode.getTokenAfter(node)
 
       fixes.push(
         fixer.insertTextAfter(
           tokenAfterNode?.loc.end.line === node.loc.end.line
             ? tokenAfterNode
             : node,
-          source.text.slice(...range),
+          sourceCode.text.slice(...range),
         ),
       )
     }

--- a/utils/range-to-diff.ts
+++ b/utils/range-to-diff.ts
@@ -1,6 +1,13 @@
 import type { TSESTree } from '@typescript-eslint/types'
+import type { TSESLint } from '@typescript-eslint/utils'
 
-export let rangeToDiff = (range: TSESTree.Range): number => {
-  let [from, to] = range
-  return to - from
+export let rangeToDiff = (
+  node: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode,
+): number => {
+  let nodeText = sourceCode.getText(node)
+  let endsWithCommaOrSemicolon =
+    nodeText.endsWith(';') || nodeText.endsWith(',')
+  let [from, to] = node.range
+  return to - from - (endsWithCommaOrSemicolon ? 1 : 0)
 }


### PR DESCRIPTION
Fixes #336.

Very little code changes outside of tests: 
![image](https://github.com/user-attachments/assets/2ea168c6-548b-4480-bff9-d17d11a14390)


## Affected rules

- `sort-classes`
- `sort-interfaces`
- `sort-object-types`
- `sort-imports`
- `sort-exports`
- `sort-switch-case` 

## Description

Today, the way commas and semicolons are handled for a given node actually depends on multiple factors:
-  It depends on the rule.
    - A node in `sort-objects` will never include `,`, while a node in `sort-interfaces` will. This is how the AST parser works. This means that rules that natively ignore commas and semicolons are not affected (`sort-enums` for example).
    - In `sort-object-types` and `sort-interfaces`, nodes will include `;` and `,`. 
    - In `sort-object-types`, commas and semicolons are ignored for computing the length of a node with the `line-length` sorting type, but not in `sort-interfaces`. https://github.com/azat-io/eslint-plugin-perfectionist/blob/b2afcfd8c1b39d99d1a0613a6a5a0a6c15bccf8e/rules/sort-object-types.ts#L252-L260
- To determine if a given node will move with its associated semicolon/comma (if it has one), we check the token after that semicolon/comma. If it exists and is on the same line as the node, the semicolon/comma associated to the node will not move.

The last point is problematic, because it fixes a problem in very specific cases (and not the one mentioned in the issue, for example).

## Proposal

This PR does the following:
- Make the `line-length` sorting type always ignore ending semicolons and commas for all rules, similarly to what `sort-object-types` does today.
- Adds a semicolon to nodes that would **potentially** require one during inline sorting (see the logic below).

## How to know if we need to add a semicolon to a node after sorting

Let's say that a node **B** needs to take the place of a node **A** after sorting.

First, **B** should indicate whether it **requires an ending semicolon if inline with a following node**. 
In `sort-classes` for example, `properties` require an ending semicolon if inline, while `non-abstract methods` don't.

If **B** requires an ending semicolon, we should check whether if ends with a semicolon (or a comma) or not (as that semicolon will be brought with it when moving).

If **B** does not end with a semicolon/comma, check whether **A** (the place that **B** will take) has at least one inline token (other than a semicolon/comma) after it. If it does, this means that we should add a semicolon after **B** for safety. 

There are cases where this process adds a semicolon when it is not actually necessary, but this does not break compilation and doesn't affect runtime. Furthermore, this is likely to be autocorrected by another ESLint rule and is easy to implement, so that's a quick-win in my book.

Also, let's not forget that although these bugs can be very problematic (breaking compilation/runtime), they are not likely to be reproduced that often in reality due to all the conditions required for those bugs to appear, so let's keep it not too complicated!

## `sort-classes`: Types of nodes and whether they require an ending semicolon or not when inline with a following node

- Methods:
  - If abstract: ✅
  - Else: ❌
- Properties/Accessors: ✅ (including function properties!)
- TS Index signature: ✅
- Static block: ❌

## Examples

<details>

#### Example 1

❌
```ts
abstract class Class {
    myFunction(){}static{}abstract myAbstractFunction()
}
```
✅
```ts
abstract class Class {
    static{}abstract myAbstractFunction();myFunction(){}
}
```

#### Example 2

❌
```ts
abstract class Class {
    constructor(){}[key: string]: string
}
```
✅
```ts
abstract class Class {
    [key: string]: string;constructor(){}
}
```

</details>

## Consequences

- Only one test (duplicated 2 times, for a different sorting type) in `sort-object-types` had its output fixed (See commit n°2: 0e79823b77a841598416bf49df1276e1ac3bd6f5)

## Additional changes

- [Refactor] Uses `sourceCode.getText()` rather than slicing.
- Avoids making a permutation autofix when a node is already at its expected place.

## Remaining to do

Add inline tests for all rules! (even the ones not affected by #336)

- [x] `sort-array-includes`
- [x] `sort-classes`
- [x] ~~`sort-decorators`~~ No separator
- [x] `sort-enums`
- [x] `sort-exports`
- [x] `sort-heritage-clauses`
- [x] `sort-imports`
- [x] `sort-interfaces`
- [x] `sort-intersection-types`
- [x] ~~`sort-jsx-props`~~ No separator
- [x] `sort-named-exports`
- [x] `sort-named-imports`
- [x] `sort-object-types`
- [x] `sort-objects`
- [x] `sort-sets`
- [x] `sort-switch-case`
- [x] `sort-union-types`
- [x] `sort-variable-declarations`

## What is the purpose of this pull request?

- [x] Bug fix

