### PR TITLE
fix(sort-classes): adds missing safety semicolon for `declare class` inline methods

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -416,7 +416,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             }
             if (member.type === 'TSAbstractMethodDefinition') {
               modifiers.push('abstract')
-            } else {
+            } else if (!node.parent.declare) {
               addSafetySemicolonWhenInline = false
             }
 

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -4472,6 +4472,60 @@ describe(ruleName, () => {
       })
 
       ruleTester.run(
+        `${ruleName}(${type}): sorts inline declare class methods correctly`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+                  declare class Class {
+                    b(); a()
+                  }
+                `,
+              output: dedent`
+                  declare class Class {
+                    a(); b();
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+            {
+              code: dedent`
+                  abstract class Class {
+                    abstract b(); abstract a();
+                  }
+                `,
+              output: dedent`
+                  abstract class Class {
+                    abstract a(); abstract b();
+                  }
+                `,
+              options: [options],
+              errors: [
+                {
+                  messageId: 'unexpectedClassesOrder',
+                  data: {
+                    left: 'b',
+                    right: 'a',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}): sorts inline properties correctly`,
         rule,
         {


### PR DESCRIPTION
### Description

`declare class` methods act like `abstract` methods and can't have an implementation. As such, they need a safety semicolon when declared inline.

### Example

```ts
declare class Class {
  b(); a()
}
```

gets sorted to

```ts
declare class Class {
  a() b();
}
```

instead of

```ts
declare class Class {
  a(); b();
}
```
This PR fixes this.

### Changes

- Fixes the bug (one line fix).
- Adds a unit test.

### What is the purpose of this pull request?

- [x] Bug fix
