### PR TITLE
fix(sort-decorators): keeps JSDoc blocks in place

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -161,7 +161,10 @@ export let sortArray = <MessageIds extends string>(
         (options.partitionByComment &&
           hasPartitionComment(
             options.partitionByComment,
-            getCommentsBefore(element, sourceCode),
+            getCommentsBefore({
+              node: element,
+              sourceCode,
+            }),
           )) ||
         (options.partitionByNewLine &&
           lastSortingNode &&

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -543,7 +543,6 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             name,
           }
 
-          let comments = getCommentsBefore(member, sourceCode)
           let lastMember = accumulator.at(-1)?.at(-1)
 
           if (
@@ -551,7 +550,13 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
               lastMember &&
               getLinesBetween(sourceCode, lastMember, sortingNode)) ||
             (options.partitionByComment &&
-              hasPartitionComment(options.partitionByComment, comments))
+              hasPartitionComment(
+                options.partitionByComment,
+                getCommentsBefore({
+                  node: member,
+                  sourceCode,
+                }),
+              ))
           ) {
             accumulator.push([])
           }

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -273,7 +273,7 @@ let sortDecorators = (
       fix: fixer =>
         makeFixes({
           sortedNodes: sortedNodesExcludingEslintDisabled,
-          ignoreFirstNodeJsDocBlock: true,
+          ignoreFirstNodeHighestBlockComment: true,
           sourceCode,
           options,
           fixer,

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -216,7 +216,10 @@ let sortDecorators = (
         options.partitionByComment &&
         hasPartitionComment(
           options.partitionByComment,
-          getCommentsBefore(decorator, sourceCode),
+          getCommentsBefore({
+            node: decorator,
+            sourceCode,
+          }),
         )
       ) {
         accumulator.push([])

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -273,6 +273,7 @@ let sortDecorators = (
       fix: fixer =>
         makeFixes({
           sortedNodes: sortedNodesExcludingEslintDisabled,
+          ignoreFirstNodeJsDocBlock: true,
           sourceCode,
           options,
           fixer,

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -151,7 +151,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             (options.partitionByComment &&
               hasPartitionComment(
                 options.partitionByComment,
-                getCommentsBefore(member, sourceCode),
+                getCommentsBefore({
+                  node: member,
+                  sourceCode,
+                }),
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -91,7 +91,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
         (partitionComment &&
           hasPartitionComment(
             partitionComment,
-            getCommentsBefore(node, sourceCode),
+            getCommentsBefore({
+              sourceCode,
+              node,
+            }),
           )) ||
         (options.partitionByNewLine &&
           lastNode &&

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -456,7 +456,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             (options.partitionByComment &&
               hasPartitionComment(
                 options.partitionByComment,
-                getCommentsBefore(sortingNode.node, sourceCode),
+                getCommentsBefore({
+                  node: sortingNode.node,
+                  sourceCode,
+                }),
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -178,7 +178,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               (options.partitionByComment &&
                 hasPartitionComment(
                   options.partitionByComment,
-                  getCommentsBefore(element, sourceCode),
+                  getCommentsBefore({
+                    node: element,
+                    sourceCode,
+                  }),
                 )) ||
               (options.partitionByNewLine &&
                 lastElement &&

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -187,7 +187,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
             (options.partitionByComment &&
               hasPartitionComment(
                 options.partitionByComment,
-                getCommentsBefore(type, sourceCode, '&'),
+                getCommentsBefore({
+                  tokenValueToIgnoreBefore: '&',
+                  node: type,
+                  sourceCode,
+                }),
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -123,7 +123,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             (options.partitionByComment &&
               hasPartitionComment(
                 options.partitionByComment,
-                getCommentsBefore(element, sourceCode),
+                getCommentsBefore({
+                  node: element,
+                  sourceCode,
+                }),
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -377,14 +377,19 @@ let analyzeModule = ({
       node,
       name,
     }
-    let comments = getCommentsBefore(node, sourceCode)
     let lastSortingNode = formattedNodes.at(-1)?.at(-1)
     if (
       (options.partitionByNewLine &&
         lastSortingNode &&
         getLinesBetween(sourceCode, lastSortingNode, sortingNode)) ||
       (options.partitionByComment &&
-        hasPartitionComment(options.partitionByComment, comments))
+        hasPartitionComment(
+          options.partitionByComment,
+          getCommentsBefore({
+            sourceCode,
+            node,
+          }),
+        ))
     ) {
       formattedNodes.push([])
     }

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -100,7 +100,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
           (options.partitionByComment &&
             hasPartitionComment(
               options.partitionByComment,
-              getCommentsBefore(specifier, sourceCode),
+              getCommentsBefore({
+                node: specifier,
+                sourceCode,
+              }),
             )) ||
           (options.partitionByNewLine &&
             lastSortingNode &&

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -109,7 +109,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
           (options.partitionByComment &&
             hasPartitionComment(
               options.partitionByComment,
-              getCommentsBefore(specifier, sourceCode),
+              getCommentsBefore({
+                node: specifier,
+                sourceCode,
+              }),
             )) ||
           (options.partitionByNewLine &&
             lastSortingNode &&

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -167,7 +167,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               (options.partitionByComment &&
                 hasPartitionComment(
                   options.partitionByComment,
-                  getCommentsBefore(member, sourceCode),
+                  getCommentsBefore({
+                    node: member,
+                    sourceCode,
+                  }),
                 )) ||
               (options.partitionByNewLine &&
                 lastSortingNode &&

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -299,7 +299,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
               return accumulator
             }
 
-            let comments = getCommentsBefore(property, sourceCode)
             let lastProperty = accumulator.at(-1)?.at(-1)
 
             let name: string
@@ -353,7 +352,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   propertySortingNode,
                 )) ||
               (options.partitionByComment &&
-                hasPartitionComment(options.partitionByComment, comments))
+                hasPartitionComment(
+                  options.partitionByComment,
+                  getCommentsBefore({
+                    node: property,
+                    sourceCode,
+                  }),
+                ))
             ) {
               accumulator.push([])
             }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -187,7 +187,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
             (options.partitionByComment &&
               hasPartitionComment(
                 options.partitionByComment,
-                getCommentsBefore(type, sourceCode, '|'),
+                getCommentsBefore({
+                  tokenValueToIgnoreBefore: '|',
+                  node: type,
+                  sourceCode,
+                }),
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -197,7 +197,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             (options.partitionByComment &&
               hasPartitionComment(
                 options.partitionByComment,
-                getCommentsBefore(declaration, sourceCode),
+                getCommentsBefore({
+                  node: declaration,
+                  sourceCode,
+                }),
               )) ||
             (options.partitionByNewLine &&
               lastSortingNode &&

--- a/test/sort-decorators.test.ts
+++ b/test/sort-decorators.test.ts
@@ -137,12 +137,12 @@ describe(ruleName, () => {
           {
             output: dedent`
               /**
+               * JSDoc comment that shouldn't move
+               */
+              /**
                * Comment A
                */
               @A
-              /**
-               * Comment B
-               */
               @B
               /* Comment C */
               @C
@@ -151,12 +151,12 @@ describe(ruleName, () => {
               class Class {
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @B
                 /* Comment C */
                 @C
@@ -165,12 +165,12 @@ describe(ruleName, () => {
                 property
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @B
                 /* Comment C */
                 @C
@@ -179,12 +179,12 @@ describe(ruleName, () => {
                 accessor field
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @B
                 /* Comment C */
                 @C
@@ -192,12 +192,12 @@ describe(ruleName, () => {
                 @D
                 method(
                   /**
+                   * JSDoc comment that shouldn't move
+                   */
+                  /**
                    * Comment A
                    */
                   @A
-                  /**
-                   * Comment B
-                   */
                   @B
                   /* Comment C */
                   @C
@@ -209,7 +209,7 @@ describe(ruleName, () => {
             `,
             code: dedent`
               /**
-               * Comment B
+               * JSDoc comment that shouldn't move
                */
               @B
               /**
@@ -223,7 +223,7 @@ describe(ruleName, () => {
               class Class {
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @B
                 /**
@@ -237,7 +237,7 @@ describe(ruleName, () => {
                 property
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @B
                 /**
@@ -251,7 +251,7 @@ describe(ruleName, () => {
                 accessor field
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @B
                 /**
@@ -264,7 +264,7 @@ describe(ruleName, () => {
                 @C
                 method(
                   /**
-                   * Comment B
+                   * JSDoc comment that shouldn't move
                    */
                   @B
                   /**
@@ -1315,12 +1315,12 @@ describe(ruleName, () => {
           {
             output: dedent`
               /**
+               * JSDoc comment that shouldn't move
+               */
+              /**
                * Comment A
                */
               @A
-              /**
-               * Comment B
-               */
               @B
               /* Comment C */
               @C
@@ -1329,12 +1329,12 @@ describe(ruleName, () => {
               class Class {
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @B
                 /* Comment C */
                 @C
@@ -1343,12 +1343,12 @@ describe(ruleName, () => {
                 property
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @B
                 /* Comment C */
                 @C
@@ -1357,12 +1357,12 @@ describe(ruleName, () => {
                 accessor field
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @B
                 /* Comment C */
                 @C
@@ -1370,12 +1370,12 @@ describe(ruleName, () => {
                 @D
                 method(
                   /**
+                   * JSDoc comment that shouldn't move
+                   */
+                  /**
                    * Comment A
                    */
                   @A
-                  /**
-                   * Comment B
-                   */
                   @B
                   /* Comment C */
                   @C
@@ -1387,7 +1387,7 @@ describe(ruleName, () => {
             `,
             code: dedent`
               /**
-               * Comment B
+               * JSDoc comment that shouldn't move
                */
               @B
               /**
@@ -1401,7 +1401,7 @@ describe(ruleName, () => {
               class Class {
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @B
                 /**
@@ -1415,7 +1415,7 @@ describe(ruleName, () => {
                 property
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @B
                 /**
@@ -1429,7 +1429,7 @@ describe(ruleName, () => {
                 accessor field
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @B
                 /**
@@ -1442,7 +1442,7 @@ describe(ruleName, () => {
                 @C
                 method(
                   /**
-                   * Comment B
+                   * JSDoc comment that shouldn't move
                    */
                   @B
                   /**
@@ -2307,12 +2307,12 @@ describe(ruleName, () => {
           {
             output: dedent`
               /**
+               * JSDoc comment that shouldn't move
+               */
+              /**
                * Comment A
                */
               @A
-              /**
-               * Comment B
-               */
               @BB
               /* Comment C */
               @CCC
@@ -2321,12 +2321,12 @@ describe(ruleName, () => {
               class Class {
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @BB
                 /* Comment C */
                 @CCC
@@ -2335,12 +2335,12 @@ describe(ruleName, () => {
                 property
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @BB
                 /* Comment C */
                 @CCC
@@ -2349,12 +2349,12 @@ describe(ruleName, () => {
                 accessor field
 
                 /**
+                 * JSDoc comment that shouldn't move
+                 */
+                /**
                  * Comment A
                  */
                 @A
-                /**
-                 * Comment B
-                 */
                 @BB
                 /* Comment C */
                 @CCC
@@ -2362,12 +2362,12 @@ describe(ruleName, () => {
                 @DDDD
                 method(
                   /**
+                   * JSDoc comment that shouldn't move
+                   */
+                  /**
                    * Comment A
                    */
                   @A
-                  /**
-                   * Comment B
-                   */
                   @BB
                   /* Comment C */
                   @CCC
@@ -2379,7 +2379,7 @@ describe(ruleName, () => {
             `,
             code: dedent`
               /**
-               * Comment B
+               * JSDoc comment that shouldn't move
                */
               @BB
               /**
@@ -2393,7 +2393,7 @@ describe(ruleName, () => {
               class Class {
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @BB
                 /**
@@ -2407,7 +2407,7 @@ describe(ruleName, () => {
                 property
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @BB
                 /**
@@ -2421,7 +2421,7 @@ describe(ruleName, () => {
                 accessor field
 
                 /**
-                 * Comment B
+                 * JSDoc comment that shouldn't move
                  */
                 @BB
                 /**
@@ -2434,7 +2434,7 @@ describe(ruleName, () => {
                 @CCC
                 method(
                   /**
-                   * Comment B
+                   * JSDoc comment that shouldn't move
                    */
                   @BB
                   /**

--- a/test/sort-decorators.test.ts
+++ b/test/sort-decorators.test.ts
@@ -369,6 +369,134 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
+      `${ruleName}(${type}): ignores first comment if it's a block`,
+      rule,
+      {
+        invalid: [
+          {
+            output: dedent`
+                class Class {
+                  // Should not move
+                  /**
+                   * JSDoc comment
+                   */
+                  // A
+                  @A()
+                  @B()
+                  foo: number;
+              }
+           `,
+            code: dedent`
+                class Class {
+                  // Should not move
+                  /**
+                   * JSDoc comment
+                   */
+                  @B()
+                  // A
+                  @A()
+                  foo: number;
+              }
+           `,
+            errors: [
+              {
+                messageId: 'unexpectedDecoratorsOrder',
+              },
+            ],
+            options: [options],
+          },
+          {
+            output: dedent`
+                class Class {
+                  // Should not move
+                  /**
+                   * JSDoc comment
+                   */
+                  /**
+                   * A
+                   */
+                  @A()
+                  @B()
+                  foo: number;
+              }
+           `,
+            code: dedent`
+                class Class {
+                  // Should not move
+                  /**
+                   * JSDoc comment
+                   */
+                  @B()
+                  /**
+                   * A
+                   */
+                  @A()
+                  foo: number;
+              }
+           `,
+            errors: [
+              {
+                messageId: 'unexpectedDecoratorsOrder',
+              },
+            ],
+            options: [options],
+          },
+          {
+            output: dedent`
+                class Class {
+                  // Shouldn't move
+                  /** JSDoc comment */
+                  @A()
+                  @B()
+                  foo: number;
+              }
+           `,
+            code: dedent`
+                class Class {
+                  // Shouldn't move
+                  /** JSDoc comment */
+                  @B()
+                  @A()
+                  foo: number;
+              }
+           `,
+            errors: [
+              {
+                messageId: 'unexpectedDecoratorsOrder',
+              },
+            ],
+            options: [options],
+          },
+          {
+            output: dedent`
+                class Class {
+                  // Not aJSDoc comment
+                  @A()
+                  @B()
+                  foo: number;
+              }
+           `,
+            code: dedent`
+                class Class {
+                  @B()
+                  // Not aJSDoc comment
+                  @A()
+                  foo: number;
+              }
+           `,
+            errors: [
+              {
+                messageId: 'unexpectedDecoratorsOrder',
+              },
+            ],
+            options: [options],
+          },
+        ],
+        valid: [],
+      },
+    )
+
+    ruleTester.run(
       `${ruleName}(${type}): allows to set groups for sorting`,
       rule,
       {

--- a/utils/get-comments-before.ts
+++ b/utils/get-comments-before.ts
@@ -1,22 +1,29 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 import type { TSESTree } from '@typescript-eslint/types'
 
+interface GetCommentsBeforeParameters {
+  tokenValueToIgnoreBefore?: string
+  sourceCode: TSESLint.SourceCode
+  node: TSESTree.Node
+}
+
 /**
  * Returns a list of comments before a given node, excluding ones that are
  * right after code. Includes comment blocks.
- * @param {TSESTree.Node} node - The node to get comments before.
- * @param {TSESLint.SourceCode} source - The source code object.
- * @param {string} [tokenValueToIgnoreBefore] - Allows the following token to
+ * @param {object} params - Parameters object.
+ * @param {TSESTree.Node} params.node - The node to get comments before.
+ * @param {TSESLint.SourceCode} params.sourceCode - The source code object.
+ * @param {string} [params.tokenValueToIgnoreBefore] - Allows the following token to
  * directly precede the node.
  * @returns {TSESTree.Comment[]} An array of comments before the given node.
  */
-export let getCommentsBefore = (
-  node: TSESTree.Node,
-  source: TSESLint.SourceCode,
-  tokenValueToIgnoreBefore?: string,
-): TSESTree.Comment[] => {
-  let commentsBefore = getCommentsBeforeNodeOrToken(source, node)
-  let tokenBeforeNode = source.getTokenBefore(node)
+export let getCommentsBefore = ({
+  tokenValueToIgnoreBefore,
+  sourceCode,
+  node,
+}: GetCommentsBeforeParameters): TSESTree.Comment[] => {
+  let commentsBefore = getCommentsBeforeNodeOrToken(sourceCode, node)
+  let tokenBeforeNode = sourceCode.getTokenBefore(node)
   if (
     commentsBefore.length ||
     !tokenValueToIgnoreBefore ||
@@ -24,7 +31,7 @@ export let getCommentsBefore = (
   ) {
     return commentsBefore
   }
-  return getCommentsBeforeNodeOrToken(source, tokenBeforeNode)
+  return getCommentsBeforeNodeOrToken(sourceCode, tokenBeforeNode)
 }
 
 let getCommentsBeforeNodeOrToken = (

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -11,13 +11,13 @@ interface GetNodeRangeParameters {
   options?: {
     partitionByComment: string[] | boolean | string
   }
-  ignoreFirstCommentIfBlock?: boolean
+  ignoreHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode
   node: TSESTree.Node
 }
 
 export let getNodeRange = ({
-  ignoreFirstCommentIfBlock,
+  ignoreHighestBlockComment,
   sourceCode,
   options,
   node,
@@ -74,7 +74,7 @@ export let getNodeRange = ({
       break
     }
 
-    if (ignoreFirstCommentIfBlock && comment === highestBlockComment) {
+    if (ignoreHighestBlockComment && comment === highestBlockComment) {
       break
     }
 

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -7,13 +7,19 @@ import { getEslintDisabledRules } from './get-eslint-disabled-rules'
 import { isPartitionComment } from './is-partition-comment'
 import { getCommentsBefore } from './get-comments-before'
 
-export let getNodeRange = (
-  node: TSESTree.Node,
-  sourceCode: TSESLint.SourceCode,
-  additionalOptions?: {
-    partitionByComment?: string[] | boolean | string
-  },
-): TSESTree.Range => {
+interface GetNodeRangeParameters {
+  options?: {
+    partitionByComment: string[] | boolean | string
+  }
+  sourceCode: TSESLint.SourceCode
+  node: TSESTree.Node
+}
+
+export let getNodeRange = ({
+  sourceCode,
+  options,
+  node,
+}: GetNodeRangeParameters): TSESTree.Range => {
   let start = node.range.at(0)!
   let end = node.range.at(1)!
 
@@ -32,8 +38,11 @@ export let getNodeRange = (
     end = bodyClosingParen.range.at(1)!
   }
 
-  let comments = getCommentsBefore(node, sourceCode)
-  let partitionComment = additionalOptions?.partitionByComment ?? false
+  let comments = getCommentsBefore({
+    sourceCode,
+    node,
+  })
+  let partitionComment = options?.partitionByComment ?? false
 
   /**
    * Iterate on all comments starting from the bottom until we reach the last

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -35,7 +35,11 @@ export let makeFixes = ({
     }
 
     let sortedNodeCode = sourceCode.text.slice(
-      ...getNodeRange(sortedNode, sourceCode, options),
+      ...getNodeRange({
+        node: sortedNode,
+        sourceCode,
+        options,
+      }),
     )
     let sortedNodeText = sourceCode.getText(sortedNode)
     let tokensAfter = sourceCode.getTokensAfter(node, {
@@ -60,7 +64,7 @@ export let makeFixes = ({
     }
     fixes.push(
       fixer.replaceTextRange(
-        getNodeRange(node, sourceCode, options),
+        getNodeRange({ sourceCode, options, node }),
         sortedNodeCode,
       ),
     )

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -9,6 +9,7 @@ interface MakeFixesParameters {
   options?: {
     partitionByComment: string[] | boolean | string
   }
+  ignoreFirstNodeJsDocBlock?: boolean
   sourceCode: TSESLint.SourceCode
   sortedNodes: SortingNode[]
   fixer: TSESLint.RuleFixer
@@ -16,6 +17,7 @@ interface MakeFixesParameters {
 }
 
 export let makeFixes = ({
+  ignoreFirstNodeJsDocBlock,
   sortedNodes,
   sourceCode,
   options,
@@ -29,6 +31,8 @@ export let makeFixes = ({
     let sortedSortingNode = sortedNodes.at(i)!
     let { node } = sortingNode
     let { addSafetySemicolonWhenInline, node: sortedNode } = sortedSortingNode
+    let isNodeFirstNode = node === nodes.at(0)!.node
+    let isSortedNodeFirstNode = sortedNode === nodes.at(0)!.node
 
     if (node === sortedNode) {
       continue
@@ -36,6 +40,8 @@ export let makeFixes = ({
 
     let sortedNodeCode = sourceCode.text.slice(
       ...getNodeRange({
+        ignoreFirstCommentIfBlock:
+          ignoreFirstNodeJsDocBlock && isSortedNodeFirstNode,
         node: sortedNode,
         sourceCode,
         options,
@@ -64,7 +70,13 @@ export let makeFixes = ({
     }
     fixes.push(
       fixer.replaceTextRange(
-        getNodeRange({ sourceCode, options, node }),
+        getNodeRange({
+          ignoreFirstCommentIfBlock:
+            ignoreFirstNodeJsDocBlock && isNodeFirstNode,
+          sourceCode,
+          options,
+          node,
+        }),
         sortedNodeCode,
       ),
     )

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -9,7 +9,7 @@ interface MakeFixesParameters {
   options?: {
     partitionByComment: string[] | boolean | string
   }
-  ignoreFirstNodeJsDocBlock?: boolean
+  ignoreFirstNodeHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode
   sortedNodes: SortingNode[]
   fixer: TSESLint.RuleFixer
@@ -17,7 +17,7 @@ interface MakeFixesParameters {
 }
 
 export let makeFixes = ({
-  ignoreFirstNodeJsDocBlock,
+  ignoreFirstNodeHighestBlockComment,
   sortedNodes,
   sourceCode,
   options,
@@ -40,8 +40,8 @@ export let makeFixes = ({
 
     let sortedNodeCode = sourceCode.text.slice(
       ...getNodeRange({
-        ignoreFirstCommentIfBlock:
-          ignoreFirstNodeJsDocBlock && isSortedNodeFirstNode,
+        ignoreHighestBlockComment:
+          ignoreFirstNodeHighestBlockComment && isSortedNodeFirstNode,
         node: sortedNode,
         sourceCode,
         options,
@@ -71,8 +71,8 @@ export let makeFixes = ({
     fixes.push(
       fixer.replaceTextRange(
         getNodeRange({
-          ignoreFirstCommentIfBlock:
-            ignoreFirstNodeJsDocBlock && isNodeFirstNode,
+          ignoreHighestBlockComment:
+            ignoreFirstNodeHighestBlockComment && isNodeFirstNode,
           sourceCode,
           options,
           node,

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -36,10 +36,14 @@ export let makeNewlinesFixes = ({
 
     let nodeGroupNumber = getGroupNumber(options.groups, sortingNode)
     let nextNodeGroupNumber = getGroupNumber(options.groups, nextSortingNode)
-    let currentNodeRange = getNodeRange(nodes.at(i)!.node, sourceCode)
-    let nextNodeRangeStart = getNodeRange(nodes.at(i + 1)!.node, sourceCode).at(
-      0,
-    )!
+    let currentNodeRange = getNodeRange({
+      node: nodes.at(i)!.node,
+      sourceCode,
+    })
+    let nextNodeRangeStart = getNodeRange({
+      node: nodes.at(i + 1)!.node,
+      sourceCode,
+    }).at(0)!
     let rangeToReplace: [number, number] = [
       currentNodeRange.at(1)!,
       nextNodeRangeStart,


### PR DESCRIPTION
Fixes #399.

Comment blocks above the first decorator are almost always meant not to be moved around.

### Description

Prevents the highest comment blocks(`/** */`) placed above the first decorator (and comments above that block) from being sorted.

### Complex example

Initially:
```ts
class Class {
  // Should not move
  /**
   * JSDoc comment
   */
  // B
  @B()
  /**
   * A
   */
  @A()
  foo: number;
}
```

Result:
```ts
class Class {
  // Should not move
  /**
   * JSDoc comment
   */
  /**
   * A
   */
  @A()
  // B
  @B()
  foo: number;
}
```

### Non-block comments

Non-block comments are not considered JSDoc comments and will not trigger this.

### Affected tests

A test duplicated 3 times had to be updated. See 7c0d57161c7764df4e8b0e85d33b0f54952ead6b. 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix