### PR TITLE
refactor: reduce amount of nested statements

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -119,95 +119,93 @@ export let sortArray = <MessageIds extends string>(
   messageId: MessageIds,
   elements: (TSESTree.SpreadElement | TSESTree.Expression | null)[],
 ) => {
+  if (elements.length <= 1) {
+    return
+  }
+
   let settings = getSettings(context.settings)
-
-  if (elements.length > 1) {
-    let options = complete(context.options.at(0), settings, defaultOptions)
-
-    let sourceCode = getSourceCode(context)
-    let partitionComment = options.partitionByComment
-
-    let formattedMembers: SortingNode[][] = elements.reduce(
-      (
-        accumulator: SortingNode[][],
-        element: TSESTree.SpreadElement | TSESTree.Expression | null,
-      ) => {
-        if (element !== null) {
-          let group = 'unknown'
-          if (typeof options.groupKind === 'string') {
-            group = element.type === 'SpreadElement' ? 'spread' : 'literal'
-          }
-
-          let lastSortingNode = accumulator.at(-1)?.at(-1)
-          let sortingNode: SortingNode = {
-            name:
-              element.type === 'Literal'
-                ? `${element.value}`
-                : sourceCode.getText(element),
-            size: rangeToDiff(element, sourceCode),
-            node: element,
-            group,
-          }
-          if (
-            (partitionComment &&
-              hasPartitionComment(
-                partitionComment,
-                getCommentsBefore(element, sourceCode),
-              )) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
-          ) {
-            accumulator.push([])
-          }
-
-          accumulator.at(-1)!.push(sortingNode)
-        }
-
-        return accumulator
-      },
-      [[]],
-    )
-
-    for (let nodes of formattedMembers) {
-      pairwise(nodes, (left, right) => {
-        let groupKindOrder = ['unknown']
-
+  let options = complete(context.options.at(0), settings, defaultOptions)
+  let sourceCode = getSourceCode(context)
+  let partitionComment = options.partitionByComment
+  let formattedMembers: SortingNode[][] = elements.reduce(
+    (
+      accumulator: SortingNode[][],
+      element: TSESTree.SpreadElement | TSESTree.Expression | null,
+    ) => {
+      if (element !== null) {
+        let group = 'unknown'
         if (typeof options.groupKind === 'string') {
-          groupKindOrder =
-            options.groupKind === 'literals-first'
-              ? ['literal', 'spread']
-              : ['spread', 'literal']
+          group = element.type === 'SpreadElement' ? 'spread' : 'literal'
         }
-        let leftNum = getGroupNumber(groupKindOrder, left)
-        let rightNum = getGroupNumber(groupKindOrder, right)
 
+        let lastSortingNode = accumulator.at(-1)?.at(-1)
+        let sortingNode: SortingNode = {
+          name:
+            element.type === 'Literal'
+              ? `${element.value}`
+              : sourceCode.getText(element),
+          size: rangeToDiff(element, sourceCode),
+          node: element,
+          group,
+        }
         if (
-          (options.groupKind !== 'mixed' && leftNum > rightNum) ||
-          ((options.groupKind === 'mixed' || leftNum === rightNum) &&
-            isPositive(compare(left, right, options)))
+          (partitionComment &&
+            hasPartitionComment(
+              partitionComment,
+              getCommentsBefore(element, sourceCode),
+            )) ||
+          (options.partitionByNewLine &&
+            lastSortingNode &&
+            getLinesBetween(sourceCode, lastSortingNode, sortingNode))
         ) {
-          context.report({
-            messageId,
-            data: {
-              left: toSingleLine(left.name),
-              right: toSingleLine(right.name),
-            },
-            node: right.node,
-            fix: fixer => {
-              let sortedNodes =
-                options.groupKind !== 'mixed'
-                  ? groupKindOrder
-                      .map(group => nodes.filter(n => n.group === group))
-                      .map(groupedNodes => sortNodes(groupedNodes, options))
-                      .flat()
-                  : sortNodes(nodes, options)
-
-              return makeFixes(fixer, nodes, sortedNodes, sourceCode, options)
-            },
-          })
+          accumulator.push([])
         }
-      })
-    }
+
+        accumulator.at(-1)!.push(sortingNode)
+      }
+
+      return accumulator
+    },
+    [[]],
+  )
+  for (let nodes of formattedMembers) {
+    pairwise(nodes, (left, right) => {
+      let groupKindOrder = ['unknown']
+
+      if (typeof options.groupKind === 'string') {
+        groupKindOrder =
+          options.groupKind === 'literals-first'
+            ? ['literal', 'spread']
+            : ['spread', 'literal']
+      }
+      let leftNum = getGroupNumber(groupKindOrder, left)
+      let rightNum = getGroupNumber(groupKindOrder, right)
+
+      if (
+        (options.groupKind !== 'mixed' && leftNum > rightNum) ||
+        ((options.groupKind === 'mixed' || leftNum === rightNum) &&
+          isPositive(compare(left, right, options)))
+      ) {
+        context.report({
+          messageId,
+          data: {
+            left: toSingleLine(left.name),
+            right: toSingleLine(right.name),
+          },
+          node: right.node,
+          fix: fixer => {
+            let sortedNodes =
+              options.groupKind !== 'mixed'
+                ? groupKindOrder
+                    .map(group => nodes.filter(n => n.group === group))
+                    .map(groupedNodes => sortNodes(groupedNodes, options))
+                    .flat()
+                : sortNodes(nodes, options)
+
+            return makeFixes(fixer, nodes, sortedNodes, sourceCode, options)
+          },
+        })
+      }
+    })
   }
 }

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -102,165 +102,158 @@ export default createEslintRule<Options, MESSAGE_ID>({
   defaultOptions: [defaultOptions],
   create: context => ({
     TSEnumDeclaration: node => {
-      let getMembers = (nodeValue: TSESTree.TSEnumDeclaration) =>
-        /* v8 ignore next 2 */
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        node.body?.members ?? nodeValue.members ?? []
-      let members = getMembers(node)
+      /* v8 ignore next 2 */
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      let members = node.body.members ?? node.members ?? []
       if (
-        members.length > 1 &&
-        members.every(({ initializer }) => initializer)
+        members.length <= 1 ||
+        !members.every(({ initializer }) => initializer)
       ) {
-        let settings = getSettings(context.settings)
-
-        let options = complete(context.options.at(0), settings, defaultOptions)
-
-        let sourceCode = getSourceCode(context)
-        let partitionComment = options.partitionByComment
-
-        let extractDependencies = (
-          expression: TSESTree.Expression,
-          enumName: string,
-        ): string[] => {
-          let dependencies: string[] = []
-
-          let checkNode = (nodeValue: TSESTree.Node) => {
-            if (
-              nodeValue.type === 'MemberExpression' &&
-              nodeValue.object.type === 'Identifier' &&
-              nodeValue.object.name === enumName &&
-              nodeValue.property.type === 'Identifier'
-            ) {
-              /**
-               * enum Enum {
-               *   A = 1,
-               *   B = Enum.A
-               * }
-               */
-              dependencies.push(nodeValue.property.name)
-            } else if (nodeValue.type === 'Identifier') {
-              /**
-               * enum Enum {
-               *   A = 1,
-               *   B = A
-               * }
-               */
-              dependencies.push(nodeValue.name)
-            }
-
-            if ('left' in nodeValue) {
-              checkNode(nodeValue.left)
-            }
-
-            if ('right' in nodeValue) {
-              checkNode(nodeValue.right)
-            }
-
-            if ('expressions' in nodeValue) {
-              nodeValue.expressions.forEach(checkNode)
-            }
-          }
-
-          checkNode(expression)
-          return dependencies
-        }
-
-        let formattedMembers: SortingNodeWithDependencies[][] = members.reduce(
-          (accumulator: SortingNodeWithDependencies[][], member) => {
-            let dependencies: string[] = []
-            if (member.initializer) {
-              dependencies = extractDependencies(
-                member.initializer,
-                node.id.name,
-              )
-            }
-            let lastSortingNode = accumulator.at(-1)?.at(-1)
-            let sortingNode: SortingNodeWithDependencies = {
-              size: rangeToDiff(member, sourceCode),
-              node: member,
-              dependencies,
-              name:
-                member.id.type === 'Literal'
-                  ? `${member.id.value}`
-                  : `${sourceCode.getText(member.id)}`,
-            }
-
-            if (
-              (partitionComment &&
-                hasPartitionComment(
-                  partitionComment,
-                  getCommentsBefore(member, sourceCode),
-                )) ||
-              (options.partitionByNewLine &&
-                lastSortingNode &&
-                getLinesBetween(sourceCode, lastSortingNode, sortingNode))
-            ) {
-              accumulator.push([])
-            }
-
-            accumulator.at(-1)!.push(sortingNode)
-            return accumulator
-          },
-          [[]],
-        )
-        let isNumericEnum = members.every(
-          member =>
-            member.initializer?.type === 'Literal' &&
-            typeof member.initializer.value === 'number',
-        )
-
-        let compareOptions: CompareOptions = {
-          // If the enum is numeric, and we sort by value, always use the `natural` sort type, which will correctly sort them.
-          type:
-            isNumericEnum && (options.forceNumericSort || options.sortByValue)
-              ? 'natural'
-              : options.type,
-          order: options.order,
-          ignoreCase: options.ignoreCase,
-          specialCharacters: options.specialCharacters,
-          locales: options.locales,
-          // Get the enum value rather than the name if needed
-          nodeValueGetter:
-            options.sortByValue || (isNumericEnum && options.forceNumericSort)
-              ? sortingNode => {
-                  if (
-                    sortingNode.node.type === 'TSEnumMember' &&
-                    sortingNode.node.initializer?.type === 'Literal'
-                  ) {
-                    return sortingNode.node.initializer.value?.toString() ?? ''
-                  }
-                  return ''
-                }
-              : undefined,
-        }
-        let sortedNodes = sortNodesByDependencies(
-          formattedMembers
-            .map(nodes => sortNodes(nodes, compareOptions))
-            .flat(),
-        )
-        let nodes = formattedMembers.flat()
-        pairwise(nodes, (left, right) => {
-          let indexOfLeft = sortedNodes.indexOf(left)
-          let indexOfRight = sortedNodes.indexOf(right)
-          if (indexOfLeft > indexOfRight) {
-            let firstUnorderedNodeDependentOnRight =
-              getFirstUnorderedNodeDependentOn(right, nodes)
-            context.report({
-              messageId: firstUnorderedNodeDependentOnRight
-                ? 'unexpectedEnumsDependencyOrder'
-                : 'unexpectedEnumsOrder',
-              data: {
-                left: toSingleLine(left.name),
-                right: toSingleLine(right.name),
-                nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
-              },
-              node: right.node,
-              fix: fixer =>
-                makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
-            })
-          }
-        })
+        return
       }
+
+      let settings = getSettings(context.settings)
+      let options = complete(context.options.at(0), settings, defaultOptions)
+      let sourceCode = getSourceCode(context)
+      let partitionComment = options.partitionByComment
+      let extractDependencies = (
+        expression: TSESTree.Expression,
+        enumName: string,
+      ): string[] => {
+        let dependencies: string[] = []
+
+        let checkNode = (nodeValue: TSESTree.Node) => {
+          if (
+            nodeValue.type === 'MemberExpression' &&
+            nodeValue.object.type === 'Identifier' &&
+            nodeValue.object.name === enumName &&
+            nodeValue.property.type === 'Identifier'
+          ) {
+            /**
+             * enum Enum {
+             *   A = 1,
+             *   B = Enum.A
+             * }
+             */
+            dependencies.push(nodeValue.property.name)
+          } else if (nodeValue.type === 'Identifier') {
+            /**
+             * enum Enum {
+             *   A = 1,
+             *   B = A
+             * }
+             */
+            dependencies.push(nodeValue.name)
+          }
+
+          if ('left' in nodeValue) {
+            checkNode(nodeValue.left)
+          }
+
+          if ('right' in nodeValue) {
+            checkNode(nodeValue.right)
+          }
+
+          if ('expressions' in nodeValue) {
+            nodeValue.expressions.forEach(checkNode)
+          }
+        }
+
+        checkNode(expression)
+        return dependencies
+      }
+      let formattedMembers: SortingNodeWithDependencies[][] = members.reduce(
+        (accumulator: SortingNodeWithDependencies[][], member) => {
+          let dependencies: string[] = []
+          if (member.initializer) {
+            dependencies = extractDependencies(member.initializer, node.id.name)
+          }
+          let lastSortingNode = accumulator.at(-1)?.at(-1)
+          let sortingNode: SortingNodeWithDependencies = {
+            size: rangeToDiff(member, sourceCode),
+            node: member,
+            dependencies,
+            name:
+              member.id.type === 'Literal'
+                ? `${member.id.value}`
+                : `${sourceCode.getText(member.id)}`,
+          }
+
+          if (
+            (partitionComment &&
+              hasPartitionComment(
+                partitionComment,
+                getCommentsBefore(member, sourceCode),
+              )) ||
+            (options.partitionByNewLine &&
+              lastSortingNode &&
+              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+          ) {
+            accumulator.push([])
+          }
+
+          accumulator.at(-1)!.push(sortingNode)
+          return accumulator
+        },
+        [[]],
+      )
+      let isNumericEnum = members.every(
+        member =>
+          member.initializer?.type === 'Literal' &&
+          typeof member.initializer.value === 'number',
+      )
+      let compareOptions: CompareOptions = {
+        // If the enum is numeric, and we sort by value, always use the `natural` sort type, which will correctly sort them.
+        type:
+          isNumericEnum && (options.forceNumericSort || options.sortByValue)
+            ? 'natural'
+            : options.type,
+        order: options.order,
+        ignoreCase: options.ignoreCase,
+        specialCharacters: options.specialCharacters,
+        locales: options.locales,
+        // Get the enum value rather than the name if needed
+        nodeValueGetter:
+          options.sortByValue || (isNumericEnum && options.forceNumericSort)
+            ? sortingNode => {
+                if (
+                  sortingNode.node.type === 'TSEnumMember' &&
+                  sortingNode.node.initializer?.type === 'Literal'
+                ) {
+                  return sortingNode.node.initializer.value?.toString() ?? ''
+                }
+                return ''
+              }
+            : undefined,
+      }
+      let sortedNodes = sortNodesByDependencies(
+        formattedMembers.map(nodes => sortNodes(nodes, compareOptions)).flat(),
+      )
+      let nodes = formattedMembers.flat()
+
+      pairwise(nodes, (left, right) => {
+        let indexOfLeft = sortedNodes.indexOf(left)
+        let indexOfRight = sortedNodes.indexOf(right)
+        if (indexOfLeft <= indexOfRight) {
+          return
+        }
+
+        let firstUnorderedNodeDependentOnRight =
+          getFirstUnorderedNodeDependentOn(right, nodes)
+        context.report({
+          messageId: firstUnorderedNodeDependentOnRight
+            ? 'unexpectedEnumsDependencyOrder'
+            : 'unexpectedEnumsOrder',
+          data: {
+            left: toSingleLine(left.name),
+            right: toSingleLine(right.name),
+            nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
+          },
+          node: right.node,
+          fix: fixer =>
+            makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
+        })
+      })
     },
   }),
 })

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -90,90 +90,89 @@ export default createEslintRule<Options, MESSAGE_ID>({
   defaultOptions: [defaultOptions],
   create: context => ({
     ExportNamedDeclaration: node => {
-      if (node.specifiers.length > 1) {
-        let settings = getSettings(context.settings)
+      if (node.specifiers.length <= 1) {
+        return
+      }
 
-        let options = complete(context.options.at(0), settings, defaultOptions)
+      let settings = getSettings(context.settings)
+      let options = complete(context.options.at(0), settings, defaultOptions)
+      let sourceCode = getSourceCode(context)
+      let partitionComment = options.partitionByComment
+      let formattedMembers: SortingNode[][] = [[]]
+      for (let specifier of node.specifiers) {
+        let group: undefined | 'value' | 'type'
+        if (specifier.exportKind === 'type') {
+          group = 'type'
+        } else {
+          group = 'value'
+        }
 
-        let sourceCode = getSourceCode(context)
-        let partitionComment = options.partitionByComment
+        let name: string
 
-        let formattedMembers: SortingNode[][] = [[]]
-        for (let specifier of node.specifiers) {
-          let group: undefined | 'value' | 'type'
-          if (specifier.exportKind === 'type') {
-            group = 'type'
-          } else {
-            group = 'value'
-          }
+        if (specifier.exported.type === 'Identifier') {
+          ;({ name } = specifier.exported)
+        } else {
+          name = specifier.exported.value
+        }
 
-          let name: string
+        let lastSortingNode = formattedMembers.at(-1)?.at(-1)
+        let sortingNode: SortingNode = {
+          size: rangeToDiff(specifier, sourceCode),
+          node: specifier,
+          group,
+          name,
+        }
+        if (
+          (partitionComment &&
+            hasPartitionComment(
+              partitionComment,
+              getCommentsBefore(specifier, sourceCode),
+            )) ||
+          (options.partitionByNewLine &&
+            lastSortingNode &&
+            getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+        ) {
+          formattedMembers.push([])
+        }
 
-          if (specifier.exported.type === 'Identifier') {
-            ;({ name } = specifier.exported)
-          } else {
-            name = specifier.exported.value
-          }
+        formattedMembers.at(-1)!.push(sortingNode)
+      }
 
-          let lastSortingNode = formattedMembers.at(-1)?.at(-1)
-          let sortingNode: SortingNode = {
-            size: rangeToDiff(specifier, sourceCode),
-            node: specifier,
-            group,
-            name,
-          }
+      let shouldGroupByKind = options.groupKind !== 'mixed'
+      let groupKindOrder =
+        options.groupKind === 'values-first'
+          ? ['value', 'type']
+          : ['type', 'value']
+
+      for (let nodes of formattedMembers) {
+        pairwise(nodes, (left, right) => {
+          let leftNum = getGroupNumber(groupKindOrder, left)
+          let rightNum = getGroupNumber(groupKindOrder, right)
+
           if (
-            (partitionComment &&
-              hasPartitionComment(
-                partitionComment,
-                getCommentsBefore(specifier, sourceCode),
-              )) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            (shouldGroupByKind && leftNum > rightNum) ||
+            ((!shouldGroupByKind || leftNum === rightNum) &&
+              isPositive(compare(left, right, options)))
           ) {
-            formattedMembers.push([])
+            let sortedNodes = shouldGroupByKind
+              ? groupKindOrder
+                  .map(group => nodes.filter(n => n.group === group))
+                  .map(groupedNodes => sortNodes(groupedNodes, options))
+                  .flat()
+              : sortNodes(nodes, options)
+
+            context.report({
+              messageId: 'unexpectedNamedExportsOrder',
+              data: {
+                left: left.name,
+                right: right.name,
+              },
+              node: right.node,
+              fix: fixer =>
+                makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
+            })
           }
-
-          formattedMembers.at(-1)!.push(sortingNode)
-        }
-
-        let shouldGroupByKind = options.groupKind !== 'mixed'
-        let groupKindOrder =
-          options.groupKind === 'values-first'
-            ? ['value', 'type']
-            : ['type', 'value']
-
-        for (let nodes of formattedMembers) {
-          pairwise(nodes, (left, right) => {
-            let leftNum = getGroupNumber(groupKindOrder, left)
-            let rightNum = getGroupNumber(groupKindOrder, right)
-
-            if (
-              (shouldGroupByKind && leftNum > rightNum) ||
-              ((!shouldGroupByKind || leftNum === rightNum) &&
-                isPositive(compare(left, right, options)))
-            ) {
-              let sortedNodes = shouldGroupByKind
-                ? groupKindOrder
-                    .map(group => nodes.filter(n => n.group === group))
-                    .map(groupedNodes => sortNodes(groupedNodes, options))
-                    .flat()
-                : sortNodes(nodes, options)
-
-              context.report({
-                messageId: 'unexpectedNamedExportsOrder',
-                data: {
-                  left: left.name,
-                  right: right.name,
-                },
-                node: right.node,
-                fix: fixer =>
-                  makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
-              })
-            }
-          })
-        }
+        })
       }
     },
   }),

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -126,187 +126,177 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   defaultOptions: [defaultOptions],
   create: context => ({
     TSTypeLiteral: node => {
-      if (node.members.length > 1) {
-        let settings = getSettings(context.settings)
+      if (node.members.length <= 1) {
+        return
+      }
 
-        let options = complete(context.options.at(0), settings, defaultOptions)
+      let settings = getSettings(context.settings)
+      let options = complete(context.options.at(0), settings, defaultOptions)
+      validateGroupsConfiguration(
+        options.groups,
+        ['multiline', 'method', 'unknown'],
+        Object.keys(options.customGroups),
+      )
+      validateNewlinesAndPartitionConfiguration(options)
+      let sourceCode = getSourceCode(context)
+      let partitionComment = options.partitionByComment
+      let formattedMembers: SortObjectTypesSortingNode[][] =
+        node.members.reduce(
+          (accumulator: SortObjectTypesSortingNode[][], member) => {
+            let name: string
+            let lastSortingNode = accumulator.at(-1)?.at(-1)
 
-        validateGroupsConfiguration(
-          options.groups,
-          ['multiline', 'method', 'unknown'],
-          Object.keys(options.customGroups),
-        )
-        validateNewlinesAndPartitionConfiguration(options)
+            let { getGroup, defineGroup, setCustomGroups } = useGroups(options)
 
-        let sourceCode = getSourceCode(context)
-        let partitionComment = options.partitionByComment
+            let formatName = (value: string): string =>
+              value.replace(/([,;])$/, '')
 
-        let formattedMembers: SortObjectTypesSortingNode[][] =
-          node.members.reduce(
-            (accumulator: SortObjectTypesSortingNode[][], member) => {
-              let name: string
-              let lastSortingNode = accumulator.at(-1)?.at(-1)
-
-              let { getGroup, defineGroup, setCustomGroups } =
-                useGroups(options)
-
-              let formatName = (value: string): string =>
-                value.replace(/([,;])$/, '')
-
-              if (member.type === 'TSPropertySignature') {
-                if (member.key.type === 'Identifier') {
-                  ;({ name } = member.key)
-                } else if (member.key.type === 'Literal') {
-                  name = `${member.key.value}`
-                } else {
-                  name = sourceCode.text.slice(
-                    member.range.at(0),
-                    member.typeAnnotation?.range.at(0),
-                  )
-                }
-              } else if (member.type === 'TSIndexSignature') {
-                let endIndex: number =
-                  member.typeAnnotation?.range.at(0) ?? member.range.at(1)!
-
-                name = formatName(
-                  sourceCode.text.slice(member.range.at(0), endIndex),
-                )
+            if (member.type === 'TSPropertySignature') {
+              if (member.key.type === 'Identifier') {
+                ;({ name } = member.key)
+              } else if (member.key.type === 'Literal') {
+                name = `${member.key.value}`
               } else {
-                name = formatName(
-                  sourceCode.text.slice(member.range.at(0), member.range.at(1)),
+                name = sourceCode.text.slice(
+                  member.range.at(0),
+                  member.typeAnnotation?.range.at(0),
                 )
               }
+            } else if (member.type === 'TSIndexSignature') {
+              let endIndex: number =
+                member.typeAnnotation?.range.at(0) ?? member.range.at(1)!
 
-              setCustomGroups(options.customGroups, name)
-
-              if (
-                member.type === 'TSMethodSignature' ||
-                (member.type === 'TSPropertySignature' &&
-                  member.typeAnnotation?.typeAnnotation.type ===
-                    'TSFunctionType')
-              ) {
-                defineGroup('method')
-              }
-
-              if (member.loc.start.line !== member.loc.end.line) {
-                defineGroup('multiline')
-              }
-
-              let sortingNode: SortObjectTypesSortingNode = {
-                size: rangeToDiff(member, sourceCode),
-                group: getGroup(),
-                node: member,
-                name,
-                addSafetySemicolonWhenInline: true,
-              }
-
-              if (
-                (partitionComment &&
-                  hasPartitionComment(
-                    partitionComment,
-                    getCommentsBefore(member, sourceCode),
-                  )) ||
-                (options.partitionByNewLine &&
-                  lastSortingNode &&
-                  getLinesBetween(sourceCode, lastSortingNode, sortingNode))
-              ) {
-                accumulator.push([])
-              }
-
-              accumulator.at(-1)?.push(sortingNode)
-
-              return accumulator
-            },
-            [[]],
-          )
-
-        for (let nodes of formattedMembers) {
-          let groupedByKind
-          if (options.groupKind !== 'mixed') {
-            groupedByKind = nodes.reduce<SortObjectTypesSortingNode[][]>(
-              (accumulator, currentNode) => {
-                let requiredIndex =
-                  options.groupKind === 'required-first' ? 0 : 1
-                let optionalIndex =
-                  options.groupKind === 'required-first' ? 1 : 0
-
-                if (
-                  'optional' in currentNode.node &&
-                  currentNode.node.optional
-                ) {
-                  accumulator[optionalIndex].push(currentNode)
-                } else {
-                  accumulator[requiredIndex].push(currentNode)
-                }
-                return accumulator
-              },
-              [[], []],
-            )
-          } else {
-            groupedByKind = [nodes]
-          }
-
-          let sortedNodes: SortObjectTypesSortingNode[] = []
-
-          for (let nodesByKind of groupedByKind) {
-            sortedNodes.push(...sortNodesByGroups(nodesByKind, options))
-          }
-
-          pairwise(nodes, (left, right) => {
-            let leftNum = getGroupNumber(options.groups, left)
-            let rightNum = getGroupNumber(options.groups, right)
-
-            let indexOfLeft = sortedNodes.indexOf(left)
-            let indexOfRight = sortedNodes.indexOf(right)
-
-            let messageIds: MESSAGE_ID[] = []
-
-            if (indexOfLeft > indexOfRight) {
-              messageIds.push(
-                leftNum !== rightNum
-                  ? 'unexpectedObjectTypesGroupOrder'
-                  : 'unexpectedObjectTypesOrder',
+              name = formatName(
+                sourceCode.text.slice(member.range.at(0), endIndex),
+              )
+            } else {
+              name = formatName(
+                sourceCode.text.slice(member.range.at(0), member.range.at(1)),
               )
             }
 
-            messageIds = [
-              ...messageIds,
-              ...getNewlinesErrors({
-                left,
-                leftNum,
-                right,
-                rightNum,
-                sourceCode,
-                missedSpacingError: 'missedSpacingBetweenObjectTypeMembers',
-                extraSpacingError: 'extraSpacingBetweenObjectTypeMembers',
-                options,
-              }),
-            ]
+            setCustomGroups(options.customGroups, name)
 
-            for (let messageId of messageIds) {
-              context.report({
-                messageId,
-                data: {
-                  left: toSingleLine(left.name),
-                  leftGroup: left.group,
-                  right: toSingleLine(right.name),
-                  rightGroup: right.group,
-                },
-                node: right.node,
-                fix: fixer => [
-                  ...makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
-                  ...makeNewlinesFixes(
-                    fixer,
-                    nodes,
-                    sortedNodes,
-                    sourceCode,
-                    options,
-                  ),
-                ],
-              })
+            if (
+              member.type === 'TSMethodSignature' ||
+              (member.type === 'TSPropertySignature' &&
+                member.typeAnnotation?.typeAnnotation.type === 'TSFunctionType')
+            ) {
+              defineGroup('method')
             }
-          })
+
+            if (member.loc.start.line !== member.loc.end.line) {
+              defineGroup('multiline')
+            }
+
+            let sortingNode: SortObjectTypesSortingNode = {
+              size: rangeToDiff(member, sourceCode),
+              group: getGroup(),
+              node: member,
+              name,
+              addSafetySemicolonWhenInline: true,
+            }
+
+            if (
+              (partitionComment &&
+                hasPartitionComment(
+                  partitionComment,
+                  getCommentsBefore(member, sourceCode),
+                )) ||
+              (options.partitionByNewLine &&
+                lastSortingNode &&
+                getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            ) {
+              accumulator.push([])
+            }
+
+            accumulator.at(-1)?.push(sortingNode)
+
+            return accumulator
+          },
+          [[]],
+        )
+      for (let nodes of formattedMembers) {
+        let groupedByKind
+        if (options.groupKind !== 'mixed') {
+          groupedByKind = nodes.reduce<SortObjectTypesSortingNode[][]>(
+            (accumulator, currentNode) => {
+              let requiredIndex = options.groupKind === 'required-first' ? 0 : 1
+              let optionalIndex = options.groupKind === 'required-first' ? 1 : 0
+
+              if ('optional' in currentNode.node && currentNode.node.optional) {
+                accumulator[optionalIndex].push(currentNode)
+              } else {
+                accumulator[requiredIndex].push(currentNode)
+              }
+              return accumulator
+            },
+            [[], []],
+          )
+        } else {
+          groupedByKind = [nodes]
         }
+
+        let sortedNodes: SortObjectTypesSortingNode[] = []
+
+        for (let nodesByKind of groupedByKind) {
+          sortedNodes.push(...sortNodesByGroups(nodesByKind, options))
+        }
+
+        pairwise(nodes, (left, right) => {
+          let leftNum = getGroupNumber(options.groups, left)
+          let rightNum = getGroupNumber(options.groups, right)
+
+          let indexOfLeft = sortedNodes.indexOf(left)
+          let indexOfRight = sortedNodes.indexOf(right)
+
+          let messageIds: MESSAGE_ID[] = []
+
+          if (indexOfLeft > indexOfRight) {
+            messageIds.push(
+              leftNum !== rightNum
+                ? 'unexpectedObjectTypesGroupOrder'
+                : 'unexpectedObjectTypesOrder',
+            )
+          }
+
+          messageIds = [
+            ...messageIds,
+            ...getNewlinesErrors({
+              left,
+              leftNum,
+              right,
+              rightNum,
+              sourceCode,
+              missedSpacingError: 'missedSpacingBetweenObjectTypeMembers',
+              extraSpacingError: 'extraSpacingBetweenObjectTypeMembers',
+              options,
+            }),
+          ]
+
+          for (let messageId of messageIds) {
+            context.report({
+              messageId,
+              data: {
+                left: toSingleLine(left.name),
+                leftGroup: left.group,
+                right: toSingleLine(right.name),
+                rightGroup: right.group,
+              },
+              node: right.node,
+              fix: fixer => [
+                ...makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
+                ...makeNewlinesFixes(
+                  fixer,
+                  nodes,
+                  sortedNodes,
+                  sourceCode,
+                  options,
+                ),
+              ],
+            })
+          }
+        })
       }
     },
   }),

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -91,168 +91,167 @@ export default createEslintRule<Options, MESSAGE_ID>({
   defaultOptions: [defaultOptions],
   create: context => ({
     VariableDeclaration: node => {
-      if (node.declarations.length > 1) {
-        let settings = getSettings(context.settings)
+      if (node.declarations.length <= 1) {
+        return
+      }
 
-        let options = complete(context.options.at(0), settings, defaultOptions)
+      let settings = getSettings(context.settings)
+      let options = complete(context.options.at(0), settings, defaultOptions)
+      let sourceCode = getSourceCode(context)
+      let partitionComment = options.partitionByComment
+      let extractDependencies = (init: TSESTree.Expression): string[] => {
+        let dependencies: string[] = []
 
-        let sourceCode = getSourceCode(context)
-        let partitionComment = options.partitionByComment
-
-        let extractDependencies = (init: TSESTree.Expression): string[] => {
-          let dependencies: string[] = []
-
-          let checkNode = (nodeValue: TSESTree.Node) => {
-            /**
-             * No need to check the body of functions and arrow functions
-             */
-            if (
-              nodeValue.type === 'ArrowFunctionExpression' ||
-              nodeValue.type === 'FunctionExpression'
-            ) {
-              return
-            }
-
-            if (nodeValue.type === 'Identifier') {
-              dependencies.push(nodeValue.name)
-            }
-
-            if (nodeValue.type === 'Property') {
-              traverseNode(nodeValue.key)
-              traverseNode(nodeValue.value)
-            }
-
-            if (nodeValue.type === 'ConditionalExpression') {
-              traverseNode(nodeValue.test)
-              traverseNode(nodeValue.consequent)
-              traverseNode(nodeValue.alternate)
-            }
-
-            if (
-              'expression' in nodeValue &&
-              typeof nodeValue.expression !== 'boolean'
-            ) {
-              traverseNode(nodeValue.expression)
-            }
-
-            if ('object' in nodeValue) {
-              traverseNode(nodeValue.object)
-            }
-
-            if ('callee' in nodeValue) {
-              traverseNode(nodeValue.callee)
-            }
-
-            if ('left' in nodeValue) {
-              traverseNode(nodeValue.left)
-            }
-
-            if ('right' in nodeValue) {
-              traverseNode(nodeValue.right as TSESTree.Node)
-            }
-
-            if ('elements' in nodeValue) {
-              nodeValue.elements
-                .filter(currentNode => currentNode !== null)
-                .forEach(traverseNode)
-            }
-
-            if ('argument' in nodeValue && nodeValue.argument) {
-              traverseNode(nodeValue.argument)
-            }
-
-            if ('arguments' in nodeValue) {
-              nodeValue.arguments.forEach(traverseNode)
-            }
-
-            if ('properties' in nodeValue) {
-              nodeValue.properties.forEach(traverseNode)
-            }
-
-            if ('expressions' in nodeValue) {
-              nodeValue.expressions.forEach(traverseNode)
-            }
+        let checkNode = (nodeValue: TSESTree.Node) => {
+          /**
+           * No need to check the body of functions and arrow functions
+           */
+          if (
+            nodeValue.type === 'ArrowFunctionExpression' ||
+            nodeValue.type === 'FunctionExpression'
+          ) {
+            return
           }
 
-          let traverseNode = (nodeValue: TSESTree.Node) => {
-            checkNode(nodeValue)
+          if (nodeValue.type === 'Identifier') {
+            dependencies.push(nodeValue.name)
           }
 
-          traverseNode(init)
-          return dependencies
+          if (nodeValue.type === 'Property') {
+            traverseNode(nodeValue.key)
+            traverseNode(nodeValue.value)
+          }
+
+          if (nodeValue.type === 'ConditionalExpression') {
+            traverseNode(nodeValue.test)
+            traverseNode(nodeValue.consequent)
+            traverseNode(nodeValue.alternate)
+          }
+
+          if (
+            'expression' in nodeValue &&
+            typeof nodeValue.expression !== 'boolean'
+          ) {
+            traverseNode(nodeValue.expression)
+          }
+
+          if ('object' in nodeValue) {
+            traverseNode(nodeValue.object)
+          }
+
+          if ('callee' in nodeValue) {
+            traverseNode(nodeValue.callee)
+          }
+
+          if ('left' in nodeValue) {
+            traverseNode(nodeValue.left)
+          }
+
+          if ('right' in nodeValue) {
+            traverseNode(nodeValue.right as TSESTree.Node)
+          }
+
+          if ('elements' in nodeValue) {
+            nodeValue.elements
+              .filter(currentNode => currentNode !== null)
+              .forEach(traverseNode)
+          }
+
+          if ('argument' in nodeValue && nodeValue.argument) {
+            traverseNode(nodeValue.argument)
+          }
+
+          if ('arguments' in nodeValue) {
+            nodeValue.arguments.forEach(traverseNode)
+          }
+
+          if ('properties' in nodeValue) {
+            nodeValue.properties.forEach(traverseNode)
+          }
+
+          if ('expressions' in nodeValue) {
+            nodeValue.expressions.forEach(traverseNode)
+          }
         }
 
-        let formattedMembers = node.declarations.reduce(
-          (accumulator: SortingNodeWithDependencies[][], declaration) => {
-            let name
+        let traverseNode = (nodeValue: TSESTree.Node) => {
+          checkNode(nodeValue)
+        }
 
-            if (
-              declaration.id.type === 'ArrayPattern' ||
-              declaration.id.type === 'ObjectPattern'
-            ) {
-              name = sourceCode.text.slice(...declaration.id.range)
-            } else {
-              ;({ name } = declaration.id)
-            }
-
-            let dependencies: string[] = []
-            if (declaration.init) {
-              dependencies = extractDependencies(declaration.init)
-            }
-
-            let lastSortingNode = accumulator.at(-1)?.at(-1)
-            let sortingNode: SortingNodeWithDependencies = {
-              size: rangeToDiff(declaration, sourceCode),
-              node: declaration,
-              dependencies,
-              name,
-            }
-            if (
-              (partitionComment &&
-                hasPartitionComment(
-                  partitionComment,
-                  getCommentsBefore(declaration, sourceCode),
-                )) ||
-              (options.partitionByNewLine &&
-                lastSortingNode &&
-                getLinesBetween(sourceCode, lastSortingNode, sortingNode))
-            ) {
-              accumulator.push([])
-            }
-
-            accumulator.at(-1)?.push(sortingNode)
-
-            return accumulator
-          },
-          [[]],
-        )
-
-        let sortedNodes = sortNodesByDependencies(
-          formattedMembers.map(nodes => sortNodes(nodes, options)).flat(),
-        )
-        let nodes = formattedMembers.flat()
-        pairwise(nodes, (left, right) => {
-          let indexOfLeft = sortedNodes.indexOf(left)
-          let indexOfRight = sortedNodes.indexOf(right)
-          if (indexOfLeft > indexOfRight) {
-            let firstUnorderedNodeDependentOnRight =
-              getFirstUnorderedNodeDependentOn(right, nodes)
-            context.report({
-              messageId: firstUnorderedNodeDependentOnRight
-                ? 'unexpectedVariableDeclarationsDependencyOrder'
-                : 'unexpectedVariableDeclarationsOrder',
-              data: {
-                left: toSingleLine(left.name),
-                right: toSingleLine(right.name),
-                nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
-              },
-              node: right.node,
-              fix: fixer =>
-                makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
-            })
-          }
-        })
+        traverseNode(init)
+        return dependencies
       }
+      let formattedMembers = node.declarations.reduce(
+        (accumulator: SortingNodeWithDependencies[][], declaration) => {
+          let name
+
+          if (
+            declaration.id.type === 'ArrayPattern' ||
+            declaration.id.type === 'ObjectPattern'
+          ) {
+            name = sourceCode.text.slice(...declaration.id.range)
+          } else {
+            ;({ name } = declaration.id)
+          }
+
+          let dependencies: string[] = []
+          if (declaration.init) {
+            dependencies = extractDependencies(declaration.init)
+          }
+
+          let lastSortingNode = accumulator.at(-1)?.at(-1)
+          let sortingNode: SortingNodeWithDependencies = {
+            size: rangeToDiff(declaration, sourceCode),
+            node: declaration,
+            dependencies,
+            name,
+          }
+          if (
+            (partitionComment &&
+              hasPartitionComment(
+                partitionComment,
+                getCommentsBefore(declaration, sourceCode),
+              )) ||
+            (options.partitionByNewLine &&
+              lastSortingNode &&
+              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+          ) {
+            accumulator.push([])
+          }
+
+          accumulator.at(-1)?.push(sortingNode)
+
+          return accumulator
+        },
+        [[]],
+      )
+      let sortedNodes = sortNodesByDependencies(
+        formattedMembers.map(nodes => sortNodes(nodes, options)).flat(),
+      )
+      let nodes = formattedMembers.flat()
+      pairwise(nodes, (left, right) => {
+        let indexOfLeft = sortedNodes.indexOf(left)
+        let indexOfRight = sortedNodes.indexOf(right)
+        if (indexOfLeft <= indexOfRight) {
+          return
+        }
+
+        let firstUnorderedNodeDependentOnRight =
+          getFirstUnorderedNodeDependentOn(right, nodes)
+        context.report({
+          messageId: firstUnorderedNodeDependentOnRight
+            ? 'unexpectedVariableDeclarationsDependencyOrder'
+            : 'unexpectedVariableDeclarationsOrder',
+          data: {
+            left: toSingleLine(left.name),
+            right: toSingleLine(right.name),
+            nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
+          },
+          node: right.node,
+          fix: fixer =>
+            makeFixes(fixer, nodes, sortedNodes, sourceCode, options),
+        })
+      })
     },
   }),
 })

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -30,6 +30,14 @@ describe(ruleName, () => {
         {
           code: dedent`
             class Class {
+              a
+            }
+          `,
+          options: [options],
+        },
+        {
+          code: dedent`
+            class Class {
               static a = 'a'
 
               protected b = 'b'

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -33,6 +33,14 @@ describe(ruleName, () => {
           code: dedent`
             interface Interface {
               a: string
+            }
+          `,
+          options: [options],
+        },
+        {
+          code: dedent`
+            interface Interface {
+              a: string
               b: 'b1' | 'b2',
               c: string
             }

--- a/test/sort-maps.test.ts
+++ b/test/sort-maps.test.ts
@@ -33,6 +33,14 @@ describe(ruleName, () => {
           {
             code: dedent`
               new Map([
+                ['a', 'a'],
+              ])
+            `,
+            options: [options],
+          },
+          {
+            code: dedent`
+              new Map([
                 ['c', 'cc'],
                 ['d', 'd'],
                 ...rest,

--- a/test/sort-named-exports.test.ts
+++ b/test/sort-named-exports.test.ts
@@ -28,6 +28,10 @@ describe(ruleName, () => {
     ruleTester.run(`${ruleName}(${type}): sorts named exports`, rule, {
       valid: [
         {
+          code: 'export { a }',
+          options: [options],
+        },
+        {
           code: 'export { aaa, bb, c }',
           options: [options],
         },

--- a/utils/pairwise.ts
+++ b/utils/pairwise.ts
@@ -2,14 +2,15 @@ export let pairwise = <T>(
   nodes: T[],
   callback: (left: T, right: T, iteration: number) => void,
 ) => {
-  if (nodes.length > 1) {
-    for (let i = 1; i < nodes.length; i++) {
-      let left = nodes.at(i - 1)
-      let right = nodes.at(i)
+  if (nodes.length <= 1) {
+    return
+  }
+  for (let i = 1; i < nodes.length; i++) {
+    let left = nodes.at(i - 1)
+    let right = nodes.at(i)
 
-      if (left && right) {
-        callback(left, right, i - 1)
-      }
+    if (left && right) {
+      callback(left, right, i - 1)
     }
   }
 }


### PR DESCRIPTION
**⚠️ Hide whitespace changes to view actual changes!**
Pretty much all the code change comes from indentation that was reduced.

I initially put this commit in #358 but thought it would be best to put it in a separate PR. Even if there are little actual changes, GitHub displays a lot of line changes.

### Description

This PR simply transforms long 

```ts
if (a) {
  if (b) {
    ...
  }
}
```

blocks into

```ts
if (!a) {
  return
}
if (!b) {
  return
}
```

This makes code more readable by greatly reducing indentation.

### Tests

No test modified, no test removed. A couple of trivial tests were added for coverage purpose.

### What is the purpose of this pull request?

- [x] Other