### PR TITLE
fix(sort-interfaces): prevents constructor declarations from being sorted

### DIFF
--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -210,7 +210,10 @@ export let sortObjectTypeElements = <MessageIds extends string>({
 
   let formattedMembers: SortObjectTypesSortingNode[][] = elements.reduce(
     (accumulator: SortObjectTypesSortingNode[][], typeElement) => {
-      if (typeElement.type === 'TSCallSignatureDeclaration') {
+      if (
+        typeElement.type === 'TSCallSignatureDeclaration' ||
+        typeElement.type === 'TSConstructSignatureDeclaration'
+      ) {
         accumulator.push([])
         return accumulator
       }

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -243,10 +243,8 @@ export let sortObjectTypeElements = <MessageIds extends string>({
         name = formatName(
           sourceCode.text.slice(typeElement.range.at(0), endIndex),
         )
-      } else if (
-        typeElement.type === 'TSMethodSignature' &&
-        'name' in typeElement.key
-      ) {
+      } else if ('name' in typeElement.key) {
+        // TSMethodSignature
         ;({ name } = typeElement.key)
         /* v8 ignore next 8 - Unsure if we can reach it */
       } else {

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -477,7 +477,7 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
-      `${ruleName}(${type}): not sorts call signature declarations`,
+      `${ruleName}(${type}): does not sort call signature declarations`,
       rule,
       {
         valid: [
@@ -491,6 +491,34 @@ describe(ruleName, () => {
                   [number],
                   A[keyof A]
                 >
+              }
+            `,
+            options: [options],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): does not sort constructor declarations`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              interface Interface {
+                new (value: number | string): number;
+                new (value: number): unknown;
+              }
+            `,
+            options: [options],
+          },
+          {
+            code: dedent`
+              interface Interface {
+                new (value: number): unknown;
+                new (value: number | string): number;
               }
             `,
             options: [options],
@@ -2462,7 +2490,7 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
-      `${ruleName}(${type}): not sorts call signature declarations`,
+      `${ruleName}(${type}): does not sort call signature declarations`,
       rule,
       {
         valid: [
@@ -3239,7 +3267,7 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
-      `${ruleName}(${type}): not sorts call signature declarations`,
+      `${ruleName}(${type}): does not sort call signature declarations`,
       rule,
       {
         valid: [

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -1834,6 +1834,57 @@ describe(ruleName, () => {
         valid: [],
       },
     )
+    ruleTester.run(
+      `${ruleName}(${type}): does not sort call signature declarations`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              type Type = {
+                <Parameters extends Record<string, number | string>>(
+                  input: AFunction<[Parameters], string>
+                ): Alternatives<Parameters>
+                <A extends CountA>(input: Input): AFunction<
+                  [number],
+                  A[keyof A]
+                >
+              }
+            `,
+            options: [options],
+          },
+        ],
+        invalid: [],
+      },
+    )
+
+    ruleTester.run(
+      `${ruleName}(${type}): does not sort constructor declarations`,
+      rule,
+      {
+        valid: [
+          {
+            code: dedent`
+              type Type = {
+                new (value: number | string): number;
+                new (value: number): unknown;
+              }
+            `,
+            options: [options],
+          },
+          {
+            code: dedent`
+              type Type = {
+                new (value: number): unknown;
+                new (value: number | string): number;
+              }
+            `,
+            options: [options],
+          },
+        ],
+        invalid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {


### PR DESCRIPTION
Fixes #414

### Description

Similarly to call signatures, this PR prevents constructor signatures from being sorted together. 

```ts
interface Interface {
  new (value: number | string): number;
  new (value: number): unknown;
}
```

### Changes

- Fixes the bug
- Adds tests for both `sort-interfaces` and `sort-object-types`.
- Renames a few tests.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
