### PR TITLE
refactor(sort-classes): make group types readable

### DIFF
--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -34,6 +34,42 @@ export type SingleCustomGroup =
   | BaseSingleCustomGroup<ConstructorSelector>
   | AdvancedSingleCustomGroup<MethodSelector>
 
+export type NonDeclarePropertyGroup = Join<
+  [
+    PublicOrProtectedOrPrivateModifierPrefix,
+    StaticOrAbstractModifierPrefix,
+    OverrideModifierPrefix,
+    ReadonlyModifierPrefix,
+    DecoratedModifierPrefix,
+    OptionalModifierPrefix,
+    PropertySelector,
+  ]
+>
+
+export type FunctionPropertyGroup = Join<
+  [
+    PublicOrProtectedOrPrivateModifierPrefix,
+    StaticModifierPrefix,
+    OverrideModifierPrefix,
+    ReadonlyModifierPrefix,
+    DecoratedModifierPrefix,
+    AsyncModifierPrefix,
+    FunctionPropertySelector,
+  ]
+>
+
+export type MethodGroup = Join<
+  [
+    PublicOrProtectedOrPrivateModifierPrefix,
+    StaticOrAbstractModifierPrefix,
+    OverrideModifierPrefix,
+    DecoratedModifierPrefix,
+    AsyncModifierPrefix,
+    OptionalModifierPrefix,
+    MethodSelector,
+  ]
+>
+
 export type Selector =
   | AccessorPropertySelector
   | FunctionPropertySelector
@@ -45,6 +81,27 @@ export type Selector =
   | PropertySelector
   | MethodSelector
 
+export type DeclarePropertyGroup = Join<
+  [
+    DeclareModifierPrefix,
+    PublicOrProtectedOrPrivateModifierPrefix,
+    StaticOrAbstractModifierPrefix,
+    ReadonlyModifierPrefix,
+    OptionalModifierPrefix,
+    PropertySelector,
+  ]
+>
+
+export type GetMethodOrSetMethodGroup = Join<
+  [
+    PublicOrProtectedOrPrivateModifierPrefix,
+    StaticOrAbstractModifierPrefix,
+    OverrideModifierPrefix,
+    DecoratedModifierPrefix,
+    GetMethodOrSetMethodSelector,
+  ]
+>
+
 export type Modifier =
   | PublicOrProtectedOrPrivateModifier
   | DecoratedModifier
@@ -55,6 +112,24 @@ export type Modifier =
   | DeclareModifier
   | StaticModifier
   | AsyncModifier
+
+export type AccessorPropertyGroup = Join<
+  [
+    PublicOrProtectedOrPrivateModifierPrefix,
+    StaticOrAbstractModifierPrefix,
+    OverrideModifierPrefix,
+    DecoratedModifierPrefix,
+    AccessorPropertySelector,
+  ]
+>
+
+export type IndexSignatureGroup = Join<
+  [StaticModifierPrefix, ReadonlyModifierPrefix, IndexSignatureSelector]
+>
+
+export type ConstructorGroup = Join<
+  [PublicOrProtectedOrPrivateModifierPrefix, ConstructorSelector]
+>
 
 export interface AnyOfCustomGroup {
   anyOf: SingleCustomGroup[]
@@ -138,29 +213,18 @@ type CustomGroup = (
     groupName: string
   }
 
-type NonDeclarePropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
-
-type FunctionPropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticModifierPrefix}${OverrideModifierPrefix}${ReadonlyModifierPrefix}${DecoratedModifierPrefix}${AsyncModifierPrefix}${FunctionPropertySelector}`
-
-type MethodGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AsyncModifierPrefix}${OptionalModifierPrefix}${MethodSelector}`
-
-type DeclarePropertyGroup =
-  `${DeclareModifierPrefix}${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${ReadonlyModifierPrefix}${OptionalModifierPrefix}${PropertySelector}`
-
-type GetMethodOrSetMethodGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${GetMethodOrSetMethodSelector}`
-
-type AccessorPropertyGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${StaticOrAbstractModifierPrefix}${OverrideModifierPrefix}${DecoratedModifierPrefix}${AccessorPropertySelector}`
-
 type AdvancedSingleCustomGroup<T extends Selector> = {
   decoratorNamePattern?: string
   elementValuePattern?: string
   elementNamePattern?: string
 } & BaseSingleCustomGroup<T>
+
+type Join<T extends string[]> = T extends [
+  infer First extends string,
+  ...infer Rest extends string[],
+]
+  ? `${First}${Join<Rest>}`
+  : ''
 
 type PublicOrProtectedOrPrivateModifierPrefix = WithDashSuffixOrEmpty<
   ProtectedModifier | PrivateModifier | PublicModifier
@@ -170,8 +234,6 @@ interface BaseSingleCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   selector?: T
 }
-type IndexSignatureGroup =
-  `${StaticModifierPrefix}${ReadonlyModifierPrefix}${IndexSignatureSelector}`
 
 type PublicOrProtectedOrPrivateModifier =
   | ProtectedModifier
@@ -181,9 +243,6 @@ type PublicOrProtectedOrPrivateModifier =
 type StaticOrAbstractModifierPrefix = WithDashSuffixOrEmpty<
   AbstractModifier | StaticModifier
 >
-
-type ConstructorGroup =
-  `${PublicOrProtectedOrPrivateModifierPrefix}${ConstructorSelector}`
 
 type GetMethodOrSetMethodSelector = GetMethodSelector | SetMethodSelector
 

--- a/test/sort-classes.test.ts
+++ b/test/sort-classes.test.ts
@@ -1,9 +1,20 @@
 import type { Rule } from 'eslint'
 
+import { expectTypeOf, afterAll, describe, it } from 'vitest'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
 import { dedent } from 'ts-dedent'
+
+import type {
+  GetMethodOrSetMethodGroup,
+  NonDeclarePropertyGroup,
+  FunctionPropertyGroup,
+  AccessorPropertyGroup,
+  DeclarePropertyGroup,
+  IndexSignatureGroup,
+  ConstructorGroup,
+  MethodGroup,
+} from '../rules/sort-classes.types'
 
 import { Alphabet } from '../utils/alphabet'
 import rule from '../rules/sort-classes'
@@ -8747,5 +8758,79 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+  })
+
+  describe(`${ruleName}: test types`, () => {
+    it('test get method or set method group type', () => {
+      expectTypeOf(
+        'get-method' as const,
+      ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+
+      expectTypeOf(
+        'set-method' as const,
+      ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+
+      expectTypeOf(
+        'protected-get-method' as const,
+      ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+
+      expectTypeOf(
+        'public-decorated-get-method' as const,
+      ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+    })
+
+    it('test non declare property group type', () => {
+      expectTypeOf(
+        'public-static-override-property' as const,
+      ).toMatchTypeOf<NonDeclarePropertyGroup>()
+    })
+
+    it('test function property group type', () => {
+      expectTypeOf(
+        'private-static-function-property' as const,
+      ).toMatchTypeOf<FunctionPropertyGroup>()
+    })
+
+    it('test accessor property group type', () => {
+      expectTypeOf(
+        'static-accessor-property' as const,
+      ).toMatchTypeOf<AccessorPropertyGroup>()
+
+      expectTypeOf(
+        'protected-static-accessor-property' as const,
+      ).toMatchTypeOf<AccessorPropertyGroup>()
+
+      expectTypeOf(
+        'accessor-property' as const,
+      ).toMatchTypeOf<AccessorPropertyGroup>()
+
+      expectTypeOf(
+        'protected-accessor-property' as const,
+      ).toMatchTypeOf<AccessorPropertyGroup>()
+    })
+
+    it('test declare property group type', () => {
+      expectTypeOf(
+        'declare-protected-static-readonly-property' as const,
+      ).toMatchTypeOf<DeclarePropertyGroup>()
+    })
+
+    it('test declare method group type', () => {
+      expectTypeOf('public-method' as const).toMatchTypeOf<MethodGroup>()
+
+      expectTypeOf('protected-method' as const).toMatchTypeOf<MethodGroup>()
+
+      expectTypeOf('private-method' as const).toMatchTypeOf<MethodGroup>()
+    })
+
+    it('test constructor group type', () => {
+      expectTypeOf('constructor' as const).toMatchTypeOf<ConstructorGroup>()
+    })
+
+    it('test index signature group type', () => {
+      expectTypeOf(
+        'index-signature' as const,
+      ).toMatchTypeOf<IndexSignatureGroup>()
+    })
   })
 })


### PR DESCRIPTION
### Description

It seems the current types for groups are pretty hard to read. I wrote a generic type to make types more readable. And added tests for types.

### Additional context

N/A.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
