### PR TITLE
feat(sort-objects): handles context-based configurations

### DIFF
--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -291,7 +291,7 @@ The `groups` attribute allows you to specify whether to use groups to sort destr
 ### useConfigurationIf
 
 <sub>
-  type: `{ allElementNamesMatchPattern?: string }`
+  type: `{ allNamesMatchPattern?: string }`
 </sub>
 <sub>default: `{}`</sub>
 
@@ -299,7 +299,7 @@ Allows you to specify filters to match a particular options configuration for a 
 
 The first matching options configuration will be used. If no configuration matches, the default options configuration will be used.
 
-- `allElementNamesMatchPattern` — A regexp pattern that all object keys must match.
+- `allNamesMatchPattern` — A regexp pattern that all object keys must match.
 
 Example configuration:
 ```ts
@@ -314,7 +314,7 @@ Example configuration:
         b: 'b',
       },
       useConfigurationIf: {
-        allElementNamesMatchPattern: '^r|g|b$',
+        allNamesMatchPattern: '^r|g|b$',
       },
     },
     {

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -288,6 +288,42 @@ Allows you to choose whether to sort standard object declarations.
 Allows you to choose whether to sort destructured objects.
 The `groups` attribute allows you to specify whether to use groups to sort destructured objects.
 
+### useConfigurationIf
+
+<sub>
+  type: `{ allElementNamesMatchPattern?: string }`
+</sub>
+<sub>default: `{}`</sub>
+
+Allows you to specify filters to match a particular options configuration for a given object.
+
+The first matching options configuration will be used. If no configuration matches, the default options configuration will be used.
+
+- `allElementNamesMatchPattern` — A regexp pattern that all object keys must match.
+
+Example configuration:
+```ts
+{
+  'perfectionist/sort-objects': [
+    'error',
+    {
+      groups: ['r', 'g', 'b'], // Sort colors by RGB
+      customGroups: {
+        r: 'r',
+        g: 'g',
+        b: 'b',
+      },
+      useConfigurationIf: {
+        allElementNamesMatchPattern: '^r|g|b$',
+      },
+    },
+    {
+      type: 'alphabetical' // Fallback configuration
+    }
+  ],
+}
+```
+
 ### groups
 
 <sub>
@@ -391,8 +427,11 @@ const user = {
                   partitionByComment: false,
                   partitionByNewLine: false,
                   newlinesBetween: 'ignore',
+                  objectDeclarations: true,
+                  destructuredObjects: true,
                   styledComponents: true,
                   ignorePattern: [],
+                  useConfigurationIf: {},
                   groups: [],
                   customGroups: {},
                 },
@@ -422,8 +461,11 @@ const user = {
                 partitionByComment: false,
                 partitionByNewLine: false,
                 newlinesBetween: 'ignore',
+                objectDeclarations: true,
+                destructuredObjects: true,
                 styledComponents: true,
                 ignorePattern: [],
+                useConfigurationIf: {},
                 groups: [],
                 customGroups: {},
               },

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -5,6 +5,7 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
+  useConfigurationIfJsonSchema,
   specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
   customGroupsJsonSchema,
@@ -20,6 +21,7 @@ import {
 } from '../utils/sort-nodes-by-dependencies'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { getMatchingContextOptions } from '../utils/get-matching-context-options'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
@@ -42,28 +44,29 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { matches } from '../utils/matches'
 
-type Options = [
-  Partial<{
-    destructuredObjects: { groups: boolean } | boolean
-    type: 'alphabetical' | 'line-length' | 'natural'
-    customGroups: Record<string, string[] | string>
-    partitionByComment: string[] | boolean | string
-    newlinesBetween: 'ignore' | 'always' | 'never'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    locales: NonNullable<Intl.LocalesArgument>
-    groups: (Group[] | Group)[]
-    partitionByNewLine: boolean
-    objectDeclarations: boolean
-    styledComponents: boolean
-    /**
-     * @deprecated for {@link `destructuredObjects`} and {@link `objectDeclarations`}
-     */
-    destructureOnly: boolean
-    ignorePattern: string[]
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-  }>,
-]
+type Options = Partial<{
+  useConfigurationIf: {
+    allElementNamesMatchPattern?: string
+  }
+  destructuredObjects: { groups: boolean } | boolean
+  type: 'alphabetical' | 'line-length' | 'natural'
+  customGroups: Record<string, string[] | string>
+  partitionByComment: string[] | boolean | string
+  newlinesBetween: 'ignore' | 'always' | 'never'
+  specialCharacters: 'remove' | 'trim' | 'keep'
+  locales: NonNullable<Intl.LocalesArgument>
+  groups: (Group[] | Group)[]
+  partitionByNewLine: boolean
+  objectDeclarations: boolean
+  styledComponents: boolean
+  /**
+   * @deprecated for {@link `destructuredObjects`} and {@link `objectDeclarations`}
+   */
+  destructureOnly: boolean
+  ignorePattern: string[]
+  order: 'desc' | 'asc'
+  ignoreCase: boolean
+}>[]
 
 type MESSAGE_ID =
   | 'missedSpacingBetweenObjectMembers'
@@ -83,6 +86,7 @@ let defaultOptions: Required<Options[0]> = {
   objectDeclarations: true,
   styledComponents: true,
   destructureOnly: false,
+  useConfigurationIf: {},
   type: 'alphabetical',
   ignorePattern: [],
   ignoreCase: true,
@@ -102,9 +106,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
       }
 
       let settings = getSettings(context.settings)
-
-      let options = complete(context.options.at(0), settings, defaultOptions)
-
+      let sourceCode = getSourceCode(context)
+      let matchedContextOptions = getMatchingContextOptions({
+        nodeNames: nodeObject.properties
+          .map(property => getNodeName({ sourceCode, property }))
+          .filter(nodeName => nodeName !== null),
+        contextOptions: context.options,
+      })
+      let options = complete(matchedContextOptions, settings, defaultOptions)
       validateGroupsConfiguration(
         options.groups,
         ['multiline', 'method', 'unknown'],
@@ -182,7 +191,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
         return
       }
 
-      let sourceCode = getSourceCode(context)
       let eslintDisabledLines = getEslintDisabledLines({
         ruleName: context.id,
         sourceCode,
@@ -480,8 +488,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
     }
   },
   meta: {
-    schema: [
-      {
+    schema: {
+      items: {
         properties: {
           destructuredObjects: {
             oneOf: [
@@ -528,6 +536,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'boolean',
           },
           partitionByNewLine: partitionByNewLineJsonSchema,
+          useConfigurationIf: useConfigurationIfJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
           customGroups: customGroupsJsonSchema,
@@ -540,7 +549,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
         additionalProperties: false,
         type: 'object',
       },
-    ],
+      uniqueItems: true,
+      type: 'array',
+    },
     messages: {
       unexpectedObjectsGroupOrder:
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
@@ -563,3 +574,24 @@ export default createEslintRule<Options, MESSAGE_ID>({
   defaultOptions: [defaultOptions],
   name: 'sort-objects',
 })
+
+let getNodeName = ({
+  sourceCode,
+  property,
+}: {
+  property:
+    | TSESTree.ObjectLiteralElement
+    | TSESTree.RestElement
+    | TSESTree.Property
+  sourceCode: ReturnType<typeof getSourceCode>
+}): string | null => {
+  if (property.type === 'SpreadElement' || property.type === 'RestElement') {
+    return null
+  }
+  if (property.key.type === 'Identifier') {
+    return property.key.name
+  } else if (property.key.type === 'Literal') {
+    return `${property.key.value}`
+  }
+  return sourceCode.getText(property.key)
+}

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -46,7 +46,7 @@ import { matches } from '../utils/matches'
 
 type Options = Partial<{
   useConfigurationIf: {
-    allElementNamesMatchPattern?: string
+    allNamesMatchPattern?: string
   }
   destructuredObjects: { groups: boolean } | boolean
   type: 'alphabetical' | 'line-length' | 'natural'

--- a/test/get-matching-context-options.test.ts
+++ b/test/get-matching-context-options.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { getMatchingContextOptions } from '../utils/get-matching-context-options'
 
 describe('get-matching-context-options', () => {
-  describe('`allElementNamesMatchPattern`', () => {
-    it('matches the appropriate context options with `allElementNamesMatchPattern`', () => {
+  describe('`allNamesMatchPattern`', () => {
+    it('matches the appropriate context options with `allNamesMatchPattern`', () => {
       let barContextOptions = buildContextOptions('bar')
       let contextOptions = [buildContextOptions('foo'), barContextOptions]
       let nodeNames = ['bar1', 'bar2']
@@ -35,10 +35,10 @@ describe('get-matching-context-options', () => {
   })
 
   let buildContextOptions = (
-    allElementNamesMatchPattern?: string,
-  ): { useConfigurationIf: { allElementNamesMatchPattern?: string } } => ({
+    allNamesMatchPattern?: string,
+  ): { useConfigurationIf: { allNamesMatchPattern?: string } } => ({
     useConfigurationIf: {
-      ...(allElementNamesMatchPattern ? { allElementNamesMatchPattern } : {}),
+      ...(allNamesMatchPattern ? { allNamesMatchPattern } : {}),
     },
   })
 })

--- a/test/get-matching-context-options.test.ts
+++ b/test/get-matching-context-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMatchingContextOptions } from '../utils/get-matching-context-options'
+
+describe('get-matching-context-options', () => {
+  describe('`allElementNamesMatchPattern`', () => {
+    it('matches the appropriate context options with `allElementNamesMatchPattern`', () => {
+      let barContextOptions = buildContextOptions('bar')
+      let contextOptions = [buildContextOptions('foo'), barContextOptions]
+      let nodeNames = ['bar1', 'bar2']
+
+      expect(getMatchingContextOptions({ contextOptions, nodeNames })).toEqual(
+        barContextOptions,
+      )
+    })
+
+    it('returns `undefined` if no configuration matches', () => {
+      let contextOptions = [buildContextOptions('foo')]
+      let nodeNames = ['bar1', 'bar2']
+
+      expect(
+        getMatchingContextOptions({ contextOptions, nodeNames }),
+      ).toBeUndefined()
+    })
+
+    it('returns the first context options if no filters are entered', () => {
+      let emptyContextOptions = buildContextOptions()
+      let contextOptions = [emptyContextOptions, buildContextOptions()]
+      let nodeNames = ['bar1', 'bar2']
+
+      expect(getMatchingContextOptions({ contextOptions, nodeNames })).toEqual(
+        emptyContextOptions,
+      )
+    })
+  })
+
+  let buildContextOptions = (
+    allElementNamesMatchPattern?: string,
+  ): { useConfigurationIf: { allElementNamesMatchPattern?: string } } => ({
+    useConfigurationIf: {
+      ...(allElementNamesMatchPattern ? { allElementNamesMatchPattern } : {}),
+    },
+  })
+})

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1853,7 +1853,7 @@ describe(ruleName, () => {
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
       ruleTester.run(
-        `${ruleName}(${type}): allows to use 'allElementNamesMatchPattern'`,
+        `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
         rule,
         {
           invalid: [
@@ -1882,7 +1882,7 @@ describe(ruleName, () => {
                 {
                   ...options,
                   useConfigurationIf: {
-                    allElementNamesMatchPattern: 'foo',
+                    allNamesMatchPattern: 'foo',
                   },
                 },
                 {
@@ -1893,7 +1893,7 @@ describe(ruleName, () => {
                     b: 'b',
                   },
                   useConfigurationIf: {
-                    allElementNamesMatchPattern: '^r|g|b$',
+                    allNamesMatchPattern: '^r|g|b$',
                   },
                   groups: ['r', 'g', 'b'],
                 },

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -1850,6 +1850,74 @@ describe(ruleName, () => {
         valid: [],
       },
     )
+
+    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use 'allElementNamesMatchPattern'`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'g',
+                    leftGroup: 'b',
+                    right: 'g',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedObjectsGroupOrder',
+                },
+                {
+                  data: {
+                    rightGroup: 'r',
+                    leftGroup: 'g',
+                    right: 'r',
+                    left: 'g',
+                  },
+                  messageId: 'unexpectedObjectsGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  useConfigurationIf: {
+                    allElementNamesMatchPattern: 'foo',
+                  },
+                },
+                {
+                  ...options,
+                  customGroups: {
+                    r: 'r',
+                    g: 'g',
+                    b: 'b',
+                  },
+                  useConfigurationIf: {
+                    allElementNamesMatchPattern: '^r|g|b$',
+                  },
+                  groups: ['r', 'g', 'b'],
+                },
+              ],
+              output: dedent`
+                let obj = {
+                  r: string,
+                  g: string,
+                  b: string
+                }
+              `,
+              code: dedent`
+                let obj = {
+                  b: string,
+                  g: string,
+                  r: string
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -106,6 +106,16 @@ export let newlinesBetweenJsonSchema: JSONSchema4 = {
   type: 'string',
 }
 
+export let useConfigurationIfJsonSchema: JSONSchema4 = {
+  properties: {
+    allElementNamesMatchPattern: {
+      type: 'string',
+    },
+  },
+  additionalProperties: false,
+  type: 'object',
+}
+
 let customGroupSortJsonSchema: Record<string, JSONSchema4> = {
   type: {
     enum: ['alphabetical', 'line-length', 'natural', 'unsorted'],

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -108,7 +108,7 @@ export let newlinesBetweenJsonSchema: JSONSchema4 = {
 
 export let useConfigurationIfJsonSchema: JSONSchema4 = {
   properties: {
-    allElementNamesMatchPattern: {
+    allNamesMatchPattern: {
       type: 'string',
     },
   },

--- a/utils/get-matching-context-options.ts
+++ b/utils/get-matching-context-options.ts
@@ -2,7 +2,7 @@ import { matches } from './matches'
 
 interface Options {
   useConfigurationIf?: {
-    allElementNamesMatchPattern?: string
+    allNamesMatchPattern?: string
   }
 }
 
@@ -14,12 +14,9 @@ export let getMatchingContextOptions = ({
   nodeNames: string[]
 }): undefined | Options =>
   contextOptions.find(options => {
-    let allElementNamesMatchPattern =
-      options.useConfigurationIf?.allElementNamesMatchPattern
+    let allNamesMatchPattern = options.useConfigurationIf?.allNamesMatchPattern
     return (
-      !allElementNamesMatchPattern ||
-      nodeNames.every(nodeName =>
-        matches(nodeName, allElementNamesMatchPattern),
-      )
+      !allNamesMatchPattern ||
+      nodeNames.every(nodeName => matches(nodeName, allNamesMatchPattern))
     )
   })

--- a/utils/get-matching-context-options.ts
+++ b/utils/get-matching-context-options.ts
@@ -1,0 +1,25 @@
+import { matches } from './matches'
+
+interface Options {
+  useConfigurationIf?: {
+    allElementNamesMatchPattern?: string
+  }
+}
+
+export let getMatchingContextOptions = ({
+  contextOptions,
+  nodeNames,
+}: {
+  contextOptions: Options[]
+  nodeNames: string[]
+}): undefined | Options =>
+  contextOptions.find(options => {
+    let allElementNamesMatchPattern =
+      options.useConfigurationIf?.allElementNamesMatchPattern
+    return (
+      !allElementNamesMatchPattern ||
+      nodeNames.every(nodeName =>
+        matches(nodeName, allElementNamesMatchPattern),
+      )
+    )
+  })


### PR DESCRIPTION
Resolves #148.
Resolves #408.

## Description

Users have been requesting a way to have different sorting rules depending on context. For example:
- Sizes `xs`, `s`, `m`, `l`, `xl`.
- color: `r`, `g`, `b`.

While custom groups may solve this, having many contextual custom groups that are unrelated to each other makes the configuration hard to read and more prone to errors.

This PR proposes to use the native ESLint feature allowing users to enter multiple option configuration to solve the problem:
- Adds a `useConfigurationIf: { allNamesMatchPattern?: string }` (by default `{}`) to `sort-objects`.

If the `allNamesMatchPattern ` is provided by the user, the entered options configuration will be used if **all** the object's keys match the entered pattern.

## Example

- Detects color objects and sort them by `r`, `g`, `b`.
- Detect size objects and sort them by `xs`, `s`, `m`, `l`, `xl`.
- Sort anything else alphabetically.

Configuration:
```ts
{
  'perfectionist/sort-objects': [
    'error',
    {
      groups: ['r', 'g', 'b'],
      customGroups: {
        r: 'r',
        g: 'g',
        b: 'b',
      },
      useConfigurationIf: {
        allNamesMatchPattern: '^r|g|b$',
      },
    },
    {
      groups: ['xs', 's', 'm', 'l', 'xl'],
      customGroups: {
        xs: 'xs',
        s: 's',
        m: 'm',
        l: 'l',
        xl: 'xl',
      },
      useConfigurationIf: {
        allNamesMatchPattern: '^xs|s|m|l|xl$',
      },
    },
    {
      type: 'alphabetical' // Fallback options
    }
  ],
}
```

## Additional points

### Extensibility

The `useConfigurationIf` option is easily extensible with additional options if requested tomorrow.

### Other rules

This option can theoretically be applied to other rules, although the use case is not clear for rules other than `sort-objects`.

## What is the purpose of this pull request?

- [x] New Feature
