### PR TITLE
feat(sort-imports): resolve aliased imports through tsconfig.json

### DIFF
--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -201,7 +201,7 @@ Specifies a maximum line length for sorting imports. When the line length exceed
 
 This option is only available when the type is set to `'line-length'`.
 
-### tsConfigRootDir
+### tsconfigRootDir
 
 <sub>default: `undefined`</sub>
 

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -201,6 +201,12 @@ Specifies a maximum line length for sorting imports. When the line length exceed
 
 This option is only available when the type is set to `'line-length'`.
 
+### tsConfigRootDir
+
+<sub>default: `undefined`</sub>
+
+Specifies the  directory of the root `tsconfig.json` file (ex: `.`). This is used for marking aliased imports as `internal` or `internal-type` in the `groups` option.
+
 ### groups
 
 <sub>

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -72,7 +72,7 @@ export type Options<T extends string[]> = [
     environment: 'node' | 'bun'
     internalPattern: string[]
     sortSideEffects: boolean
-    tsConfigRootDir?: string
+    tsconfigRootDir?: string
     maxLineLength?: number
     order: 'desc' | 'asc'
     ignoreCase: boolean
@@ -125,7 +125,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             minimum: 0,
             exclusiveMinimum: true,
           },
-          tsConfigRootDir: {
+          tsconfigRootDir: {
             description: 'Specifies the tsConfig root directory.',
             type: 'string',
           },
@@ -205,7 +205,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       sortSideEffects: false,
       newlinesBetween: 'always',
       maxLineLength: undefined,
-      tsConfigRootDir: undefined,
+      tsconfigRootDir: undefined,
       groups: [
         'type',
         ['builtin', 'external'],
@@ -278,10 +278,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       ],
     )
 
-    let compilerOptions = options.tsConfigRootDir
+    let compilerOptions = options.tsconfigRootDir
       ? readClosestTsConfigByPath({
           filePath: context.physicalFilename,
-          tsConfigRootDir: options.tsConfigRootDir,
+          tsconfigRootDir: options.tsconfigRootDir,
         })
       : null
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -278,9 +278,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       ],
     )
 
-    let compilerOptions = options.tsconfigRootDir
+    let tsConfigOutput = options.tsconfigRootDir
       ? readClosestTsConfigByPath({
           filePath: context.physicalFilename,
+          contextCwd: context.cwd,
           tsconfigRootDir: options.tsconfigRootDir,
         })
       : null
@@ -420,15 +421,16 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         if (isRelativeImport) {
           return null
         }
-        if (!compilerOptions) {
+        if (!tsConfigOutput) {
           return 'external'
         }
 
         let resolution = typescriptImport.resolveModuleName(
           value,
           context.filename,
-          compilerOptions,
+          tsConfigOutput.compilerOptions,
           typescriptImport.sys,
+          tsConfigOutput.cache,
         )
         // If the module can't be resolved, assume it is external
         if (resolution.resolvedModule?.isExternalLibraryImport === undefined) {

--- a/test/get-typescript-import.test.ts
+++ b/test/get-typescript-import.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as ts from 'typescript'
+
+import type { getTypescriptImport as testedFunction } from '../utils/get-typescript-import'
+
+const mockCreateRequire = vi.fn()
+vi.mock('node:module', _ => ({
+  createRequire: () => () => mockCreateRequire(),
+}))
+
+describe('getTypescriptImport', () => {
+  let getTypescriptImport: typeof testedFunction
+
+  beforeEach(async () => {
+    ;({ getTypescriptImport } = await import('../utils/get-typescript-import'))
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('returns null when typescript is not present', () => {
+    mockCreateRequire.mockImplementation(() => {
+      throw new Error()
+    })
+
+    let result = getTypescriptImport()
+
+    expect(result).toBeNull()
+  })
+
+  it('tries loading typescript once if typescript does not exist', () => {
+    mockCreateRequire.mockImplementation(() => {
+      throw new Error()
+    })
+
+    getTypescriptImport()
+    let result = getTypescriptImport()
+
+    expect(result).toBeNull()
+    expect(mockCreateRequire).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads typescript once if typescript exists', () => {
+    mockCreateRequire.mockReturnValue(ts)
+
+    getTypescriptImport()
+    let result = getTypescriptImport()
+
+    expect(result).toEqual(ts)
+    expect(mockCreateRequire).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/read-closest-ts-config-by-path.test.ts
+++ b/test/read-closest-ts-config-by-path.test.ts
@@ -24,6 +24,7 @@ vi.mock('node:module', _ => ({
       mockParseJsonConfigFileContent(content),
     convertCompilerOptionsFromJson: (content: object) =>
       mockConvertCompilerOptionsFromJson(content),
+    createModuleResolutionCache: () => vi.fn(),
     sys: ts.sys,
   }),
 }))
@@ -36,6 +37,7 @@ vi.mock('../utils/get-typescript-import', () => ({
 const testInput = {
   filePath: './repos/repo/packages/package/file.ts',
   tsconfigRootDir: './repos/repo',
+  contextCwd: './',
 }
 
 const tsConfigContent = {
@@ -118,7 +120,9 @@ describe('readClosestTsConfigByPath', () => {
         readClosestTsConfigByPath(testInput)
         let actual = readClosestTsConfigByPath(testInput)
 
-        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(actual?.compilerOptions).toEqual(
+          tsConfigContent.raw.config.compilerOptions,
+        )
         expect(mockExistsSync).toHaveBeenCalledTimes(1)
       })
 
@@ -134,6 +138,7 @@ describe('readClosestTsConfigByPath', () => {
         readClosestTsConfigByPath({
           filePath: './a/b/c/d.ts',
           tsconfigRootDir: './a',
+          contextCwd: './',
         })
 
         // This should call to fs.existsSync once: e
@@ -141,9 +146,12 @@ describe('readClosestTsConfigByPath', () => {
         let actual = readClosestTsConfigByPath({
           filePath: './a/b/c/e/f.ts',
           tsconfigRootDir: './a',
+          contextCwd: './',
         })
 
-        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(actual?.compilerOptions).toEqual(
+          tsConfigContent.raw.config.compilerOptions,
+        )
         expect(mockExistsSync).toHaveBeenCalledTimes(4)
       })
 
@@ -159,6 +167,7 @@ describe('readClosestTsConfigByPath', () => {
         readClosestTsConfigByPath({
           filePath: './a/b/c/d/e.ts',
           tsconfigRootDir: './a',
+          contextCwd: './',
         })
 
         // This should call to fs.existsSync 2: g, f
@@ -166,9 +175,12 @@ describe('readClosestTsConfigByPath', () => {
         let actual = readClosestTsConfigByPath({
           filePath: './a/b/f/g/h.ts',
           tsconfigRootDir: './a',
+          contextCwd: './',
         })
 
-        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(actual?.compilerOptions).toEqual(
+          tsConfigContent.raw.config.compilerOptions,
+        )
         expect(mockExistsSync).toHaveBeenCalledTimes(6)
       })
     })
@@ -182,7 +194,9 @@ describe('readClosestTsConfigByPath', () => {
 
         let actual = readClosestTsConfigByPath(testInput)
 
-        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(actual?.compilerOptions).toEqual(
+          tsConfigContent.raw.config.compilerOptions,
+        )
       })
 
       it('returns a parent tsconfig.json when matched', () => {
@@ -195,7 +209,9 @@ describe('readClosestTsConfigByPath', () => {
 
         let actual = readClosestTsConfigByPath(testInput)
 
-        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(actual?.compilerOptions).toEqual(
+          tsConfigContent.raw.config.compilerOptions,
+        )
       })
 
       it('throws when searching hits.', () => {

--- a/test/read-closest-ts-config-by-path.test.ts
+++ b/test/read-closest-ts-config-by-path.test.ts
@@ -35,7 +35,7 @@ vi.mock('../utils/get-typescript-import', () => ({
 
 const testInput = {
   filePath: './repos/repo/packages/package/file.ts',
-  tsConfigRootDir: './repos/repo',
+  tsconfigRootDir: './repos/repo',
 }
 
 const tsConfigContent = {
@@ -133,14 +133,14 @@ describe('readClosestTsConfigByPath', () => {
         // This should call to fs.existsSync three times: c, b, a
         readClosestTsConfigByPath({
           filePath: './a/b/c/d.ts',
-          tsConfigRootDir: './a',
+          tsconfigRootDir: './a',
         })
 
         // This should call to fs.existsSync once: e
         // Then it should retrieve c from cache, pointing to a
         let actual = readClosestTsConfigByPath({
           filePath: './a/b/c/e/f.ts',
-          tsConfigRootDir: './a',
+          tsconfigRootDir: './a',
         })
 
         expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
@@ -158,14 +158,14 @@ describe('readClosestTsConfigByPath', () => {
         // This should call to fs.existsSync 4 times: d, c, b, a
         readClosestTsConfigByPath({
           filePath: './a/b/c/d/e.ts',
-          tsConfigRootDir: './a',
+          tsconfigRootDir: './a',
         })
 
         // This should call to fs.existsSync 2: g, f
         // Then it should retrieve b from cache, pointing to a
         let actual = readClosestTsConfigByPath({
           filePath: './a/b/f/g/h.ts',
-          tsConfigRootDir: './a',
+          tsconfigRootDir: './a',
         })
 
         expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
@@ -210,13 +210,13 @@ describe('readClosestTsConfigByPath', () => {
         )
       })
 
-      it('throws when searching passes the tsConfigRootDir', () => {
+      it('throws when searching passes the tsconfigRootDir', () => {
         mockExistsSync.mockReturnValue(false)
         mockReadConfigFileReturnValue()
         mockParseJsonConfigFileContentReturnValue()
 
         expect(() =>
-          readClosestTsConfigByPath({ ...testInput, tsConfigRootDir: '/' }),
+          readClosestTsConfigByPath({ ...testInput, tsconfigRootDir: '/' }),
         ).toThrowErrorMatchingInlineSnapshot(
           `[Error: Couldn't find any tsconfig.json relative to './repos/repo/packages/package/file.ts' within '/'.]`,
         )

--- a/test/read-closest-ts-config-by-path.test.ts
+++ b/test/read-closest-ts-config-by-path.test.ts
@@ -1,0 +1,243 @@
+import type { Diagnostic } from 'typescript'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import path from 'node:path'
+import ts from 'typescript'
+
+import type { readClosestTsConfigByPath as testedFunction } from '../utils/read-closest-ts-config-by-path'
+
+// Heavily inspired from https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/tests/lib/getProjectConfigFiles.test.ts
+
+const mockExistsSync = vi.fn()
+vi.mock('node:fs', () => ({
+  existsSync: (filePath: string): boolean => mockExistsSync(filePath),
+}))
+
+const mockConvertCompilerOptionsFromJson = vi.fn()
+const mockReadConfigFile = vi.fn()
+const mockParseJsonConfigFileContent = vi.fn()
+vi.mock('node:module', _ => ({
+  createRequire: () => () => ({
+    readConfigFile: (filePath: string): ts.ParsedCommandLine =>
+      mockReadConfigFile(filePath),
+    parseJsonConfigFileContent: (content: object): ts.ParsedCommandLine =>
+      mockParseJsonConfigFileContent(content),
+    convertCompilerOptionsFromJson: (content: object) =>
+      mockConvertCompilerOptionsFromJson(content),
+    sys: ts.sys,
+  }),
+}))
+
+const mockGetTypescriptImport = vi.fn()
+vi.mock('../utils/get-typescript-import', () => ({
+  getTypescriptImport: () => mockGetTypescriptImport(),
+}))
+
+const testInput = {
+  filePath: './repos/repo/packages/package/file.ts',
+  tsConfigRootDir: './repos/repo',
+}
+
+const tsConfigContent = {
+  raw: {
+    config: {
+      compilerOptions: {
+        baseUrl: './packages/package',
+      },
+    },
+  },
+} as const
+
+describe('readClosestTsConfigByPath', () => {
+  let readClosestTsConfigByPath: typeof testedFunction
+
+  beforeEach(async () => {
+    ;({ readClosestTsConfigByPath } = await import(
+      '../utils/read-closest-ts-config-by-path'
+    ))
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('returns null when typescript is not present', () => {
+    mockGetTypescriptImport.mockReturnValue(null)
+
+    let expectedConfig = readClosestTsConfigByPath(testInput)
+
+    expect(expectedConfig).toBeNull()
+    expect(mockExistsSync).toHaveBeenCalledTimes(0)
+  })
+
+  describe('with typescript present', () => {
+    beforeEach(async () => {
+      let actualGetTypescriptImport = await vi.importActual(
+        '../utils/get-typescript-import',
+      )
+      mockGetTypescriptImport.mockImplementation(
+        actualGetTypescriptImport.getTypescriptImport as never,
+      )
+    })
+
+    it("throws an error if the config can't be read", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadConfigFileReturnValue({
+        error: {
+          code: 1,
+        } as Diagnostic,
+      })
+
+      expect(() =>
+        readClosestTsConfigByPath(testInput),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Error reading tsconfig file: {"code":1}]`,
+      )
+    })
+
+    it("throws an error if the compiler options can't be converted", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadConfigFileReturnValue()
+      mockParseJsonConfigFileContentReturnValue()
+      mockConvertCompilerOptionsFromJson.mockReturnValue({
+        errors: [{ code: 1 }] as Diagnostic[],
+      })
+
+      expect(() =>
+        readClosestTsConfigByPath(testInput),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Error getting compiler options: [{"code":1}]]`,
+      )
+    })
+
+    describe('when caching hits', () => {
+      it('returns a local tsconfig.json without calling existsSync a second time', () => {
+        mockExistsSync.mockReturnValue(true)
+        mockReadConfigFileReturnValue()
+        mockParseJsonConfigFileContentReturnValue()
+        mockConvertCompilerOptionsFromJsonReturnValue()
+
+        readClosestTsConfigByPath(testInput)
+        let actual = readClosestTsConfigByPath(testInput)
+
+        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(mockExistsSync).toHaveBeenCalledTimes(1)
+      })
+
+      it('returns a nearby parent tsconfig.json when it was previously cached by a different directory search', () => {
+        mockExistsSync.mockImplementation(
+          input => input === path.normalize('a/tsconfig.json'),
+        )
+        mockReadConfigFileReturnValue()
+        mockParseJsonConfigFileContentReturnValue()
+        mockConvertCompilerOptionsFromJsonReturnValue()
+
+        // This should call to fs.existsSync three times: c, b, a
+        readClosestTsConfigByPath({
+          filePath: './a/b/c/d.ts',
+          tsConfigRootDir: './a',
+        })
+
+        // This should call to fs.existsSync once: e
+        // Then it should retrieve c from cache, pointing to a
+        let actual = readClosestTsConfigByPath({
+          filePath: './a/b/c/e/f.ts',
+          tsConfigRootDir: './a',
+        })
+
+        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(mockExistsSync).toHaveBeenCalledTimes(4)
+      })
+
+      it('returns a distant parent tsconfig.json when it was previously cached by a different directory search', () => {
+        mockExistsSync.mockImplementation(
+          input => input === path.normalize('a/tsconfig.json'),
+        )
+        mockReadConfigFileReturnValue()
+        mockParseJsonConfigFileContentReturnValue()
+        mockConvertCompilerOptionsFromJsonReturnValue()
+
+        // This should call to fs.existsSync 4 times: d, c, b, a
+        readClosestTsConfigByPath({
+          filePath: './a/b/c/d/e.ts',
+          tsConfigRootDir: './a',
+        })
+
+        // This should call to fs.existsSync 2: g, f
+        // Then it should retrieve b from cache, pointing to a
+        let actual = readClosestTsConfigByPath({
+          filePath: './a/b/f/g/h.ts',
+          tsConfigRootDir: './a',
+        })
+
+        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+        expect(mockExistsSync).toHaveBeenCalledTimes(6)
+      })
+    })
+
+    describe('when caching misses', () => {
+      it('returns a local tsconfig.json when matched', () => {
+        mockExistsSync.mockReturnValue(true)
+        mockReadConfigFileReturnValue()
+        mockParseJsonConfigFileContentReturnValue()
+        mockConvertCompilerOptionsFromJsonReturnValue()
+
+        let actual = readClosestTsConfigByPath(testInput)
+
+        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+      })
+
+      it('returns a parent tsconfig.json when matched', () => {
+        mockExistsSync.mockImplementation(
+          filePath => filePath === path.normalize('repos/repo/tsconfig.json'),
+        )
+        mockReadConfigFileReturnValue()
+        mockParseJsonConfigFileContentReturnValue()
+        mockConvertCompilerOptionsFromJsonReturnValue()
+
+        let actual = readClosestTsConfigByPath(testInput)
+
+        expect(actual).toEqual(tsConfigContent.raw.config.compilerOptions)
+      })
+
+      it('throws when searching hits.', () => {
+        mockExistsSync.mockReturnValue(false)
+        mockReadConfigFileReturnValue()
+        mockParseJsonConfigFileContentReturnValue()
+
+        expect(() =>
+          readClosestTsConfigByPath(testInput),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[Error: Couldn't find any tsconfig.json relative to './repos/repo/packages/package/file.ts' within './repos/repo'.]`,
+        )
+      })
+
+      it('throws when searching passes the tsConfigRootDir', () => {
+        mockExistsSync.mockReturnValue(false)
+        mockReadConfigFileReturnValue()
+        mockParseJsonConfigFileContentReturnValue()
+
+        expect(() =>
+          readClosestTsConfigByPath({ ...testInput, tsConfigRootDir: '/' }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[Error: Couldn't find any tsconfig.json relative to './repos/repo/packages/package/file.ts' within '/'.]`,
+        )
+      })
+    })
+
+    let mockReadConfigFileReturnValue = (
+      value: ReturnType<typeof ts.readConfigFile> = {},
+    ) => {
+      mockReadConfigFile.mockReturnValue(value)
+    }
+
+    let mockParseJsonConfigFileContentReturnValue = () => {
+      mockParseJsonConfigFileContent.mockReturnValue(tsConfigContent)
+    }
+
+    let mockConvertCompilerOptionsFromJsonReturnValue = () => {
+      mockConvertCompilerOptionsFromJson.mockReturnValue({
+        options: tsConfigContent.raw.config.compilerOptions,
+        errors: [],
+      })
+    }
+  })
+})

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3,6 +3,7 @@ import type { CompilerOptions } from 'typescript'
 
 import { afterAll, describe, expect, it, vi } from 'vitest'
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createModuleResolutionCache } from 'typescript'
 import { dedent } from 'ts-dedent'
 
 import type { MESSAGE_ID, Options } from '../rules/sort-imports'
@@ -5918,12 +5919,23 @@ describe(ruleName, () => {
     })
 
     let mockReadClosestTsConfigByPathWith = (
-      returnValue: CompilerOptions | null,
+      compilerOptions: CompilerOptions | null,
     ) => {
       vi.spyOn(
         readClosestTsConfigUtils,
         'readClosestTsConfigByPath',
-      ).mockReturnValue(returnValue)
+      ).mockReturnValue(
+        !compilerOptions
+          ? null
+          : {
+              compilerOptions,
+              cache: createModuleResolutionCache(
+                '.',
+                filename => filename,
+                compilerOptions,
+              ),
+            },
+      )
     }
   })
 })

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -1,11 +1,14 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
+import type { CompilerOptions } from 'typescript'
 
+import { afterAll, describe, expect, it, vi } from 'vitest'
 import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, expect, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
 import type { MESSAGE_ID, Options } from '../rules/sort-imports'
 
+import * as readClosestTsConfigUtils from '../utils/read-closest-ts-config-by-path'
+import * as getTypescriptImportUtils from '../utils/get-typescript-import'
 import rule from '../rules/sort-imports'
 
 let ruleName = 'sort-imports'
@@ -5797,5 +5800,130 @@ describe(ruleName, () => {
         ).not.toThrow(expectedThrownError)
       })
     })
+
+    describe(`${ruleName}: handles tsconfig.json`, () => {
+      ruleTester.run(
+        `${ruleName}: marks internal imports as 'internal'`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                import { x } from 'sort-imports'
+
+                import { a } from './a';
+              `,
+              options: [
+                {
+                  tsConfigRootDir: '.',
+                  groups: ['internal', 'unknown'],
+                },
+              ],
+              before: () => {
+                mockReadClosestTsConfigByPathWith({
+                  baseUrl: './rules/',
+                })
+              },
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: marks external imports as 'external'`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                import type { ParsedCommandLine } from 'typescript'
+
+                import { a } from './a';
+              `,
+              options: [
+                {
+                  tsConfigRootDir: '.',
+                  groups: ['external', 'unknown'],
+                },
+              ],
+              before: () => {
+                mockReadClosestTsConfigByPathWith({
+                  baseUrl: '.',
+                })
+              },
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: marks non-resolved imports as 'external'`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                import { b } from 'b'
+
+                import { a } from './a';
+              `,
+              options: [
+                {
+                  tsConfigRootDir: '.',
+                  groups: ['external', 'unknown'],
+                },
+              ],
+              before: () => {
+                mockReadClosestTsConfigByPathWith({
+                  baseUrl: '.',
+                })
+              },
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: uses the fallback algorithm if typescript is not present`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                import { b } from 'b'
+
+                import { a } from './a';
+              `,
+              options: [
+                {
+                  tsConfigRootDir: '.',
+                  groups: ['external', 'unknown'],
+                },
+              ],
+              before: () => {
+                mockReadClosestTsConfigByPathWith(null)
+                vi.spyOn(
+                  getTypescriptImportUtils,
+                  'getTypescriptImport',
+                ).mockReturnValue(null)
+              },
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    let mockReadClosestTsConfigByPathWith = (
+      returnValue: CompilerOptions | null,
+    ) => {
+      vi.spyOn(
+        readClosestTsConfigUtils,
+        'readClosestTsConfigByPath',
+      ).mockReturnValue(returnValue)
+    }
   })
 })

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -5815,7 +5815,7 @@ describe(ruleName, () => {
               `,
               options: [
                 {
-                  tsConfigRootDir: '.',
+                  tsconfigRootDir: '.',
                   groups: ['internal', 'unknown'],
                 },
               ],
@@ -5843,7 +5843,7 @@ describe(ruleName, () => {
               `,
               options: [
                 {
-                  tsConfigRootDir: '.',
+                  tsconfigRootDir: '.',
                   groups: ['external', 'unknown'],
                 },
               ],
@@ -5871,7 +5871,7 @@ describe(ruleName, () => {
               `,
               options: [
                 {
-                  tsConfigRootDir: '.',
+                  tsconfigRootDir: '.',
                   groups: ['external', 'unknown'],
                 },
               ],
@@ -5899,7 +5899,7 @@ describe(ruleName, () => {
               `,
               options: [
                 {
-                  tsConfigRootDir: '.',
+                  tsconfigRootDir: '.',
                   groups: ['external', 'unknown'],
                 },
               ],

--- a/utils/get-typescript-import.ts
+++ b/utils/get-typescript-import.ts
@@ -1,0 +1,25 @@
+import type ts from 'typescript'
+
+import { createRequire } from 'node:module'
+
+let cachedImport: typeof ts | undefined
+let hasTriedLoadingTypescript = false
+
+/**
+ * Dynamically loads the typescript module if it's available and caches it.
+ */
+export const getTypescriptImport = (): typeof ts | null => {
+  if (cachedImport) {
+    return cachedImport
+  }
+  if (hasTriedLoadingTypescript) {
+    return null
+  }
+  hasTriedLoadingTypescript = true
+  try {
+    cachedImport = createRequire(import.meta.url)('typescript') as typeof ts
+  } catch (_) {
+    return null
+  }
+  return cachedImport
+}

--- a/utils/read-closest-ts-config-by-path.ts
+++ b/utils/read-closest-ts-config-by-path.ts
@@ -1,0 +1,86 @@
+import type ts from 'typescript'
+
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+
+import { getTypescriptImport } from './get-typescript-import'
+
+// Heavily inspired from https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
+
+interface InputProps {
+  tsConfigRootDir: string
+  filePath: string
+}
+
+export const directoryCacheByPath = new Map<string, string>()
+export const contentCacheByPath = new Map<string, ts.CompilerOptions>()
+
+export const readClosestTsConfigByPath = (
+  input: InputProps,
+): ts.CompilerOptions | null => {
+  let typescriptImport = getTypescriptImport()
+  if (!typescriptImport) {
+    return null
+  }
+
+  let directory = path.dirname(input.filePath)
+  let checkedDirectories = [directory]
+
+  do {
+    let tsconfigPath = path.join(directory, 'tsconfig.json')
+    let cachedDirectory = directoryCacheByPath.get(directory)
+    if (!cachedDirectory && fs.existsSync(tsconfigPath)) {
+      cachedDirectory = tsconfigPath
+    }
+
+    if (cachedDirectory) {
+      for (let dir of checkedDirectories) {
+        directoryCacheByPath.set(dir, cachedDirectory)
+      }
+      return getCompilerOptions(typescriptImport, cachedDirectory)
+    }
+
+    directory = path.dirname(directory)
+    checkedDirectories.push(directory)
+  } while (
+    directory.length > 1 &&
+    directory.length >= input.tsConfigRootDir.length
+  )
+
+  throw new Error(
+    `Couldn't find any tsconfig.json relative to '${input.filePath}' within '${input.tsConfigRootDir}'.`,
+  )
+}
+
+const getCompilerOptions = (typescriptImport: typeof ts, filePath: string) => {
+  if (contentCacheByPath.has(filePath)) {
+    return contentCacheByPath.get(filePath)!
+  }
+  let configFileRead = typescriptImport.readConfigFile(
+    filePath,
+    typescriptImport.sys.readFile,
+  )
+  if (configFileRead.error) {
+    throw new Error(
+      'Error reading tsconfig file: ' + JSON.stringify(configFileRead.error),
+    )
+  }
+  let parsedContent = typescriptImport.parseJsonConfigFileContent(
+    configFileRead,
+    typescriptImport.sys,
+    './',
+  )
+  let compilerOptionsConverted =
+    typescriptImport.convertCompilerOptionsFromJson(
+      parsedContent.raw.config.compilerOptions,
+      './',
+    )
+  if (compilerOptionsConverted.errors.length) {
+    throw new Error(
+      'Error getting compiler options: ' +
+        JSON.stringify(compilerOptionsConverted.errors),
+    )
+  }
+  contentCacheByPath.set(filePath, compilerOptionsConverted.options)
+  return compilerOptionsConverted.options
+}

--- a/utils/read-closest-ts-config-by-path.ts
+++ b/utils/read-closest-ts-config-by-path.ts
@@ -68,12 +68,12 @@ const getCompilerOptions = (typescriptImport: typeof ts, filePath: string) => {
   let parsedContent = typescriptImport.parseJsonConfigFileContent(
     configFileRead,
     typescriptImport.sys,
-    './',
+    path.dirname(filePath),
   )
   let compilerOptionsConverted =
     typescriptImport.convertCompilerOptionsFromJson(
       parsedContent.raw.config.compilerOptions,
-      './',
+      path.dirname(filePath),
     )
   if (compilerOptionsConverted.errors.length) {
     throw new Error(

--- a/utils/read-closest-ts-config-by-path.ts
+++ b/utils/read-closest-ts-config-by-path.ts
@@ -8,7 +8,7 @@ import { getTypescriptImport } from './get-typescript-import'
 // Heavily inspired from https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
 
 interface InputProps {
-  tsConfigRootDir: string
+  tsconfigRootDir: string
   filePath: string
 }
 
@@ -44,11 +44,11 @@ export const readClosestTsConfigByPath = (
     checkedDirectories.push(directory)
   } while (
     directory.length > 1 &&
-    directory.length >= input.tsConfigRootDir.length
+    directory.length >= input.tsconfigRootDir.length
   )
 
   throw new Error(
-    `Couldn't find any tsconfig.json relative to '${input.filePath}' within '${input.tsConfigRootDir}'.`,
+    `Couldn't find any tsconfig.json relative to '${input.filePath}' within '${input.tsconfigRootDir}'.`,
   )
 }
 


### PR DESCRIPTION
Resolves #317

## Description

Adds a `tsconfigRootDir?: string` option (can be changed if needed). When passed by the user, each time a file is linted, the nearest `tsconfig.json` file will be searched, read, and used to determine if an import is internal or not.

Will try to dynamically load (and cache) `typescript` so this should not impact non-typescript users.

The `tsconfig.json` search and cache algorithm was taken from https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts 🙏. 

##  Process

- Linting is run for a given file.
- Check if `tsconfigRootDir` is entered. If not, sort as usual.
- Ensures that `typescript` is present. If not, sort as usual.
- If it is, search and read the closest `tsconfig.json` file and get the compiler options.
- If no file is found, sort as usual. If an error occurs (config file is invalid, for example), throw an error.
- For each import, use the compiler options to determine if that import can be marked as `internal` or `internal-type` (for the `groups` option).

## Assigning the `internal` / `internal-type` / `external` / `external-type` group to an import

Reminder: currently, `internal` and `internal-type` are **only** assigned to groups that match the `internalPattern` option. Non-external imports are not automatically matched with the `internal` / `internal-type` group.

I have chosen to keep this, and add the following:
If an import is considered 'internal' according to the user's `tsconfig`, that import will be matched with the `internal` / `internal-type` group as if it was matching `internalPattern`.

Everything below also applies for `type` imports with `internal-type` and `external-type`.

For a given import:

- If `typescript` is not present, use the standard process: the import is `external` if it starts with `.` or `/`.
- Else: If `typescript.isExternalModuleNameRelative(import)`, do not assign `internal` nor `external` at this stage.
- If `tsconfigRootDir` is not entered or if no `tsconfig.json` file was found, assign `external`.
- Get typescript information about the import using `typescript.resolveModuleName`.
- If the resolution fails, assign `external`.
- If the resolution succeeds, assign `external` if `resolution.resolvedModule.isExternalLibraryImport === true`, otherwise `internal`.

## Performance

Tests on a ~10k files codebase, 1 `tsconfig.json`.

#### Without caching `resolveModuleName` attempts

![image](https://github.com/user-attachments/assets/a4697d55-e4d6-4bf8-844e-46c8ae31ccda)

#### With caching `resolveModuleName` attempts

![image](https://github.com/user-attachments/assets/c85a83c2-a81e-48df-a278-3aa1a0636343)

#### Without `tsconfigRootDir` option (what we have today)

(Some other rules were disabled)

![image](https://github.com/user-attachments/assets/01dc332c-2d73-4399-8a1e-72adcac38e12)

#### Bottlenecks

Tests made while caching `resolveModuleName` attempts (~950ms)

- Without searching `tsconfig.json`: ~900ms
- Without `typescript.resolveModuleName`: ~620ms

#### Conclusion

Some significant performance hit despite caching.

- Searching for the appropriate `tsconfig.json`: ~+15%
- `typescript.resolveModuleName`: ~+75%
- Reading and parsing the config: ~300ms? 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature
