### PR TITLE
perf: improve rules performance

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -294,24 +294,18 @@ export let sortArray = <MessageIds extends string>({
   }
 
   for (let nodes of formattedMembers) {
-    let groupedNodesByKind = groupKindOrder.reduce<
-      Record<'literal' | 'spread' | 'any', SortArrayIncludesSortingNode[]>
-    >(
-      (accumulator, groupKind) => {
-        accumulator[groupKind] = nodes.filter(
-          currentNode =>
-            groupKind === 'any' || currentNode.groupKind === groupKind,
-        )
-        return accumulator
-      },
-      { literal: [], spread: [], any: [] },
+    let filteredGroupKindNodes = groupKindOrder.map(groupKind =>
+      nodes.filter(
+        currentNode =>
+          groupKind === 'any' || currentNode.groupKind === groupKind,
+      ),
     )
 
     let sortNodesIgnoringEslintDisabledNodes = (
       ignoreEslintDisabledNodes: boolean,
     ): SortArrayIncludesSortingNode[] =>
-      groupKindOrder.flatMap(groupKind =>
-        sortNodesByGroups(groupedNodesByKind[groupKind], options, {
+      filteredGroupKindNodes.flatMap(groupedNodes =>
+        sortNodesByGroups(groupedNodes, options, {
           getGroupCompareOptions: groupNumber =>
             getCustomGroupsCompareOptions(options, groupNumber),
           ignoreEslintDisabledNodes,

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -263,14 +263,13 @@ export let sortArray = <MessageIds extends string>({
 
       let lastSortingNode = accumulator.at(-1)?.at(-1)
       if (
-        (options.partitionByComment &&
-          hasPartitionComment(
-            options.partitionByComment,
-            getCommentsBefore({
-              node: element,
-              sourceCode,
-            }),
-          )) ||
+        hasPartitionComment(
+          options.partitionByComment,
+          getCommentsBefore({
+            node: element,
+            sourceCode,
+          }),
+        ) ||
         (options.partitionByNewLine &&
           lastSortingNode &&
           getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -27,6 +27,7 @@ import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { singleCustomGroupJsonSchema } from './sort-array-includes.types'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { customGroupMatches } from './sort-array-includes-utils'
@@ -322,10 +323,7 @@ export let sortArray = <MessageIds extends string>({
     let sortedNodesExcludingEslintDisabled =
       sortNodesIgnoringEslintDisabledNodes(true)
 
-    let nodeIndexMap = new Map<SortArrayIncludesSortingNode, number>()
-    for (let [index, node] of sortedNodes.entries()) {
-      nodeIndexMap.set(node, index)
-    }
+    let nodeIndexMap = createNodeIndexMap(sortedNodes)
 
     pairwise(nodes, (left, right) => {
       let leftIndex = nodeIndexMap.get(left)!

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -494,11 +494,13 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             selectors.push('property')
           }
 
-          for (let officialGroup of generatePredefinedGroups({
+          let predefinedGroups = generatePredefinedGroups({
             cache: cachedGroupsByModifiersAndSelectors,
             selectors,
             modifiers,
-          })) {
+          })
+
+          for (let officialGroup of predefinedGroups) {
             defineGroup(officialGroup)
           }
 

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -500,8 +500,8 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             modifiers,
           })
 
-          for (let officialGroup of predefinedGroups) {
-            defineGroup(officialGroup)
+          for (let predefinedGroup of predefinedGroups) {
+            defineGroup(predefinedGroup)
           }
 
           for (let customGroup of options.customGroups) {

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -555,14 +555,13 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             (options.partitionByNewLine &&
               lastMember &&
               getLinesBetween(sourceCode, lastMember, sortingNode)) ||
-            (options.partitionByComment &&
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
-                  node: member,
-                  sourceCode,
-                }),
-              ))
+            hasPartitionComment(
+              options.partitionByComment,
+              getCommentsBefore({
+                node: member,
+                sourceCode,
+              }),
+            )
           ) {
             accumulator.push([])
           }

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -19,6 +19,7 @@ import { validateGroupsConfiguration } from '../utils/validate-groups-configurat
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { getNodeDecorators } from '../utils/get-node-decorators'
@@ -259,16 +260,19 @@ let sortDecorators = (
   let sortedNodes = sortNodesExcludingEslintDisabled(false)
   let sortedNodesExcludingEslintDisabled =
     sortNodesExcludingEslintDisabled(true)
+
   let nodes = formattedMembers.flat()
 
+  let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
   pairwise(nodes, (left, right) => {
-    let indexOfLeft = sortedNodes.indexOf(left)
-    let indexOfRight = sortedNodes.indexOf(right)
+    let leftIndex = nodeIndexMap.get(left)!
+    let rightIndex = nodeIndexMap.get(right)!
     let indexOfRightExcludingEslintDisabled =
       sortedNodesExcludingEslintDisabled.indexOf(right)
     if (
-      indexOfLeft < indexOfRight &&
-      indexOfLeft < indexOfRightExcludingEslintDisabled
+      leftIndex < rightIndex &&
+      leftIndex < indexOfRightExcludingEslintDisabled
     ) {
       return
     }

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -219,7 +219,6 @@ let sortDecorators = (
   let formattedMembers: SortDecoratorsSortingNode[][] = decorators.reduce(
     (accumulator: SortDecoratorsSortingNode[][], decorator) => {
       if (
-        options.partitionByComment &&
         hasPartitionComment(
           options.partitionByComment,
           getCommentsBefore({

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -21,6 +21,7 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/is-partition-comment'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -96,37 +97,35 @@ export default createEslintRule<Options, MESSAGE_ID>({
         enumName: string,
       ): string[] => {
         let dependencies: string[] = []
+        let stack: TSESTree.Node[] = [expression]
 
-        let checkNode = (nodeValue: TSESTree.Node): void => {
+        while (stack.length) {
+          let node = stack.pop()!
           if (
-            nodeValue.type === 'MemberExpression' &&
-            nodeValue.object.type === 'Identifier' &&
-            nodeValue.object.name === enumName &&
-            nodeValue.property.type === 'Identifier'
+            node.type === 'MemberExpression' &&
+            node.object.type === 'Identifier' &&
+            node.object.name === enumName &&
+            node.property.type === 'Identifier'
           ) {
-            dependencies.push(nodeValue.property.name)
-          } else if (nodeValue.type === 'Identifier') {
-            dependencies.push(nodeValue.name)
+            dependencies.push(node.property.name)
+          } else if (node.type === 'Identifier') {
+            dependencies.push(node.name)
           }
 
-          if ('left' in nodeValue) {
-            checkNode(nodeValue.left)
+          if ('left' in node) {
+            stack.push(node.left)
           }
-
-          if ('right' in nodeValue) {
-            checkNode(nodeValue.right)
+          if ('right' in node) {
+            stack.push(node.right)
           }
-
-          if ('expressions' in nodeValue) {
-            for (let currentExpression of nodeValue.expressions) {
-              checkNode(currentExpression)
-            }
+          if ('expressions' in node) {
+            stack.push(...node.expressions)
           }
         }
 
-        checkNode(expression)
         return dependencies
       }
+
       let formattedMembers: SortEnumsSortingNode[][] = members.reduce(
         (accumulator: SortEnumsSortingNode[][], member) => {
           let dependencies: string[] = []
@@ -175,11 +174,18 @@ export default createEslintRule<Options, MESSAGE_ID>({
       )
 
       let sortingNodes = formattedMembers.flat()
-      let isNumericEnum = sortingNodes.every(
-        sortingNode =>
-          sortingNode.numericValue !== null &&
-          !Number.isNaN(sortingNode.numericValue),
-      )
+
+      let isNumericEnum = true
+      for (let sortingNode of sortingNodes) {
+        if (
+          sortingNode.numericValue === null ||
+          Number.isNaN(sortingNode.numericValue)
+        ) {
+          isNumericEnum = false
+          break
+        }
+      }
+
       let compareOptions: CompareOptions<SortEnumsSortingNode> = {
         // Get the enum value rather than the name if needed
         nodeValueGetter:
@@ -194,7 +200,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 return ''
               }
             : null,
-        // If the enum is numeric, and we sort by value, always use the `natural` sort type, which will correctly sort them.
+        /**
+         * If the enum is numeric, and we sort by value, always use the
+         * `natural` sort type, which will correctly sort them.
+         */
         type:
           isNumericEnum && (options.forceNumericSort || options.sortByValue)
             ? 'natural'
@@ -219,18 +228,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ignoreEslintDisabledNodes,
           },
         )
+
       let sortedNodes = sortNodesIgnoringEslintDisabledNodes(false)
       let sortedNodesExcludingEslintDisabled =
         sortNodesIgnoringEslintDisabledNodes(true)
 
+      let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
       pairwise(sortingNodes, (left, right) => {
-        let indexOfLeft = sortedNodes.indexOf(left)
-        let indexOfRight = sortedNodes.indexOf(right)
+        let leftIndex = nodeIndexMap.get(left)!
+        let rightIndex = nodeIndexMap.get(right)!
+
         let indexOfRightExcludingEslintDisabled =
           sortedNodesExcludingEslintDisabled.indexOf(right)
         if (
-          indexOfLeft < indexOfRight &&
-          indexOfLeft < indexOfRightExcludingEslintDisabled
+          leftIndex < rightIndex &&
+          leftIndex < indexOfRightExcludingEslintDisabled
         ) {
           return
         }

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -175,16 +175,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
       let sortingNodes = formattedMembers.flat()
 
-      let isNumericEnum = true
-      for (let sortingNode of sortingNodes) {
-        if (
-          sortingNode.numericValue === null ||
-          Number.isNaN(sortingNode.numericValue)
-        ) {
-          isNumericEnum = false
-          break
-        }
-      }
+      let isNumericEnum = sortingNodes.every(
+        sortingNode =>
+          sortingNode.numericValue !== null &&
+          !Number.isNaN(sortingNode.numericValue),
+      )
 
       let compareOptions: CompareOptions<SortEnumsSortingNode> = {
         // Get the enum value rather than the name if needed

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -154,14 +154,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
           }
 
           if (
-            (options.partitionByComment &&
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
-                  node: member,
-                  sourceCode,
-                }),
-              )) ||
+            hasPartitionComment(
+              options.partitionByComment,
+              getCommentsBefore({
+                node: member,
+                sourceCode,
+              }),
+            ) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -15,6 +15,7 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -136,18 +137,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 ignoreEslintDisabledNodes,
               }),
             )
+
           let sortedNodes = sortNodesExcludingEslintDisabled(false)
           let sortedNodesExcludingEslintDisabled =
             sortNodesExcludingEslintDisabled(true)
 
+          let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
           pairwise(nodes, (left, right) => {
-            let indexOfLeft = sortedNodes.indexOf(left)
-            let indexOfRight = sortedNodes.indexOf(right)
+            let leftIndex = nodeIndexMap.get(left)!
+            let rightIndex = nodeIndexMap.get(right)!
+
             let indexOfRightExcludingEslintDisabled =
               sortedNodesExcludingEslintDisabled.indexOf(right)
             if (
-              indexOfLeft < indexOfRight &&
-              indexOfLeft < indexOfRightExcludingEslintDisabled
+              leftIndex < rightIndex &&
+              leftIndex < indexOfRightExcludingEslintDisabled
             ) {
               return
             }

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -458,14 +458,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           let lastSortingNode = formattedMembers.at(-1)?.at(-1)
 
           if (
-            (options.partitionByComment &&
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
-                  node: sortingNode.node,
-                  sourceCode,
-                }),
-              )) ||
+            hasPartitionComment(
+              options.partitionByComment,
+              getCommentsBefore({
+                node: sortingNode.node,
+                sourceCode,
+              }),
+            ) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode)) ||

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -217,7 +217,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       /* Avoid matching on named imports without specifiers */
       !/\}\s*from\s+/u.test(sourceCode.getText(node))
 
-    let styleExtensions = new Set([
+    let styleExtensions = [
       '.less',
       '.scss',
       '.sass',
@@ -225,12 +225,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       '.pcss',
       '.css',
       '.sss',
-    ])
+    ]
     let isStyle = (value: string): boolean => {
       let [cleanedValue] = value.split('?')
-      return [...styleExtensions].some(extension =>
-        cleanedValue.endsWith(extension),
-      )
+      return styleExtensions.some(extension => cleanedValue.endsWith(extension))
     }
 
     let flatGroups = new Set(options.groups.flat())

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -17,6 +17,7 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
@@ -117,69 +118,48 @@ export default createEslintRule<Options, MESSAGE_ID>({
         sourceCode,
       })
 
+      let typeToGroupMap: Record<string, Group> = {
+        TSIntersectionType: 'intersection',
+        TSTemplateLiteralType: 'literal',
+        TSConditionalType: 'conditional',
+        TSUndefinedKeyword: 'nullish',
+        TSConstructorType: 'function',
+        TSIndexedAccessType: 'named',
+        TSBooleanKeyword: 'keyword',
+        TSUnknownKeyword: 'keyword',
+        TSFunctionType: 'function',
+        TSBigIntKeyword: 'keyword',
+        TSNumberKeyword: 'keyword',
+        TSObjectKeyword: 'keyword',
+        TSStringKeyword: 'keyword',
+        TSSymbolKeyword: 'keyword',
+        TSTypeOperator: 'operator',
+        TSNeverKeyword: 'keyword',
+        TSLiteralType: 'literal',
+        TSTypeReference: 'named',
+        TSQualifiedName: 'named',
+        TSNullKeyword: 'nullish',
+        TSVoidKeyword: 'nullish',
+        TSAnyKeyword: 'keyword',
+        TSTypeQuery: 'operator',
+        TSTypeLiteral: 'object',
+        TSMappedType: 'object',
+        TSImportType: 'import',
+        TSThisType: 'keyword',
+        TSArrayType: 'named',
+        TSInferType: 'named',
+        TSTupleType: 'tuple',
+        TSUnionType: 'union',
+      }
+
       let formattedMembers: SortingNode[][] = node.types.reduce(
         (accumulator: SortingNode[][], type) => {
           let { defineGroup, getGroup } = useGroups(options)
 
-          switch (type.type) {
-            case 'TSTemplateLiteralType':
-            case 'TSLiteralType':
-              defineGroup('literal')
-              break
-            case 'TSIndexedAccessType':
-            case 'TSTypeReference':
-            case 'TSQualifiedName':
-            case 'TSArrayType':
-            case 'TSInferType':
-              defineGroup('named')
-              break
-            case 'TSIntersectionType':
-              defineGroup('intersection')
-              break
-            case 'TSUndefinedKeyword':
-            case 'TSNullKeyword':
-            case 'TSVoidKeyword':
-              defineGroup('nullish')
-              break
-            case 'TSConditionalType':
-              defineGroup('conditional')
-              break
-            case 'TSConstructorType':
-            case 'TSFunctionType':
-              defineGroup('function')
-              break
-            case 'TSBooleanKeyword':
-            case 'TSUnknownKeyword':
-            case 'TSBigIntKeyword':
-            case 'TSNumberKeyword':
-            case 'TSObjectKeyword':
-            case 'TSStringKeyword':
-            case 'TSSymbolKeyword':
-            case 'TSNeverKeyword':
-            case 'TSAnyKeyword':
-            case 'TSThisType':
-              defineGroup('keyword')
-              break
-            case 'TSTypeOperator':
-            case 'TSTypeQuery':
-              defineGroup('operator')
-              break
-            case 'TSTypeLiteral':
-            case 'TSMappedType':
-              defineGroup('object')
-              break
-            case 'TSImportType':
-              defineGroup('import')
-              break
-            case 'TSTupleType':
-              defineGroup('tuple')
-              break
-            case 'TSUnionType':
-              defineGroup('union')
-              break
-          }
+          defineGroup(typeToGroupMap[type.type])
 
-          let lastSortingNode = accumulator.at(-1)?.at(-1)
+          let lastGroup = accumulator.at(-1)
+          let lastSortingNode = lastGroup?.at(-1)
           let sortingNode: SortingNode = {
             isEslintDisabled: isNodeEslintDisabled(type, eslintDisabledLines),
             size: rangeToDiff(type, sourceCode),
@@ -200,10 +180,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))
           ) {
-            accumulator.push([])
+            lastGroup = []
+            accumulator.push(lastGroup)
           }
 
-          accumulator.at(-1)?.push(sortingNode)
+          lastGroup?.push(sortingNode)
 
           return accumulator
         },
@@ -215,24 +196,28 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreEslintDisabledNodes: boolean,
         ): SortingNode[] =>
           sortNodesByGroups(nodes, options, { ignoreEslintDisabledNodes })
+
         let sortedNodes = sortNodesExcludingEslintDisabled(false)
         let sortedNodesExcludingEslintDisabled =
           sortNodesExcludingEslintDisabled(true)
+
+        let nodeIndexMap = createNodeIndexMap(sortedNodes)
 
         pairwise(nodes, (left, right) => {
           let leftNumber = getGroupNumber(options.groups, left)
           let rightNumber = getGroupNumber(options.groups, right)
 
-          let indexOfLeft = sortedNodes.indexOf(left)
-          let indexOfRight = sortedNodes.indexOf(right)
+          let leftIndex = nodeIndexMap.get(left)!
+          let rightIndex = nodeIndexMap.get(right)!
+
           let indexOfRightExcludingEslintDisabled =
             sortedNodesExcludingEslintDisabled.indexOf(right)
 
           let messageIds: MESSAGE_ID[] = []
 
           if (
-            indexOfLeft > indexOfRight ||
-            indexOfLeft >= indexOfRightExcludingEslintDisabled
+            leftIndex > rightIndex ||
+            leftIndex >= indexOfRightExcludingEslintDisabled
           ) {
             messageIds.push(
               leftNumber === rightNumber

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -188,15 +188,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
             node: type,
           }
           if (
-            (options.partitionByComment &&
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
-                  tokenValueToIgnoreBefore: '&',
-                  node: type,
-                  sourceCode,
-                }),
-              )) ||
+            hasPartitionComment(
+              options.partitionByComment,
+              getCommentsBefore({
+                tokenValueToIgnoreBefore: '&',
+                node: type,
+                sourceCode,
+              }),
+            ) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -118,45 +118,67 @@ export default createEslintRule<Options, MESSAGE_ID>({
         sourceCode,
       })
 
-      let typeToGroupMap: Record<string, Group> = {
-        TSIntersectionType: 'intersection',
-        TSTemplateLiteralType: 'literal',
-        TSConditionalType: 'conditional',
-        TSUndefinedKeyword: 'nullish',
-        TSConstructorType: 'function',
-        TSIndexedAccessType: 'named',
-        TSBooleanKeyword: 'keyword',
-        TSUnknownKeyword: 'keyword',
-        TSFunctionType: 'function',
-        TSBigIntKeyword: 'keyword',
-        TSNumberKeyword: 'keyword',
-        TSObjectKeyword: 'keyword',
-        TSStringKeyword: 'keyword',
-        TSSymbolKeyword: 'keyword',
-        TSTypeOperator: 'operator',
-        TSNeverKeyword: 'keyword',
-        TSLiteralType: 'literal',
-        TSTypeReference: 'named',
-        TSQualifiedName: 'named',
-        TSNullKeyword: 'nullish',
-        TSVoidKeyword: 'nullish',
-        TSAnyKeyword: 'keyword',
-        TSTypeQuery: 'operator',
-        TSTypeLiteral: 'object',
-        TSMappedType: 'object',
-        TSImportType: 'import',
-        TSThisType: 'keyword',
-        TSArrayType: 'named',
-        TSInferType: 'named',
-        TSTupleType: 'tuple',
-        TSUnionType: 'union',
-      }
-
       let formattedMembers: SortingNode[][] = node.types.reduce(
         (accumulator: SortingNode[][], type) => {
           let { defineGroup, getGroup } = useGroups(options)
 
-          defineGroup(typeToGroupMap[type.type])
+          switch (type.type) {
+            case 'TSTemplateLiteralType':
+            case 'TSLiteralType':
+              defineGroup('literal')
+              break
+            case 'TSIndexedAccessType':
+            case 'TSTypeReference':
+            case 'TSQualifiedName':
+            case 'TSArrayType':
+            case 'TSInferType':
+              defineGroup('named')
+              break
+            case 'TSIntersectionType':
+              defineGroup('intersection')
+              break
+            case 'TSUndefinedKeyword':
+            case 'TSNullKeyword':
+            case 'TSVoidKeyword':
+              defineGroup('nullish')
+              break
+            case 'TSConditionalType':
+              defineGroup('conditional')
+              break
+            case 'TSConstructorType':
+            case 'TSFunctionType':
+              defineGroup('function')
+              break
+            case 'TSBooleanKeyword':
+            case 'TSUnknownKeyword':
+            case 'TSBigIntKeyword':
+            case 'TSNumberKeyword':
+            case 'TSObjectKeyword':
+            case 'TSStringKeyword':
+            case 'TSSymbolKeyword':
+            case 'TSNeverKeyword':
+            case 'TSAnyKeyword':
+            case 'TSThisType':
+              defineGroup('keyword')
+              break
+            case 'TSTypeOperator':
+            case 'TSTypeQuery':
+              defineGroup('operator')
+              break
+            case 'TSTypeLiteral':
+            case 'TSMappedType':
+              defineGroup('object')
+              break
+            case 'TSImportType':
+              defineGroup('import')
+              break
+            case 'TSTupleType':
+              defineGroup('tuple')
+              break
+            case 'TSUnionType':
+              defineGroup('union')
+              break
+          }
 
           let lastGroup = accumulator.at(-1)
           let lastSortingNode = lastGroup?.at(-1)

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -16,6 +16,7 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -118,9 +119,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
           if (attribute.value === null) {
             defineGroup('shorthand')
-          }
-
-          if (attribute.loc.start.line !== attribute.loc.end.line) {
+          } else if (attribute.loc.start.line !== attribute.loc.end.line) {
             defineGroup('multiline')
           }
 
@@ -151,14 +150,17 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         let sortedNodesExcludingEslintDisabled =
           sortNodesExcludingEslintDisabled(true)
 
+        let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
         pairwise(nodes, (left, right) => {
-          let indexOfLeft = sortedNodes.indexOf(left)
-          let indexOfRight = sortedNodes.indexOf(right)
+          let leftIndex = nodeIndexMap.get(left)!
+          let rightIndex = nodeIndexMap.get(right)!
+
           let indexOfRightExcludingEslintDisabled =
             sortedNodesExcludingEslintDisabled.indexOf(right)
           if (
-            indexOfLeft < indexOfRight &&
-            indexOfLeft < indexOfRightExcludingEslintDisabled
+            leftIndex < rightIndex &&
+            leftIndex < indexOfRightExcludingEslintDisabled
           ) {
             return
           }

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -15,6 +15,7 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -152,14 +153,17 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let sortedNodesExcludingEslintDisabled =
             sortNodesExcludingEslintDisabled(true)
 
+          let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
           pairwise(nodes, (left, right) => {
-            let indexOfLeft = sortedNodes.indexOf(left)
-            let indexOfRight = sortedNodes.indexOf(right)
+            let leftIndex = nodeIndexMap.get(left)!
+            let rightIndex = nodeIndexMap.get(right)!
+
             let indexOfRightExcludingEslintDisabled =
               sortedNodesExcludingEslintDisabled.indexOf(right)
             if (
-              indexOfLeft < indexOfRight &&
-              indexOfLeft < indexOfRightExcludingEslintDisabled
+              leftIndex < rightIndex &&
+              leftIndex < indexOfRightExcludingEslintDisabled
             ) {
               return
             }

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -126,14 +126,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
           }
 
           if (
-            (options.partitionByComment &&
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
-                  node: element,
-                  sourceCode,
-                }),
-              )) ||
+            hasPartitionComment(
+              options.partitionByComment,
+              getCommentsBefore({
+                node: element,
+                sourceCode,
+              }),
+            ) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -353,14 +353,13 @@ let analyzeModule = ({
       (options.partitionByNewLine &&
         lastSortingNode &&
         getLinesBetween(sourceCode, lastSortingNode, sortingNode)) ||
-      (options.partitionByComment &&
-        hasPartitionComment(
-          options.partitionByComment,
-          getCommentsBefore({
-            sourceCode,
-            node,
-          }),
-        ))
+      hasPartitionComment(
+        options.partitionByComment,
+        getCommentsBefore({
+          sourceCode,
+          node,
+        }),
+      )
     ) {
       formattedNodes.push([])
     }

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -210,7 +210,7 @@ let analyzeModule = ({
         | TSESTree.DefaultExportDeclarations
         | TSESTree.NamedExportDeclarations
         | TSESTree.ProgramStatement,
-    ): boolean => {
+    ): void => {
       if ('declare' in nodeToParse && nodeToParse.declare) {
         modifiers.push('declare')
       }
@@ -297,12 +297,11 @@ let analyzeModule = ({
           break
         default:
       }
-
-      return !!selector && !!name
     }
     /* eslint-enable @typescript-eslint/no-loop-func */
+    parseNode(node)
 
-    if (!parseNode(node)) {
+    if (!selector || !name) {
       continue
     }
 
@@ -316,18 +315,18 @@ let analyzeModule = ({
     }
 
     let { defineGroup, getGroup } = useGroups(options)
-    for (let officialGroup of generatePredefinedGroups({
+    for (let predefinedGroup of generatePredefinedGroups({
       cache: cachedGroupsByModifiersAndSelectors,
-      selectors: [selector!],
+      selectors: [selector],
       modifiers,
     })) {
-      defineGroup(officialGroup)
+      defineGroup(predefinedGroup)
     }
     for (let customGroup of options.customGroups) {
       if (
         customGroupMatches({
-          selectors: [selector!],
-          elementName: name!,
+          selectors: [selector],
+          elementName: name,
           customGroup,
           decorators,
           modifiers,
@@ -347,7 +346,7 @@ let analyzeModule = ({
       dependencyName: name,
       group: getGroup(),
       dependencies,
-      name: name!,
+      name,
       node,
     }
     let lastSortingNode = formattedNodes.at(-1)?.at(-1)

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -15,6 +15,7 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -144,18 +145,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
               ignoreEslintDisabledNodes,
             }),
           )
+
         let sortedNodes = sortNodesExcludingEslintDisabled(false)
         let sortedNodesExcludingEslintDisabled =
           sortNodesExcludingEslintDisabled(true)
 
+        let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
         pairwise(nodes, (left, right) => {
-          let indexOfLeft = sortedNodes.indexOf(left)
-          let indexOfRight = sortedNodes.indexOf(right)
+          let leftIndex = nodeIndexMap.get(left)!
+          let rightIndex = nodeIndexMap.get(right)!
+
           let indexOfRightExcludingEslintDisabled =
             sortedNodesExcludingEslintDisabled.indexOf(right)
           if (
-            indexOfLeft < indexOfRight &&
-            indexOfLeft < indexOfRightExcludingEslintDisabled
+            leftIndex < rightIndex &&
+            leftIndex < indexOfRightExcludingEslintDisabled
           ) {
             return
           }

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -103,14 +103,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
           name,
         }
         if (
-          (options.partitionByComment &&
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
-                node: specifier,
-                sourceCode,
-              }),
-            )) ||
+          hasPartitionComment(
+            options.partitionByComment,
+            getCommentsBefore({
+              node: specifier,
+              sourceCode,
+            }),
+          ) ||
           (options.partitionByNewLine &&
             lastSortingNode &&
             getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -112,14 +112,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
         }
 
         if (
-          (options.partitionByComment &&
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
-                node: specifier,
-                sourceCode,
-              }),
-            )) ||
+          hasPartitionComment(
+            options.partitionByComment,
+            getCommentsBefore({
+              node: specifier,
+              sourceCode,
+            }),
+          ) ||
           (options.partitionByNewLine &&
             lastSortingNode &&
             getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -15,6 +15,7 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -153,18 +154,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
               ignoreEslintDisabledNodes,
             }),
           )
+
         let sortedNodes = sortNodesExcludingEslintDisabled(false)
         let sortedNodesExcludingEslintDisabled =
           sortNodesExcludingEslintDisabled(true)
 
+        let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
         pairwise(nodes, (left, right) => {
-          let indexOfLeft = sortedNodes.indexOf(left)
-          let indexOfRight = sortedNodes.indexOf(right)
+          let leftIndex = nodeIndexMap.get(left)!
+          let rightIndex = nodeIndexMap.get(right)!
+
           let indexOfRightExcludingEslintDisabled =
             sortedNodesExcludingEslintDisabled.indexOf(right)
           if (
-            indexOfLeft < indexOfRight &&
-            indexOfLeft < indexOfRightExcludingEslintDisabled
+            leftIndex < rightIndex &&
+            leftIndex < indexOfRightExcludingEslintDisabled
           ) {
             return
           }

--- a/rules/sort-object-types-utils.ts
+++ b/rules/sort-object-types-utils.ts
@@ -51,7 +51,9 @@ export let customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
       props.elementName,
       props.customGroup.elementNamePattern,
     )
-    return matchesElementNamePattern
+    if (!matchesElementNamePattern) {
+      return false
+    }
   }
 
   return true

--- a/rules/sort-object-types-utils.ts
+++ b/rules/sort-object-types-utils.ts
@@ -51,9 +51,7 @@ export let customGroupMatches = (props: CustomGroupMatchesProps): boolean => {
       props.elementName,
       props.customGroup.elementNamePattern,
     )
-    if (!matchesElementNamePattern) {
-      return false
-    }
+    return matchesElementNamePattern
   }
 
   return true

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -343,14 +343,13 @@ export let sortObjectTypeElements = <MessageIds extends string>({
       }
 
       if (
-        (options.partitionByComment &&
-          hasPartitionComment(
-            options.partitionByComment,
-            getCommentsBefore({
-              node: typeElement,
-              sourceCode,
-            }),
-          )) ||
+        hasPartitionComment(
+          options.partitionByComment,
+          getCommentsBefore({
+            node: typeElement,
+            sourceCode,
+          }),
+        ) ||
         (options.partitionByNewLine &&
           lastSortingNode &&
           getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -27,6 +27,7 @@ import { validateGroupsConfiguration } from '../utils/validate-groups-configurat
 import { getMatchingContextOptions } from '../utils/get-matching-context-options'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
@@ -410,14 +411,18 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let sortedNodes = sortNodesIgnoringEslintDisabledNodes(false)
       let sortedNodesExcludingEslintDisabled =
         sortNodesIgnoringEslintDisabledNodes(true)
+
       let nodes = formattedMembers.flat()
+
+      let nodeIndexMap = createNodeIndexMap(sortedNodes)
 
       pairwise(nodes, (left, right) => {
         let leftNumber = getGroupNumber(options.groups, left)
         let rightNumber = getGroupNumber(options.groups, right)
 
-        let indexOfLeft = sortedNodes.indexOf(left)
-        let indexOfRight = sortedNodes.indexOf(right)
+        let leftIndex = nodeIndexMap.get(left)!
+        let rightIndex = nodeIndexMap.get(right)!
+
         let indexOfRightExcludingEslintDisabled =
           sortedNodesExcludingEslintDisabled.indexOf(right)
 
@@ -427,8 +432,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
           | undefined
 
         if (
-          indexOfLeft > indexOfRight ||
-          indexOfLeft >= indexOfRightExcludingEslintDisabled
+          leftIndex > rightIndex ||
+          leftIndex >= indexOfRightExcludingEslintDisabled
         ) {
           firstUnorderedNodeDependentOnRight = getFirstUnorderedNodeDependentOn(
             right,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -369,14 +369,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   lastProperty,
                   propertySortingNode,
                 )) ||
-              (options.partitionByComment &&
-                hasPartitionComment(
-                  options.partitionByComment,
-                  getCommentsBefore({
-                    node: property,
-                    sourceCode,
-                  }),
-                ))
+              hasPartitionComment(
+                options.partitionByComment,
+                getCommentsBefore({
+                  node: property,
+                  sourceCode,
+                }),
+              )
             ) {
               accumulator.push([])
             }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -188,15 +188,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
             node: type,
           }
           if (
-            (options.partitionByComment &&
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
-                  tokenValueToIgnoreBefore: '|',
-                  node: type,
-                  sourceCode,
-                }),
-              )) ||
+            hasPartitionComment(
+              options.partitionByComment,
+              getCommentsBefore({
+                tokenValueToIgnoreBefore: '|',
+                node: type,
+                sourceCode,
+              }),
+            ) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -118,45 +118,67 @@ export default createEslintRule<Options, MESSAGE_ID>({
         sourceCode,
       })
 
-      let typeToGroupMap: Record<string, Group> = {
-        TSIntersectionType: 'intersection',
-        TSTemplateLiteralType: 'literal',
-        TSConditionalType: 'conditional',
-        TSUndefinedKeyword: 'nullish',
-        TSConstructorType: 'function',
-        TSIndexedAccessType: 'named',
-        TSBooleanKeyword: 'keyword',
-        TSUnknownKeyword: 'keyword',
-        TSFunctionType: 'function',
-        TSBigIntKeyword: 'keyword',
-        TSNumberKeyword: 'keyword',
-        TSObjectKeyword: 'keyword',
-        TSStringKeyword: 'keyword',
-        TSSymbolKeyword: 'keyword',
-        TSTypeOperator: 'operator',
-        TSNeverKeyword: 'keyword',
-        TSLiteralType: 'literal',
-        TSTypeReference: 'named',
-        TSQualifiedName: 'named',
-        TSNullKeyword: 'nullish',
-        TSVoidKeyword: 'nullish',
-        TSAnyKeyword: 'keyword',
-        TSTypeQuery: 'operator',
-        TSTypeLiteral: 'object',
-        TSMappedType: 'object',
-        TSImportType: 'import',
-        TSThisType: 'keyword',
-        TSArrayType: 'named',
-        TSInferType: 'named',
-        TSTupleType: 'tuple',
-        TSUnionType: 'union',
-      }
-
       let formattedMembers: SortingNode[][] = node.types.reduce(
         (accumulator: SortingNode[][], type) => {
           let { defineGroup, getGroup } = useGroups(options)
 
-          defineGroup(typeToGroupMap[type.type])
+          switch (type.type) {
+            case 'TSTemplateLiteralType':
+            case 'TSLiteralType':
+              defineGroup('literal')
+              break
+            case 'TSIndexedAccessType':
+            case 'TSTypeReference':
+            case 'TSQualifiedName':
+            case 'TSArrayType':
+            case 'TSInferType':
+              defineGroup('named')
+              break
+            case 'TSIntersectionType':
+              defineGroup('intersection')
+              break
+            case 'TSUndefinedKeyword':
+            case 'TSNullKeyword':
+            case 'TSVoidKeyword':
+              defineGroup('nullish')
+              break
+            case 'TSConditionalType':
+              defineGroup('conditional')
+              break
+            case 'TSConstructorType':
+            case 'TSFunctionType':
+              defineGroup('function')
+              break
+            case 'TSBooleanKeyword':
+            case 'TSUnknownKeyword':
+            case 'TSBigIntKeyword':
+            case 'TSNumberKeyword':
+            case 'TSObjectKeyword':
+            case 'TSStringKeyword':
+            case 'TSSymbolKeyword':
+            case 'TSNeverKeyword':
+            case 'TSAnyKeyword':
+            case 'TSThisType':
+              defineGroup('keyword')
+              break
+            case 'TSTypeOperator':
+            case 'TSTypeQuery':
+              defineGroup('operator')
+              break
+            case 'TSTypeLiteral':
+            case 'TSMappedType':
+              defineGroup('object')
+              break
+            case 'TSImportType':
+              defineGroup('import')
+              break
+            case 'TSTupleType':
+              defineGroup('tuple')
+              break
+            case 'TSUnionType':
+              defineGroup('union')
+              break
+          }
 
           let lastGroup = accumulator.at(-1)
           let lastSortingNode = lastGroup?.at(-1)

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -19,6 +19,7 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -237,16 +238,20 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let sortedNodes = sortNodesIgnoringEslintDisabledNodes(false)
       let sortedNodesExcludingEslintDisabled =
         sortNodesIgnoringEslintDisabledNodes(true)
+
       let nodes = formattedMembers.flat()
 
+      let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
       pairwise(nodes, (left, right) => {
-        let indexOfLeft = sortedNodes.indexOf(left)
-        let indexOfRight = sortedNodes.indexOf(right)
+        let leftIndex = nodeIndexMap.get(left)!
+        let rightIndex = nodeIndexMap.get(right)!
+
         let indexOfRightExcludingEslintDisabled =
           sortedNodesExcludingEslintDisabled.indexOf(right)
         if (
-          indexOfLeft < indexOfRight &&
-          indexOfLeft < indexOfRightExcludingEslintDisabled
+          leftIndex < rightIndex &&
+          leftIndex < indexOfRightExcludingEslintDisabled
         ) {
           return
         }

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -200,14 +200,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
             name,
           }
           if (
-            (options.partitionByComment &&
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
-                  node: declaration,
-                  sourceCode,
-                }),
-              )) ||
+            hasPartitionComment(
+              options.partitionByComment,
+              getCommentsBefore({
+                node: declaration,
+                sourceCode,
+              }),
+            ) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/utils/create-node-index-map.ts
+++ b/utils/create-node-index-map.ts
@@ -1,9 +1,11 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
 import type { SortingNode } from '../typings'
 
-export let createNodeIndexMap = (
-  nodes: SortingNode[],
+export let createNodeIndexMap = <Node extends TSESTree.Node>(
+  nodes: SortingNode<Node>[],
 ): Map<SortingNode, number> => {
-  let nodeIndexMap = new Map<SortingNode, number>()
+  let nodeIndexMap = new Map<SortingNode<Node>, number>()
   for (let [index, node] of nodes.entries()) {
     nodeIndexMap.set(node, index)
   }

--- a/utils/create-node-index-map.ts
+++ b/utils/create-node-index-map.ts
@@ -1,0 +1,11 @@
+import type { SortingNode } from '../typings'
+
+export let createNodeIndexMap = (
+  nodes: SortingNode[],
+): Map<SortingNode, number> => {
+  let nodeIndexMap = new Map<SortingNode, number>()
+  for (let [index, node] of nodes.entries()) {
+    nodeIndexMap.set(node, index)
+  }
+  return nodeIndexMap
+}

--- a/utils/is-partition-comment.ts
+++ b/utils/is-partition-comment.ts
@@ -7,7 +7,7 @@ export let isPartitionComment = (
   partitionComment: string[] | boolean | string,
   comment: string,
 ): boolean => {
-  if (getEslintDisabledRules(comment)) {
+  if (getEslintDisabledRules(comment) || !partitionComment) {
     return false
   }
   return (

--- a/utils/pairwise.ts
+++ b/utils/pairwise.ts
@@ -11,8 +11,6 @@ export let pairwise = <T>(
     let left = nodes.at(i - 1)
     let right = nodes.at(i)
 
-    if (left && right) {
-      callback(left, right, i - 1)
-    }
+    callback(left!, right!, i - 1)
   }
 }

--- a/utils/validate-groups-configuration.ts
+++ b/utils/validate-groups-configuration.ts
@@ -37,10 +37,18 @@ export let validateNoDuplicatedGroups = (
   groups: (string[] | string)[],
 ): void => {
   let flattenGroups = groups.flat()
-  let duplicatedGroups = flattenGroups.filter(
-    (group, index) => flattenGroups.indexOf(group) !== index,
-  )
-  if (duplicatedGroups.length) {
-    throw new Error(`Duplicated group(s): ${duplicatedGroups.join(', ')}`)
+  let seenGroups = new Set<string>()
+  let duplicatedGroups = new Set<string>()
+
+  for (let group of flattenGroups) {
+    if (seenGroups.has(group)) {
+      duplicatedGroups.add(group)
+    } else {
+      seenGroups.add(group)
+    }
+  }
+
+  if (duplicatedGroups.size > 0) {
+    throw new Error(`Duplicated group(s): ${[...duplicatedGroups].join(', ')}`)
   }
 }


### PR DESCRIPTION
### Description

Some micro-optimizations of the code.

**sort-array-includes:**

- Remove an unnecessary call `getNodeName` function.
- Move the `generatePredefinedGroups` function call outside the loop. Currently, this function is called at each iteration of the loop.
- Pre-group nodes by `groupKind` using `reduce`, reducing sorting complexity from O(n × k) to O(n).
- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-classes:**

- Move the `generatePredefinedGroups` function call outside the loop. Currently, this function is called at each iteration of the loop.

**sort-decorators:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-enums:**

- Replace recursion in `extractDependencies` with an iterative approach using an explicit stack. This improves performance by avoiding call stack overhead and prevents stack overflow errors for deeply nested AST nodes.
- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Optimize `isNumericEnum` check, replace `Array.prototype.every` with an early-exit loop.

**sort-exports:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-heritage-clauses:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Remove unnecessary checking if node is `undefined`.

**sort-imports:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Reduce `formattedMembers.at(-1)` call.
- Replace the current array-based extension check in `isStyle` with a `Set` to enable faster membership testing

**sort-intersection-types:**

- Replace repetitive calls to `defineGroup` in the `switch-case` block with a precomputed mapping of `type` to group, reducing redundant operations and improving readability.
- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Reduce `formattedMembers.at(-1)` call.

**sort-jsx-props:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Do not check if a prop is multiline if it is already an shorthand

**sort-maps:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-modules:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Move the validation of `selector` and `name` inside the `parseNode` function. This ensures that nodes without these required values are skipped immediately, avoiding unnecessary operations in the main loop.

**sort-named-exports:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-named-imports:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-object-types:**

- Move `formatName` function outside loop.
- Reduce `accumulator.at(-1)` call.
- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Simplify selector checking.
- Move the `generatePredefinedGroups` function call outside the loop. Currently, this function is called at each iteration of the loop.

**sort-objects:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-switch-case:**

- Simplify `caseHasBreakOrReturn` function. Reduce its complexity.
- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**sort-union-types:**

- Replace repetitive calls to `defineGroup` in the `switch-case` block with a precomputed mapping of `type` to group, reducing redundant operations and improving readability.
- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).
- Reduce `formattedMembers.at(-1)` call.

**sort-variable-declararations:**

- Replace repeated `indexOf` calls with a `Map` for node indices, reducing order-checking complexity from O(n²) to O(n).

**Utils:**

- **pairwise:** Remove unnecessary variable check.
- **validate-groups-configuration:** Replace the `filter` approach with a `Set` to track already seen groups. By iterating through the array only once and checking membership in the `Set`, the complexity is reduced to linear time (O(n)).

### Additional context

N/A.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
