### PR TITLE
fix: fixes invalid `isSortable` import

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import { isSortable } from 'utils/is-sortable'
 import { builtinModules } from 'node:module'
 
 import type { SortingNode } from '../typings'
@@ -33,6 +32,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
+import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -1,7 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import { isSortable } from 'utils/is-sortable'
-
 import type { SortingNode } from '../typings'
 
 import {
@@ -22,6 +20,7 @@ import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
+import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
 import { makeFixes } from '../utils/make-fixes'
 import { pairwise } from '../utils/pairwise'

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -1,7 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import { isSortable } from 'utils/is-sortable'
-
 import type { SortingNode } from '../typings'
 
 import {
@@ -23,6 +21,7 @@ import { getSourceCode } from '../utils/get-source-code'
 import { toSingleLine } from '../utils/to-single-line'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
+import { isSortable } from '../utils/is-sortable'
 import { sortNodes } from '../utils/sort-nodes'
 import { makeFixes } from '../utils/make-fixes'
 import { complete } from '../utils/complete'


### PR DESCRIPTION
### Description

Replaces 

```ts
import { isSortable } from 'utils/is-sortable'
```

Occurrences with

```ts
import { isSortable } from '../utils/is-sortable'
```

to prevent runtime errors.

### What is the purpose of this pull request?

- [x] Bug fix
