### PR TITLE
feat(sort-objects): adds `objectDeclarations ` and `destructuredObjects ` options

### DIFF
--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -264,11 +264,29 @@ Allows you to specify names or patterns for object types that should be ignored 
 
 You can specify their names or a regexp pattern to ignore, for example: `'^User.+'` to ignore all object types whose names begin with the word “User”.
 
-### destructureOnly
+### [DEPRECATED] destructureOnly
 
 <sub>default: `false`</sub>
 
-Allows you to sort only objects that are part of a destructuring pattern. When set to `true`, the rule will apply sorting exclusively to destructured objects, leaving other object declarations unchanged.
+Use the [objectDeclarations](#objectdeclarations) and [destructuredObjects](#destructuredobjects) options instead.
+
+Allows you to only sort objects that are part of a destructuring pattern. When set to `true`, the rule will apply sorting exclusively to destructured objects, leaving other object declarations unchanged.
+
+### objectDeclarations
+
+<sub>default: `true`</sub>
+
+Allows you to choose whether to sort standard object declarations.
+
+### destructuredObjects
+
+<sub>
+  type: `boolean | { groups: boolean }`
+</sub>
+<sub>default: `true`</sub>
+
+Allows you to choose whether to sort destructured objects.
+The `groups` attribute allows you to specify whether to use groups to sort destructured objects.
 
 ### groups
 

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -3850,7 +3850,7 @@ describe(ruleName, () => {
       ],
     })
 
-    ruleTester.run(`${ruleName}: allow to use for destructuring only`, rule, {
+    ruleTester.run(`${ruleName}: allow to use 'destructureOnly'`, rule, {
       invalid: [
         {
           errors: [
@@ -3912,6 +3912,202 @@ describe(ruleName, () => {
           ],
         },
       ],
+    })
+
+    ruleTester.run(`${ruleName}: allow to use 'objectDeclarations'`, rule, {
+      invalid: [
+        {
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              c: 'c',
+              a: 'a',
+              b: 'b',
+            }
+
+            let { a, b, c } = obj
+          `,
+          code: dedent`
+            let obj = {
+              c: 'c',
+              a: 'a',
+              b: 'b',
+            }
+
+            let { c, b, a } = obj
+          `,
+          options: [
+            {
+              objectDeclarations: false,
+            },
+          ],
+        },
+      ],
+      valid: [
+        {
+          code: dedent`
+            let obj = {
+              c: 'c',
+              a: 'a',
+              b: 'b',
+            }
+
+            let { a, b, c } = obj
+          `,
+          options: [
+            {
+              objectDeclarations: false,
+            },
+          ],
+        },
+      ],
+    })
+
+    describe(`${ruleName}: allow to use 'destructuredObjects'`, () => {
+      ruleTester.run(`${ruleName}: boolean 'destructuredObjects'`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'b',
+                  left: 'c',
+                },
+                messageId: 'unexpectedObjectsOrder',
+              },
+              {
+                data: {
+                  right: 'a',
+                  left: 'b',
+                },
+                messageId: 'unexpectedObjectsOrder',
+              },
+            ],
+            output: dedent`
+              let obj = {
+                a: 'a',
+                b: 'b',
+                c: 'c',
+              }
+
+              let { c, a, b } = obj
+            `,
+            code: dedent`
+              let obj = {
+                c: 'c',
+                b: 'b',
+                a: 'a',
+              }
+
+              let { c, a, b } = obj
+            `,
+            options: [
+              {
+                destructuredObjects: false,
+              },
+            ],
+          },
+        ],
+        valid: [
+          {
+            code: dedent`
+              let obj = {
+                a: 'a',
+                b: 'b',
+                c: 'c',
+              }
+
+              let { b, c, a } = obj
+            `,
+            options: [
+              {
+                destructuredObjects: false,
+              },
+            ],
+          },
+        ],
+      })
+
+      ruleTester.run(
+        `${ruleName}: object 'destructuredObjects': 'groups' attribute`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    leftGroup: 'unknown',
+                    rightGroup: 'top',
+                    right: 'c',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedObjectsGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: {
+                    top: 'c',
+                  },
+                  destructuredObjects: { groups: true },
+                  groups: ['top', 'unknown'],
+                },
+              ],
+              output: dedent`
+                let { c, a, b } = obj
+              `,
+              code: dedent`
+                let { a, c, b } = obj
+              `,
+            },
+            {
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'unknown',
+                    leftGroup: 'top',
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedObjectsGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: {
+                    top: 'c',
+                  },
+                  destructuredObjects: { groups: false },
+                  groups: ['top', 'unknown'],
+                },
+              ],
+              output: dedent`
+                let { a, b, c } = obj
+              `,
+              code: dedent`
+                let { a, c, b } = obj
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     ruleTester.run(`${ruleName}: works with settings`, rule, {


### PR DESCRIPTION
Resolves #392

## Changes

- Deprecates the `destructureOnly` option in the documentation (still usable).
- Adds a `objectDeclarations: boolean` option (by default `true`): when false, will not sort object declarations. 
- Adds a `destructuredObjects: boolean | { groups: boolean }` option (by default `true`): when false, will not sort destructured objects. When `{ groups: false }`, will not use groups to sort destructured objects.

## Advantages of using `{ groups: boolean }` rather than `{ disableGrouping: boolean }`

- Uses the same existing option name `groups`, making it clear that this sub-option is linked with the parent `groups` option.
- Gives flexibility later if users require specifying specific grouping for destructured objects: `{ groups: boolean }` can be extended to `{ groups: boolean | string[] | string[][] }`.

### What is the purpose of this pull request?

- [x] New Feature
