### PR TITLE
TODO

### DIFF
--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -36,6 +36,22 @@ export type SingleCustomGroup =
   | BaseSingleCustomGroup<ConstructorSelector>
   | AdvancedSingleCustomGroup<MethodSelector>
 
+export type CustomGroup = {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+} & (
+  | {
+      order?: SortClassesOptions[0]['order']
+      type?: SortClassesOptions[0]['type']
+    }
+  | {
+      type?: 'unsorted'
+    }
+) &
+  (SingleCustomGroup | AnyOfCustomGroup)
+
 export type NonDeclarePropertyGroup = JoinWithDash<
   [
     PublicOrProtectedOrPrivateModifier,
@@ -201,19 +217,6 @@ type Group =
   | MethodGroup
   | 'unknown'
   | string
-
-type CustomGroup = (
-  | {
-      order?: SortClassesOptions[0]['order']
-      type?: SortClassesOptions[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) &
-  (SingleCustomGroup | AnyOfCustomGroup) & {
-    groupName: string
-  }
 
 type AdvancedSingleCustomGroup<T extends Selector> = {
   decoratorNamePattern?: string

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -537,12 +537,15 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             messageIds = [
               ...messageIds,
               ...getNewlinesErrors({
+                options: {
+                  ...options,
+                  customGroups: [],
+                },
                 missedSpacingError: 'missedSpacingBetweenImports',
                 extraSpacingError: 'extraSpacingBetweenImports',
                 rightNum: rightNumber,
                 leftNum: leftNumber,
                 sourceCode,
-                options,
                 right,
                 left,
               }),
@@ -559,10 +562,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     fixer,
                   }),
                   ...makeNewlinesFixes({
+                    options: {
+                      ...options,
+                      customGroups: [],
+                    },
                     sortedNodes: sortedNodesExcludingEslintDisabled,
                     nodes: nodeList,
                     sourceCode,
-                    options,
                     fixer,
                   }),
                 ],

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -67,7 +67,12 @@ interface AllowedModifiersPerSelector {
   type: DeclareModifier | ExportModifier
 }
 
-type CustomGroup = (
+type CustomGroup = {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+} & (
   | {
       order?: SortModulesOptions[0]['order']
       type?: SortModulesOptions[0]['type']
@@ -76,9 +81,7 @@ type CustomGroup = (
       type?: 'unsorted'
     }
 ) &
-  (SingleCustomGroup | AnyOfCustomGroup) & {
-    groupName: string
-  }
+  (SingleCustomGroup | AnyOfCustomGroup)
 /**
  * Only used in code, so I don't know if it's worth maintaining this.
  */

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -56,6 +56,22 @@ export interface AnyOfCustomGroup {
   anyOf: SingleCustomGroup[]
 }
 
+type CustomGroup = {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+} & (
+  | {
+      order?: Options[0]['order']
+      type?: Options[0]['type']
+    }
+  | {
+      type?: 'unsorted'
+    }
+) &
+  (SingleCustomGroup | AnyOfCustomGroup)
+
 /**
  * Only used in code as well
  */
@@ -66,19 +82,6 @@ interface AllowedModifiersPerSelector {
   multiline: OptionalModifier | RequiredModifier
   'index-signature': never
 }
-
-type CustomGroup = (
-  | {
-      order?: Options[0]['order']
-      type?: Options[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) &
-  (SingleCustomGroup | AnyOfCustomGroup) & {
-    groupName: string
-  }
 
 type IndexSignatureGroup = JoinWithDash<
   [

--- a/test/get-newlines-between-option.test.ts
+++ b/test/get-newlines-between-option.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from 'vitest'
+
+import type { GetNewlinesBetweenOptionParameters } from '../utils/get-newlines-between-option'
+import type { SortingNode } from '../types/sorting-node'
+
+import { getNewlinesBetweenOption } from '../utils/get-newlines-between-option'
+
+describe('get-newlines-between-option', () => {
+  describe('global "newlinesBetween" option', () => {
+    it('should return the global option if "customGroups" is not defined', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'ignore',
+          }),
+        ),
+      ).toBe('ignore')
+    })
+
+    it('should return the global option if "customGroups" is not an array', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'ignore',
+            customGroups: {},
+          }),
+        ),
+      ).toBe('ignore')
+    })
+
+    it('should return "ignore" if "newlinesBetween" is "ignore"', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'ignore',
+          }),
+        ),
+      ).toBe('ignore')
+    })
+
+    it('should return "never" if "newlinesBetween" is "never"', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'never',
+          }),
+        ),
+      ).toBe('never')
+    })
+
+    it('should return "always" if "newlinesBetween" is "always" and nodeGroupNumber !== nextNodeGroupNumber', () => {
+      expect(
+        getNewlinesBetweenOption({
+          options: {
+            groups: ['group1', 'group2'],
+            newlinesBetween: 'always',
+          },
+          nextSortingNode: generateSortingNodeWithGroup('group1'),
+          sortingNode: generateSortingNodeWithGroup('group2'),
+        }),
+      ).toBe('always')
+    })
+
+    it('should return "never" if "newlinesBetween" is "always" and nodeGroupNumber === nextNodeGroupNumber', () => {
+      expect(
+        getNewlinesBetweenOption({
+          options: {
+            newlinesBetween: 'always',
+            groups: ['group1'],
+          },
+          nextSortingNode: generateSortingNodeWithGroup('group1'),
+          sortingNode: generateSortingNodeWithGroup('group1'),
+        }),
+      ).toBe('never')
+    })
+
+    it("should return the global option if the node's group is within an array", () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            customGroups: [
+              {
+                groupName: 'group1',
+              },
+            ],
+            groups: [['group1', 'group3'], 'group2'],
+            newlinesBetween: 'never',
+          }),
+        ),
+      ).toBe('never')
+    })
+
+    it("should return the global option if the next node's group is within an array", () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            customGroups: [
+              {
+                groupName: 'group1',
+              },
+            ],
+            groups: ['group1', ['group2', 'group3']],
+            newlinesBetween: 'never',
+          }),
+        ),
+      ).toBe('never')
+    })
+  })
+
+  describe('custom groups "newlinesBetween" option', () => {
+    describe('when the node and next node belong to the same custom group', () => {
+      let parameters = {
+        customGroups: [
+          {
+            newlinesInside: 'always',
+            groupName: 'group1',
+          },
+        ],
+        nextSortingNodeGroup: 'group1',
+        sortingNodeGroup: 'group1',
+        newlinesBetween: 'never',
+      } as const
+
+      it('should return the "newlinesInside" option if defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              ...parameters,
+              customGroups: [
+                {
+                  newlinesInside: 'always',
+                  groupName: 'group1',
+                },
+              ],
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the global option if the "newlinesInside" option is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              ...parameters,
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+              ],
+            }),
+          ),
+        ).toBe('never')
+      })
+    })
+
+    describe('when the node and next node do not belong to the same custom group', () => {
+      it('should return the global option if the node "newlinesBelow" option is not defined and the next node "newlinesAbove" option is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+                {
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('never')
+      })
+
+      it('should return the next node "newlinesAbove" option if the node option "newlinesBelow" is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the next node "newlinesAbove" option if the node option "newlinesBelow" is "ignore"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'ignore',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the node option "newlinesBelow" if the next node "newlinesAbove" option is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the node option "newlinesBelow" if the next node "newlinesAbove" option is "ignore"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesBelow: 'ignore',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return "ignore" if the node "newlinesAbove" option is "always" and the next node "newlinesBelow" is "never"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'never',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('ignore')
+      })
+
+      it('should return "ignore" if the node "newlinesAbove" option is "never" and the next node "newlinesBelow" is "always"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'never',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('ignore')
+      })
+
+      it('should return "always" if the node "newlinesAbove" option is "always" and the next node "newlinesBelow" is "ignore"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'ignore',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return "always" if the node "newlinesAbove" option is "ignore" and the next node "newlinesBelow" is "always"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'ignore',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return "never" if the node "newlinesAbove" option and the next node "newlinesBelow" option is "never"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'never',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'never',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('never')
+      })
+    })
+  })
+
+  let buildParameters = ({
+    nextSortingNodeGroup,
+    sortingNodeGroup,
+    newlinesBetween,
+    customGroups,
+    groups,
+  }: {
+    newlinesBetween: GetNewlinesBetweenOptionParameters['options']['newlinesBetween']
+    customGroups?: GetNewlinesBetweenOptionParameters['options']['customGroups']
+    groups?: GetNewlinesBetweenOptionParameters['options']['groups']
+    nextSortingNodeGroup?: string
+    sortingNodeGroup?: string
+  }): GetNewlinesBetweenOptionParameters => ({
+    options: {
+      groups: groups ?? ['group1', 'group2'],
+      newlinesBetween,
+      customGroups,
+    },
+    nextSortingNode: generateSortingNodeWithGroup(
+      nextSortingNodeGroup ?? 'group2',
+    ),
+    sortingNode: generateSortingNodeWithGroup(sortingNodeGroup ?? 'group1'),
+  })
+
+  let generateSortingNodeWithGroup = (group: string): SortingNode =>
+    ({
+      group,
+    }) as SortingNode
+})

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -7787,6 +7787,114 @@ describe(ruleName, () => {
         invalid: [],
       },
     )
+
+    describe('newlinesInside', () => {
+      ruleTester.run(
+        `${ruleName}: allows to use newlinesInside: always`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'c',
+                    left: 'b',
+                  },
+                  messageId: 'missedSpacingBetweenClassMembers',
+                },
+                {
+                  data: {
+                    right: 'd',
+                    left: 'c',
+                  },
+                  messageId: 'extraSpacingBetweenClassMembers',
+                },
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'methodsWithNewlinesInside',
+                      newlinesInside: 'always',
+                      selector: 'method',
+                    },
+                  ],
+                  groups: ['unknown', 'methodsWithNewlinesInside'],
+                },
+              ],
+              code: dedent`
+                class Class {
+                  a
+                  b() {}
+                  c() {}
+
+
+                  d() {}
+                }
+              `,
+              output: dedent`
+                class Class {
+                  a
+                  b() {}
+
+                  c() {}
+
+                  d() {}
+                }
+            `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(`${ruleName}: allows to use newlinesInside: never`, rule, {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'methodsWithoutNewlinesInside',
+                    newlinesInside: 'never',
+                    selector: 'method',
+                  },
+                ],
+                groups: ['unknown', 'methodsWithoutNewlinesInside'],
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  right: 'd',
+                  left: 'c',
+                },
+                messageId: 'extraSpacingBetweenClassMembers',
+              },
+            ],
+            output: dedent`
+              class Class {
+                a
+
+                c() {}
+                d() {}
+              }
+            `,
+            code: dedent`
+              class Class {
+                a
+
+                c() {}
+
+                d() {}
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+    })
   })
 
   describe(`${ruleName}: misc`, () => {

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -292,26 +292,12 @@ describe(ruleName, () => {
             },
             {
               data: {
-                left: '~/c',
-                right: 't',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
                 rightGroup: 'internal',
                 leftGroup: 'parent',
                 left: '../../e',
                 right: '~/b',
               },
               messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                left: '../../e',
-                right: '~/b',
-              },
-              messageId: 'extraSpacingBetweenImports',
             },
           ],
           options: [
@@ -2625,26 +2611,12 @@ describe(ruleName, () => {
             },
             {
               data: {
-                left: '~/c',
-                right: 't',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
                 rightGroup: 'internal',
                 leftGroup: 'parent',
                 left: '../../e',
                 right: '~/b',
               },
               messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                left: '../../e',
-                right: '~/b',
-              },
-              messageId: 'extraSpacingBetweenImports',
             },
           ],
           options: [
@@ -4239,26 +4211,12 @@ describe(ruleName, () => {
             },
             {
               data: {
-                left: '~/c',
-                right: 't',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
                 rightGroup: 'internal',
                 leftGroup: 'parent',
                 left: '../../e',
                 right: '~/b',
               },
               messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                left: '../../e',
-                right: '~/b',
-              },
-              messageId: 'extraSpacingBetweenImports',
             },
           ],
           options: [

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -899,13 +899,6 @@ describe(ruleName, () => {
               },
               messageId: 'unexpectedImportsGroupOrder',
             },
-            {
-              data: {
-                left: './b',
-                right: 'c',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
           ],
           options: [
             {
@@ -3239,13 +3232,6 @@ describe(ruleName, () => {
               },
               messageId: 'unexpectedImportsGroupOrder',
             },
-            {
-              data: {
-                left: './b',
-                right: 'c',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
           ],
           options: [
             {
@@ -4829,13 +4815,6 @@ describe(ruleName, () => {
                 right: 'c',
               },
               messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                left: './b',
-                right: 'c',
-              },
-              messageId: 'extraSpacingBetweenImports',
             },
           ],
           options: [

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1345,6 +1345,101 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      describe('newlinesInside', () => {
+        ruleTester.run(
+          `${ruleName}: allows to use newlinesInside: always`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    customGroups: [
+                      {
+                        newlinesInside: 'always',
+                        selector: 'property',
+                        groupName: 'group1',
+                      },
+                    ],
+                    groups: ['group1'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenInterfaceMembers',
+                  },
+                ],
+                output: dedent`
+                  interface Interface {
+                    a
+
+                    b
+                  }
+                `,
+                code: dedent`
+                  interface Interface {
+                    a
+                    b
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}: allows to use newlinesInside: never`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    customGroups: [
+                      {
+                        newlinesInside: 'never',
+                        selector: 'property',
+                        groupName: 'group1',
+                      },
+                    ],
+                    type: 'alphabetical',
+                    groups: ['group1'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'extraSpacingBetweenInterfaceMembers',
+                  },
+                ],
+                output: dedent`
+                  interface Interface {
+                    a
+                    b
+                  }
+                `,
+                code: dedent`
+                  interface Interface {
+                    a
+
+                    b
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -801,6 +801,93 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      describe('newlinesInside', () => {
+        ruleTester.run(
+          `${ruleName}: allows to use newlinesInside: always`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    customGroups: [
+                      {
+                        newlinesInside: 'always',
+                        groupName: 'group1',
+                        selector: 'type',
+                      },
+                    ],
+                    groups: ['group1'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'B',
+                      left: 'A',
+                    },
+                    messageId: 'missedSpacingBetweenModulesMembers',
+                  },
+                ],
+                output: dedent`
+                  type A = {}
+
+                  type B = {}
+              `,
+                code: dedent`
+                  type A = {}
+                  type B = {}
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}: allows to use newlinesInside: never`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    customGroups: [
+                      {
+                        newlinesInside: 'never',
+                        groupName: 'group1',
+                        selector: 'type',
+                      },
+                    ],
+                    type: 'alphabetical',
+                    groups: ['group1'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'B',
+                      left: 'A',
+                    },
+                    messageId: 'extraSpacingBetweenModulesMembers',
+                  },
+                ],
+                output: dedent`
+                  type A = {}
+                  type B = {}
+                `,
+                code: dedent`
+                  type A = {}
+
+                  type B = {}
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
     })
 
     describe(`${ruleName}(${type}): interface modifiers priority`, () => {

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -1920,13 +1920,6 @@ describe(ruleName, () => {
                 },
                 {
                   data: {
-                    right: 'y',
-                    left: 'A',
-                  },
-                  messageId: 'extraSpacingBetweenModulesMembers',
-                },
-                {
-                  data: {
                     right: 'b',
                     left: 'z',
                   },

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -1086,6 +1086,101 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      describe('newlinesInside', () => {
+        ruleTester.run(
+          `${ruleName}: allows to use newlinesInside: always`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    customGroups: [
+                      {
+                        newlinesInside: 'always',
+                        selector: 'property',
+                        groupName: 'group1',
+                      },
+                    ],
+                    groups: ['group1'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenObjectTypeMembers',
+                  },
+                ],
+                output: dedent`
+                  type type = {
+                    a
+
+                    b
+                  }
+                `,
+                code: dedent`
+                  type type = {
+                    a
+                    b
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}: allows to use newlinesInside: never`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    customGroups: [
+                      {
+                        newlinesInside: 'never',
+                        selector: 'property',
+                        groupName: 'group1',
+                      },
+                    ],
+                    type: 'alphabetical',
+                    groups: ['group1'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'extraSpacingBetweenObjectTypeMembers',
+                  },
+                ],
+                output: dedent`
+                  type type = {
+                    a
+                    b
+                  }
+                `,
+                code: dedent`
+                  type type = {
+                    a
+
+                    b
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -113,8 +113,7 @@ export let partitionByNewLineJsonSchema: JSONSchema4 = {
 }
 
 export let newlinesBetweenJsonSchema: JSONSchema4 = {
-  description:
-    'Specifies how new lines should be handled between modules members groups.',
+  description: 'Specifies how new lines should be handled between groups.',
   enum: ['ignore', 'always', 'never'],
   type: 'string',
 }
@@ -154,6 +153,33 @@ let customGroupNameJsonSchema: Record<string, JSONSchema4> = {
   },
 }
 
+let customGroupNewlinesInsideJsonSchema: Record<string, JSONSchema4> = {
+  newlinesInside: {
+    description:
+      'Specifies how new lines should be handled between members of the custom group.',
+    enum: ['always', 'never'],
+    type: 'string',
+  },
+}
+
+let customGroupNewlinesAboveJsonSchema: Record<string, JSONSchema4> = {
+  newlinesAbove: {
+    description:
+      'Specifies how new lines should be handled right above the custom group.',
+    enum: ['ignore', 'always', 'never'],
+    type: 'string',
+  },
+}
+
+let customGroupNewlinesBelowJsonSchema: Record<string, JSONSchema4> = {
+  newlinesBelow: {
+    description:
+      'Specifies how new lines should be handled right below the custom group.',
+    enum: ['ignore', 'always', 'never'],
+    type: 'string',
+  },
+}
+
 export let buildCustomGroupsArrayJsonSchema = ({
   singleCustomGroupJsonSchema,
 }: {
@@ -165,6 +191,9 @@ export let buildCustomGroupsArrayJsonSchema = ({
         properties: {
           ...customGroupNameJsonSchema,
           ...customGroupSortJsonSchema,
+          ...customGroupNewlinesAboveJsonSchema,
+          ...customGroupNewlinesInsideJsonSchema,
+          ...customGroupNewlinesBelowJsonSchema,
           anyOf: {
             items: {
               properties: {
@@ -185,6 +214,9 @@ export let buildCustomGroupsArrayJsonSchema = ({
         properties: {
           ...customGroupNameJsonSchema,
           ...customGroupSortJsonSchema,
+          ...customGroupNewlinesAboveJsonSchema,
+          ...customGroupNewlinesInsideJsonSchema,
+          ...customGroupNewlinesBelowJsonSchema,
           ...singleCustomGroupJsonSchema,
         },
         description: 'Custom group.',

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -1,0 +1,130 @@
+import type { SortingNode } from '../types/sorting-node'
+
+import { getGroupNumber } from './get-group-number'
+
+export interface GetNewlinesBetweenOptionParameters {
+  nextSortingNode: SortingNode
+  sortingNode: SortingNode
+  options: Options
+}
+
+interface CustomGroup {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+}
+
+interface Options {
+  customGroups?: Record<string, string[] | string> | CustomGroup[]
+  newlinesBetween: 'ignore' | 'always' | 'never'
+  groups: (string[] | string)[]
+}
+
+/**
+ * Get the `newlinesBetween` option to use between two consecutive nodes.
+ * The result is based on the global `newlinesBetween` option and the custom
+ * groups, which can override the global option.
+ * - If the two nodes are in the same custom group, the `newlinesInside` option
+ * of the group is used.
+ * - If the two nodes are in different custom groups, the `newlinesAbove` option
+ * of the previous group and the `newlinesBelow` option of the next group are
+ * used.
+ * - Groups that are part of a group array are ignored
+ * - `always` has a higher priority than `never`.
+ * - The fallback is the global `newlinesBetween` option.
+ * @param {GetNewlinesBetweenOptionParameters} props - The function arguments
+ * @param {SortingNode} props.nextSortingNode - The next node to sort
+ * @param {SortingNode} props.sortingNode - The current node to sort
+ * @param {Options} props.options - Newlines between related options
+ * @returns {'ignore' | 'always' | 'never'} - The `newlinesBetween` option to
+ * use
+ */
+export let getNewlinesBetweenOption = ({
+  nextSortingNode,
+  sortingNode,
+  options,
+}: GetNewlinesBetweenOptionParameters): 'ignore' | 'always' | 'never' => {
+  let nodeGroupNumber = getGroupNumber(options.groups, sortingNode)
+  let nextNodeGroupNumber = getGroupNumber(options.groups, nextSortingNode)
+  let globalNewlinesBetweenOption = getGlobalNewlinesBetweenOption({
+    newlinesBetween: options.newlinesBetween,
+    nextNodeGroupNumber,
+    nodeGroupNumber,
+  })
+
+  if (!options.customGroups || !Array.isArray(options.customGroups)) {
+    return globalNewlinesBetweenOption
+  }
+
+  let nodeGroup = options.groups[nodeGroupNumber]
+  let nextNodeGroup = options.groups[nextNodeGroupNumber]
+
+  if (Array.isArray(nodeGroup) || Array.isArray(nextNodeGroup)) {
+    return globalNewlinesBetweenOption
+  }
+
+  let nodeCustomGroup = options.customGroups.find(
+    customGroup => customGroup.groupName === nodeGroup,
+  )
+  let nextNodeCustomGroup = options.customGroups.find(
+    customGroup => customGroup.groupName === nextNodeGroup,
+  )
+
+  if (
+    nodeCustomGroup &&
+    nextNodeCustomGroup &&
+    nodeCustomGroup.groupName === nextNodeCustomGroup.groupName
+  ) {
+    return nodeCustomGroup.newlinesInside ?? globalNewlinesBetweenOption
+  }
+
+  return (
+    getNewlinesBetweenOptionForCustomGroups({
+      previousCustomGroupOption: nodeCustomGroup?.newlinesBelow,
+      nextCustomGroupOption: nextNodeCustomGroup?.newlinesAbove,
+    }) ?? globalNewlinesBetweenOption
+  )
+}
+
+let getGlobalNewlinesBetweenOption = ({
+  nextNodeGroupNumber,
+  newlinesBetween,
+  nodeGroupNumber,
+}: {
+  newlinesBetween: 'ignore' | 'always' | 'never'
+  nextNodeGroupNumber: number
+  nodeGroupNumber: number
+}): 'always' | 'ignore' | 'never' => {
+  if (newlinesBetween === 'ignore') {
+    return 'ignore'
+  }
+  if (newlinesBetween === 'never') {
+    return 'never'
+  }
+  return nodeGroupNumber === nextNodeGroupNumber ? 'never' : 'always'
+}
+
+let getNewlinesBetweenOptionForCustomGroups = ({
+  previousCustomGroupOption,
+  nextCustomGroupOption,
+}: {
+  previousCustomGroupOption?: 'ignore' | 'always' | 'never'
+  nextCustomGroupOption?: 'ignore' | 'always' | 'never'
+}): undefined | 'ignore' | 'always' | 'never' => {
+  if (!previousCustomGroupOption || previousCustomGroupOption === 'ignore') {
+    return nextCustomGroupOption
+  }
+  if (!nextCustomGroupOption || nextCustomGroupOption === 'ignore') {
+    return previousCustomGroupOption
+  }
+  if (
+    (nextCustomGroupOption === 'always' &&
+      previousCustomGroupOption === 'never') ||
+    (previousCustomGroupOption === 'always' &&
+      nextCustomGroupOption === 'never')
+  ) {
+    return 'ignore'
+  }
+  return nextCustomGroupOption
+}

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -42,6 +42,9 @@ export let getNewlinesErrors = <T extends string>({
     sortingNode: left,
     options,
   })
+  if (leftNum > rightNum) {
+    return []
+  }
   let numberOfEmptyLinesBetween = getLinesBetween(sourceCode, left, right)
   switch (newlinesBetween) {
     case 'ignore':
@@ -49,9 +52,6 @@ export let getNewlinesErrors = <T extends string>({
     case 'never':
       return numberOfEmptyLinesBetween > 0 ? [extraSpacingError] : []
     case 'always':
-      if (leftNum > rightNum) {
-        return []
-      }
       if (numberOfEmptyLinesBetween === 0) {
         return [missedSpacingError]
       } else if (numberOfEmptyLinesBetween > 1) {

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -49,7 +49,10 @@ export let getNewlinesErrors = <T extends string>({
     case 'never':
       return numberOfEmptyLinesBetween > 0 ? [extraSpacingError] : []
     case 'always':
-      if (leftNum < rightNum && numberOfEmptyLinesBetween === 0) {
+      if (leftNum > rightNum) {
+        return []
+      }
+      if (numberOfEmptyLinesBetween === 0) {
         return [missedSpacingError]
       } else if (numberOfEmptyLinesBetween > 1) {
         return [extraSpacingError]

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -4,19 +4,17 @@ import type { SortingNode } from '../types/sorting-node'
 
 import { getLinesBetween } from './get-lines-between'
 
-interface Props<T extends string> {
+interface GetNewlinesErrorsParameters<T extends string> {
   sourceCode: TSESLint.SourceCode
   missedSpacingError: T
   extraSpacingError: T
   right: SortingNode
   left: SortingNode
   rightNum: number
-  options: Options
+  options: {
+    newlinesBetween: 'ignore' | 'always' | 'never'
+  }
   leftNum: number
-}
-
-interface Options {
-  newlinesBetween: 'ignore' | 'always' | 'never'
 }
 
 export let getNewlinesErrors = <T extends string>({
@@ -28,7 +26,7 @@ export let getNewlinesErrors = <T extends string>({
   options,
   right,
   left,
-}: Props<T>): T[] => {
+}: GetNewlinesErrorsParameters<T>): T[] => {
   let errors: T[] = []
 
   let numberOfEmptyLinesBetween = getLinesBetween(sourceCode, left, right)

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -31,6 +31,8 @@ export let makeNewlinesFixes = ({
   let fixes: TSESLint.RuleFix[] = []
 
   for (let i = 0; i < sortedNodes.length - 1; i++) {
+    let sortingNode = nodes.at(i)!
+    let nextSortingNode = nodes.at(i + 1)!
     let sortedSortingNode = sortedNodes.at(i)!
     let nextSortedSortingNode = sortedNodes.at(i + 1)!
 
@@ -40,11 +42,11 @@ export let makeNewlinesFixes = ({
       nextSortedSortingNode,
     )
     let currentNodeRange = getNodeRange({
-      node: nodes.at(i)!.node,
+      node: sortingNode.node,
       sourceCode,
     })
     let nextNodeRangeStart = getNodeRange({
-      node: nodes.at(i + 1)!.node,
+      node: nextSortingNode.node,
       sourceCode,
     }).at(0)!
     let rangeToReplace: [number, number] = [
@@ -58,8 +60,8 @@ export let makeNewlinesFixes = ({
 
     let linesBetweenMembers = getLinesBetween(
       sourceCode,
-      nodes.at(i)!,
-      nodes.at(i + 1)!,
+      sortingNode,
+      nextSortingNode,
     )
 
     let rangeReplacement: undefined | string
@@ -84,7 +86,7 @@ export let makeNewlinesFixes = ({
       )
       let isOnSameLine =
         linesBetweenMembers === 0 &&
-        nodes.at(i)!.node.loc.end.line === nodes.at(i + 1)!.node.loc.start.line
+        sortingNode.node.loc.end.line === nextSortingNode.node.loc.start.line
       if (isOnSameLine) {
         rangeReplacement = addNewlineBeforeFirstNewline(rangeReplacement)
       }

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -24,18 +24,21 @@ export let makeNewlinesFixes = ({
   fixer,
   nodes,
 }: MakeNewlinesFixesParameters): TSESLint.RuleFix[] => {
+  if (options.newlinesBetween === 'ignore') {
+    return []
+  }
+
   let fixes: TSESLint.RuleFix[] = []
 
-  for (let max = sortedNodes.length, i = 0; i < max; i++) {
-    let sortingNode = sortedNodes.at(i)!
-    let nextSortingNode = sortedNodes.at(i + 1)
+  for (let i = 0; i < sortedNodes.length - 1; i++) {
+    let sortedSortingNode = sortedNodes.at(i)!
+    let nextSortedSortingNode = sortedNodes.at(i + 1)!
 
-    if (options.newlinesBetween === 'ignore' || !nextSortingNode) {
-      continue
-    }
-
-    let nodeGroupNumber = getGroupNumber(options.groups, sortingNode)
-    let nextNodeGroupNumber = getGroupNumber(options.groups, nextSortingNode)
+    let nodeGroupNumber = getGroupNumber(options.groups, sortedSortingNode)
+    let nextNodeGroupNumber = getGroupNumber(
+      options.groups,
+      nextSortedSortingNode,
+    )
     let currentNodeRange = getNodeRange({
       node: nodes.at(i)!.node,
       sourceCode,

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -2,19 +2,29 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import type { SortingNode } from '../types/sorting-node'
 
+import { getNewlinesBetweenOption } from './get-newlines-between-option'
 import { getLinesBetween } from './get-lines-between'
-import { getGroupNumber } from './get-group-number'
 import { getNodeRange } from './get-node-range'
 
+interface CustomGroup {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+}
+
 interface MakeNewlinesFixesParameters {
-  options: {
-    newlinesBetween: 'ignore' | 'always' | 'never'
-    groups: (string[] | string)[]
-  }
   sourceCode: TSESLint.SourceCode
   sortedNodes: SortingNode[]
   fixer: TSESLint.RuleFixer
   nodes: SortingNode[]
+  options: Options
+}
+
+interface Options {
+  customGroups?: Record<string, string[] | string> | CustomGroup[]
+  newlinesBetween: 'ignore' | 'always' | 'never'
+  groups: (string[] | string)[]
 }
 
 export let makeNewlinesFixes = ({
@@ -24,10 +34,6 @@ export let makeNewlinesFixes = ({
   fixer,
   nodes,
 }: MakeNewlinesFixesParameters): TSESLint.RuleFix[] => {
-  if (options.newlinesBetween === 'ignore') {
-    return []
-  }
-
   let fixes: TSESLint.RuleFix[] = []
 
   for (let i = 0; i < sortedNodes.length - 1; i++) {
@@ -36,11 +42,16 @@ export let makeNewlinesFixes = ({
     let sortedSortingNode = sortedNodes.at(i)!
     let nextSortedSortingNode = sortedNodes.at(i + 1)!
 
-    let nodeGroupNumber = getGroupNumber(options.groups, sortedSortingNode)
-    let nextNodeGroupNumber = getGroupNumber(
-      options.groups,
-      nextSortedSortingNode,
-    )
+    let newlinesBetween = getNewlinesBetweenOption({
+      nextSortingNode: nextSortedSortingNode,
+      sortingNode: sortedSortingNode,
+      options,
+    })
+
+    if (newlinesBetween === 'ignore') {
+      continue
+    }
+
     let currentNodeRange = getNodeRange({
       node: sortingNode.node,
       sourceCode,
@@ -65,20 +76,11 @@ export let makeNewlinesFixes = ({
     )
 
     let rangeReplacement: undefined | string
-    if (
-      (options.newlinesBetween === 'always' &&
-        nodeGroupNumber === nextNodeGroupNumber &&
-        linesBetweenMembers !== 0) ||
-      (options.newlinesBetween === 'never' && linesBetweenMembers > 0)
-    ) {
+    if (newlinesBetween === 'never' && linesBetweenMembers !== 0) {
       rangeReplacement = getStringWithoutInvalidNewlines(textBetweenNodes)
     }
 
-    if (
-      options.newlinesBetween === 'always' &&
-      nodeGroupNumber !== nextNodeGroupNumber &&
-      linesBetweenMembers !== 1
-    ) {
+    if (newlinesBetween === 'always' && linesBetweenMembers !== 1) {
       rangeReplacement = addNewlineBeforeFirstNewline(
         linesBetweenMembers > 1
           ? getStringWithoutInvalidNewlines(textBetweenNodes)


### PR DESCRIPTION
Related to https://github.com/azat-io/eslint-plugin-perfectionist/issues/401.
- ⚙️ **PR 1 (this)**: Add the options and enable them in rules that already handle array-based `customGroups` (new API).
- ❌ **PR 2**: Add custom groups to `sort-imports` and enable these options.

# Description

We currently have the `newlinesBetween` option, which applies the same newlines-related rules between all groups.
This PR adds 3 sub-options for the new array-based `customGroups`:
- `newlinesInside?: 'ignore' | 'always' | 'never'`
- `newlinesAbove?: 'ignore' | 'always' | 'never'`
- `newlinesBelow?: 'ignore' | 'always' | 'never' `

Here is the list of rules with this new addition:
- `sort-classes`
- `sort-modules`
- `sort-object-types`
- `sort-interfaces`

# Options

## `customGroup.newlinesInside?: 'ignore' | 'always' | 'never'`

Newlines rule that should be applied between two consecutive nodes of the **same** custom group.

Example: Enforce a newline between all class methods.
```ts
{
  customGroups: [
    {
      groupName: "methodsWithNewlinesBetween",
      selector: "method",
      newlinesInside: "always"
    }
  ]
}
```

## `customGroup.newlinesBelow?: 'ignore' | 'always' | 'never'`

Newlines rule that should be applied between a node of the custom group THEN a node of a **different** group.

See example under.

## `customGroup.newlinesAbove?: 'ignore' | 'always' | 'never'`

Newlines rule that should be applied between a node of a **different** group THEN a node of the custom group.

Example: Enforce separating class properties and methods with a newline, but public, protected and private properties should not have newlines between them.
```ts
{
  groups: ["public-properties", "protected-properties", "private-properties", "methods"],
  customGroups: [
    {
      groupName: "public-properties",
      selector: "property",
      modifier: "public",
      newlinesBelow: "never"
    },
    {
      groupName: "protected-properties",
      selector: "property",
      modifier: "protected",
      newlinesBelow: "never"
    },
    {
      groupName: "private-properties",
      selector: "property",
      modifier: "private",
      newlinesBelow: "always"
    },
    {
      groupName: "methods",
      selector: "method",
      // newlinesAbove: "always" - This is useless as the `private-properties` custom group defines `newlinesBelow` already
    },
  ]
}
```

## List of newlines-related behaviors between two consecutive nodes 

Let's take two sorted nodes **node1** (`group1`)  before (above) **node2** (`group2`).
The three possible newline behaviors are:
- `ignore`: Don't enforce anything.
- `always`: Enforce a single line between the two nodes.
- `never`: Enforce no newline between the two nodes.

The "global" `options.newlinesBetween` option coexist with custom groups `newlinesBetween`, `newlinesAbove` and `newlinesBelow` in the following ways:

- If `options.customGroups` is `undefined`, `options.newlinesBetween` takes priority.
- If `options.customGroups` is not an array (new API), `options.newlinesBetween` takes priority.
- If one of the groups (`group1` or `group2`) is within an array in `options.groups`, `options.newlinesBetween` takes priority.
- If `node1` and `node2` belong to the same custom group `group1`:
  -  If `group1.newlinesInside` is defined, it takes priority.
  -  If `group1.newlinesInside` is `undefined`, `options.newlinesBetween` takes priority.
- If `node1` and `node2` do NOT belong to the **same** custom group:
  - if `group1` is not a custom group, or if `group1.newlinesBelow` is `💤 ignore` or `undefined`, `group2.newlinesAbove` takes priority.
  - if `group2` is not a custom group, or if `group2.newlinesAbove` is `💤  ignore` or `undefined`, `group1.newlinesBelow` takes priority.
  - if both `group1` and `group2` are not custom groups, or if `group1.newlinesBelow` and `group2.newlinesAbove` are both `undefined`, `options.newlinesBetween` takes priority.
  - if both `group1.newlinesBelow` and `group2.newlinesAbove` are `❌ never`, the chosen behavior will be `❌ never`.
  - if both `group1.newlinesBelow` and `group2.newlinesAbove` are `✅ always`, the chosen behavior will be `✅ always`.
  - if `group1.newlinesBelow` is `✅ always` and `group2.newlinesAbove` is `❌ never`, or the opposite, the chosen behavior will be `💤 ignore`.

### What is the purpose of this pull request?

- [x] New Feature