### PR TITLE
feat(sort-classes): adds `ignoreCallbackDependenciesPatterns` option

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -258,6 +258,24 @@ Specifies how new lines should be handled between class member groups.
 
 This options is only applicable when `partitionByNewLine` is `false`.
 
+### ignoreCallbackDependenciesPatterns
+
+<sub>default: `[]`</sub>
+
+Allows you to specify regexp patterns of function names that should ignore dependency sorting in their callback functions.
+
+Example with `ignoreCallbackDependenciesPatterns: ['^computed$']`:
+
+```ts
+class User {
+  fullName = computed(() => this.role + ' - ' + this.username);
+  role = signal('admin');
+  username = signal('John');
+};
+```
+
+Without `ignoreCallbackDependenciesPatterns: ['^computed$']`, `role` and `username` would be sorted before `fullName` as it depends on them.
+
 ### groups
 
 <sub>

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -190,6 +190,7 @@ export type SortClassesOptions = [
     partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    ignoreCallbackDependenciesPatterns: string[]
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     customGroups: CustomGroup[]

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -3990,6 +3990,30 @@ describe(ruleName, () => {
           ],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): should ignore callback dependencies in 'ignoreCallbackDependenciesPatterns'`,
+        rule,
+        {
+          invalid: [],
+          valid: [
+            {
+              code: dedent`
+                class Class {
+                  a = computed(() => this.c)
+                  c
+                  b = notComputed(() => this.c)
+                }
+              `,
+              options: [
+                {
+                  ignoreCallbackDependenciesPatterns: ['^computed$'],
+                },
+              ],
+            },
+          ],
+        },
+      )
     })
 
     ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {


### PR DESCRIPTION
Resolves #350

## Description

In `sort-classes`, dependencies are detected and placed above class members that depend on them when needed. This process is required to ensure that compilation and runtime behavior is preserved.

There is one case where this process can feel overly cautious for users: when examining callback functions.

### Example

```ts
function someFunction(fn: () => any) {
    return fn()
}

class Class {
    a = someFunction(() => {
        return this.b
    })
    b = 1
};

console.log(new Class().a) // prints undefined
``` 

In this example, we detect that `b` should be before `a` (good).

## Use-case in different frameworks

Some front-end frameworks (`Vue` or `Angular` to only name a few) offer reactive features, such as [Signals](https://angular.dev/guide/signals) or [Computed properties](https://vuejs.org/guide/essentials/computed.html) which rely on callback functions where dependencies matter less

### Example

```ts
class User {
  fullName = computed(() => this.role + ' - ' + this.username); // This can be put here safely in the context of Angular signals
  role = signal('admin');
  username = signal('John');
};
```

## Proposal

This PR adds an option `ignoreCallbackDependenciesPatterns`, by default `[]`. It accepts an array of regexp patterns, allowing users to specify function names to ignore when checking dependencies in callback functions (ex: `^computed$`).

### Example based on #350

<details>
<summary>Before</summary>

```ts
export class Foo {
    state = rxState(({ connect, set }) => {
        set({ limit: 5 });
    });
    searchQuery = this.state.signal('searchQuery');
    eventsFamilyIds = this.state.computed(() => this.searchQuery().eventsFamilyIds || []);
    eventsIds = this.state.computed(() => this.searchQuery().eventsIds || []);
    metadata = injectQuery(() => ({
        queryKey: ['reports', 'metadata'] as const,
    }));
    eventsFamily = computed(() => markSelected(this.metadata().data?.eventsFamily, [...this.eventsFamilyIds(), ...this.eventsIds()]));
    groups = computed(
        () =>
            this.metadata().data?.groups?.map((g) => ({
                label: g.name,
                value: g.groupId,
            })) || []
    );
    items = computed(
        () =>
            this.metadata().data?.items?.map((i) => ({
                label: i.name,
                parent: i.parent,
                value: i.value,
            })) || []
    );
    maxDate = computed(() => this.metadata().data?.toDate && parseISO(`${this.metadata().data?.toDate}`));
    model = computed(() => ['fromDate', 'toDate']);
}
```

</details>

<details>
<summary>After</summary>

```ts
export class Foo {
    state = rxState(({ connect, set }) => {
        set({ limit: 5 });
    });
    eventsFamily = computed(() => markSelected(this.metadata().data?.eventsFamily, [...this.eventsFamilyIds(), ...this.eventsIds()]));
    searchQuery = this.state.signal('searchQuery');
    eventsFamilyIds = this.state.computed(() => this.searchQuery().eventsFamilyIds || []);
    eventsIds = this.state.computed(() => this.searchQuery().eventsIds || []);
    groups = computed(
        () =>
            this.metadata().data?.groups?.map((g) => ({
                label: g.name,
                value: g.groupId,
            })) || []
    );
    items = computed(
        () =>
            this.metadata().data?.items?.map((i) => ({
                label: i.name,
                parent: i.parent,
                value: i.value,
            })) || []
    );
    maxDate = computed(() => this.metadata().data?.toDate && parseISO(`${this.metadata().data?.toDate}`));
    model = computed(() => ['fromDate', 'toDate']);
    metadata = injectQuery(() => ({
        queryKey: ['reports', 'metadata'] as const,
    }));
}
```

</details>

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature
