### PR TITLE
fix: removes `baseUrl` from `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "target": "esnext",
     "types": ["node"],
     "allowJs": true,
-    "baseUrl": ".",
     "strict": true,
     "noEmit": true
   }


### PR DESCRIPTION
### Description

Reduces the potential of import errors by removing the `baseUrl: "."` option in `tsconfig.json`.

`import { pairwise } from 'utils/pairwise'` or similar imports will now raise errors.

I don't think there should be any side effect in this.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Other
