### PR TITLE
fix(sort-classes): fix # properties not being detected as dependencies

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -584,12 +584,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
 
             let comments = getCommentsBefore(member, sourceCode)
             let lastMember = accumulator.at(-1)?.at(-1)
-            if (
-              options.partitionByComment &&
-              hasPartitionComment(options.partitionByComment, comments)
-            ) {
-              accumulator.push([])
-            }
+
             if (
               (options.partitionByNewLine &&
                 lastMember &&

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3612,6 +3612,54 @@ describe(ruleName, () => {
         },
       )
 
+      ruleTester.run(`${ruleName}(${type}): detects # dependencies`, rule, {
+        valid: [
+          {
+            code: dedent`
+              class Class {
+               static a = Class.a
+               static b = 1
+               static #b = 1
+               static #a = this.#b
+              }
+            `,
+            options: [
+              {
+                ...options,
+              },
+            ],
+          },
+          {
+            code: dedent`
+              class Class {
+               static #b = () => 1
+               static #a = this.#b()
+              }
+            `,
+            options: [
+              {
+                ...options,
+              },
+            ],
+          },
+          {
+            code: dedent`
+              class Class {
+               static #a = this.#b()
+               static #b() {}
+              }
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['unknown'],
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      })
+
       ruleTester.run(
         `${ruleName}(${type}) separates static from non-static dependencies`,
         rule,


### PR DESCRIPTION
Fixes #355

### Description

Hash private properties (`#a` for example) were not detected as dependencies. 

### Changes

- Fixes the bug and adds tests.
- Also removes some duplicate code.

### What is the purpose of this pull request?

- [x] Bug fix
