### PR TITLE
feat: improves function detection

### DIFF
--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -27,6 +27,7 @@ import { singleCustomGroupJsonSchema } from './sort-object-types.types'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { allModifiers, allSelectors } from './sort-object-types.types'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { isNodeFunctionType } from '../utils/is-node-function-type'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
@@ -256,11 +257,7 @@ export let sortObjectTypeElements = <MessageIds extends string>({
         selectors.push('index-signature')
       }
 
-      if (
-        typeElement.type === 'TSMethodSignature' ||
-        (typeElement.type === 'TSPropertySignature' &&
-          typeElement.typeAnnotation?.typeAnnotation.type === 'TSFunctionType')
-      ) {
+      if (isNodeFunctionType(typeElement)) {
         selectors.push('method')
       }
 

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -1789,7 +1789,7 @@ describe(ruleName, () => {
           code: dedent`
               interface Interface {
                 b(): void
-                c: () => void
+                c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
                 a: string
                 d: string
               }
@@ -2773,7 +2773,7 @@ describe(ruleName, () => {
           code: dedent`
               interface Interface {
                 b(): void
-                c: () => void
+                c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
                 a: string
                 d: string
               }
@@ -3758,7 +3758,7 @@ describe(ruleName, () => {
         {
           code: dedent`
               interface Interface {
-                c: () => void
+                c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
                 b(): void
                 a: string
                 d: string

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -1613,7 +1613,7 @@ describe(ruleName, () => {
           code: dedent`
               type Type = {
                 b(): void
-                c: () => void
+                c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
                 a: string
                 d: string
               }
@@ -2395,7 +2395,7 @@ describe(ruleName, () => {
           code: dedent`
               type Type = {
                 b(): void
-                c: () => void
+                c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
                 a: string
                 d: string
               }
@@ -2977,7 +2977,7 @@ describe(ruleName, () => {
         {
           code: dedent`
               type Type = {
-                c: () => void
+                c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
                 b(): void
                 a: string
                 d: string

--- a/utils/is-node-function-type.ts
+++ b/utils/is-node-function-type.ts
@@ -1,0 +1,14 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+export let isNodeFunctionType = (node: TSESTree.Node): boolean => {
+  if (node.type === 'TSMethodSignature' || node.type === 'TSFunctionType') {
+    return true
+  }
+  if (node.type === 'TSUnionType' || node.type === 'TSIntersectionType') {
+    return node.types.every(isNodeFunctionType)
+  }
+  if (node.type === 'TSPropertySignature' && node.typeAnnotation) {
+    return isNodeFunctionType(node.typeAnnotation.typeAnnotation)
+  }
+  return false
+}


### PR DESCRIPTION
Fixes #409.

### Description

Allows union and intersection types resulting in functions to be detected, such as

```ts
(((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
