### PR TITLE
refactor: uses `Join` for other rules

### DIFF
--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { Join } from '../typings'
+import type { JoinWithDash } from '../typings'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -36,18 +36,7 @@ export type SingleCustomGroup =
   | BaseSingleCustomGroup<ConstructorSelector>
   | AdvancedSingleCustomGroup<MethodSelector>
 
-export type Selector =
-  | AccessorPropertySelector
-  | FunctionPropertySelector
-  | IndexSignatureSelector
-  | ConstructorSelector
-  | StaticBlockSelector
-  | GetMethodSelector
-  | SetMethodSelector
-  | PropertySelector
-  | MethodSelector
-
-export type NonDeclarePropertyGroup = Join<
+export type NonDeclarePropertyGroup = JoinWithDash<
   [
     PublicOrProtectedOrPrivateModifier,
     StaticOrAbstractModifier,
@@ -59,7 +48,18 @@ export type NonDeclarePropertyGroup = Join<
   ]
 >
 
-export type FunctionPropertyGroup = Join<
+export type Selector =
+  | AccessorPropertySelector
+  | FunctionPropertySelector
+  | IndexSignatureSelector
+  | ConstructorSelector
+  | StaticBlockSelector
+  | GetMethodSelector
+  | SetMethodSelector
+  | PropertySelector
+  | MethodSelector
+
+export type FunctionPropertyGroup = JoinWithDash<
   [
     PublicOrProtectedOrPrivateModifier,
     StaticModifier,
@@ -68,6 +68,18 @@ export type FunctionPropertyGroup = Join<
     DecoratedModifier,
     AsyncModifier,
     FunctionPropertySelector,
+  ]
+>
+
+export type MethodGroup = JoinWithDash<
+  [
+    PublicOrProtectedOrPrivateModifier,
+    StaticOrAbstractModifier,
+    OverrideModifier,
+    DecoratedModifier,
+    AsyncModifier,
+    OptionalModifier,
+    MethodSelector,
   ]
 >
 
@@ -82,19 +94,7 @@ export type Modifier =
   | StaticModifier
   | AsyncModifier
 
-export type MethodGroup = Join<
-  [
-    PublicOrProtectedOrPrivateModifier,
-    StaticOrAbstractModifier,
-    OverrideModifier,
-    DecoratedModifier,
-    AsyncModifier,
-    OptionalModifier,
-    MethodSelector,
-  ]
->
-
-export type DeclarePropertyGroup = Join<
+export type DeclarePropertyGroup = JoinWithDash<
   [
     DeclareModifier,
     PublicOrProtectedOrPrivateModifier,
@@ -105,7 +105,7 @@ export type DeclarePropertyGroup = Join<
   ]
 >
 
-export type GetMethodOrSetMethodGroup = Join<
+export type GetMethodOrSetMethodGroup = JoinWithDash<
   [
     PublicOrProtectedOrPrivateModifier,
     StaticOrAbstractModifier,
@@ -115,7 +115,7 @@ export type GetMethodOrSetMethodGroup = Join<
   ]
 >
 
-export type AccessorPropertyGroup = Join<
+export type AccessorPropertyGroup = JoinWithDash<
   [
     PublicOrProtectedOrPrivateModifier,
     StaticOrAbstractModifier,
@@ -125,11 +125,11 @@ export type AccessorPropertyGroup = Join<
   ]
 >
 
-export type IndexSignatureGroup = Join<
+export type IndexSignatureGroup = JoinWithDash<
   [StaticModifier, ReadonlyModifier, IndexSignatureSelector]
 >
 
-export type ConstructorGroup = Join<
+export type ConstructorGroup = JoinWithDash<
   [PublicOrProtectedOrPrivateModifier, ConstructorSelector]
 >
 

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -221,13 +221,6 @@ type AdvancedSingleCustomGroup<T extends Selector> = {
   elementNamePattern?: string
 } & BaseSingleCustomGroup<T>
 
-type Join<T extends string[]> = T extends [
-  infer First extends string,
-  ...infer Rest extends string[],
-]
-  ? `${First}${Join<Rest>}`
-  : ''
-
 type PublicOrProtectedOrPrivateModifierPrefix = WithDashSuffixOrEmpty<
   ProtectedModifier | PrivateModifier | PublicModifier
 >

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -1,5 +1,7 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { WithDashSuffixOrEmpty, Join } from '../typings'
+
 import {
   buildCustomGroupModifiersJsonSchema,
   buildCustomGroupSelectorJsonSchema,
@@ -259,8 +261,6 @@ type DeclareModifierPrefix = WithDashSuffixOrEmpty<DeclareModifier>
 type StaticModifierPrefix = WithDashSuffixOrEmpty<StaticModifier>
 
 type AsyncModifierPrefix = WithDashSuffixOrEmpty<AsyncModifier>
-
-type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''
 
 type FunctionPropertySelector = 'function-property'
 

--- a/rules/sort-classes.types.ts
+++ b/rules/sort-classes.types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { WithDashSuffixOrEmpty, Join } from '../typings'
+import type { Join } from '../typings'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -36,42 +36,6 @@ export type SingleCustomGroup =
   | BaseSingleCustomGroup<ConstructorSelector>
   | AdvancedSingleCustomGroup<MethodSelector>
 
-export type NonDeclarePropertyGroup = Join<
-  [
-    PublicOrProtectedOrPrivateModifierPrefix,
-    StaticOrAbstractModifierPrefix,
-    OverrideModifierPrefix,
-    ReadonlyModifierPrefix,
-    DecoratedModifierPrefix,
-    OptionalModifierPrefix,
-    PropertySelector,
-  ]
->
-
-export type FunctionPropertyGroup = Join<
-  [
-    PublicOrProtectedOrPrivateModifierPrefix,
-    StaticModifierPrefix,
-    OverrideModifierPrefix,
-    ReadonlyModifierPrefix,
-    DecoratedModifierPrefix,
-    AsyncModifierPrefix,
-    FunctionPropertySelector,
-  ]
->
-
-export type MethodGroup = Join<
-  [
-    PublicOrProtectedOrPrivateModifierPrefix,
-    StaticOrAbstractModifierPrefix,
-    OverrideModifierPrefix,
-    DecoratedModifierPrefix,
-    AsyncModifierPrefix,
-    OptionalModifierPrefix,
-    MethodSelector,
-  ]
->
-
 export type Selector =
   | AccessorPropertySelector
   | FunctionPropertySelector
@@ -83,24 +47,27 @@ export type Selector =
   | PropertySelector
   | MethodSelector
 
-export type DeclarePropertyGroup = Join<
+export type NonDeclarePropertyGroup = Join<
   [
-    DeclareModifierPrefix,
-    PublicOrProtectedOrPrivateModifierPrefix,
-    StaticOrAbstractModifierPrefix,
-    ReadonlyModifierPrefix,
-    OptionalModifierPrefix,
+    PublicOrProtectedOrPrivateModifier,
+    StaticOrAbstractModifier,
+    OverrideModifier,
+    ReadonlyModifier,
+    DecoratedModifier,
+    OptionalModifier,
     PropertySelector,
   ]
 >
 
-export type GetMethodOrSetMethodGroup = Join<
+export type FunctionPropertyGroup = Join<
   [
-    PublicOrProtectedOrPrivateModifierPrefix,
-    StaticOrAbstractModifierPrefix,
-    OverrideModifierPrefix,
-    DecoratedModifierPrefix,
-    GetMethodOrSetMethodSelector,
+    PublicOrProtectedOrPrivateModifier,
+    StaticModifier,
+    OverrideModifier,
+    ReadonlyModifier,
+    DecoratedModifier,
+    AsyncModifier,
+    FunctionPropertySelector,
   ]
 >
 
@@ -115,22 +82,55 @@ export type Modifier =
   | StaticModifier
   | AsyncModifier
 
+export type MethodGroup = Join<
+  [
+    PublicOrProtectedOrPrivateModifier,
+    StaticOrAbstractModifier,
+    OverrideModifier,
+    DecoratedModifier,
+    AsyncModifier,
+    OptionalModifier,
+    MethodSelector,
+  ]
+>
+
+export type DeclarePropertyGroup = Join<
+  [
+    DeclareModifier,
+    PublicOrProtectedOrPrivateModifier,
+    StaticOrAbstractModifier,
+    ReadonlyModifier,
+    OptionalModifier,
+    PropertySelector,
+  ]
+>
+
+export type GetMethodOrSetMethodGroup = Join<
+  [
+    PublicOrProtectedOrPrivateModifier,
+    StaticOrAbstractModifier,
+    OverrideModifier,
+    DecoratedModifier,
+    GetMethodOrSetMethodSelector,
+  ]
+>
+
 export type AccessorPropertyGroup = Join<
   [
-    PublicOrProtectedOrPrivateModifierPrefix,
-    StaticOrAbstractModifierPrefix,
-    OverrideModifierPrefix,
-    DecoratedModifierPrefix,
+    PublicOrProtectedOrPrivateModifier,
+    StaticOrAbstractModifier,
+    OverrideModifier,
+    DecoratedModifier,
     AccessorPropertySelector,
   ]
 >
 
 export type IndexSignatureGroup = Join<
-  [StaticModifierPrefix, ReadonlyModifierPrefix, IndexSignatureSelector]
+  [StaticModifier, ReadonlyModifier, IndexSignatureSelector]
 >
 
 export type ConstructorGroup = Join<
-  [PublicOrProtectedOrPrivateModifierPrefix, ConstructorSelector]
+  [PublicOrProtectedOrPrivateModifier, ConstructorSelector]
 >
 
 export interface AnyOfCustomGroup {
@@ -221,10 +221,6 @@ type AdvancedSingleCustomGroup<T extends Selector> = {
   elementNamePattern?: string
 } & BaseSingleCustomGroup<T>
 
-type PublicOrProtectedOrPrivateModifierPrefix = WithDashSuffixOrEmpty<
-  ProtectedModifier | PrivateModifier | PublicModifier
->
-
 interface BaseSingleCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   selector?: T
@@ -235,25 +231,9 @@ type PublicOrProtectedOrPrivateModifier =
   | PrivateModifier
   | PublicModifier
 
-type StaticOrAbstractModifierPrefix = WithDashSuffixOrEmpty<
-  AbstractModifier | StaticModifier
->
-
 type GetMethodOrSetMethodSelector = GetMethodSelector | SetMethodSelector
 
-type DecoratedModifierPrefix = WithDashSuffixOrEmpty<DecoratedModifier>
-
-type OverrideModifierPrefix = WithDashSuffixOrEmpty<OverrideModifier>
-
-type OptionalModifierPrefix = WithDashSuffixOrEmpty<OptionalModifier>
-
-type ReadonlyModifierPrefix = WithDashSuffixOrEmpty<ReadonlyModifier>
-
-type DeclareModifierPrefix = WithDashSuffixOrEmpty<DeclareModifier>
-
-type StaticModifierPrefix = WithDashSuffixOrEmpty<StaticModifier>
-
-type AsyncModifierPrefix = WithDashSuffixOrEmpty<AsyncModifier>
+type StaticOrAbstractModifier = AbstractModifier | StaticModifier
 
 type FunctionPropertySelector = 'function-property'
 

--- a/rules/sort-modules.types.ts
+++ b/rules/sort-modules.types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { Join } from '../typings'
+import type { JoinWithDash } from '../typings'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -99,27 +99,27 @@ interface BaseSingleCustomGroup<T extends Selector> {
   selector?: T
 }
 
-type NonDefaultClassGroup = Join<
+type NonDefaultClassGroup = JoinWithDash<
   [ExportModifier, DeclareModifier, DecoratedModifier, ClassSelector]
 >
 
-type DefaultFunctionGroup = Join<
+type DefaultFunctionGroup = JoinWithDash<
   [ExportModifier, DefaultModifier, AsyncModifier, FunctionSelector]
 >
 
-type DefaultClassGroup = Join<
+type DefaultClassGroup = JoinWithDash<
   [ExportModifier, DefaultModifier, DecoratedModifier, ClassSelector]
 >
 
-type NonDefaultInterfaceGroup = Join<
+type NonDefaultInterfaceGroup = JoinWithDash<
   [ExportModifier, DeclareModifier, InterfaceSelector]
 >
 
-type NonDefaultFunctionGroup = Join<
+type NonDefaultFunctionGroup = JoinWithDash<
   [ExportModifier, DeclareModifier, FunctionSelector]
 >
 
-type DefaultInterfaceGroup = Join<
+type DefaultInterfaceGroup = JoinWithDash<
   [ExportModifier, DefaultModifier, InterfaceSelector]
 >
 
@@ -131,9 +131,9 @@ interface ElementNamePatternFilterCustomGroup {
   elementNamePattern?: string
 }
 
-type TypeGroup = Join<[ExportModifier, DeclareModifier, TypeSelector]>
+type TypeGroup = JoinWithDash<[ExportModifier, DeclareModifier, TypeSelector]>
 
-type EnumGroup = Join<[ExportModifier, DeclareModifier, EnumSelector]>
+type EnumGroup = JoinWithDash<[ExportModifier, DeclareModifier, EnumSelector]>
 
 type DecoratedModifier = 'decorated'
 

--- a/rules/sort-modules.types.ts
+++ b/rules/sort-modules.types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { WithDashSuffixOrEmpty, Join } from '../typings'
+import type { Join } from '../typings'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -94,56 +94,33 @@ type Group =
   | 'unknown'
   | string
 
-type NonDefaultClassGroup = Join<
-  [
-    ExportModifierPrefix,
-    DeclareModifierPrefix,
-    DecoratedModifierPrefix,
-    ClassSelector,
-  ]
->
-
-type DefaultFunctionGroup = Join<
-  [
-    ExportModifierPrefix,
-    DefaultModifierPrefix,
-    AsyncModifierPrefix,
-    FunctionSelector,
-  ]
->
-
-type DefaultClassGroup = Join<
-  [
-    ExportModifierPrefix,
-    DefaultModifierPrefix,
-    DecoratedModifierPrefix,
-    ClassSelector,
-  ]
->
-
 interface BaseSingleCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   selector?: T
 }
 
+type NonDefaultClassGroup = Join<
+  [ExportModifier, DeclareModifier, DecoratedModifier, ClassSelector]
+>
+
+type DefaultFunctionGroup = Join<
+  [ExportModifier, DefaultModifier, AsyncModifier, FunctionSelector]
+>
+
+type DefaultClassGroup = Join<
+  [ExportModifier, DefaultModifier, DecoratedModifier, ClassSelector]
+>
+
 type NonDefaultInterfaceGroup = Join<
-  [ExportModifierPrefix, DeclareModifierPrefix, InterfaceSelector]
+  [ExportModifier, DeclareModifier, InterfaceSelector]
 >
 
 type NonDefaultFunctionGroup = Join<
-  [ExportModifierPrefix, DeclareModifierPrefix, FunctionSelector]
+  [ExportModifier, DeclareModifier, FunctionSelector]
 >
 
 type DefaultInterfaceGroup = Join<
-  [ExportModifierPrefix, DefaultModifierPrefix, InterfaceSelector]
->
-
-type TypeGroup = Join<
-  [ExportModifierPrefix, DeclareModifierPrefix, TypeSelector]
->
-
-type EnumGroup = Join<
-  [ExportModifierPrefix, DeclareModifierPrefix, EnumSelector]
+  [ExportModifier, DefaultModifier, InterfaceSelector]
 >
 
 interface DecoratorNamePatternFilterCustomGroup {
@@ -154,15 +131,9 @@ interface ElementNamePatternFilterCustomGroup {
   elementNamePattern?: string
 }
 
-type DecoratedModifierPrefix = WithDashSuffixOrEmpty<DecoratedModifier>
+type TypeGroup = Join<[ExportModifier, DeclareModifier, TypeSelector]>
 
-type DeclareModifierPrefix = WithDashSuffixOrEmpty<DeclareModifier>
-
-type DefaultModifierPrefix = WithDashSuffixOrEmpty<DefaultModifier>
-
-type ExportModifierPrefix = WithDashSuffixOrEmpty<ExportModifier>
-
-type AsyncModifierPrefix = WithDashSuffixOrEmpty<AsyncModifier>
+type EnumGroup = Join<[ExportModifier, DeclareModifier, EnumSelector]>
 
 type DecoratedModifier = 'decorated'
 

--- a/rules/sort-modules.types.ts
+++ b/rules/sort-modules.types.ts
@@ -1,5 +1,7 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { WithDashSuffixOrEmpty } from '../typings'
+
 import {
   buildCustomGroupModifiersJsonSchema,
   buildCustomGroupSelectorJsonSchema,
@@ -138,8 +140,6 @@ type DefaultModifierPrefix = WithDashSuffixOrEmpty<DefaultModifier>
 type ExportModifierPrefix = WithDashSuffixOrEmpty<ExportModifier>
 
 type AsyncModifierPrefix = WithDashSuffixOrEmpty<AsyncModifier>
-
-type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''
 
 type DecoratedModifier = 'decorated'
 

--- a/rules/sort-modules.types.ts
+++ b/rules/sort-modules.types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { WithDashSuffixOrEmpty } from '../typings'
+import type { WithDashSuffixOrEmpty, Join } from '../typings'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -94,34 +94,57 @@ type Group =
   | 'unknown'
   | string
 
-type NonDefaultClassGroup =
-  `${ExportModifierPrefix}${DeclareModifierPrefix}${DecoratedModifierPrefix}${ClassSelector}`
+type NonDefaultClassGroup = Join<
+  [
+    ExportModifierPrefix,
+    DeclareModifierPrefix,
+    DecoratedModifierPrefix,
+    ClassSelector,
+  ]
+>
 
-type DefaultFunctionGroup =
-  `${ExportModifierPrefix}${DefaultModifierPrefix}${AsyncModifierPrefix}${FunctionSelector}`
+type DefaultFunctionGroup = Join<
+  [
+    ExportModifierPrefix,
+    DefaultModifierPrefix,
+    AsyncModifierPrefix,
+    FunctionSelector,
+  ]
+>
 
-type DefaultClassGroup =
-  `${ExportModifierPrefix}${DefaultModifierPrefix}${DecoratedModifierPrefix}${ClassSelector}`
+type DefaultClassGroup = Join<
+  [
+    ExportModifierPrefix,
+    DefaultModifierPrefix,
+    DecoratedModifierPrefix,
+    ClassSelector,
+  ]
+>
 
 interface BaseSingleCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   selector?: T
 }
 
-type NonDefaultInterfaceGroup =
-  `${ExportModifierPrefix}${DeclareModifierPrefix}${InterfaceSelector}`
+type NonDefaultInterfaceGroup = Join<
+  [ExportModifierPrefix, DeclareModifierPrefix, InterfaceSelector]
+>
 
-type NonDefaultFunctionGroup =
-  `${ExportModifierPrefix}${DeclareModifierPrefix}${FunctionSelector}`
+type NonDefaultFunctionGroup = Join<
+  [ExportModifierPrefix, DeclareModifierPrefix, FunctionSelector]
+>
 
-type DefaultInterfaceGroup =
-  `${ExportModifierPrefix}${DefaultModifierPrefix}${InterfaceSelector}`
+type DefaultInterfaceGroup = Join<
+  [ExportModifierPrefix, DefaultModifierPrefix, InterfaceSelector]
+>
 
-type TypeGroup =
-  `${ExportModifierPrefix}${DeclareModifierPrefix}${TypeSelector}`
+type TypeGroup = Join<
+  [ExportModifierPrefix, DeclareModifierPrefix, TypeSelector]
+>
 
-type EnumGroup =
-  `${ExportModifierPrefix}${DeclareModifierPrefix}${EnumSelector}`
+type EnumGroup = Join<
+  [ExportModifierPrefix, DeclareModifierPrefix, EnumSelector]
+>
 
 interface DecoratorNamePatternFilterCustomGroup {
   decoratorNamePattern?: string

--- a/rules/sort-object-types.types.ts
+++ b/rules/sort-object-types.types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { Join } from '../typings'
+import type { JoinWithDash } from '../typings'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -75,7 +75,7 @@ type CustomGroup = (
     groupName: string
   }
 
-type IndexSignatureGroup = Join<
+type IndexSignatureGroup = JoinWithDash<
   [
     OptionalModifier,
     RequiredModifier,
@@ -101,22 +101,22 @@ interface BaseSingleCustomGroup<T extends Selector> {
   selector?: T
 }
 
-type PropertyGroup = Join<
+type PropertyGroup = JoinWithDash<
   [OptionalModifier, RequiredModifier, MultilineModifier, PropertySelector]
 >
 
-type MemberGroup = Join<
+type MemberGroup = JoinWithDash<
   [OptionalModifier, RequiredModifier, MultilineModifier, MemberSelector]
 >
 
-type MethodGroup = Join<
+type MethodGroup = JoinWithDash<
   [OptionalModifier, RequiredModifier, MultilineModifier, MethodSelector]
 >
 
 /**
  * @deprecated For {@link `MultilineModifier`}
  */
-type MultilineGroup = Join<
+type MultilineGroup = JoinWithDash<
   [OptionalModifier, RequiredModifier, MultilineSelector]
 >
 

--- a/rules/sort-object-types.types.ts
+++ b/rules/sort-object-types.types.ts
@@ -75,6 +75,24 @@ type CustomGroup = (
     groupName: string
   }
 
+type MemberGroup = Join<
+  [
+    OptionalModifierPrefix,
+    RequiredModifierPrefix,
+    MultilineModifierPrefix,
+    MemberSelector,
+  ]
+>
+
+type MethodGroup = Join<
+  [
+    OptionalModifierPrefix,
+    RequiredModifierPrefix,
+    MultilineModifierPrefix,
+    MethodSelector,
+  ]
+>
+
 type IndexSignatureGroup =
   `${OptionalModifierPrefix | RequiredModifierPrefix}${MultilineModifierPrefix}${IndexSignatureSelector}`
 
@@ -98,14 +116,12 @@ interface BaseSingleCustomGroup<T extends Selector> {
   selector?: T
 }
 
-type MemberGroup =
-  `${OptionalModifierPrefix | RequiredModifierPrefix}${MultilineModifierPrefix}${MemberSelector}`
-
-type MethodGroup =
-  `${OptionalModifierPrefix | RequiredModifierPrefix}${MultilineModifierPrefix}${MethodSelector}`
-
-type MultilineGroup =
-  `${OptionalModifierPrefix | RequiredModifierPrefix}${MultilineSelector}`
+/**
+ * @deprecated For {@link `MultilineModifier`}
+ */
+type MultilineGroup = Join<
+  [OptionalModifierPrefix, RequiredModifierPrefix, MultilineSelector]
+>
 
 interface ElementNamePatternFilterCustomGroup {
   elementNamePattern?: string

--- a/rules/sort-object-types.types.ts
+++ b/rules/sort-object-types.types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { WithDashSuffixOrEmpty, Join } from '../typings'
+import type { Join } from '../typings'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -75,26 +75,14 @@ type CustomGroup = (
     groupName: string
   }
 
-type MemberGroup = Join<
+type IndexSignatureGroup = Join<
   [
-    OptionalModifierPrefix,
-    RequiredModifierPrefix,
-    MultilineModifierPrefix,
-    MemberSelector,
+    OptionalModifier,
+    RequiredModifier,
+    MultilineModifier,
+    IndexSignatureSelector,
   ]
 >
-
-type MethodGroup = Join<
-  [
-    OptionalModifierPrefix,
-    RequiredModifierPrefix,
-    MultilineModifierPrefix,
-    MethodSelector,
-  ]
->
-
-type IndexSignatureGroup =
-  `${OptionalModifierPrefix | RequiredModifierPrefix}${MultilineModifierPrefix}${IndexSignatureSelector}`
 
 /**
  * Only used in code, so I don't know if it's worth maintaining this.
@@ -108,30 +96,33 @@ type Group =
   | 'unknown'
   | string
 
-type PropertyGroup =
-  `${OptionalModifierPrefix | RequiredModifierPrefix}${MultilineModifierPrefix}${PropertySelector}`
-
 interface BaseSingleCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]
   selector?: T
 }
 
+type PropertyGroup = Join<
+  [OptionalModifier, RequiredModifier, MultilineModifier, PropertySelector]
+>
+
+type MemberGroup = Join<
+  [OptionalModifier, RequiredModifier, MultilineModifier, MemberSelector]
+>
+
+type MethodGroup = Join<
+  [OptionalModifier, RequiredModifier, MultilineModifier, MethodSelector]
+>
+
 /**
  * @deprecated For {@link `MultilineModifier`}
  */
 type MultilineGroup = Join<
-  [OptionalModifierPrefix, RequiredModifierPrefix, MultilineSelector]
+  [OptionalModifier, RequiredModifier, MultilineSelector]
 >
 
 interface ElementNamePatternFilterCustomGroup {
   elementNamePattern?: string
 }
-
-type MultilineModifierPrefix = WithDashSuffixOrEmpty<MultilineModifier>
-
-type RequiredModifierPrefix = WithDashSuffixOrEmpty<RequiredModifier>
-
-type OptionalModifierPrefix = WithDashSuffixOrEmpty<OptionalModifier>
 
 type IndexSignatureSelector = 'index-signature'
 

--- a/rules/sort-object-types.types.ts
+++ b/rules/sort-object-types.types.ts
@@ -1,5 +1,7 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { WithDashSuffixOrEmpty, Join } from '../typings'
+
 import {
   buildCustomGroupModifiersJsonSchema,
   buildCustomGroupSelectorJsonSchema,
@@ -114,8 +116,6 @@ type MultilineModifierPrefix = WithDashSuffixOrEmpty<MultilineModifier>
 type RequiredModifierPrefix = WithDashSuffixOrEmpty<RequiredModifier>
 
 type OptionalModifierPrefix = WithDashSuffixOrEmpty<OptionalModifier>
-
-type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''
 
 type IndexSignatureSelector = 'index-signature'
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,11 +1,1 @@
-import type { TSESTree } from '@typescript-eslint/types'
-
-export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
-  hasMultipleImportDeclarations?: boolean
-  addSafetySemicolonWhenInline?: boolean
-  isEslintDisabled: boolean
-  group?: string
-  name: string
-  size: number
-  node: Node
-}
+export type { SortingNode } from './sorting-node'

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,1 +1,2 @@
+export type { WithDashSuffixOrEmpty } from './with-dash-suffix-or-empty'
 export type { SortingNode } from './sorting-node'

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,3 +1,2 @@
-export type { WithDashSuffixOrEmpty } from './with-dash-suffix-or-empty'
 export type { SortingNode } from './sorting-node'
 export type { Join } from './join'

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,2 +1,3 @@
 export type { WithDashSuffixOrEmpty } from './with-dash-suffix-or-empty'
 export type { SortingNode } from './sorting-node'
+export type { Join } from './join'

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,2 +1,2 @@
+export type { JoinWithDash } from './join-with-dash'
 export type { SortingNode } from './sorting-node'
-export type { Join } from './join'

--- a/typings/join-with-dash.ts
+++ b/typings/join-with-dash.ts
@@ -1,10 +1,3 @@
-export type JoinWithDash<T extends string[]> = T extends [
-  infer First extends string,
-  ...infer Rest extends string[],
-]
-  ? Rest extends []
-    ? `${First}`
-    : `${WithDashSuffixOrEmpty<First>}${JoinWithDash<Rest>}`
-  : never
+import type { Join } from './join'
 
-type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''
+export type JoinWithDash<T extends string[]> = Join<T, '-'>

--- a/typings/join-with-dash.ts
+++ b/typings/join-with-dash.ts
@@ -1,10 +1,10 @@
-export type Join<T extends string[]> = T extends [
+export type JoinWithDash<T extends string[]> = T extends [
   infer First extends string,
   ...infer Rest extends string[],
 ]
   ? Rest extends []
     ? `${First}`
-    : `${WithDashSuffixOrEmpty<First>}${Join<Rest>}`
+    : `${WithDashSuffixOrEmpty<First>}${JoinWithDash<Rest>}`
   : never
 
 type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''

--- a/typings/join.ts
+++ b/typings/join.ts
@@ -2,5 +2,9 @@ export type Join<T extends string[]> = T extends [
   infer First extends string,
   ...infer Rest extends string[],
 ]
-  ? `${First}${Join<Rest>}`
-  : ''
+  ? Rest extends []
+    ? `${First}`
+    : `${WithDashSuffixOrEmpty<First>}${Join<Rest>}`
+  : never
+
+type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''

--- a/typings/join.ts
+++ b/typings/join.ts
@@ -1,0 +1,12 @@
+export type Join<T extends string[], Separator extends string> = T extends [
+  infer First extends string,
+  ...infer Rest extends string[],
+]
+  ? Rest extends []
+    ? `${First}`
+    : `${WithSeparatorOrEmpty<First, Separator>}${Join<Rest, Separator>}`
+  : never
+
+type WithSeparatorOrEmpty<T extends string, Separator extends string> =
+  | `${T}${Separator}`
+  | ''

--- a/typings/join.ts
+++ b/typings/join.ts
@@ -1,0 +1,6 @@
+export type Join<T extends string[]> = T extends [
+  infer First extends string,
+  ...infer Rest extends string[],
+]
+  ? `${First}${Join<Rest>}`
+  : ''

--- a/typings/sorting-node.ts
+++ b/typings/sorting-node.ts
@@ -1,0 +1,11 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
+  hasMultipleImportDeclarations?: boolean
+  addSafetySemicolonWhenInline?: boolean
+  isEslintDisabled: boolean
+  group?: string
+  name: string
+  size: number
+  node: Node
+}

--- a/typings/with-dash-suffix-or-empty.ts
+++ b/typings/with-dash-suffix-or-empty.ts
@@ -1,1 +1,0 @@
-export type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''

--- a/typings/with-dash-suffix-or-empty.ts
+++ b/typings/with-dash-suffix-or-empty.ts
@@ -1,0 +1,1 @@
+export type WithDashSuffixOrEmpty<T extends string> = `${T}-` | ''


### PR DESCRIPTION
### Changes

- Extract the following types into their own files: `Join`, `SortingNode`.
- Transforms `Join` introduced in https://github.com/azat-io/eslint-plugin-perfectionist/pull/416  to `JoinWithDash` and uses it for other rules.

### What is the purpose of this pull request?

- [x] Other
