### PR TITLE
refactor: reduce JSON schema and options duplication

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -5,6 +5,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -67,22 +68,9 @@ export let jsonSchema: JSONSchema4 = {
       type: 'string',
     },
     partitionByComment: {
+      ...partitionByCommentJsonSchema,
       description:
         'Allows you to use comments to separate the array members into logical groups.',
-      anyOf: [
-        {
-          type: 'array',
-          items: {
-            type: 'string',
-          },
-        },
-        {
-          type: 'boolean',
-        },
-        {
-          type: 'string',
-        },
-      ],
     },
     partitionByNewLine: {
       description:

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -122,9 +122,7 @@ export let sortArray = <MessageIds extends string>(
   let settings = getSettings(context.settings)
 
   if (elements.length > 1) {
-    let options = complete(context.options.at(0), settings, {
-      ...defaultOptions,
-    })
+    let options = complete(context.options.at(0), settings, defaultOptions)
 
     let sourceCode = getSourceCode(context)
     let partitionComment = options.partitionByComment

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -35,6 +35,17 @@ export type Options = [
   }>,
 ]
 
+export const defaultOptions: Required<Options[0]> = {
+  groupKind: 'literals-first',
+  type: 'alphabetical',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  matcher: 'minimatch',
+  order: 'asc',
+  partitionByComment: false,
+  partitionByNewLine: false,
+}
+
 export let jsonSchema: JSONSchema4 = {
   type: 'object',
   properties: {
@@ -110,18 +121,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      groupKind: 'literals-first',
-      partitionByComment: false,
-      partitionByNewLine: false,
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     MemberExpression: node => {
       if (
@@ -149,15 +149,8 @@ export let sortArray = <MessageIds extends string>(
 
   if (elements.length > 1) {
     let options = complete(context.options.at(0), settings, {
-      groupKind: 'literals-first',
-      type: 'alphabetical',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      order: 'asc',
-      partitionByComment: false,
-      partitionByNewLine: false,
-    } as const)
+      ...defaultOptions,
+    })
 
     let sourceCode = getSourceCode(context)
     let partitionComment = options.partitionByComment

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -4,6 +4,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -49,32 +56,11 @@ export const defaultOptions: Required<Options[0]> = {
 export let jsonSchema: JSONSchema4 = {
   type: 'object',
   properties: {
-    type: {
-      description: 'Specifies the sorting method.',
-      type: 'string',
-      enum: ['alphabetical', 'natural', 'line-length'],
-    },
-    order: {
-      description:
-        'Determines whether the sorted items should be in ascending or descending order.',
-      type: 'string',
-      enum: ['asc', 'desc'],
-    },
-    matcher: {
-      description: 'Specifies the string matcher.',
-      type: 'string',
-      enum: ['minimatch', 'regex'],
-    },
-    ignoreCase: {
-      description: 'Controls whether sorting should be case-sensitive or not.',
-      type: 'boolean',
-    },
-    specialCharacters: {
-      description:
-        'Controls how special characters should be handled before sorting.',
-      type: 'string',
-      enum: ['remove', 'trim', 'keep'],
-    },
+    type: typeJsonSchema,
+    order: orderJsonSchema,
+    matcher: matcherJsonSchema,
+    ignoreCase: ignoreCaseJsonSchema,
+    specialCharacters: specialCharactersJsonSchema,
     groupKind: {
       description: 'Specifies top-level groups.',
       enum: ['mixed', 'literals-first', 'spreads-first'],

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -165,9 +165,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
       if (node.body.length > 1) {
         let settings = getSettings(context.settings)
 
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         validateGroupsConfiguration(options.groups, options.customGroups)
 

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -9,19 +9,20 @@ import type {
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
-  validateGroupsConfiguration,
-  getOverloadSignatureGroups,
-  generateOfficialGroups,
-  customGroupMatches,
-  getCompareOptions,
-} from './sort-classes-utils'
-import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  validateGroupsConfiguration,
+  getOverloadSignatureGroups,
+  generateOfficialGroups,
+  customGroupMatches,
+  getCompareOptions,
+} from './sort-classes-utils'
 import {
   singleCustomGroupJsonSchema,
   customGroupNameJsonSchema,
@@ -102,22 +103,9 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows to use comments to separate the class members into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           groups: {
             description: 'Specifies the order of the groups.',

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -16,6 +16,13 @@ import {
   getCompareOptions,
 } from './sort-classes-utils'
 import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
+import {
   singleCustomGroupJsonSchema,
   customGroupNameJsonSchema,
   customGroupSortJsonSchema,
@@ -89,33 +96,11 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
             description:
               'Allows to use comments to separate the class members into logical groups.',

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -13,6 +13,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -107,23 +108,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             description:
               'Allows to use comments to separate the class members into logical groups.',
           },
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'array',

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -43,30 +43,39 @@ type MESSAGE_ID =
   | 'unexpectedClassesGroupOrder'
   | 'unexpectedClassesOrder'
 
-const defaultGroups: SortClassesOptions[0]['groups'] = [
-  'index-signature',
-  ['static-property', 'static-accessor-property'],
-  ['static-get-method', 'static-set-method'],
-  ['protected-static-property', 'protected-static-accessor-property'],
-  ['protected-static-get-method', 'protected-static-set-method'],
-  ['private-static-property', 'private-static-accessor-property'],
-  ['private-static-get-method', 'private-static-set-method'],
-  'static-block',
-  ['property', 'accessor-property'],
-  ['get-method', 'set-method'],
-  ['protected-property', 'protected-accessor-property'],
-  ['protected-get-method', 'protected-set-method'],
-  ['private-property', 'private-accessor-property'],
-  ['private-get-method', 'private-set-method'],
-  'constructor',
-  ['static-method', 'static-function-property'],
-  ['protected-static-method', 'protected-static-function-property'],
-  ['private-static-method', 'private-static-function-property'],
-  ['method', 'function-property'],
-  ['protected-method', 'protected-function-property'],
-  ['private-method', 'private-function-property'],
-  'unknown',
-]
+const defaultOptions: Required<SortClassesOptions[0]> = {
+  groups: [
+    'index-signature',
+    ['static-property', 'static-accessor-property'],
+    ['static-get-method', 'static-set-method'],
+    ['protected-static-property', 'protected-static-accessor-property'],
+    ['protected-static-get-method', 'protected-static-set-method'],
+    ['private-static-property', 'private-static-accessor-property'],
+    ['private-static-get-method', 'private-static-set-method'],
+    'static-block',
+    ['property', 'accessor-property'],
+    ['get-method', 'set-method'],
+    ['protected-property', 'protected-accessor-property'],
+    ['protected-get-method', 'protected-set-method'],
+    ['private-property', 'private-accessor-property'],
+    ['private-get-method', 'private-set-method'],
+    'constructor',
+    ['static-method', 'static-function-property'],
+    ['protected-static-method', 'protected-static-function-property'],
+    ['private-static-method', 'private-static-function-property'],
+    ['method', 'function-property'],
+    ['protected-method', 'protected-function-property'],
+    ['private-method', 'private-function-property'],
+    'unknown',
+  ],
+  matcher: 'minimatch',
+  partitionByComment: false,
+  type: 'alphabetical',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  customGroups: [],
+  order: 'asc',
+}
 
 export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
   name: 'sort-classes',
@@ -192,33 +201,15 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
         'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByComment: false,
-      groups: defaultGroups,
-      customGroups: [],
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     ClassBody: node => {
       if (node.body.length > 1) {
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
-          groups: defaultGroups,
-          matcher: 'minimatch',
-          partitionByComment: false,
-          type: 'alphabetical',
-          ignoreCase: true,
-          specialCharacters: 'keep',
-          customGroups: [],
-          order: 'asc',
-        } as const)
+          ...defaultOptions,
+        })
 
         validateGroupsConfiguration(options.groups, options.customGroups)
 

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -133,9 +133,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
 
-    let options = complete(context.options.at(0), settings, {
-      ...defaultOptions,
-    })
+    let options = complete(context.options.at(0), settings, defaultOptions)
 
     validateGroupsConfiguration(
       options.groups,

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -4,6 +4,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -109,22 +110,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             type: 'boolean',
           },
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the decorators into logical groups.',
-            anyOf: [
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-            ],
           },
           groups: {
             description: 'Specifies the order of the groups.',

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -3,6 +3,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
@@ -71,33 +78,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           sortOnClasses: {
             description:
               'Controls whether sorting should be enabled for class decorators.',

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -8,6 +8,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -114,23 +115,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the decorators into logical groups.',
           },
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'object',

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -6,6 +6,7 @@ import type { SortingNode } from '../typings'
 import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
+  customGroupsJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
   groupsJsonSchema,
@@ -116,23 +117,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               'Allows you to use comments to separate the decorators into logical groups.',
           },
           groups: groupsJsonSchema,
-          customGroups: {
-            description: 'Specifies custom groups.',
-            type: 'object',
-            additionalProperties: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          customGroups: customGroupsJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -43,6 +43,22 @@ export type Options<T extends string[]> = [
 
 type SortDecoratorsSortingNode = SortingNode<TSESTree.Decorator>
 
+const defaultOptions: Required<Options<string[]>[0]> = {
+  type: 'alphabetical',
+  matcher: 'minimatch',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  partitionByComment: false,
+  customGroups: {},
+  order: 'asc',
+  groups: [],
+  sortOnClasses: true,
+  sortOnMethods: true,
+  sortOnAccessors: true,
+  sortOnProperties: true,
+  sortOnParameters: true,
+}
+
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: 'sort-decorators',
   meta: {
@@ -170,41 +186,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      partitionByComment: false,
-      matcher: 'minimatch',
-      groups: [],
-      customGroups: {},
-      sortOnClasses: true,
-      sortOnMethods: true,
-      sortOnAccessors: true,
-      sortOnProperties: true,
-      sortOnParameters: true,
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => {
     let settings = getSettings(context.settings)
 
     let options = complete(context.options.at(0), settings, {
-      type: 'alphabetical',
-      matcher: 'minimatch',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      partitionByComment: false,
-      customGroups: {},
-      order: 'asc',
-      groups: [],
-      sortOnClasses: true,
-      sortOnMethods: true,
-      sortOnAccessors: true,
-      sortOnProperties: true,
-      sortOnParameters: true,
-    } as const)
+      ...defaultOptions,
+    })
 
     validateGroupsConfiguration(
       options.groups,

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -4,6 +4,13 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 import type { CompareOptions } from '../utils/compare'
 
 import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
+import {
   getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
@@ -60,33 +67,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           sortByValue: {
             description: 'Compare enum values instead of names.',
             type: 'boolean',

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -4,6 +4,7 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 import type { CompareOptions } from '../utils/compare'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -82,22 +83,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'boolean',
           },
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the members of enums into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -116,9 +116,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       ) {
         let settings = getSettings(context.settings)
 
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -36,6 +36,18 @@ export type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  partitionByComment: false,
+  partitionByNewLine: false,
+  type: 'alphabetical',
+  matcher: 'minimatch',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  order: 'asc',
+  sortByValue: false,
+  forceNumericSort: false,
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-enums',
   meta: {
@@ -117,19 +129,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      sortByValue: false,
-      partitionByComment: false,
-      partitionByNewLine: false,
-      forceNumericSort: false,
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     TSEnumDeclaration: node => {
       let getMembers = (nodeValue: TSESTree.TSEnumDeclaration) =>
@@ -144,16 +144,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
-          partitionByComment: false,
-          partitionByNewLine: false,
-          type: 'alphabetical',
-          matcher: 'minimatch',
-          ignoreCase: true,
-          specialCharacters: 'keep',
-          order: 'asc',
-          sortByValue: false,
-          forceNumericSort: false,
-        } as const)
+          ...defaultOptions,
+        })
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -2,6 +2,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -56,33 +63,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
             description:
               'Allows you to use comments to separate the exports into logical groups.',

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -69,22 +70,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the exports into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -33,6 +33,17 @@ type SortExportsSortingNode = SortingNode<
   TSESTree.ExportNamedDeclarationWithSource | TSESTree.ExportAllDeclaration
 >
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  order: 'asc',
+  matcher: 'minimatch',
+  partitionByComment: false,
+  partitionByNewLine: false,
+  groupKind: 'mixed',
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-exports',
   meta: {
@@ -108,31 +119,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
       unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByComment: false,
-      partitionByNewLine: false,
-      groupKind: 'mixed',
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => {
     let settings = getSettings(context.settings)
 
     let options = complete(context.options.at(0), settings, {
-      type: 'alphabetical',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      order: 'asc',
-      matcher: 'minimatch',
-      partitionByComment: false,
-      partitionByNewLine: false,
-      groupKind: 'mixed',
-    } as const)
+      ...defaultOptions,
+    })
 
     let sourceCode = getSourceCode(context)
     let partitionComment = options.partitionByComment

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -96,9 +96,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
 
-    let options = complete(context.options.at(0), settings, {
-      ...defaultOptions,
-    })
+    let options = complete(context.options.at(0), settings, defaultOptions)
 
     let sourceCode = getSourceCode(context)
     let partitionComment = options.partitionByComment

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -87,9 +87,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
 
-    let options = complete(context.options.at(0), settings, {
-      ...defaultOptions,
-    })
+    let options = complete(context.options.at(0), settings, defaultOptions)
 
     validateGroupsConfiguration(
       options.groups,

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -5,6 +5,7 @@ import type { SortingNode } from '../typings'
 
 import {
   specialCharactersJsonSchema,
+  customGroupsJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
   groupsJsonSchema,
@@ -70,23 +71,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           groups: groupsJsonSchema,
-          customGroups: {
-            description: 'Specifies custom groups.',
-            type: 'object',
-            additionalProperties: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          customGroups: customGroupsJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -34,6 +34,16 @@ export type Options<T extends string[]> = [
   }>,
 ]
 
+const defaultOptions: Required<Options<string[]>[0]> = {
+  type: 'alphabetical',
+  matcher: 'minimatch',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  customGroups: {},
+  order: 'asc',
+  groups: [],
+}
+
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: 'sort-heritage-clauses',
   meta: {
@@ -118,29 +128,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      groups: [],
-      customGroups: {},
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => {
     let settings = getSettings(context.settings)
 
     let options = complete(context.options.at(0), settings, {
-      type: 'alphabetical',
-      matcher: 'minimatch',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      customGroups: {},
-      order: 'asc',
-      groups: [],
-    } as const)
+      ...defaultOptions,
+    })
 
     validateGroupsConfiguration(
       options.groups,

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -7,6 +7,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -68,23 +69,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           matcher: matcherJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'object',

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -3,6 +3,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -56,33 +63,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           groups: {
             description: 'Specifies the order of the groups.',
             type: 'array',

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -4,6 +4,13 @@ import { builtinModules } from 'node:module'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getOptionsWithCleanGroups } from '../utils/get-options-with-clean-groups'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
@@ -85,33 +92,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         id: 'sort-imports',
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           internalPattern: {
             description: 'Specifies the pattern for internal modules.',
             items: {

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -8,6 +8,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -121,23 +122,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             minimum: 0,
             exclusiveMinimum: true,
           },
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'object',

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -1,5 +1,12 @@
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -72,33 +79,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           ignorePattern: {
             description:
               'Specifies names or patterns for nodes that should be ignored by rule.',

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -5,6 +5,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -114,23 +115,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             enum: ['mixed', 'optional-first', 'required-first'],
             type: 'string',
           },
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'object',

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -45,6 +45,21 @@ export type Options<T extends string[]> = [
   }>,
 ]
 
+const defaultOptions: Required<Options<string[]>[0]> = {
+  partitionByComment: false,
+  partitionByNewLine: false,
+  type: 'alphabetical',
+  groupKind: 'mixed',
+  matcher: 'minimatch',
+  newlinesBetween: 'ignore',
+  ignorePattern: [],
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  customGroups: {},
+  order: 'asc',
+  groups: [],
+}
+
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: 'sort-interfaces',
   meta: {
@@ -175,39 +190,14 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         'Extra spacing between "{{left}}" and "{{right}}" interfaces.',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      ignorePattern: [],
-      partitionByComment: false,
-      partitionByNewLine: false,
-      groupKind: 'mixed',
-      groups: [],
-      customGroups: {},
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     TSInterfaceDeclaration: node => {
       if (node.body.body.length > 1) {
         let settings = getSettings(context.settings)
         let options = complete(context.options.at(0), settings, {
-          partitionByComment: false,
-          partitionByNewLine: false,
-          type: 'alphabetical',
-          groupKind: 'mixed',
-          matcher: 'minimatch',
-          ignorePattern: [],
-          ignoreCase: true,
-          newlinesBetween: 'ignore',
-          specialCharacters: 'keep',
-          customGroups: {},
-          order: 'asc',
-          groups: [],
-        } as const)
+          ...defaultOptions,
+        })
 
         validateGroupsConfiguration(
           options.groups,

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -1,6 +1,7 @@
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -93,22 +94,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             type: 'array',
           },
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the interface properties into logical groups.',
-            anyOf: [
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -138,9 +138,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
     TSInterfaceDeclaration: node => {
       if (node.body.body.length > 1) {
         let settings = getSettings(context.settings)
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         validateGroupsConfiguration(
           options.groups,

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -3,6 +3,7 @@ import type { SortingNode } from '../typings'
 import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
+  customGroupsJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
   groupsJsonSchema,
@@ -116,23 +117,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             type: 'string',
           },
           groups: groupsJsonSchema,
-          customGroups: {
-            description: 'Specifies custom groups.',
-            type: 'object',
-            additionalProperties: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          customGroups: customGroupsJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -54,6 +54,18 @@ type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  order: 'asc',
+  matcher: 'minimatch',
+  newlinesBetween: 'ignore',
+  partitionByComment: false,
+  partitionByNewLine: false,
+  groups: [],
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-intersection-types',
   meta: {
@@ -154,33 +166,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Extra spacing between "{{left}}" and "{{right}}" types.',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByNewLine: false,
-      partitionByComment: false,
-      groups: [],
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     TSIntersectionType: node => {
       let settings = getSettings(context.settings)
 
       let options = complete(context.options.at(0), settings, {
-        type: 'alphabetical',
-        ignoreCase: true,
-        specialCharacters: 'keep',
-        order: 'asc',
-        matcher: 'minimatch',
-        newlinesBetween: 'ignore',
-        partitionByComment: false,
-        partitionByNewLine: false,
-        groups: [],
-      } as const)
+        ...defaultOptions,
+      })
 
       validateGroupsConfiguration(
         options.groups,

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -1,5 +1,12 @@
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -78,33 +85,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           groups: {
             description: 'Specifies the order of the groups.',
             type: 'array',

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -5,6 +5,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -91,23 +92,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           matcher: matcherJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           partitionByComment: {
             ...partitionByCommentJsonSchema,
             description:

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -129,9 +129,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     TSIntersectionType: node => {
       let settings = getSettings(context.settings)
 
-      let options = complete(context.options.at(0), settings, {
-        ...defaultOptions,
-      })
+      let options = complete(context.options.at(0), settings, defaultOptions)
 
       validateGroupsConfiguration(
         options.groups,

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -1,6 +1,7 @@
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -108,22 +109,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
             },
           },
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the intersection types members into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -100,9 +100,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       if (node.openingElement.attributes.length > 1) {
         let settings = getSettings(context.settings)
 
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         validateGroupsConfiguration(
           options.groups,

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -2,6 +2,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -59,33 +66,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           ignorePattern: {
             description:
               'Specifies names or patterns for nodes that should be ignored by rule.',

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -6,6 +6,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -79,23 +80,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             },
             type: 'array',
           },
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'object',

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -4,6 +4,7 @@ import type { SortingNode } from '../typings'
 
 import {
   specialCharactersJsonSchema,
+  customGroupsJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
   groupsJsonSchema,
@@ -81,23 +82,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             type: 'array',
           },
           groups: groupsJsonSchema,
-          customGroups: {
-            description: 'Specifies custom groups.',
-            type: 'object',
-            additionalProperties: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          customGroups: customGroupsJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -36,6 +36,17 @@ type Options<T extends string[]> = [
   }>,
 ]
 
+const defaultOptions: Required<Options<string[]>[0]> = {
+  type: 'alphabetical',
+  ignorePattern: [],
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  matcher: 'minimatch',
+  customGroups: {},
+  order: 'asc',
+  groups: [],
+}
+
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: 'sort-jsx-props',
   meta: {
@@ -128,33 +139,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      ignorePattern: [],
-      groups: [],
-      customGroups: {},
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     JSXElement: node => {
       if (node.openingElement.attributes.length > 1) {
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
-          type: 'alphabetical',
-          ignorePattern: [],
-          ignoreCase: true,
-          specialCharacters: 'keep',
-          matcher: 'minimatch',
-          customGroups: {},
-          order: 'asc',
-          groups: [],
-        } as const)
+          ...defaultOptions,
+        })
 
         validateGroupsConfiguration(
           options.groups,

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -66,22 +67,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the maps members into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -99,9 +99,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
         if (elements.length > 1) {
           let settings = getSettings(context.settings)
 
-          let options = complete(context.options.at(0), settings, {
-            ...defaultOptions,
-          })
+          let options = complete(
+            context.options.at(0),
+            settings,
+            defaultOptions,
+          )
 
           let sourceCode = getSourceCode(context)
           let partitionComment = options.partitionByComment

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -2,6 +2,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -53,33 +60,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
             description:
               'Allows you to use comments to separate the maps members into logical groups.',

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -31,6 +31,16 @@ type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  order: 'asc',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  matcher: 'minimatch',
+  partitionByComment: false,
+  partitionByNewLine: false,
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-maps',
   meta: {
@@ -102,17 +112,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByComment: false,
-      partitionByNewLine: false,
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     NewExpression: node => {
       if (
@@ -127,14 +127,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let settings = getSettings(context.settings)
 
           let options = complete(context.options.at(0), settings, {
-            type: 'alphabetical',
-            ignoreCase: true,
-            specialCharacters: 'keep',
-            order: 'asc',
-            matcher: 'minimatch',
-            partitionByComment: false,
-            partitionByNewLine: false,
-          } as const)
+            ...defaultOptions,
+          })
 
           let sourceCode = getSourceCode(context)
           let partitionComment = options.partitionByComment

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -96,9 +96,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       if (node.specifiers.length > 1) {
         let settings = getSettings(context.settings)
 
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -1,6 +1,7 @@
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -71,22 +72,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'string',
           },
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the named exports members into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -30,6 +30,17 @@ type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  order: 'asc',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  matcher: 'minimatch',
+  partitionByNewLine: false,
+  partitionByComment: false,
+  groupKind: 'mixed',
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-named-exports',
   meta: {
@@ -106,33 +117,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByNewLine: false,
-      partitionByComment: false,
-      groupKind: 'mixed',
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     ExportNamedDeclaration: node => {
       if (node.specifiers.length > 1) {
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
-          type: 'alphabetical',
-          groupKind: 'mixed',
-          ignoreCase: true,
-          specialCharacters: 'keep',
-          matcher: 'minimatch',
-          partitionByNewLine: false,
-          partitionByComment: false,
-          order: 'asc',
-        } as const)
+          ...defaultOptions,
+        })
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -1,5 +1,12 @@
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -53,33 +60,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           groupKind: {
             description: 'Specifies top-level groups.',
             enum: ['mixed', 'values-first', 'types-first'],

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -1,6 +1,7 @@
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -77,22 +78,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'string',
           },
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the named imports members into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -1,5 +1,12 @@
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -55,33 +62,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           ignoreAlias: {
             description: 'Controls whether to ignore alias names.',
             type: 'boolean',

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -106,9 +106,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       if (specifiers.length > 1) {
         let settings = getSettings(context.settings)
 
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -31,6 +31,18 @@ type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  ignoreAlias: false,
+  groupKind: 'mixed',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  matcher: 'minimatch',
+  partitionByNewLine: false,
+  partitionByComment: false,
+  order: 'asc',
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-named-imports',
   meta: {
@@ -111,18 +123,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreAlias: false,
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      partitionByNewLine: false,
-      partitionByComment: false,
-      groupKind: 'mixed',
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     ImportDeclaration: node => {
       let specifiers = node.specifiers.filter(
@@ -133,16 +134,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
-          type: 'alphabetical',
-          ignoreAlias: false,
-          groupKind: 'mixed',
-          ignoreCase: true,
-          specialCharacters: 'keep',
-          matcher: 'minimatch',
-          partitionByNewLine: false,
-          partitionByComment: false,
-          order: 'asc',
-        } as const)
+          ...defaultOptions,
+        })
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -5,6 +5,7 @@ import type { SortingNode } from '../typings'
 import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
+  customGroupsJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
   groupsJsonSchema,
@@ -109,23 +110,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             enum: ['mixed', 'required-first', 'optional-first'],
           },
           groups: groupsJsonSchema,
-          customGroups: {
-            description: 'Specifies custom groups.',
-            type: 'object',
-            additionalProperties: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          customGroups: customGroupsJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -86,22 +87,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the type members into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -7,6 +7,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -107,23 +108,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             type: 'string',
             enum: ['mixed', 'required-first', 'optional-first'],
           },
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'object',

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -2,6 +2,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -73,33 +80,11 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
             description:
               'Allows you to use comments to separate the type members into logical groups.',

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -132,9 +132,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       if (node.members.length > 1) {
         let settings = getSettings(context.settings)
 
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         validateGroupsConfiguration(
           options.groups,

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -47,6 +47,20 @@ type Options<T extends string[]> = [
 
 type SortObjectTypesSortingNode = SortingNode<TSESTree.TypeElement>
 
+const defaultOptions: Required<Options<string[]>[0]> = {
+  partitionByComment: false,
+  partitionByNewLine: false,
+  type: 'alphabetical',
+  groupKind: 'mixed',
+  matcher: 'minimatch',
+  newlinesBetween: 'ignore',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  customGroups: {},
+  order: 'asc',
+  groups: [],
+}
+
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: 'sort-object-types',
   meta: {
@@ -169,39 +183,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         'Extra spacing between "{{left}}" and "{{right}}" types.',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      newlinesBetween: 'ignore',
-      partitionByComment: false,
-      partitionByNewLine: false,
-      groupKind: 'mixed',
-      groups: [],
-      customGroups: {},
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     TSTypeLiteral: node => {
       if (node.members.length > 1) {
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
-          partitionByComment: false,
-          partitionByNewLine: false,
-          type: 'alphabetical',
-          groupKind: 'mixed',
-          matcher: 'minimatch',
-          ignoreCase: true,
-          newlinesBetween: 'ignore',
-          specialCharacters: 'keep',
-          customGroups: {},
-          order: 'asc',
-          groups: [],
-        } as const)
+          ...defaultOptions,
+        })
 
         validateGroupsConfiguration(
           options.groups,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -53,6 +53,22 @@ type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  partitionByNewLine: false,
+  partitionByComment: false,
+  styledComponents: true,
+  destructureOnly: false,
+  type: 'alphabetical',
+  ignorePattern: [],
+  matcher: 'minimatch',
+  newlinesBetween: 'ignore',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  customGroups: {},
+  order: 'asc',
+  groups: [],
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-objects',
   meta: {
@@ -187,22 +203,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Extra spacing between "{{left}}" and "{{right}}" objects.',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByComment: false,
-      partitionByNewLine: false,
-      styledComponents: true,
-      destructureOnly: false,
-      ignorePattern: [],
-      groups: [],
-      customGroups: {},
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => {
     let sortObject = (
       node: TSESTree.ObjectExpression | TSESTree.ObjectPattern,
@@ -210,20 +211,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let settings = getSettings(context.settings)
 
       let options = complete(context.options.at(0), settings, {
-        partitionByNewLine: false,
-        partitionByComment: false,
-        styledComponents: true,
-        destructureOnly: false,
-        type: 'alphabetical',
-        ignorePattern: [],
-        matcher: 'minimatch',
-        ignoreCase: true,
-        newlinesBetween: 'ignore',
-        specialCharacters: 'keep',
-        customGroups: {},
-        order: 'asc',
-        groups: [],
-      } as const)
+        ...defaultOptions,
+      })
 
       validateGroupsConfiguration(
         options.groups,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -5,6 +5,7 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 import {
   partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
+  customGroupsJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
   groupsJsonSchema,
@@ -128,23 +129,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'array',
           },
           groups: groupsJsonSchema,
-          customGroups: {
-            description: 'Specifies custom groups.',
-            type: 'object',
-            additionalProperties: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          customGroups: customGroupsJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -7,6 +7,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -126,23 +127,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             },
             type: 'array',
           },
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           customGroups: {
             description: 'Specifies custom groups.',
             type: 'object',

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -153,9 +153,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     ) => {
       let settings = getSettings(context.settings)
 
-      let options = complete(context.options.at(0), settings, {
-        ...defaultOptions,
-      })
+      let options = complete(context.options.at(0), settings, defaultOptions)
 
       validateGroupsConfiguration(
         options.groups,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -94,22 +95,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the keys of objects into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -3,6 +3,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
+import {
   getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
@@ -81,33 +88,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
             description:
               'Allows you to use comments to separate the keys of objects into logical groups.',

--- a/rules/sort-sets.ts
+++ b/rules/sort-sets.ts
@@ -1,7 +1,7 @@
 import type { Options } from './sort-array-includes'
 
+import { defaultOptions, jsonSchema, sortArray } from './sort-array-includes'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { jsonSchema, sortArray } from './sort-array-includes'
 
 type MESSAGE_ID = 'unexpectedSetsOrder'
 
@@ -18,16 +18,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       unexpectedSetsOrder: 'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      groupKind: 'literals-first',
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     NewExpression: node => {
       if (

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -72,9 +72,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     SwitchStatement: node => {
       let settings = getSettings(context.settings)
 
-      let options = complete(context.options.at(0), settings, {
-        ...defaultOptions,
-      })
+      let options = complete(context.options.at(0), settings, defaultOptions)
 
       let sourceCode = getSourceCode(context)
 

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -3,6 +3,12 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -48,28 +54,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -29,6 +29,13 @@ interface SortSwitchCaseSortingNode extends SortingNode<TSESTree.SwitchCase> {
   isDefaultClause: boolean
 }
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  order: 'asc',
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-switch-case',
   meta: {
@@ -72,24 +79,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Expected "{{right}}" to come before "{{left}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     SwitchStatement: node => {
       let settings = getSettings(context.settings)
 
       let options = complete(context.options.at(0), settings, {
-        type: 'alphabetical',
-        ignoreCase: true,
-        specialCharacters: 'keep',
-        order: 'asc',
-      } as const)
+        ...defaultOptions,
+      })
 
       let sourceCode = getSourceCode(context)
 

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -1,6 +1,7 @@
 import type { SortingNode } from '../typings'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -108,22 +109,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
             },
           },
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the union types into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -54,6 +54,18 @@ type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  order: 'asc',
+  groups: [],
+  matcher: 'minimatch',
+  newlinesBetween: 'ignore',
+  partitionByNewLine: false,
+  partitionByComment: false,
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-union-types',
   meta: {
@@ -154,33 +166,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Extra spacing between "{{left}}" and "{{right}}" types.',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByNewLine: false,
-      partitionByComment: false,
-      groups: [],
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     TSUnionType: node => {
       let settings = getSettings(context.settings)
 
       let options = complete(context.options.at(0), settings, {
-        type: 'alphabetical',
-        ignoreCase: true,
-        specialCharacters: 'keep',
-        order: 'asc',
-        groups: [],
-        matcher: 'minimatch',
-        newlinesBetween: 'ignore',
-        partitionByNewLine: false,
-        partitionByComment: false,
-      } as const)
+        ...defaultOptions,
+      })
 
       validateGroupsConfiguration(
         options.groups,

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -1,5 +1,12 @@
 import type { SortingNode } from '../typings'
 
+import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -78,33 +85,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           groups: {
             description: 'Specifies the order of the groups.',
             type: 'array',

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -129,9 +129,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     TSUnionType: node => {
       let settings = getSettings(context.settings)
 
-      let options = complete(context.options.at(0), settings, {
-        ...defaultOptions,
-      })
+      let options = complete(context.options.at(0), settings, defaultOptions)
 
       validateGroupsConfiguration(
         options.groups,

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -5,6 +5,7 @@ import {
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
+  groupsJsonSchema,
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
@@ -91,23 +92,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           matcher: matcherJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
-          groups: {
-            description: 'Specifies the order of the groups.',
-            type: 'array',
-            items: {
-              oneOf: [
-                {
-                  type: 'string',
-                },
-                {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                  },
-                },
-              ],
-            },
-          },
+          groups: groupsJsonSchema,
           partitionByComment: {
             ...partitionByCommentJsonSchema,
             description:

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -35,6 +35,16 @@ type Options = [
   }>,
 ]
 
+const defaultOptions: Required<Options[0]> = {
+  type: 'alphabetical',
+  ignoreCase: true,
+  specialCharacters: 'keep',
+  partitionByNewLine: false,
+  matcher: 'minimatch',
+  partitionByComment: false,
+  order: 'asc',
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   name: 'sort-variable-declarations',
   meta: {
@@ -108,31 +118,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
         'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
     },
   },
-  defaultOptions: [
-    {
-      type: 'alphabetical',
-      order: 'asc',
-      ignoreCase: true,
-      specialCharacters: 'keep',
-      matcher: 'minimatch',
-      partitionByComment: false,
-      partitionByNewLine: false,
-    },
-  ],
+  defaultOptions: [defaultOptions],
   create: context => ({
     VariableDeclaration: node => {
       if (node.declarations.length > 1) {
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
-          type: 'alphabetical',
-          ignoreCase: true,
-          specialCharacters: 'keep',
-          partitionByNewLine: false,
-          matcher: 'minimatch',
-          partitionByComment: false,
-          order: 'asc',
-        } as const)
+          ...defaultOptions,
+        })
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -3,6 +3,13 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
+  specialCharactersJsonSchema,
+  ignoreCaseJsonSchema,
+  matcherJsonSchema,
+  orderJsonSchema,
+  typeJsonSchema,
+} from '../utils/common-json-schemas'
+import {
   getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
@@ -57,33 +64,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         type: 'object',
         properties: {
-          type: {
-            description: 'Specifies the sorting method.',
-            type: 'string',
-            enum: ['alphabetical', 'natural', 'line-length'],
-          },
-          order: {
-            description:
-              'Determines whether the sorted items should be in ascending or descending order.',
-            type: 'string',
-            enum: ['asc', 'desc'],
-          },
-          matcher: {
-            description: 'Specifies the string matcher.',
-            type: 'string',
-            enum: ['minimatch', 'regex'],
-          },
-          ignoreCase: {
-            description:
-              'Controls whether sorting should be case-sensitive or not.',
-            type: 'boolean',
-          },
-          specialCharacters: {
-            description:
-              'Controls how special characters should be handled before sorting.',
-            type: 'string',
-            enum: ['remove', 'trim', 'keep'],
-          },
+          type: typeJsonSchema,
+          order: orderJsonSchema,
+          matcher: matcherJsonSchema,
+          ignoreCase: ignoreCaseJsonSchema,
+          specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
             description:
               'Allows you to use comments to separate the variable declarations into logical groups.',

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
 import {
+  partitionByCommentJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   matcherJsonSchema,
@@ -70,22 +71,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreCase: ignoreCaseJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           partitionByComment: {
+            ...partitionByCommentJsonSchema,
             description:
               'Allows you to use comments to separate the variable declarations into logical groups.',
-            anyOf: [
-              {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'string',
-              },
-            ],
           },
           partitionByNewLine: {
             description:

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -97,9 +97,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       if (node.declarations.length > 1) {
         let settings = getSettings(context.settings)
 
-        let options = complete(context.options.at(0), settings, {
-          ...defaultOptions,
-        })
+        let options = complete(context.options.at(0), settings, defaultOptions)
 
         let sourceCode = getSourceCode(context)
         let partitionComment = options.partitionByComment

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -1,0 +1,32 @@
+import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
+
+export let typeJsonSchema: JSONSchema4 = {
+  enum: ['alphabetical', 'natural', 'line-length'],
+  description: 'Specifies the sorting method.',
+  type: 'string',
+}
+
+export let orderJsonSchema: JSONSchema4 = {
+  description:
+    'Determines whether the sorted items should be in ascending or descending order.',
+  enum: ['asc', 'desc'],
+  type: 'string',
+}
+
+export let matcherJsonSchema: JSONSchema4 = {
+  description: 'Specifies the string matcher.',
+  enum: ['minimatch', 'regex'],
+  type: 'string',
+}
+
+export let ignoreCaseJsonSchema: JSONSchema4 = {
+  description: 'Controls whether sorting should be case-sensitive or not.',
+  type: 'boolean',
+}
+
+export let specialCharactersJsonSchema: JSONSchema4 = {
+  description:
+    'Controls how special characters should be handled before sorting.',
+  enum: ['remove', 'trim', 'keep'],
+  type: 'string',
+}

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -31,6 +31,24 @@ export let specialCharactersJsonSchema: JSONSchema4 = {
   type: 'string',
 }
 
+export let groupsJsonSchema: JSONSchema4 = {
+  items: {
+    oneOf: [
+      {
+        type: 'string',
+      },
+      {
+        items: {
+          type: 'string',
+        },
+        type: 'array',
+      },
+    ],
+  },
+  description: 'Specifies the order of the groups.',
+  type: 'array',
+}
+
 export let partitionByCommentJsonSchema: JSONSchema4 = {
   anyOf: [
     {

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -49,6 +49,24 @@ export let groupsJsonSchema: JSONSchema4 = {
   type: 'array',
 }
 
+export let customGroupsJsonSchema: JSONSchema4 = {
+  additionalProperties: {
+    oneOf: [
+      {
+        type: 'string',
+      },
+      {
+        items: {
+          type: 'string',
+        },
+        type: 'array',
+      },
+    ],
+  },
+  description: 'Specifies custom groups.',
+  type: 'object',
+}
+
 export let partitionByCommentJsonSchema: JSONSchema4 = {
   anyOf: [
     {

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -30,3 +30,20 @@ export let specialCharactersJsonSchema: JSONSchema4 = {
   enum: ['remove', 'trim', 'keep'],
   type: 'string',
 }
+
+export let partitionByCommentJsonSchema: JSONSchema4 = {
+  anyOf: [
+    {
+      items: {
+        type: 'string',
+      },
+      type: 'array',
+    },
+    {
+      type: 'boolean',
+    },
+    {
+      type: 'string',
+    },
+  ],
+}

--- a/utils/complete.ts
+++ b/utils/complete.ts
@@ -4,4 +4,4 @@ export let complete = <T extends { [key: string]: unknown }>(
   options: Partial<T> = {},
   settings: Settings = {},
   defaults: T,
-): T => Object.assign(defaults, settings, options)
+): T => ({ ...defaults, ...settings, ...options })


### PR DESCRIPTION
### Description

This PR reduces code duplication in 2 ways:
- Each rule has duplicated `defaultOptions`. Creates a single constant for that per rule.
- All rules share some similar JSON schemas, for `type`, `order`, etc. Put these in common in a `utils/common-json-schemas.ts` file.

Here is the list of JSON schemas attributes put in common:
- `type`
- `order`
- `matcher`
- `ignoreCase`
- `specialCharacters`
- `groups`
- `customGroups` (Object-based API)
- `partitionByComment`

No other code logic or tests have been touched.

### Other changes

- Makes `complete` return a new object rather than using `Object.assign`.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Other
