### PR TITLE
feat(sort-classes): adds `partitionByNewLine` and `newlinesBetween` options

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -213,6 +213,39 @@ Allows you to use comments to separate the class members into logical groups. Th
 -	`false` — Comments will not be used as delimiters.
 - string — A regexp pattern to specify which comments should act as delimiters.
 
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of a class if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+class User {
+  // Group 1
+  firstName: string;
+  lastName: string;
+
+  // Group 2
+  age: number;
+  birthDate: Date;
+
+  // Group 3
+  address: {
+    street: string;
+    city: string;
+  };
+  phone?: string;
+
+  // Group 4
+  updateAddress(address: string) {}
+  updatePhone(phone?: string) {}
+
+  // Group 5
+  editFirstName(firstName: string) {}
+  editLastName(lastName: string) {}
+};
+```
+
 ### groups
 
 <sub>

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -246,6 +246,18 @@ class User {
 };
 ```
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between class member groups.
+
+- `ignore` — Do not report errors related to new lines between object type groups.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed in object types.
+
+This options is only applicable when `partitionByNewLine` is `false`.
+
 ### groups
 
 <sub>

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -10,6 +10,7 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -116,11 +117,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             description:
               'Allows to use comments to separate the class members into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: {
             description:
               'Specifies how new lines should be handled between class members groups.',

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -190,6 +190,7 @@ export type SortClassesOptions = [
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
+    partitionByNewLine: boolean
     customGroups: CustomGroup[]
     groups: (Group[] | Group)[]
     order: 'desc' | 'asc'

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -188,6 +188,7 @@ export type SortClassesOptions = [
   Partial<{
     type: 'alphabetical' | 'line-length' | 'natural'
     partitionByComment: string[] | boolean | string
+    newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -5,6 +5,7 @@ import type { CompareOptions } from '../utils/compare'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -87,11 +88,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the members of enums into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -4,6 +4,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -74,11 +75,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the exports into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
           groupKind: {
             description: 'Specifies top-level groups.',
             type: 'string',

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -2,6 +2,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
@@ -100,11 +101,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the interface properties into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: {
             description:
               'Specifies how new lines should be handled between object types groups.',

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -2,6 +2,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -98,11 +99,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the intersection types members into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: {
             description:
               'Specifies how new lines should be handled between object types groups.',

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -4,6 +4,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -71,11 +72,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the maps members into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -2,6 +2,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -76,11 +77,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the named exports members into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -2,6 +2,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -82,11 +83,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the named imports members into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
         },
         additionalProperties: false,
       },

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -4,6 +4,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
@@ -93,11 +94,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the type members into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: {
             description:
               'Specifies how new lines should be handled between object types groups.',

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -4,6 +4,7 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   customGroupsJsonSchema,
   ignoreCaseJsonSchema,
@@ -101,11 +102,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the keys of objects into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: {
             description:
               'Specifies how new lines should be handled between object types groups.',

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -2,6 +2,7 @@ import type { SortingNode } from '../typings'
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -98,11 +99,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the union types into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: {
             description:
               'Specifies how new lines should be handled between object types groups.',

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -4,6 +4,7 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 
 import {
   partitionByCommentJsonSchema,
+  partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
   ignoreCaseJsonSchema,
   localesJsonSchema,
@@ -75,11 +76,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description:
               'Allows you to use comments to separate the variable declarations into logical groups.',
           },
-          partitionByNewLine: {
-            description:
-              'Allows to use spaces to separate the nodes into logical groups.',
-            type: 'boolean',
-          },
+          partitionByNewLine: partitionByNewLineJsonSchema,
         },
         additionalProperties: false,
       },

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3836,6 +3836,47 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                class Class {
+                  b = this.a
+
+                  a
+                }
+              `,
+              output: dedent`
+                class Class {
+                  a
+
+                  b = this.a
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByNewLine: true,
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesDependencyOrder',
+                  data: {
+                    right: 'a',
+                    nodeDependentOnRight: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}): works with left and right dependencies`,
         rule,
         {
@@ -7723,6 +7764,76 @@ describe(ruleName, () => {
             invalid: [],
           },
         )
+      })
+
+      ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
+        valid: [
+          {
+            code: dedent`
+              class Class {
+                d = 'dd'
+                e = 'e'
+
+                c = 'ccc'
+
+                a = 'aaaaa'
+                b = 'bbbb'
+              }
+            `,
+            options: [
+              {
+                partitionByNewLine: true,
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              class Class {
+                e = 'e'
+                d = 'dd'
+
+                c = 'ccc'
+
+                b = 'bbbb'
+                a = 'aaaaa'
+              }
+            `,
+            output: dedent`
+              class Class {
+                d = 'dd'
+                e = 'e'
+
+                c = 'ccc'
+
+                a = 'aaaaa'
+                b = 'bbbb'
+              }
+            `,
+            options: [
+              {
+                partitionByNewLine: true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'e',
+                  right: 'd',
+                },
+              },
+              {
+                messageId: 'unexpectedClassesOrder',
+                data: {
+                  left: 'b',
+                  right: 'a',
+                },
+              },
+            ],
+          },
+        ],
       })
     })
   })

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -4129,6 +4129,131 @@ describe(ruleName, () => {
       invalid: [],
     })
 
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                class Class {
+                  a = () => null
+
+
+                 y = "y"
+                z = "z"
+
+                    b = "b"
+                }
+              `,
+              output: dedent`
+                class Class {
+                  a = () => null
+                 b = "b"
+                y = "y"
+                    z = "z"
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'never',
+                  groups: ['method', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenClassMembers',
+                  data: {
+                    left: 'a',
+                    right: 'y',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'z',
+                    right: 'b',
+                  },
+                },
+                {
+                  messageId: 'extraSpacingBetweenClassMembers',
+                  data: {
+                    left: 'z',
+                    right: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                class Class {
+                  a = () => null
+
+
+                 z = "z"
+                y = "y"
+                    b() {}
+                }
+              `,
+              output: dedent`
+                class Class {
+                  a = () => null
+
+                 y = "y"
+                z = "z"
+
+                    b() {}
+                }
+                `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'always',
+                  groups: ['function-property', 'unknown', 'method'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'extraSpacingBetweenClassMembers',
+                  data: {
+                    left: 'a',
+                    right: 'z',
+                  },
+                },
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'z',
+                    right: 'y',
+                  },
+                },
+                {
+                  messageId: 'missedSpacingBetweenClassMembers',
+                  data: {
+                    left: 'y',
+                    right: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
+
     describe(`${ruleName}(${type}): sorts inline elements correctly`, () => {
       describe(`${ruleName}(${type}): methods`, () => {
         describe(`${ruleName}(${type}): non-abstract methods`, () => {

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -92,3 +92,9 @@ export let partitionByCommentJsonSchema: JSONSchema4 = {
     },
   ],
 }
+
+export let partitionByNewLineJsonSchema: JSONSchema4 = {
+  description:
+    'Allows to use newlines to separate the nodes into logical groups.',
+  type: 'boolean',
+}


### PR DESCRIPTION
The majority of lines added are tests and documentation.

### Description

Simply adds those two options to `sort-classes`.

### Changes

- Adds `partitionByNewLine` option. `partitionByComment` already exists and probably is a better use case, but supporting `partitionByNewline` is a matter of a couple of lines. Might as well add it!
- Adds `newlinesBetween` option (requested here: https://github.com/azat-io/eslint-plugin-perfectionist/issues/350#issuecomment-2453047795)
- Creates a `partitionByNewLineJsonSchema` JSON schema to reduce code duplication.

As with other rules using this option, `partitionByNewLine` and `newlinesBetween` can not be used together.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature

