### PR TITLE
fix: fixes `natural` sort ignoring `order`

### DIFF
--- a/test/compare.test.ts
+++ b/test/compare.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SortingNode } from '../typings'
+
+import { compare } from '../utils/compare'
+
+describe('compare', () => {
+  describe('alphabetical', () => {
+    let compareOptions = {
+      specialCharacters: 'keep',
+      type: 'alphabetical',
+      ignoreCase: false,
+      locales: 'en-US',
+      order: 'asc',
+    } as const
+
+    it('sorts by order asc', () => {
+      expect(
+        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'a' }), {
+          ...compareOptions,
+        }),
+      ).toBe(1)
+    })
+
+    it('sorts by order desc', () => {
+      expect(
+        compare(createTestNode({ name: 'a' }), createTestNode({ name: 'b' }), {
+          ...compareOptions,
+          order: 'desc',
+        }),
+      ).toBe(1)
+    })
+
+    it('sorts ignoring case', () => {
+      expect(
+        compare(
+          createTestNode({ name: 'aB' }),
+          createTestNode({ name: 'Ab' }),
+          {
+            ...compareOptions,
+            ignoreCase: true,
+          },
+        ),
+      ).toBe(0)
+    })
+
+    it('sorts while trimming special characters', () => {
+      expect(
+        compare(createTestNode({ name: '_a' }), createTestNode({ name: 'a' }), {
+          ...compareOptions,
+          specialCharacters: 'trim',
+        }),
+      ).toBe(0)
+    })
+
+    it('sorts while removing special characters', () => {
+      expect(
+        compare(
+          createTestNode({ name: 'ab' }),
+          createTestNode({ name: 'a_b' }),
+          {
+            ...compareOptions,
+            specialCharacters: 'remove',
+          },
+        ),
+      ).toBe(0)
+    })
+  })
+
+  describe('natural', () => {
+    let compareOptions = {
+      specialCharacters: 'keep',
+      ignoreCase: false,
+      locales: 'en-US',
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts by order asc', () => {
+      expect(
+        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'a' }), {
+          ...compareOptions,
+        }),
+      ).toBe(1)
+    })
+
+    it('sorts by order desc', () => {
+      expect(
+        compare(createTestNode({ name: 'a' }), createTestNode({ name: 'b' }), {
+          ...compareOptions,
+          order: 'desc',
+        }),
+      ).toBe(1)
+    })
+
+    it('sorts ignoring case', () => {
+      expect(
+        compare(
+          createTestNode({ name: 'aB' }),
+          createTestNode({ name: 'Ab' }),
+          {
+            ...compareOptions,
+            ignoreCase: true,
+          },
+        ),
+      ).toBe(0)
+    })
+
+    it('sorts while trimming special characters', () => {
+      expect(
+        compare(createTestNode({ name: '_a' }), createTestNode({ name: 'a' }), {
+          ...compareOptions,
+          specialCharacters: 'trim',
+        }),
+      ).toBe(0)
+    })
+
+    it('sorts while removing special characters', () => {
+      expect(
+        compare(
+          createTestNode({ name: 'ab' }),
+          createTestNode({ name: 'a_b' }),
+          {
+            ...compareOptions,
+            specialCharacters: 'remove',
+          },
+        ),
+      ).toBe(0)
+    })
+  })
+
+  let createTestNode = ({ name }: { name: string }): SortingNode =>
+    ({
+      name,
+    }) as SortingNode
+})

--- a/test/compare.test.ts
+++ b/test/compare.test.ts
@@ -16,9 +16,11 @@ describe('compare', () => {
 
     it('sorts by order asc', () => {
       expect(
-        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-        }),
+        compare(
+          createTestNode({ name: 'b' }),
+          createTestNode({ name: 'a' }),
+          compareOptions,
+        ),
       ).toBe(1)
     })
 

--- a/test/compare.test.ts
+++ b/test/compare.test.ts
@@ -80,9 +80,11 @@ describe('compare', () => {
 
     it('sorts by order asc', () => {
       expect(
-        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-        }),
+        compare(
+          createTestNode({ name: 'b' }),
+          createTestNode({ name: 'a' }),
+          compareOptions,
+        ),
       ).toBe(1)
     })
 

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -59,7 +59,6 @@ export let compare = <T extends SortingNode>(
   } else if (options.type === 'natural') {
     let naturalCompare = createNaturalCompare({
       locale: options.locales.toString(),
-      order: 'asc',
     })
     let formatString = getFormatStringFunction(
       options.ignoreCase,

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -59,7 +59,7 @@ export let compare = <T extends SortingNode>(
   } else if (options.type === 'natural') {
     let naturalCompare = createNaturalCompare({
       locale: options.locales.toString(),
-      order: options.order,
+      order: 'asc',
     })
     let formatString = getFormatStringFunction(
       options.ignoreCase,


### PR DESCRIPTION
Fixes #405.

### Description

One line fix.

The issue comes from the fact that the sort order is provided to the `natural-orderby` library, while an additional sort by order is done at the end, cancelling it.

https://github.com/azat-io/eslint-plugin-perfectionist/blob/eed1b809a954778baed8117abd72efcd39c9c0c8/utils/compare.ts#L60-L63

https://github.com/azat-io/eslint-plugin-perfectionist/blob/eed1b809a954778baed8117abd72efcd39c9c0c8/utils/compare.ts#L46

https://github.com/azat-io/eslint-plugin-perfectionist/blob/eed1b809a954778baed8117abd72efcd39c9c0c8/utils/compare.ts#L97

The PR also adds some simple additional unit tests for the `compare` function to prevent potential regressions in the future.

### What is the purpose of this pull request?
- [x] Bug fix
