### PR TITLE
fix: fixes runtime errors in non typescript-eslint projects 

### DIFF
--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -19,6 +19,7 @@ import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
+import { getNodeDecorators } from '../utils/get-node-decorators'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getDecoratorName } from '../utils/get-decorator-name'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -163,19 +164,31 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       },
       PropertyDefinition: propertyDefinition =>
         options.sortOnProperties
-          ? sortDecorators(context, options, propertyDefinition.decorators)
+          ? sortDecorators(
+              context,
+              options,
+              getNodeDecorators(propertyDefinition),
+            )
           : null,
       AccessorProperty: accessorDefinition =>
         options.sortOnAccessors
-          ? sortDecorators(context, options, accessorDefinition.decorators)
+          ? sortDecorators(
+              context,
+              options,
+              getNodeDecorators(accessorDefinition),
+            )
           : null,
       MethodDefinition: methodDefinition =>
         options.sortOnMethods
-          ? sortDecorators(context, options, methodDefinition.decorators)
+          ? sortDecorators(
+              context,
+              options,
+              getNodeDecorators(methodDefinition),
+            )
           : null,
-      ClassDeclaration: Declaration =>
+      ClassDeclaration: declaration =>
         options.sortOnClasses
-          ? sortDecorators(context, options, Declaration.decorators)
+          ? sortDecorators(context, options, getNodeDecorators(declaration))
           : null,
     }
   },

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -114,9 +114,10 @@ let sortHeritageClauses = (
   options: Required<Options<string[]>[0]>,
   heritageClauses:
     | TSESTree.TSInterfaceHeritage[]
-    | TSESTree.TSClassImplements[],
+    | TSESTree.TSClassImplements[]
+    | undefined,
 ): void => {
-  if (!isSortable(heritageClauses)) {
+  if (!heritageClauses || !isSortable(heritageClauses)) {
     return
   }
   let sourceCode = getSourceCode(context)

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -43,6 +43,7 @@ import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
 import { getCommentsBefore } from '../utils/get-comments-before'
+import { getNodeDecorators } from '../utils/get-node-decorators'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -295,10 +296,12 @@ let analyzeModule = ({
         case AST_NODE_TYPES.ClassDeclaration:
           selector = 'class'
           name = nodeToParse.id?.name
-          if (nodeToParse.decorators.length > 0) {
+          // eslint-disable-next-line no-case-declarations -- Easier to handle
+          let nodeDecorators = getNodeDecorators(nodeToParse)
+          if (nodeDecorators.length > 0) {
             modifiers.push('decorated')
           }
-          for (let decorator of nodeToParse.decorators) {
+          for (let decorator of nodeDecorators) {
             if (decorator.expression.type === 'Identifier') {
               decorators.push(decorator.expression.name)
             } else if (

--- a/test/sort-array-includes.test.ts
+++ b/test/sort-array-includes.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1788,5 +1792,25 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              [
+                'a',
+                'b',
+                'c',
+              ].includes(value)
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -8549,5 +8553,31 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              class A {
+
+                static {}
+
+                b
+                a = this.b
+
+                constructor() {}
+
+                method() {}
+              }
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-decorators.test.ts
+++ b/test/sort-decorators.test.ts
@@ -1,6 +1,8 @@
 import type { TestCaseError } from '@typescript-eslint/rule-tester'
+import type { Rule } from 'eslint'
 
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -17,6 +19,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -4010,6 +4013,27 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              class A {
+
+                property
+
+                method() {}
+              }
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })
 

--- a/test/sort-exports.test.ts
+++ b/test/sort-exports.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1379,5 +1383,23 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              export { a } from 'a'
+              export * from 'b'
+              export { c } from 'c'
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-heritage-clauses.test.ts
+++ b/test/sort-heritage-clauses.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1677,5 +1681,21 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              class Class extends A {}
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-imports.test.ts
+++ b/test/sort-imports.test.ts
@@ -3,10 +3,12 @@ import type {
   RuleContext,
 } from '@typescript-eslint/utils/ts-eslint'
 import type { CompilerOptions } from 'typescript'
+import type { Rule } from 'eslint'
 
 import { afterAll, describe, expect, it, vi } from 'vitest'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { createModuleResolutionCache } from 'typescript'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { dedent } from 'ts-dedent'
 
 import type { MESSAGE_ID, Options } from '../rules/sort-imports'
@@ -26,6 +28,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -6511,5 +6514,24 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import { d } from '~./d.scss'
+              import { a } from 'a'
+              import * as b from 'b'
+              import { c } from 'c'
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-maps.test.ts
+++ b/test/sort-maps.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1524,5 +1528,25 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              new Map([
+                ['a', 'a'],
+                ['b', 'b'],
+                ['c', 'c'],
+              ])
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-modules.test.ts
+++ b/test/sort-modules.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -3324,5 +3328,23 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              class A {}
+
+              function func() {}
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-named-exports.test.ts
+++ b/test/sort-named-exports.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1176,5 +1180,21 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              export { a, b, c } from './module';
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-named-imports.test.ts
+++ b/test/sort-named-imports.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1794,5 +1798,21 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              import { a, b, c } from './module';
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -4468,5 +4472,26 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+                let Func = ({
+                  b = () => 1,
+                  a = b(),
+                }) => {
+                  // ...
+                }
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-sets.test.ts
+++ b/test/sort-sets.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1735,5 +1739,25 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              new Set([
+                'a',
+                'b',
+                'c',
+              ])
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -2589,6 +2593,29 @@ describe(ruleName, () => {
               }
             `,
         ],
+      },
+    )
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              switch (variable) {
+                case 'a':
+                case 'b':
+                  break
+                case 'c':
+                default:
+                  break
+                }
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
       },
     )
   })

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -2496,96 +2496,100 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
-  })
 
-  ruleTester.run(`${ruleName}: default should be last`, rule, {
-    invalid: [
-      {
-        output: dedent`
-          switch (value) {
-            case 'aa':
-              return true
-            case 'b':
-              return true
-            default:
-              return false
-          }
-        `,
-        code: dedent`
-          switch (value) {
-            case 'aa':
-              return true
-            default:
-              return false
-            case 'b':
-              return true
-          }
-        `,
-        errors: [
-          {
-            data: {
-              left: 'default',
-              right: 'b',
+    ruleTester.run(`${ruleName}: default should be last`, rule, {
+      invalid: [
+        {
+          output: dedent`
+            switch (value) {
+              case 'aa':
+                return true
+              case 'b':
+                return true
+              default:
+                return false
+            }
+          `,
+          code: dedent`
+            switch (value) {
+              case 'aa':
+                return true
+              default:
+                return false
+              case 'b':
+                return true
+            }
+          `,
+          errors: [
+            {
+              data: {
+                left: 'default',
+                right: 'b',
+              },
+              messageId: 'unexpectedSwitchCaseOrder',
             },
-            messageId: 'unexpectedSwitchCaseOrder',
+          ],
+        },
+      ],
+      valid: [],
+    })
+
+    ruleTester.run(
+      `${ruleName}: handles default case and default clause`,
+      rule,
+      {
+        invalid: [
+          {
+            output: dedent`
+              switch (variable) {
+                case 'add':
+                  break
+                case 'default':
+                  break
+                case 'remove':
+                  break
+                default:
+                  break
+                }
+              `,
+            code: dedent`
+              switch (variable) {
+                case 'default':
+                  break
+                case 'add':
+                  break
+                case 'remove':
+                  break
+                default:
+                  break
+                }
+              `,
+            errors: [
+              {
+                data: {
+                  left: 'default',
+                  right: 'add',
+                },
+                messageId: 'unexpectedSwitchCaseOrder',
+              },
+            ],
           },
         ],
-      },
-    ],
-    valid: [],
-  })
-
-  ruleTester.run(`${ruleName}: handles default case and default clause`, rule, {
-    invalid: [
-      {
-        output: dedent`
-        switch (variable) {
-          case 'add':
-            break
-          case 'default':
-            break
-          case 'remove':
-            break
-          default:
-            break
-          }
-        `,
-        code: dedent`
-        switch (variable) {
-          case 'default':
-            break
-          case 'add':
-            break
-          case 'remove':
-            break
-          default:
-            break
-          }
-        `,
-        errors: [
-          {
-            data: {
-              left: 'default',
-              right: 'add',
-            },
-            messageId: 'unexpectedSwitchCaseOrder',
-          },
+        valid: [
+          dedent`
+            switch (variable) {
+              case 'add':
+                break
+              case 'default':
+                break
+              case 'remove':
+                break
+              default:
+                break
+              }
+            `,
         ],
       },
-    ],
-    valid: [
-      dedent`
-        switch (variable) {
-          case 'add':
-            break
-          case 'default':
-            break
-          case 'remove':
-            break
-          default:
-            break
-          }
-        `,
-    ],
+    )
   })
 })

--- a/test/sort-variable-declarations.test.ts
+++ b/test/sort-variable-declarations.test.ts
@@ -1,4 +1,7 @@
+import type { Rule } from 'eslint'
+
 import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
 
@@ -15,6 +18,7 @@ describe(ruleName, () => {
   RuleTester.it = it
 
   let ruleTester = new RuleTester()
+  let eslintRuleTester = new EslintRuleTester()
 
   describe(`${ruleName}: sorting by alphabetical order`, () => {
     let type = 'alphabetical-order'
@@ -1695,5 +1699,23 @@ describe(ruleName, () => {
       ],
       valid: [],
     })
+
+    eslintRuleTester.run(
+      `${ruleName}: handles non typescript-eslint parser`,
+      rule as unknown as Rule.RuleModule,
+      {
+        valid: [
+          {
+            code: dedent`
+              const b = 1,
+                    a = b + 2,
+                    c = a + 3;
+            `,
+            options: [{}],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 })

--- a/utils/get-node-decorators.ts
+++ b/utils/get-node-decorators.ts
@@ -1,0 +1,15 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+type NodeWithDecorator = {
+  decorators: TSESTree.Decorator[]
+} & TSESTree.Node
+
+/*
+ * Projects without typescript-eslint parser will not have the `decorators`
+ * property on the node, so add a fallback.
+ */
+export let getNodeDecorators = (
+  node: NodeWithDecorator,
+  /* v8 ignore next 2 */
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+): TSESTree.Decorator[] => node.decorators ?? []


### PR DESCRIPTION
### Description

Some runtime errors happen in projects that do not user `typescript-eslint` parser.

For example, decorators are not detected (and the `decorators` property will not exist on nodes, even though `typescript-eslint` types will say it necessarily exists).

This PR fixes them and adds for each rule some basic tests to ensure that the rule works fine in a non-typescript environment, using `eslint`'s Rule Tester rather than `typescript-eslint`'s Rule Tester.

- [x] Bug fix