### PR TITLE
fix(sort-switch-case): fixes block case statements ignoring break/return

### DIFF
--- a/docs/content/rules/sort-switch-case.mdx
+++ b/docs/content/rules/sort-switch-case.mdx
@@ -27,6 +27,10 @@ This practice contributes to a more readable and maintainable codebase, allowing
 
 By integrating this rule into your ESLint configuration, you can focus on the functionality of your code, confident that your switch statements are consistently structured and easy to manage.
 
+<Important>
+It is highly recommended to disable the [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) rule to avoid conflicts (see [this issue](https://github.com/azat-io/eslint-plugin-perfectionist/issues/348)).
+</Important>
+
 ## Try it out
 
 <CodeExample

--- a/docs/content/rules/sort-switch-case.mdx
+++ b/docs/content/rules/sort-switch-case.mdx
@@ -27,10 +27,6 @@ This practice contributes to a more readable and maintainable codebase, allowing
 
 By integrating this rule into your ESLint configuration, you can focus on the functionality of your code, confident that your switch statements are consistently structured and easy to manage.
 
-<Important>
-It is highly recommended to disable the [`no-useless-return`](https://eslint.org/docs/latest/rules/no-useless-return) rule to avoid conflicts (see [this issue](https://github.com/azat-io/eslint-plugin-perfectionist/issues/348)).
-</Important>
-
 ## Try it out
 
 <CodeExample

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -217,13 +217,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       // Ensure case blocks are in the correct order
       let sortingNodeGroupsForBlockSort = reduceCaseSortingNodes(
         sortingNodes,
-        caseNode =>
-          caseNode.node.consequent.some(
-            currentConsequent =>
-              currentConsequent.type === 'BreakStatement' ||
-              currentConsequent.type === 'ReturnStatement' ||
-              currentConsequent.type === 'BlockStatement',
-          ),
+        caseNode => caseHasBreakOrReturn(caseNode.node),
       )
       let sortedSortingNodeGroupsForBlockSort = [
         ...sortingNodeGroupsForBlockSort,
@@ -298,3 +292,18 @@ const reduceCaseSortingNodes = (
     },
     [[]],
   )
+
+const caseHasBreakOrReturn = (caseNode: TSESTree.SwitchCase) => {
+  if (caseNode.consequent.length === 0) {
+    return false
+  }
+  if (caseNode.consequent[0]?.type === 'BlockStatement') {
+    return caseNode.consequent[0].body.some(statementIsBreakOrReturn)
+  }
+  return caseNode.consequent.some(currentConsequent =>
+    statementIsBreakOrReturn(currentConsequent),
+  )
+}
+
+const statementIsBreakOrReturn = (statement: TSESTree.Statement) =>
+  statement.type === 'BreakStatement' || statement.type === 'ReturnStatement'

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -252,15 +252,19 @@ describe(ruleName, () => {
                 switch(name) {
                   case 'aaa': {
                     height = 1
+                    break
                   }
                   case 'c': {
                     height = 3
+                    break
                   }
                   case 'bb': {
                     height = 2
+                    break
                   }
                   default:
                     height = NaN
+                    break
                 }
                 return size
               }
@@ -271,15 +275,19 @@ describe(ruleName, () => {
                 switch(name) {
                   case 'aaa': {
                     height = 1
+                    break
                   }
                   case 'bb': {
                     height = 2
+                    break
                   }
                   case 'c': {
                     height = 3
+                    break
                   }
                   default:
                     height = NaN
+                    break
                 }
                 return size
               }
@@ -1143,15 +1151,19 @@ describe(ruleName, () => {
                 switch(name) {
                   case 'aaa': {
                     height = 1
+                    break
                   }
                   case 'c': {
                     height = 3
+                    break
                   }
                   case 'bb': {
                     height = 2
+                    break
                   }
                   default:
                     height = NaN
+                    break
                 }
                 return size
               }
@@ -1162,15 +1174,19 @@ describe(ruleName, () => {
                 switch(name) {
                   case 'aaa': {
                     height = 1
+                    break
                   }
                   case 'bb': {
                     height = 2
+                    break
                   }
                   case 'c': {
                     height = 3
+                    break
                   }
                   default:
                     height = NaN
+                    break
                 }
                 return size
               }
@@ -1760,15 +1776,19 @@ describe(ruleName, () => {
                 switch(name) {
                   case 'aaa': {
                     height = 1
+                    break
                   }
                   case 'c': {
                     height = 3
+                    break
                   }
                   case 'bb': {
                     height = 2
+                    break
                   }
                   default:
                     height = NaN
+                    break
                 }
                 return size
               }
@@ -1779,15 +1799,19 @@ describe(ruleName, () => {
                 switch(name) {
                   case 'aaa': {
                     height = 1
+                    break
                   }
                   case 'bb': {
                     height = 2
+                    break
                   }
                   case 'c': {
                     height = 3
+                    break
                   }
                   default:
                     height = NaN
+                    break
                 }
                 return size
               }

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -323,6 +323,109 @@ describe(ruleName, () => {
       },
     )
 
+    ruleTester.run(
+      `${ruleName}(${type}): sorts switch cases without ending statements`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              function func(name) {
+                switch(name) {
+                  case 'b':
+                    let b
+                    break
+                  case 'a':
+                }
+              }
+            `,
+            options: [options],
+          },
+          {
+            code: dedent`
+              function func(name) {
+                switch(name) {
+                  case 'b':
+                    let b
+                    break
+                  case 'a':
+                    let a
+                }
+              }
+            `,
+            options: [options],
+          },
+          {
+            code: dedent`
+              function func(name) {
+                switch(name) {
+                  case 'b':
+                    let b
+                    break
+                  default:
+                }
+              }
+            `,
+            options: [options],
+          },
+          {
+            code: dedent`
+              function func(name) {
+                switch(name) {
+                  case 'b':
+                    let b
+                    break
+                  default:
+                    let x
+                }
+              }
+            `,
+            options: [options],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              function func(name) {
+                switch(name) {
+                  case 'c':
+                    let c
+                    break
+                  case 'b':
+                    let b
+                    break
+                  case 'a':
+                }
+              }
+            `,
+            output: dedent`
+              function func(name) {
+                switch(name) {
+                  case 'b':
+                    let b
+                    break
+                  case 'c':
+                    let c
+                    break
+                  case 'a':
+                }
+              }
+            `,
+            options: [options],
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'c',
+                  right: 'b',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
     ruleTester.run(`${ruleName}(${type}): works with grouped cases`, rule, {
       valid: [
         {

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -32,6 +32,22 @@ describe(ruleName, () => {
         valid: [
           {
             code: dedent`
+              switch(x) {
+              }
+            `,
+            options: [{}],
+          },
+          {
+            code: dedent`
+              switch(x) {
+                case "a":
+                  break;
+              }
+            `,
+            options: [{}],
+          },
+          {
+            code: dedent`
               function func(name) {
                 switch(name) {
                   case 'aaa':
@@ -946,6 +962,91 @@ describe(ruleName, () => {
               messageId: 'unexpectedSwitchCaseOrder',
               data: {
                 left: 'b',
+                right: 'a',
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    ruleTester.run(`${ruleName}: handles last case without break`, rule, {
+      valid: [
+        {
+          code: dedent`
+              switch(x) {
+                case "b": {
+                  break
+                }
+                case "a": {
+                  let a
+                }
+              }
+            `,
+          options: [{}],
+        },
+        {
+          code: dedent`
+              switch(x) {
+                default: {
+                  break
+                }
+                case "a": {
+                  let a
+                }
+              }
+            `,
+          options: [{}],
+        },
+        {
+          code: dedent`
+              switch(x) {
+                case "b":
+                  break
+                case "a":
+                  let a
+              }
+            `,
+          options: [{}],
+        },
+        {
+          code: dedent`
+              switch(x) {
+                default:
+                  break;
+                case "a":
+                  let a
+              }
+            `,
+          options: [{}],
+        },
+      ],
+      invalid: [
+        {
+          code: dedent`
+            switch(x) {
+              default:
+                break;
+              case "a":
+                break;
+              case "a":
+            }
+          `,
+          output: dedent`
+            switch(x) {
+              case "a":
+                break;
+              default:
+                break;
+              case "a":
+            }
+          `,
+          options: [{}],
+          errors: [
+            {
+              messageId: 'unexpectedSwitchCaseOrder',
+              data: {
+                left: 'default',
                 right: 'a',
               },
             },


### PR DESCRIPTION
### Description

Fixes #348

Despite being wrapped in `{ }`, block case statements need `break`.

### Changes

- Fixes `break` and `return` not being considered necessary for block case statements. This means that block statements without `break/return` might still get sorted when they should not. 1 test duplicated 3 times had to be updated (commit 1: 15e07e3ef82dfe43425f1d713e7cf5370a05861b)
- Fixes an issue with the new feature, allowing sorting nodes that don't have break/return: if the **last** node has no `break/return`: the whole cases group associated must stay in place. 
- Fixes #348.

### Checklist

- [x] Update documentation for #348
- [x] Add tests 

#### Footer

- [x] Bug fix
- [x] Documentation update 
