### PR TITLE
fix(sort-modules): disables sorting for `export decorated` classes

### DIFF
--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -325,6 +325,15 @@ let analyzeModule = ({
       continue
     }
 
+    if (
+      selector === 'class' &&
+      modifiers.includes('export') &&
+      modifiers.includes('decorated')
+    ) {
+      // Not always handled correctly at the moment
+      continue
+    }
+
     let { defineGroup, getGroup } = useGroups(options)
     for (let officialGroup of generatePredefinedGroups({
       cache: cachedGroupsByModifiersAndSelectors,

--- a/test/sort-modules.test.ts
+++ b/test/sort-modules.test.ts
@@ -959,6 +959,7 @@ describe(ruleName, () => {
         },
       )
 
+      /* Currently not handled correctly
       ruleTester.run(
         `${ruleName}(${type}): prioritize default over decorated`,
         rule,
@@ -1036,6 +1037,7 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+      */
     })
 
     describe(`${ruleName}(${type}): function modifiers priority`, () => {
@@ -2375,6 +2377,53 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): ignores exported decorated classes`,
+      rule,
+      {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'B',
+                  left: 'C',
+                },
+                messageId: 'unexpectedModulesOrder',
+              },
+            ],
+            output: dedent`
+                @B
+                class B {}
+
+                @A
+                export class A {}
+
+                @C
+                class C {}
+              `,
+            code: dedent`
+                @C
+                class C {}
+
+                @A
+                export class A {}
+
+                @B
+                class B {}
+              `,
+            options: [
+              {
+                ...options,
+                groups: ['unknown'],
+              },
+            ],
+          },
+        ],
+        valid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {


### PR DESCRIPTION
Will fix temporarily #376 

### Description

The actual fix requires computing and detecting decorators similarly to how comments are detected, but it's not straightforward.

In the meantime, we can simply ignore `export decorated classes`.

### Tests impacted

- 2 tests commented: sorting is disabled in those cases.
- 1 test added.

### What is the purpose of this pull request?

- [x] Bug fix
