### PR TITLE
fix(sort-imports): support optional chaining imports

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -353,10 +353,12 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       /* Avoid matching on named imports without specifiers */
       !/\}\s*from\s+/u.test(sourceCode.getText(node))
 
-    let isStyle = (value: string): boolean =>
-      ['.less', '.scss', '.sass', '.styl', '.pcss', '.css', '.sss'].some(
-        extension => value.endsWith(extension),
+    let isStyle = (value: string): boolean => {
+      let [cleanedValue] = value.split('?')
+      return ['.less', '.scss', '.sass', '.styl', '.pcss', '.css', '.sss'].some(
+        extension => cleanedValue.endsWith(extension),
       )
+    }
 
     let flatGroups = new Set(options.groups.flat())
     let shouldRegroupSideEffectNodes = flatGroups.has('side-effect')

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -2308,6 +2308,63 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): supports style imports with optional chaining`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import b from './b.css?raw'
+              import c from './c.css'
+
+              import a from './a.js'
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['style', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import a from './a.js'
+              import b from './b.css?raw'
+              import c from './c.css'
+            `,
+            output: dedent`
+              import b from './b.css?raw'
+              import c from './c.css'
+
+              import a from './a.js'
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['style', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedImportsGroupOrder',
+                data: {
+                  left: './a.js',
+                  leftGroup: 'unknown',
+                  right: './b.css?raw',
+                  rightGroup: 'style',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {
@@ -3798,6 +3855,63 @@ describe(ruleName, () => {
                 data: {
                   left: 'bb',
                   right: 'aaa',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): supports style imports with optional chaining`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import b from './b.css?raw'
+              import c from './c.css'
+
+              import a from './a.js'
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['style', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import a from './a.js'
+              import b from './b.css?raw'
+              import c from './c.css'
+            `,
+            output: dedent`
+              import b from './b.css?raw'
+              import c from './c.css'
+
+              import a from './a.js'
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['style', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedImportsGroupOrder',
+                data: {
+                  left: './a.js',
+                  leftGroup: 'unknown',
+                  right: './b.css?raw',
+                  rightGroup: 'style',
                 },
               },
             ],
@@ -5367,6 +5481,63 @@ describe(ruleName, () => {
                 data: {
                   left: 'bb',
                   right: 'aaa',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): supports style imports with optional chaining`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import b from './b.css?raw'
+              import c from './c.css'
+
+              import a from './a.js'
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['style', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+          },
+        ],
+        invalid: [
+          {
+            code: dedent`
+              import a from './a.js'
+              import b from './b.css?raw'
+              import c from './c.css'
+            `,
+            output: dedent`
+              import b from './b.css?raw'
+              import c from './c.css'
+
+              import a from './a.js'
+            `,
+            options: [
+              {
+                ...options,
+                groups: ['style', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedImportsGroupOrder',
+                data: {
+                  left: './a.js',
+                  leftGroup: 'unknown',
+                  right: './b.css?raw',
+                  rightGroup: 'style',
                 },
               },
             ],


### PR DESCRIPTION
### Description

Support optional chaining imports:

```js
import styles from './styles.scss?module'
```

### Additional context

N/A.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
