### PR TITLE
docs: small fixes

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -180,7 +180,7 @@ Allows you to group array elements by their kind, determining whether spread val
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of arrays into logical groups. This can help in organizing and maintaining large arrays by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of arrays into logical groups. This can help in organizing and maintaining large arrays by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -205,7 +205,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the class members into logical groups. This can help in organizing and maintaining large classes by creating partitions within the enum based on comments.
+Allows you to use comments to separate the class members into logical groups. This can help in organizing and maintaining large classes by creating partitions within the class based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -129,7 +129,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the exports into logical groups. This can help in organizing and maintaining large export blocks by creating partitions within the enum based on comments.
+Allows you to use comments to separate the exports into logical groups. This can help in organizing and maintaining large export blocks by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -125,7 +125,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of intersection types into logical groups. This can help in organizing and maintaining large intersection types by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of intersection types into logical groups. This can help in organizing and maintaining large intersection types by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -130,7 +130,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of maps into logical groups. This can help in organizing and maintaining large maps by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of maps into logical groups. This can help in organizing and maintaining large maps by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -228,7 +228,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the module members into logical groups. This can help in organizing and maintaining large modules by creating partitions within the enum based on comments.
+Allows you to use comments to separate the module members into logical groups. This can help in organizing and maintaining large modules by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -30,29 +30,9 @@ By sorting module members systematically, confusion is minimized, and the code b
 
 <CodeExample
   alphabetical={dedent`
-    export interface FindUserInput {
-      id: string
-      cache: CacheType
-    }
-
     enum CacheType {
       ALWAYS = 'ALWAYS',
       NEVER = 'NEVER',
-    }
-
-    export type FindUserOutput = {
-      id: string
-      name: string
-      age: number
-    }
-
-    function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-      // Some logic
-    }
-
-    export function findUser(input: FindUserInput): FindUserOutput {
-      assertInputIsCorrect(input)
-      return _findUserByIds([input.id])[0]
     }
 
     export type FindAllUsersInput = {
@@ -62,12 +42,32 @@ By sorting module members systematically, confusion is minimized, and the code b
 
     export type FindAllUsersOutput = FindUserOutput[]
 
+    export interface FindUserInput {
+      id: string
+      cache: CacheType
+    }
+
+    export type FindUserOutput = {
+      id: string
+      name: string
+      age: number
+    }
+
+    class Cache {
+      // Some logic
+    }
+
     export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
       assertInputIsCorrect(input)
       return _findUserByIds(input.ids)
     }
 
-    class Cache {
+    export function findUser(input: FindUserInput): FindUserOutput {
+      assertInputIsCorrect(input)
+      return _findUserByIds([input.id])[0]
+    }
+
+    function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
       // Some logic
     }
   `}
@@ -77,10 +77,11 @@ By sorting module members systematically, confusion is minimized, and the code b
       NEVER = 'NEVER',
     }
 
-    export type FindUserOutput = {
+    export type FindAllUsersOutput = FindUserOutput[]
+
+    export interface FindUserInput {
       id: string
-      name: string
-      age: number
+      cache: CacheType
     }
 
     export type FindAllUsersInput = {
@@ -88,25 +89,24 @@ By sorting module members systematically, confusion is minimized, and the code b
       cache: CacheType
     }
 
-    export interface FindUserInput {
+    export type FindUserOutput = {
       id: string
-      cache: CacheType
+      name: string
+      age: number
     }
-
-    export type FindAllUsersOutput = FindUserOutput[]
 
     class Cache {
       // Some logic
     }
 
-    export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-      assertInputIsCorrect(input)
-      return _findUserByIds(input.ids)
-    }
-
     export function findUser(input: FindUserInput): FindUserOutput {
       assertInputIsCorrect(input)
       return _findUserByIds([input.id])[0]
+    }
+
+    export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+      assertInputIsCorrect(input)
+      return _findUserByIds(input.ids)
     }
 
     function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -158,7 +158,7 @@ Allows you to group named exports by their kind, determining whether value expor
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of named exports into logical groups. This can help in organizing and maintaining large named exports by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of named exports into logical groups. This can help in organizing and maintaining large named exports by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -168,7 +168,7 @@ Allows you to group named imports by their kind, determining whether value impor
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of named imports into logical groups. This can help in organizing and maintaining large named imports by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of named imports into logical groups. This can help in organizing and maintaining large named imports by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -146,7 +146,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of types into logical groups. This can help in organizing and maintaining large object types by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of types into logical groups. This can help in organizing and maintaining large object types by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 - `false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -204,7 +204,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the keys of objects into logical groups. This can help in organizing and maintaining large objects by creating partitions within the enum based on comments.
+Allows you to use comments to separate the keys of objects into logical groups. This can help in organizing and maintaining large objects by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 - `false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -186,7 +186,7 @@ Allows you to group set elements by their kind, determining whether spread value
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of sets into logical groups. This can help in organizing and maintaining large sets by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of sets into logical groups. This can help in organizing and maintaining large sets by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -145,7 +145,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of union types into logical groups. This can help in organizing and maintaining large union types by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of union types into logical groups. This can help in organizing and maintaining large union types by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -129,7 +129,7 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 <sub>default: `false`</sub>
 
-Allows you to use comments to separate the members of variable declarations into logical groups. This can help in organizing and maintaining large variable declaration blocks by creating partitions within the enum based on comments.
+Allows you to use comments to separate the members of variable declarations into logical groups. This can help in organizing and maintaining large variable declaration blocks by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.


### PR DESCRIPTION
### Description

Small documentation fixes.

- Fixes invalid `enum` references.
- Fixes invalid example in `sort-modules` to follow the current default options.

### What is the purpose of this pull request?

- [x] Documentation update
