### PR TITLE
feat!: move from natural-compare-lite to natural-orderby

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -126,7 +126,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -161,7 +161,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-decorators.mdx
+++ b/docs/content/rules/sort-decorators.mdx
@@ -125,7 +125,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -91,7 +91,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -85,7 +85,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-heritage-clauses.mdx
+++ b/docs/content/rules/sort-heritage-clauses.mdx
@@ -68,7 +68,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -124,7 +124,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -140,7 +140,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -81,7 +81,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -141,7 +141,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -86,7 +86,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -184,7 +184,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -104,7 +104,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -105,7 +105,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -102,7 +102,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -160,7 +160,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -132,7 +132,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-switch-case.mdx
+++ b/docs/content/rules/sort-switch-case.mdx
@@ -153,7 +153,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -101,7 +101,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -85,7 +85,7 @@ This rule accepts an options object with the following properties:
 Specifies the sorting method.
 
 - `'alphabetical'` — Sort items alphabetically (e.g., “a” < “b” < “c”) using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
-- `'natural'` — Sort items in a [natural](https://github.com/litejs/natural-compare-lite) order (e.g., “item2” < “item10”).
+- `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 
 ### order

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@azat-io/eslint-config": "^2.0.0",
     "@typescript-eslint/types": "^8.14.0",
     "@typescript-eslint/utils": "^8.14.0",
-    "natural-compare-lite": "^1.4.0"
+    "natural-orderby": "^5.0.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
@@ -66,7 +66,6 @@
     "@poppanator/sveltekit-svg": "5.0.0",
     "@shikijs/transformers": "^1.22.2",
     "@types/mdast": "^4.0.4",
-    "@types/natural-compare-lite": "^1.4.2",
     "@types/node": "^22.9.0",
     "@types/unist": "^3.0.3",
     "@typescript-eslint/parser": "^8.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.14.0
         version: 8.14.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3)
-      natural-compare-lite:
-        specifier: ^1.4.0
-        version: 1.4.0
+      natural-orderby:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
@@ -60,9 +60,6 @@ importers:
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
-      '@types/natural-compare-lite':
-        specifier: ^1.4.2
-        version: 1.4.2
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0
@@ -2009,9 +2006,6 @@ packages:
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
-
-  '@types/natural-compare-lite@1.4.2':
-    resolution: {integrity: sha512-kk1ie31cI6AUm17qOi72lEOBfpRhcknJPsJQoKBulaZC9y00MHUWqxGTk/luWEnenLB+lHoNThrKAKdYVydlew==}
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
@@ -4839,6 +4833,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  natural-orderby@5.0.0:
+    resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
+    engines: {node: '>=18'}
 
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
@@ -8589,8 +8587,6 @@ snapshots:
   '@types/minimatch@5.1.2': {}
 
   '@types/ms@0.7.34': {}
-
-  '@types/natural-compare-lite@1.4.2': {}
 
   '@types/nlcst@2.0.3':
     dependencies:
@@ -12355,6 +12351,8 @@ snapshots:
   natural-compare-lite@1.4.0: {}
 
   natural-compare@1.4.0: {}
+
+  natural-orderby@5.0.0: {}
 
   neotraverse@0.6.18: {}
 

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -2904,8 +2904,8 @@ describe(ruleName, () => {
           {
             code: dedent`
               import type { T } from '../t'
-              import type { U } from '~/u'
               import type { V } from 'v'
+              import type { U } from '~/u'
             `,
             options: [
               {
@@ -2927,14 +2927,14 @@ describe(ruleName, () => {
             code: dedent`
               import type { T } from '../t'
 
-              import type { U } from '~/u'
-
               import type { V } from 'v'
+
+              import type { U } from '~/u'
             `,
             output: dedent`
               import type { T } from '../t'
-              import type { U } from '~/u'
               import type { V } from 'v'
+              import type { U } from '~/u'
             `,
             options: [
               {
@@ -2954,14 +2954,14 @@ describe(ruleName, () => {
                 messageId: 'extraSpacingBetweenImports',
                 data: {
                   left: '../t',
-                  right: '~/u',
+                  right: 'v',
                 },
               },
               {
                 messageId: 'extraSpacingBetweenImports',
                 data: {
-                  left: '~/u',
-                  right: 'v',
+                  left: 'v',
+                  right: '~/u',
                 },
               },
             ],

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -1275,10 +1275,10 @@ describe(ruleName, () => {
           {
             code: dedent`
               type Type = {
+                [8]: Value
                 [...values]
                 [[data]]: string
                 [name in v]?
-                [8]: Value
                 arrowFunc?: () => void
                 func(): void
               }
@@ -1300,16 +1300,23 @@ describe(ruleName, () => {
             `,
             output: dedent`
               type Type = {
+                [8]: Value
                 [...values]
                 [[data]]: string
                 [name in v]?
-                [8]: Value
                 arrowFunc?: () => void
                 func(): void
               }
             `,
             options: [options],
             errors: [
+              {
+                messageId: 'unexpectedObjectTypesOrder',
+                data: {
+                  left: '[name in v]?',
+                  right: '8',
+                },
+              },
               {
                 messageId: 'unexpectedObjectTypesOrder',
                 data: {

--- a/test/sort-union-types.test.ts
+++ b/test/sort-union-types.test.ts
@@ -1193,8 +1193,8 @@ describe(ruleName, () => {
               | boolean
               | keyof A
               | typeof B
-              | 'aaa'
               | 1
+              | 'aaa'
               | (new () => SomeClass)
               | (import('path'))
               | (A extends B ? C : D)
@@ -1254,8 +1254,8 @@ describe(ruleName, () => {
               | boolean
               | keyof A
               | typeof B
-              | 'aaa'
               | 1
+              | 'aaa'
               | (import('path'))
               | (A extends B ? C : D)
               | { name: 'a' }

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -1028,7 +1028,7 @@ describe(ruleName, () => {
         valid: [
           {
             code: dedent`
-              const [c] = C, { bb } = B, aaa
+              const [c] = C, aaa, { bb } = B
             `,
             options: [options],
           },
@@ -1039,17 +1039,10 @@ describe(ruleName, () => {
               const aaa, { bb } = B, [c] = C
             `,
             output: dedent`
-              const [c] = C, { bb } = B, aaa
+              const [c] = C, aaa, { bb } = B
             `,
             options: [options],
             errors: [
-              {
-                messageId: 'unexpectedVariableDeclarationsOrder',
-                data: {
-                  left: 'aaa',
-                  right: '{ bb }',
-                },
-              },
               {
                 messageId: 'unexpectedVariableDeclarationsOrder',
                 data: {


### PR DESCRIPTION
### Description

Hi. This is probably the last breaking change in the upcoming release. But I'm not entirely sure we need it. I'd like to discuss it.

This pull request changes the current library for natural sorting from  [natural-compare-lite](https://github.com/litejs/natural-compare-lite) to [natural-orderby](https://github.com/yobacca/natural-orderby).

#### Pros

- **Supported Library**. The last release of the library we are currently using was 9 years ago. We can't influence its development in any way, we can't inform the author of the library about any problems. At the same time, the last release of the new library was today.

- **Support numeric separators**. The old library came out quite a long time ago and therefore did not support numeric separators (`1_000_000`). The new library started to support this out of the box: https://github.com/yobacca/natural-orderby/pull/231

- **Ability to select locale**. We added new option to select locale for alpabetical sorting (https://github.com/azat-io/eslint-plugin-perfectionist/pull/328). The new library support this also out of the box: https://github.com/yobacca/natural-orderby/pull/240

- **More functionality**. The new library takes into account not only numbers, but can also work with dates, IP addresses and complex numbers.

#### Cons

- **The weight of the library.** The new library is not huge, but it weighs noticeably more than the old one. Is it critical for us?

```
du -sh ./node_modules/natural-compare-lite/
 12K	./node_modules/natural-compare-lite/

du -sh ./node_modules/natural-orderby/
100K	./node_modules/natural-orderby/
```

- **The order is a little different**. You can see the changes in the tests of the current pull-request.

I'd like to hear your opinion, is it worth replacing the old library with the new one? Or is the current library completely satisfied with us and the advantages are not so significant?

@hugop95 @OlivierZal What do you think?

@JoshuaKGoldberg I don't use natural sorting, but I know you do. I would be glad if you could give me your opinion.

### Additional context

N/A.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
