### PR TITLE
feat(sort-switch-case): Improvements

### DIFF
--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -9,11 +9,11 @@ import {
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
+import { makeCommentAfterFixes } from '../utils/make-comment-after-fixes'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { isPositive } from '../utils/is-positive'
 import { makeFixes } from '../utils/make-fixes'
 import { sortNodes } from '../utils/sort-nodes'
 import { pairwise } from '../utils/pairwise'
@@ -69,7 +69,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
   },
   defaultOptions: [defaultOptions],
   create: context => ({
-    SwitchStatement: node => {
+    SwitchStatement: switchNode => {
       let settings = getSettings(context.settings)
 
       let options = complete(context.options.at(0), settings, defaultOptions)
@@ -77,188 +77,224 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let sourceCode = getSourceCode(context)
 
       let isDiscriminantTrue =
-        node.discriminant.type === 'Literal' && node.discriminant.value === true
-      let isCasesHasBreak = node.cases
-        .filter(caseNode => caseNode.test !== null)
-        .every(
-          caseNode =>
-            caseNode.consequent.length === 0 ||
-            caseNode.consequent.some(
-              currentConsequent =>
-                currentConsequent.type === 'BreakStatement' ||
-                currentConsequent.type === 'ReturnStatement' ||
-                currentConsequent.type === 'BlockStatement',
-            ),
-        )
+        switchNode.discriminant.type === 'Literal' &&
+        switchNode.discriminant.value === true
+      if (isDiscriminantTrue) {
+        return
+      }
 
-      if (!isDiscriminantTrue && isCasesHasBreak) {
-        let nodes = node.cases.map<SortSwitchCaseSortingNode>(
-          (caseNode: TSESTree.SwitchCase) => {
-            let name: string
-            let isDefaultClause = false
-            if (caseNode.test?.type === 'Literal') {
-              name = `${caseNode.test.value}`
-            } else if (caseNode.test === null) {
-              name = 'default'
-              isDefaultClause = true
-            } else {
-              name = sourceCode.getText(caseNode.test)
-            }
-
-            return {
-              size: rangeToDiff(caseNode.test ?? caseNode, sourceCode),
-              node: caseNode,
-              isDefaultClause,
-              addSafetySemicolonWhenInline: true,
-              name,
-            }
-          },
-        )
-
-        pairwise(nodes, (left, right, iteration) => {
-          let compareValue: boolean
-          let lefter = nodes.at(iteration - 1)
-          let isCaseGrouped =
-            lefter?.node.consequent.length === 0 &&
-            left.node.consequent.length !== 0
-
-          let isGroupContainsDefault = (group: SortSwitchCaseSortingNode[]) =>
-            group.some(currentNode => currentNode.isDefaultClause)
-
-          let leftCaseGroup = [left]
-          let rightCaseGroup = [right]
-          for (let i = iteration - 1; i >= 0; i--) {
-            if (nodes.at(i)!.node.consequent.length === 0) {
-              leftCaseGroup.unshift(nodes.at(i)!)
-            } else {
-              break
-            }
-          }
-          if (right.node.consequent.length === 0) {
-            for (let i = iteration + 1; i < nodes.length; i++) {
-              if (nodes.at(i)!.node.consequent.length === 0) {
-                rightCaseGroup.push(nodes.at(i)!)
-              } else {
-                rightCaseGroup.push(nodes.at(i)!)
-                break
-              }
-            }
-          }
-
-          if (isGroupContainsDefault(leftCaseGroup)) {
-            compareValue = true
-          } else if (isGroupContainsDefault(rightCaseGroup)) {
-            compareValue = false
-          } else if (isCaseGrouped) {
-            compareValue = isPositive(compare(leftCaseGroup[0], right, options))
-          } else {
-            compareValue = isPositive(compare(left, right, options))
-          }
-
-          if (compareValue) {
-            context.report({
-              messageId: 'unexpectedSwitchCaseOrder',
-              data: {
-                left: left.name,
-                right: right.name,
-              },
-              node: right.node,
-              fix: fixer => {
-                let additionalFixes: TSESLint.RuleFix[] = []
-                let nodeGroups = nodes.reduce<SortSwitchCaseSortingNode[][]>(
-                  (
-                    accumulator: SortSwitchCaseSortingNode[][],
-                    currentNode: SortSwitchCaseSortingNode,
-                    index,
-                  ) => {
-                    if (index === 0) {
-                      accumulator.at(-1)!.push(currentNode)
-                    } else if (
-                      accumulator.at(-1)!.at(-1)?.node.consequent.length === 0
-                    ) {
-                      accumulator.at(-1)!.push(currentNode)
-                    } else {
-                      accumulator.push([currentNode])
-                    }
-                    return accumulator
-                  },
-                  [[]],
-                )
-
-                let sortedNodeGroups = nodeGroups
-                  .map(group => {
-                    let sortedGroup = sortNodes(group, options).sort((a, b) => {
-                      if (b.isDefaultClause) {
-                        return -1
-                      }
-                      return 1
-                    })
-
-                    if (group.at(-1)!.name !== sortedGroup.at(-1)!.name) {
-                      let consequentNodeIndex = sortedGroup.findIndex(
-                        currentNode => currentNode.node.consequent.length !== 0,
-                      )
-                      let firstSortedNodeConsequent =
-                        sortedGroup.at(consequentNodeIndex)!.node.consequent
-                      let consequentStart = firstSortedNodeConsequent
-                        .at(0)
-                        ?.range.at(0)
-                      let consequentEnd = firstSortedNodeConsequent
-                        .at(-1)
-                        ?.range.at(1)
-                      let lastNode = group.at(-1)!.node
-
-                      if (consequentStart && consequentEnd && lastNode.test) {
-                        lastNode.range = [
-                          lastNode.range.at(0)!,
-                          lastNode.test.range.at(1)! + 1,
-                        ]
-                        additionalFixes.push(
-                          ...makeFixes(fixer, group, sortedGroup, sourceCode),
-                          fixer.removeRange([
-                            lastNode.range.at(1)!,
-                            consequentEnd,
-                          ]),
-                          fixer.insertTextAfter(
-                            lastNode,
-                            sourceCode.text.slice(
-                              lastNode.range.at(1),
-                              consequentEnd,
-                            ),
-                          ),
-                        )
-                      }
-                    }
-
-                    return sortedGroup
-                  })
-                  .sort((a, b) => {
-                    if (isGroupContainsDefault(a)) {
-                      return 1
-                    } else if (isGroupContainsDefault(b)) {
-                      return -1
-                    }
-                    return compare(a.at(0)!, b.at(0)!, options)
-                  })
-
-                let sortedNodes = sortedNodeGroups.flat()
-
-                for (let max = sortedNodes.length, i = 0; i < max; i++) {
-                  if (sortedNodes.at(i)!.isDefaultClause) {
-                    sortedNodes.push(sortedNodes.splice(i, 1).at(0)!)
-                  }
-                }
-
-                if (additionalFixes.length) {
-                  return additionalFixes
-                }
-
-                return makeFixes(fixer, nodes, sortedNodes, sourceCode)
-              },
+      let caseNameSortingNodeGroups = switchNode.cases.reduce(
+        (
+          accumulator: SortingNode[][],
+          caseNode: TSESTree.SwitchCase,
+          index: number,
+        ) => {
+          if (caseNode.test) {
+            accumulator.at(-1)!.push({
+              size: rangeToDiff(caseNode.test, sourceCode),
+              node: caseNode.test,
+              name: getCaseName(sourceCode, caseNode),
             })
           }
+          if (
+            caseNode.consequent.length &&
+            index !== switchNode.cases.length - 1
+          ) {
+            accumulator.push([])
+          }
+          return accumulator
+        },
+        [[]],
+      )
+
+      // For each case group, ensure the nodes are in the correct order
+      let hasUnsortedNodes = false
+      for (let caseNodesSortingNodeGroup of caseNameSortingNodeGroups) {
+        let sortedCaseNameSortingNodes = sortNodes(
+          caseNodesSortingNodeGroup,
+          options,
+        )
+        hasUnsortedNodes =
+          hasUnsortedNodes ||
+          sortedCaseNameSortingNodes.some(
+            (node, index) => node !== caseNodesSortingNodeGroup[index],
+          )
+
+        pairwise(caseNodesSortingNodeGroup, (left, right) => {
+          let indexOfLeft = sortedCaseNameSortingNodes.indexOf(left)
+          let indexOfRight = sortedCaseNameSortingNodes.indexOf(right)
+          if (indexOfLeft < indexOfRight) {
+            return
+          }
+
+          context.report({
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: {
+              left: left.name,
+              right: right.name,
+            },
+            node: right.node,
+            fix: fixer =>
+              makeFixes(
+                fixer,
+                caseNodesSortingNodeGroup,
+                sortedCaseNameSortingNodes,
+                sourceCode,
+              ),
+          })
         })
       }
+
+      let sortingNodes = switchNode.cases.map(
+        (caseNode: TSESTree.SwitchCase) => ({
+          size: caseNode.test
+            ? rangeToDiff(caseNode.test, sourceCode)
+            : 'default'.length,
+          node: caseNode,
+          isDefaultClause: !caseNode.test,
+          name: getCaseName(sourceCode, caseNode),
+          addSafetySemicolonWhenInline: true,
+        }),
+      )
+
+      // Ensure default is at the end
+      let sortingNodeGroupsForDefaultSort = reduceCaseSortingNodes(
+        sortingNodes,
+        caseNode => !!caseNode.node.consequent.length,
+      )
+      let sortingNodesGroupWithDefault = sortingNodeGroupsForDefaultSort.find(
+        caseNodeGroup => caseNodeGroup.some(node => node.isDefaultClause),
+      )
+      if (
+        sortingNodesGroupWithDefault &&
+        !sortingNodesGroupWithDefault.at(-1)!.isDefaultClause
+      ) {
+        let defaultCase = sortingNodesGroupWithDefault.find(
+          node => node.isDefaultClause,
+        )!
+        let lastCase = sortingNodesGroupWithDefault.at(-1)!
+        context.report({
+          messageId: 'unexpectedSwitchCaseOrder',
+          data: {
+            left: defaultCase.name,
+            right: lastCase.name,
+          },
+          node: defaultCase.node,
+          fix: fixer => {
+            let punctuatorAfterLastCase = sourceCode.getTokenAfter(
+              lastCase.node.test!,
+            )!
+            let lastCaseRange = [
+              lastCase.node.range[0],
+              punctuatorAfterLastCase.range[1],
+            ] as const
+            return [
+              fixer.replaceText(
+                defaultCase.node,
+                sourceCode.text.slice(...lastCaseRange),
+              ),
+              fixer.replaceTextRange(
+                lastCaseRange,
+                sourceCode.getText(defaultCase.node),
+              ),
+              ...makeCommentAfterFixes(
+                fixer,
+                defaultCase.node,
+                punctuatorAfterLastCase,
+                sourceCode,
+              ),
+              ...makeCommentAfterFixes(
+                fixer,
+                punctuatorAfterLastCase,
+                defaultCase.node,
+                sourceCode,
+              ),
+            ]
+          },
+        })
+      }
+
+      // Ensure case blocks are in the correct order
+      let sortingNodeGroupsForBlockSort = reduceCaseSortingNodes(
+        sortingNodes,
+        caseNode =>
+          caseNode.node.consequent.some(
+            currentConsequent =>
+              currentConsequent.type === 'BreakStatement' ||
+              currentConsequent.type === 'ReturnStatement' ||
+              currentConsequent.type === 'BlockStatement',
+          ),
+      )
+      let sortedSortingNodeGroupsForBlockSort = [
+        ...sortingNodeGroupsForBlockSort,
+      ]
+        .sort((a, b) => {
+          if (a.some(node => node.isDefaultClause)) {
+            return 1
+          }
+          if (b.some(node => node.isDefaultClause)) {
+            return -1
+          }
+          return compare(a.at(0)!, b.at(0)!, options)
+        })
+        .flat()
+      let sortingNodeGroupsForBlockSortFlat =
+        sortingNodeGroupsForBlockSort.flat()
+      pairwise(sortingNodeGroupsForBlockSortFlat, (left, right) => {
+        let indexOfLeft = sortedSortingNodeGroupsForBlockSort.indexOf(left)
+        let indexOfRight = sortedSortingNodeGroupsForBlockSort.indexOf(right)
+        if (indexOfLeft < indexOfRight) {
+          return
+        }
+        context.report({
+          messageId: 'unexpectedSwitchCaseOrder',
+          data: {
+            left: left.name,
+            right: right.name,
+          },
+          node: right.node,
+          fix: fixer =>
+            hasUnsortedNodes
+              ? [] // Raise errors but only sort on second iteration
+              : makeFixes(
+                  fixer,
+                  sortingNodeGroupsForBlockSortFlat,
+                  sortedSortingNodeGroupsForBlockSort,
+                  sourceCode,
+                ),
+        })
+      })
     },
   }),
 })
+
+const getCaseName = (
+  sourceCode: TSESLint.SourceCode,
+  caseNode: TSESTree.SwitchCase,
+) => {
+  if (caseNode.test?.type === 'Literal') {
+    return `${caseNode.test.value}`
+  } else if (caseNode.test === null) {
+    return 'default'
+  }
+  return sourceCode.getText(caseNode.test)
+}
+
+const reduceCaseSortingNodes = (
+  caseNodes: SortSwitchCaseSortingNode[],
+  endsBlock: (caseNode: SortSwitchCaseSortingNode) => boolean,
+): SortSwitchCaseSortingNode[][] =>
+  caseNodes.reduce(
+    (
+      accumulator: SortSwitchCaseSortingNode[][],
+      caseNode: SortSwitchCaseSortingNode,
+      index: number,
+    ) => {
+      accumulator.at(-1)!.push(caseNode)
+      if (endsBlock(caseNode) && index !== caseNodes.length - 1) {
+        accumulator.push([])
+      }
+      return accumulator
+    },
+    [[]],
+  )

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -339,22 +339,40 @@ describe(ruleName, () => {
                 return 'unknown'
             }
           `,
-          output: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'cccc':
-              case 'ee':
-              case 'f':
-                return 'tertiary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
+          output: [
+            dedent`
+              switch (value) {
+                case 'aaaaaa':
+                  return 'primary'
+                case 'cccc':
+                case 'ee':
+                case 'f':
+                  return 'tertiary'
+                case 'bbbbb':
+                case 'ddd':
+                  return 'secondary'
+                case 'x':
+                default:
+                  return 'unknown'
+              }
+            `,
+            dedent`
+              switch (value) {
+                case 'aaaaaa':
+                  return 'primary'
+                case 'bbbbb':
+                case 'ddd':
+                  return 'secondary'
+                case 'cccc':
+                case 'ee':
+                case 'f':
+                  return 'tertiary'
+                case 'x':
+                default:
+                  return 'unknown'
+              }
+            `,
+          ],
           options: [options],
           errors: [
             {
@@ -1088,22 +1106,40 @@ describe(ruleName, () => {
                 return 'unknown'
             }
           `,
-          output: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'cccc':
-              case 'ee':
-              case 'f':
-                return 'tertiary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
+          output: [
+            dedent`
+              switch (value) {
+                case 'aaaaaa':
+                  return 'primary'
+                case 'cccc':
+                case 'ee':
+                case 'f':
+                  return 'tertiary'
+                case 'bbbbb':
+                case 'ddd':
+                  return 'secondary'
+                case 'x':
+                default:
+                  return 'unknown'
+              }
+            `,
+            dedent`
+              switch (value) {
+                case 'aaaaaa':
+                  return 'primary'
+                case 'bbbbb':
+                case 'ddd':
+                  return 'secondary'
+                case 'cccc':
+                case 'ee':
+                case 'f':
+                  return 'tertiary'
+                case 'x':
+                default:
+                  return 'unknown'
+              }
+            `,
+          ],
           options: [options],
           errors: [
             {
@@ -1687,22 +1723,40 @@ describe(ruleName, () => {
                 return 'unknown'
             }
           `,
-          output: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'cccc':
-              case 'ee':
-              case 'f':
-                return 'tertiary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
+          output: [
+            dedent`
+              switch (value) {
+                case 'aaaaaa':
+                  return 'primary'
+                case 'cccc':
+                case 'ee':
+                case 'f':
+                  return 'tertiary'
+                case 'bbbbb':
+                case 'ddd':
+                  return 'secondary'
+                case 'x':
+                default:
+                  return 'unknown'
+              }
+            `,
+            dedent`
+              switch (value) {
+                case 'aaaaaa':
+                  return 'primary'
+                case 'bbbbb':
+                case 'ddd':
+                  return 'secondary'
+                case 'cccc':
+                case 'ee':
+                case 'f':
+                  return 'tertiary'
+                case 'x':
+                default:
+                  return 'unknown'
+              }
+            `,
+          ],
           options: [options],
           errors: [
             {

--- a/utils/get-comment-after.ts
+++ b/utils/get-comment-after.ts
@@ -2,12 +2,12 @@ import type { TSESLint } from '@typescript-eslint/utils'
 import type { TSESTree } from '@typescript-eslint/types'
 
 export let getCommentAfter = (
-  node: TSESTree.Node,
+  node: TSESTree.Token | TSESTree.Node,
   source: TSESLint.SourceCode,
 ): TSESTree.Comment | null => {
   let token = source.getTokenAfter(node, {
     filter: ({ value, type }) =>
-      !(type === 'Punctuator' && [',', ';'].includes(value)),
+      !(type === 'Punctuator' && [',', ';', ':'].includes(value)),
     includeComments: true,
   })
 

--- a/utils/make-comment-after-fixes.ts
+++ b/utils/make-comment-after-fixes.ts
@@ -1,0 +1,39 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { getCommentAfter } from './get-comment-after'
+
+export const makeCommentAfterFixes = (
+  fixer: TSESLint.RuleFixer,
+  node: TSESTree.Token | TSESTree.Node,
+  sortedNode: TSESTree.Token | TSESTree.Node,
+  sourceCode: TSESLint.SourceCode,
+) => {
+  let commentAfter = getCommentAfter(sortedNode, sourceCode)
+  let areNodesOnSameLine = node.loc.start.line === sortedNode.loc.end.line
+  if (!commentAfter || areNodesOnSameLine) {
+    return []
+  }
+
+  let fixes: TSESLint.RuleFix[] = []
+  let tokenBefore = sourceCode.getTokenBefore(commentAfter)
+
+  let range: TSESTree.Range = [
+    tokenBefore!.range.at(1)!,
+    commentAfter.range.at(1)!,
+  ]
+
+  fixes.push(fixer.replaceTextRange(range, ''))
+
+  let tokenAfterNode = sourceCode.getTokenAfter(node)
+  fixes.push(
+    fixer.insertTextAfter(
+      tokenAfterNode?.loc.end.line === node.loc.end.line
+        ? tokenAfterNode
+        : node,
+      sourceCode.text.slice(...range),
+    ),
+  )
+
+  return fixes
+}

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -36,14 +36,18 @@ export const makeFixes = (
       count: 1,
     })
     let nextToken = tokensAfter.at(0)
+
+    let sortedNextNodeEndsWithSafeCharacter =
+      sortedNodeText.endsWith(';') || sortedNodeText.endsWith(',')
+    let isNextTokenOnSameLineAsNode =
+      nextToken?.loc.start.line === node.loc.end.line
+    let isNextTokenSafeCharacter =
+      nextToken?.value === ';' || nextToken?.value === ','
     if (
-      !sortedNodeText.endsWith(';') &&
-      !sortedNodeText.endsWith(',') &&
       sortedSortingNode.addSafetySemicolonWhenInline &&
-      nextToken &&
-      node.loc.start.line === nextToken.loc.start.line &&
-      nextToken.value !== ';' &&
-      nextToken.value !== ','
+      isNextTokenOnSameLineAsNode &&
+      !sortedNextNodeEndsWithSafeCharacter &&
+      !isNextTokenSafeCharacter
     ) {
       sortedNodeCode += ';'
     }

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -1,12 +1,11 @@
-import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
 import type { SortingNode } from '../typings'
 
-import { getCommentAfter } from './get-comment-after'
+import { makeCommentAfterFixes } from './make-comment-after-fixes'
 import { getNodeRange } from './get-node-range'
 
-export let makeFixes = (
+export const makeFixes = (
   fixer: TSESLint.RuleFixer,
   nodes: SortingNode[],
   sortedNodes: SortingNode[],
@@ -18,67 +17,46 @@ export let makeFixes = (
 ) => {
   let fixes: TSESLint.RuleFix[] = []
 
-  let isSingleline =
-    nodes.at(0)?.node.loc.start.line === nodes.at(-1)?.node.loc.end.line
-
   for (let max = nodes.length, i = 0; i < max; i++) {
     let sortingNode = nodes.at(i)!
     let sortedSortingNode = sortedNodes.at(i)!
     let { node } = sortingNode
     let { node: sortedNode } = sortedSortingNode
 
-    if (node !== sortedNode) {
-      let sortedNodeCode = sourceCode.text.slice(
-        ...getNodeRange(sortedNode, sourceCode, additionalOptions),
-      )
-      let sortedNodeText = sourceCode.getText(sortedNode)
-      let tokensAfter = sourceCode.getTokensAfter(node, {
-        includeComments: false,
-        count: 1,
-      })
-      let nextToken = tokensAfter.at(0)
-      if (
-        !sortedNodeText.endsWith(';') &&
-        !sortedNodeText.endsWith(',') &&
-        sortedSortingNode.addSafetySemicolonWhenInline &&
-        nextToken &&
-        node.loc.start.line === nextToken.loc.start.line &&
-        nextToken.value !== ';' &&
-        nextToken.value !== ','
-      ) {
-        sortedNodeCode += ';'
-      }
-      fixes.push(
-        fixer.replaceTextRange(
-          getNodeRange(node, sourceCode, additionalOptions),
-          sortedNodeCode,
-        ),
-      )
+    if (node === sortedNode) {
+      continue
     }
 
-    let commentAfter = getCommentAfter(sortedNodes.at(i)!.node, sourceCode)
-
-    if (commentAfter && !isSingleline) {
-      let tokenBefore = sourceCode.getTokenBefore(commentAfter)
-
-      let range: TSESTree.Range = [
-        tokenBefore!.range.at(1)!,
-        commentAfter.range.at(1)!,
-      ]
-
-      fixes.push(fixer.replaceTextRange(range, ''))
-
-      let tokenAfterNode = sourceCode.getTokenAfter(node)
-
-      fixes.push(
-        fixer.insertTextAfter(
-          tokenAfterNode?.loc.end.line === node.loc.end.line
-            ? tokenAfterNode
-            : node,
-          sourceCode.text.slice(...range),
-        ),
-      )
+    let sortedNodeCode = sourceCode.text.slice(
+      ...getNodeRange(sortedNode, sourceCode, additionalOptions),
+    )
+    let sortedNodeText = sourceCode.getText(sortedNode)
+    let tokensAfter = sourceCode.getTokensAfter(node, {
+      includeComments: false,
+      count: 1,
+    })
+    let nextToken = tokensAfter.at(0)
+    if (
+      !sortedNodeText.endsWith(';') &&
+      !sortedNodeText.endsWith(',') &&
+      sortedSortingNode.addSafetySemicolonWhenInline &&
+      nextToken &&
+      node.loc.start.line === nextToken.loc.start.line &&
+      nextToken.value !== ';' &&
+      nextToken.value !== ','
+    ) {
+      sortedNodeCode += ';'
     }
+    fixes.push(
+      fixer.replaceTextRange(
+        getNodeRange(node, sourceCode, additionalOptions),
+        sortedNodeCode,
+      ),
+    )
+    fixes = [
+      ...fixes,
+      ...makeCommentAfterFixes(fixer, node, sortedNode, sourceCode),
+    ]
   }
 
   return fixes


### PR DESCRIPTION
Fixes #335.
Fixes #343.

## Description

This PR refactors and improves `sort-switch-case` to
- Use `makeFixes` and the new `makeAfterCommentFixes` as much as possible, which handles comments (for #335 and #343).
- Enable users to sort switch statements with cases that do **not** break/return.

## Sorting phases

There are **3** sorting phases. Phases **1** and **2** fixes are done in the same ESLint cycle. Phase **3** errors are shown, but fixes are done in another cycle once all phase 1 and 2 errors are fixed (this is invisible to the user).

## Phase 1: Sort `case` statements (without default) for each group

A group is a list of consecutive case statements that can safely be re-ordered within that group. 

![image](https://github.com/user-attachments/assets/4a85714b-5efc-43c1-926f-719f36d3724a)

Order them using `makeFixes` which properly handles comments.

## Phase 2: Ensure `default` is at the end of its `case` group

This is not done in Phase 1 due to the differences between `case` nodes and `default` nodes AST-parser wise. This doesn't use `makeFixes` directly, but still uses the new `makeCommentAfterFixes` (which `makeFixes` internally uses now), so comments placed after `default` clauses are still handled correctly.

## Phase 3: Sort `case` statement groups together

If a `case` group contains the `default` statement, that group must go at the bottom. Otherwise, use the first `case` statement of each group to sort them accordingly.

![Screenshot 2024-10-28 at 09 07 28](https://github.com/user-attachments/assets/9a203c69-61a8-4663-95e0-76a867c73d91)

## Affected test

- No input/output/errors changed, but for one test (duplicated 3 times), the linting happens over 2 iterations rather than one (this is invisible to the user). 

See ff39b16c5eb8f9c53169fc3d141278e6b1ee8d64.

## Changes

- Fixes issues with inline comments (#335).
- Now handles case blocks without `return`/`break`.
- Adds additional tests.

### Example

```ts
switch (value) {
  default:
  case "y":
  case "x":
      // Do something but don't break or return
  case "b":
    return;
  case "a":
    break;
}
```

Result:

```ts
switch (value) {
  case "a":
    break;
  case "x":
  case "y":
  default:
      // Do something but don't break or return
  case "b":
    return;
}
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature