### PR TITLE
feat: allows users to enter a number for `partitionByNewline`

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -191,9 +191,16 @@ Allows you to use comments to separate the members of arrays into logical groups
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an array if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of an array if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 if ([

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -215,9 +215,16 @@ Allows you to use comments to separate the class members into logical groups. Th
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of a class if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of a class if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 class User {

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -166,9 +166,16 @@ Allows you to use comments to separate the members of enums into logical groups.
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an enum if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of an enum if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 enum Enum {

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -140,9 +140,16 @@ Allows you to use comments to separate the exports into logical groups. This can
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the exports if there is an empty line between them. This can be useful for keeping logically separated groups of exports in their defined order.
+The rule will not sort the exports if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of exports in their defined order.
 
 ```js
 // Group 1

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -196,9 +196,16 @@ Allows you to use comments to separate imports into logical groups.
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort imports if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort imports if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 import { b1, b2 } from 'b'

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -203,9 +203,16 @@ Allows you to use comments to separate the properties of interfaces into logical
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an interface if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of an interface if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 interface User {

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -136,9 +136,16 @@ Allows you to use comments to separate the members of intersection types into lo
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an intersection type if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of an intersection type if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 type Employee =

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -141,9 +141,16 @@ Allows you to use comments to separate the members of maps into logical groups. 
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of a map if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of a map if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 new Map([

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -169,9 +169,16 @@ Allows you to use comments to separate the members of named exports into logical
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of named exports if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of named exports if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 export {

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -179,9 +179,16 @@ Allows you to use comments to separate the members of named imports into logical
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of named imports if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of named imports if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 import {

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -157,9 +157,16 @@ Allows you to use comments to separate the members of types into logical groups.
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an object if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of an object if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 type User = {

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -215,6 +215,9 @@ Allows you to use comments to separate the keys of objects into logical groups. 
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
 When `true`, the rule will not sort the object’s keys if there is an empty line between them. This can be useful for keeping logically separated groups of keys in their defined order.

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -197,9 +197,16 @@ Allows you to use comments to separate the members of sets into logical groups. 
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of a set if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of a set if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 let items = new Set([

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -156,9 +156,16 @@ Allows you to use comments to separate the members of union types into logical g
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an union type if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of a union type if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 type CarBrand =

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -140,9 +140,16 @@ Allows you to use comments to separate the members of variable declarations into
 
 ### partitionByNewLine
 
+<sub>
+  type: `boolean | number`
+</sub>
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of a variable declaration if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+The rule will not sort the members of a variable declaration if:
+- `true` — There is an empty line between them.
+- `number` — There are at least `number` empty lines between them.
+
+This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 const

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -35,6 +35,7 @@ import {
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -43,7 +44,6 @@ import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
 import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
@@ -611,12 +611,16 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           }
 
           let comments = getCommentsBefore(member, sourceCode)
-          let lastMember = accumulator.at(-1)?.at(-1)
+          let lastSortingNode = accumulator.at(-1)?.at(-1)
 
           if (
-            (options.partitionByNewLine &&
-              lastMember &&
-              getLinesBetween(sourceCode, lastMember, sortingNode)) ||
+            (lastSortingNode &&
+              matchesPartitionByNewLine({
+                options,
+                sortingNode,
+                sourceCode,
+                lastSortingNode,
+              })) ||
             (options.partitionByComment &&
               hasPartitionComment(options.partitionByComment, comments))
           ) {

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -192,7 +192,7 @@ export type SortClassesOptions = [
     specialCharacters: 'remove' | 'trim' | 'keep'
     ignoreCallbackDependenciesPatterns: string[]
     locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
+    partitionByNewLine: boolean | number
     customGroups: CustomGroup[]
     groups: (Group[] | Group)[]
     order: 'desc' | 'asc'

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -16,12 +16,12 @@ import {
   getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -40,7 +40,7 @@ export type Options = [
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
+    partitionByNewLine: boolean | number
     forceNumericSort: boolean
     order: 'desc' | 'asc'
     sortByValue: boolean
@@ -195,9 +195,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 options.partitionByComment,
                 getCommentsBefore(member, sourceCode),
               )) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            (lastSortingNode &&
+              matchesPartitionByNewLine({
+                options,
+                sortingNode,
+                sourceCode,
+                lastSortingNode,
+              }))
           ) {
             accumulator.push([])
           }

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -12,6 +12,7 @@ import {
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -20,7 +21,6 @@ import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
 import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
@@ -59,8 +59,8 @@ type Options = [
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
+    partitionByNewLine: boolean | number
     groups: (Group[] | Group)[]
-    partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -233,9 +233,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 options.partitionByComment,
                 getCommentsBefore(type, sourceCode, '&'),
               )) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            (lastSortingNode &&
+              matchesPartitionByNewLine({
+                options,
+                sortingNode,
+                sourceCode,
+                lastSortingNode,
+              }))
           ) {
             accumulator.push([])
           }

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -11,12 +11,12 @@ import {
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -35,7 +35,7 @@ type Options = [
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
+    partitionByNewLine: boolean | number
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -157,9 +157,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 options.partitionByComment,
                 getCommentsBefore(element, sourceCode),
               )) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            (lastSortingNode &&
+              matchesPartitionByNewLine({
+                options,
+                sortingNode,
+                sourceCode,
+                lastSortingNode,
+              }))
           ) {
             formattedMembers.push([])
           }

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -11,12 +11,12 @@ import {
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -35,7 +35,7 @@ type Options = [
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
+    partitionByNewLine: boolean | number
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -139,9 +139,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
               options.partitionByComment,
               getCommentsBefore(specifier, sourceCode),
             )) ||
-          (options.partitionByNewLine &&
-            lastSortingNode &&
-            getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+          (lastSortingNode &&
+            matchesPartitionByNewLine({
+              options,
+              sortingNode,
+              sourceCode,
+              lastSortingNode,
+            }))
         ) {
           formattedMembers.push([])
         }

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -11,12 +11,12 @@ import {
   orderJsonSchema,
   typeJsonSchema,
 } from '../utils/common-json-schemas'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -35,7 +35,7 @@ type Options = [
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
+    partitionByNewLine: boolean | number
     order: 'desc' | 'asc'
     ignoreAlias: boolean
     ignoreCase: boolean
@@ -152,9 +152,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
               options.partitionByComment,
               getCommentsBefore(specifier, sourceCode),
             )) ||
-          (options.partitionByNewLine &&
-            lastSortingNode &&
-            getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+          (lastSortingNode &&
+            matchesPartitionByNewLine({
+              options,
+              sortingNode,
+              sourceCode,
+              lastSortingNode,
+            }))
         ) {
           formattedMembers.push([])
         }

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -24,7 +25,6 @@ import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
 import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { isMemberOptional } from '../utils/is-member-optional'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
@@ -53,8 +53,8 @@ type Options<T extends string[]> = [
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
+    partitionByNewLine: boolean | number
     groups: (Group<T>[] | Group<T>)[]
-    partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -219,9 +219,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   options.partitionByComment,
                   getCommentsBefore(member, sourceCode),
                 )) ||
-              (options.partitionByNewLine &&
-                lastSortingNode &&
-                getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+              (lastSortingNode &&
+                matchesPartitionByNewLine({
+                  options,
+                  sortingNode,
+                  sourceCode,
+                  lastSortingNode,
+                }))
             ) {
               accumulator.push([])
             }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -12,6 +12,7 @@ import {
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -20,7 +21,6 @@ import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
 import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
@@ -59,8 +59,8 @@ type Options = [
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
+    partitionByNewLine: boolean | number
     groups: (Group[] | Group)[]
-    partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -233,9 +233,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 options.partitionByComment,
                 getCommentsBefore(type, sourceCode, '|'),
               )) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            (lastSortingNode &&
+              matchesPartitionByNewLine({
+                options,
+                sortingNode,
+                sourceCode,
+                lastSortingNode,
+              }))
           ) {
             accumulator.push([])
           }

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -15,12 +15,12 @@ import {
   getFirstUnorderedNodeDependentOn,
   sortNodesByDependencies,
 } from '../utils/sort-nodes-by-dependencies'
+import { matchesPartitionByNewLine } from '../utils/matches-partition-by-new-line'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -41,7 +41,7 @@ type Options = [
     partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
+    partitionByNewLine: boolean | number
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
@@ -223,9 +223,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 options.partitionByComment,
                 getCommentsBefore(declaration, sourceCode),
               )) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            (lastSortingNode &&
+              matchesPartitionByNewLine({
+                options,
+                sortingNode,
+                sourceCode,
+                lastSortingNode,
+              }))
           ) {
             accumulator.push([])
           }

--- a/test/sort-array-includes.test.ts
+++ b/test/sort-array-includes.test.ts
@@ -311,7 +311,39 @@ describe(ruleName, () => {
         `${ruleName}(${type}): allows to use new line as partition`,
         rule,
         {
-          valid: [],
+          valid: [
+            {
+              code: dedent`
+                [
+                  'a',
+
+                  'b',
+                ].includes(value)
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByNewLine: 2,
+                },
+              ],
+            },
+            {
+              code: dedent`
+                [
+                  'b',
+
+
+                  'a',
+                ].includes(value)
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByNewLine: 2,
+                },
+              ],
+            },
+          ],
           invalid: [
             {
               code: dedent`

--- a/test/validate-newlines-and-partition-configuration.test.ts
+++ b/test/validate-newlines-and-partition-configuration.test.ts
@@ -3,21 +3,17 @@ import { describe, expect, it } from 'vitest'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 
 describe('validate-newlines-and-partition-configuration', () => {
-  let partitionByCommentValues: (string[] | boolean | string)[] = [
-    true,
-    'partitionComment',
-    ['partition1', 'partition2'],
-  ]
+  let partitionByNewlineValues = [true, 1] as const
 
   it("throws an error when 'partitionComment' is enabled and 'newlinesBetween' is not 'ignore'", () => {
     let newlinesBetweenValues = ['always', 'never'] as const
 
     for (let newlinesBetween of newlinesBetweenValues) {
-      for (let partitionByComment of partitionByCommentValues) {
+      for (let partitionByNewline of partitionByNewlineValues) {
         expect(() => {
           validateNewlinesAndPartitionConfiguration({
             newlinesBetween,
-            partitionByNewLine: partitionByComment,
+            partitionByNewLine: partitionByNewline,
           })
         }).toThrow(
           "The 'partitionByNewLine' and 'newlinesBetween' options cannot be used together",
@@ -26,12 +22,12 @@ describe('validate-newlines-and-partition-configuration', () => {
     }
   })
 
-  it("allows 'partitionComment' when 'newlinesBetween' is 'ignore'", () => {
-    for (let partitionByComment of partitionByCommentValues) {
+  it("allows 'partitionByNewLine' when 'newlinesBetween' is 'ignore'", () => {
+    for (let partitionByNewLine of partitionByNewlineValues) {
       expect(() => {
         validateNewlinesAndPartitionConfiguration({
           newlinesBetween: 'ignore',
-          partitionByNewLine: partitionByComment,
+          partitionByNewLine,
         })
       }).not.toThrow()
     }

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -96,5 +96,13 @@ export let partitionByCommentJsonSchema: JSONSchema4 = {
 export let partitionByNewLineJsonSchema: JSONSchema4 = {
   description:
     'Allows to use newlines to separate the nodes into logical groups.',
-  type: 'boolean',
+  oneOf: [
+    {
+      type: 'boolean',
+    },
+    {
+      type: 'number',
+      minimum: 1,
+    },
+  ],
 }

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -5,7 +5,7 @@ export type Settings = Partial<{
   partitionByComment: string[] | boolean | string
   specialCharacters: 'remove' | 'trim' | 'keep'
   locales: NonNullable<Intl.LocalesArgument>
-  partitionByNewLine: boolean
+  partitionByNewLine: boolean | number
   ignorePattern: string[]
   order: 'desc' | 'asc'
   ignoreCase: boolean

--- a/utils/matches-partition-by-new-line.ts
+++ b/utils/matches-partition-by-new-line.ts
@@ -1,0 +1,29 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { SortingNode } from '../typings'
+
+import { getLinesBetween } from './get-lines-between'
+
+interface Props {
+  options: { partitionByNewLine: boolean | number }
+  sourceCode: TSESLint.SourceCode
+  lastSortingNode: SortingNode
+  sortingNode: SortingNode
+}
+
+export let matchesPartitionByNewLine = ({
+  options,
+  sortingNode,
+  sourceCode,
+  lastSortingNode,
+}: Props): boolean => {
+  if (!options.partitionByNewLine) {
+    return false
+  }
+  let linesBetween = getLinesBetween(sourceCode, lastSortingNode, sortingNode)
+  return (
+    (options.partitionByNewLine === true && linesBetween > 0) ||
+    (typeof options.partitionByNewLine === 'number' &&
+      linesBetween >= options.partitionByNewLine)
+  )
+}

--- a/utils/validate-newlines-and-partition-configuration.ts
+++ b/utils/validate-newlines-and-partition-configuration.ts
@@ -1,6 +1,6 @@
 interface Options {
-  partitionByNewLine: string[] | boolean | string
   newlinesBetween: 'ignore' | 'always' | 'never'
+  partitionByNewLine: boolean | number
 }
 
 export let validateNewlinesAndPartitionConfiguration = ({


### PR DESCRIPTION
### Description

Today, `partitionByNewLine` will partition elements with a single newline. In some rules, however (typically `sort-classes`), it's very common to separate `methods` with a newline without wanting to partition them.

This PR allows users to enter a `number` for the `partitionByNewLine` option. That number represents the number of newlines required to partition elements (a common use-case would be `2`).

- Almost no code change (one added function), most lines changed are tests and updated documentation.
- No test impacted.
- `boolean` still supported.
- `default` behavior and value unchanged.

### Remaining to do

- Add tests for each rule.

### What is the purpose of this pull request?
- [x] New Feature
