### PR TITLE
feat: makes `partitionByComment` support `line` and `block` filters

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -192,11 +192,6 @@ Allows you to group array elements by their kind, determining whether spread val
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of arrays into logical groups. This can help in organizing and maintaining large arrays by creating partitions based on comments.
@@ -205,7 +200,7 @@ Allows you to use comments to separate the members of arrays into logical groups
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -192,6 +192,11 @@ Allows you to group array elements by their kind, determining whether spread val
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of arrays into logical groups. This can help in organizing and maintaining large arrays by creating partitions based on comments.
@@ -200,6 +205,7 @@ Allows you to use comments to separate the members of arrays into logical groups
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -214,6 +214,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the class members into logical groups. This can help in organizing and maintaining large classes by creating partitions within the class based on comments.
@@ -221,6 +226,7 @@ Allows you to use comments to separate the class members into logical groups. Th
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.
 - string — A regexp pattern to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -214,11 +214,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the class members into logical groups. This can help in organizing and maintaining large classes by creating partitions within the class based on comments.
@@ -226,7 +221,7 @@ Allows you to use comments to separate the class members into logical groups. Th
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.
 - string — A regexp pattern to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-decorators.mdx
+++ b/docs/content/rules/sort-decorators.mdx
@@ -208,6 +208,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate class decorators into logical groups.
@@ -216,6 +221,7 @@ Allows you to use comments to separate class decorators into logical groups.
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### groups
 

--- a/docs/content/rules/sort-decorators.mdx
+++ b/docs/content/rules/sort-decorators.mdx
@@ -208,11 +208,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate class decorators into logical groups.
@@ -221,7 +216,7 @@ Allows you to use comments to separate class decorators into logical groups.
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### groups
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -164,6 +164,11 @@ Controls whether numeric enums should always be sorted numerically, regardless o
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of enums into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
@@ -172,6 +177,7 @@ Allows you to use comments to separate the members of enums into logical groups.
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -164,11 +164,6 @@ Controls whether numeric enums should always be sorted numerically, regardless o
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of enums into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
@@ -177,7 +172,7 @@ Allows you to use comments to separate the members of enums into logical groups.
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -138,6 +138,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the exports into logical groups. This can help in organizing and maintaining large export blocks by creating partitions based on comments.
@@ -146,6 +151,7 @@ Allows you to use comments to separate the exports into logical groups. This can
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -138,11 +138,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the exports into logical groups. This can help in organizing and maintaining large export blocks by creating partitions based on comments.
@@ -151,7 +146,7 @@ Allows you to use comments to separate the exports into logical groups. This can
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -194,6 +194,11 @@ Specifies whether side effect imports should be sorted. By default, sorting side
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate imports into logical groups.
@@ -202,6 +207,7 @@ Allows you to use comments to separate imports into logical groups.
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -194,11 +194,6 @@ Specifies whether side effect imports should be sorted. By default, sorting side
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate imports into logical groups.
@@ -207,7 +202,7 @@ Allows you to use comments to separate imports into logical groups.
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -204,11 +204,6 @@ You can specify their names or a regexp pattern to ignore, for example: `'^Compo
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the properties of interfaces into logical groups. This can help in organizing and maintaining large interfaces by creating partitions within the interface based on comments.
@@ -217,7 +212,7 @@ Allows you to use comments to separate the properties of interfaces into logical
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -204,6 +204,11 @@ You can specify their names or a regexp pattern to ignore, for example: `'^Compo
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the properties of interfaces into logical groups. This can help in organizing and maintaining large interfaces by creating partitions within the interface based on comments.
@@ -212,6 +217,7 @@ Allows you to use comments to separate the properties of interfaces into logical
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -134,6 +134,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of intersection types into logical groups. This can help in organizing and maintaining large intersection types by creating partitions based on comments.
@@ -142,6 +147,7 @@ Allows you to use comments to separate the members of intersection types into lo
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -134,11 +134,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of intersection types into logical groups. This can help in organizing and maintaining large intersection types by creating partitions based on comments.
@@ -147,7 +142,7 @@ Allows you to use comments to separate the members of intersection types into lo
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -139,6 +139,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of maps into logical groups. This can help in organizing and maintaining large maps by creating partitions based on comments.
@@ -147,6 +152,7 @@ Allows you to use comments to separate the members of maps into logical groups. 
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -139,11 +139,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of maps into logical groups. This can help in organizing and maintaining large maps by creating partitions based on comments.
@@ -152,7 +147,7 @@ Allows you to use comments to separate the members of maps into logical groups. 
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -237,6 +237,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the module members into logical groups. This can help in organizing and maintaining large modules by creating partitions based on comments.
@@ -244,6 +249,7 @@ Allows you to use comments to separate the module members into logical groups. T
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.
 - string — A regexp pattern to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -237,11 +237,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the module members into logical groups. This can help in organizing and maintaining large modules by creating partitions based on comments.
@@ -249,7 +244,7 @@ Allows you to use comments to separate the module members into logical groups. T
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.
 - string — A regexp pattern to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -167,11 +167,6 @@ Allows you to group named exports by their kind, determining whether value expor
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of named exports into logical groups. This can help in organizing and maintaining large named exports by creating partitions based on comments.
@@ -180,7 +175,7 @@ Allows you to use comments to separate the members of named exports into logical
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -167,6 +167,11 @@ Allows you to group named exports by their kind, determining whether value expor
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of named exports into logical groups. This can help in organizing and maintaining large named exports by creating partitions based on comments.
@@ -175,6 +180,7 @@ Allows you to use comments to separate the members of named exports into logical
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -177,11 +177,6 @@ Allows you to group named imports by their kind, determining whether value impor
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of named imports into logical groups. This can help in organizing and maintaining large named imports by creating partitions based on comments.
@@ -190,7 +185,7 @@ Allows you to use comments to separate the members of named imports into logical
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -177,6 +177,11 @@ Allows you to group named imports by their kind, determining whether value impor
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of named imports into logical groups. This can help in organizing and maintaining large named imports by creating partitions based on comments.
@@ -185,6 +190,7 @@ Allows you to use comments to separate the members of named imports into logical
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -166,6 +166,11 @@ You can specify their names or a regexp pattern to ignore, for example: `'^Compo
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of types into logical groups. This can help in organizing and maintaining large object types by creating partitions based on comments.
@@ -174,6 +179,7 @@ Allows you to use comments to separate the members of types into logical groups.
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -166,11 +166,6 @@ You can specify their names or a regexp pattern to ignore, for example: `'^Compo
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of types into logical groups. This can help in organizing and maintaining large object types by creating partitions based on comments.
@@ -179,7 +174,7 @@ Allows you to use comments to separate the members of types into logical groups.
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -214,11 +214,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the keys of objects into logical groups. This can help in organizing and maintaining large objects by creating partitions based on comments.
@@ -227,7 +222,7 @@ Allows you to use comments to separate the keys of objects into logical groups. 
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -214,6 +214,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the keys of objects into logical groups. This can help in organizing and maintaining large objects by creating partitions based on comments.
@@ -222,6 +227,7 @@ Allows you to use comments to separate the keys of objects into logical groups. 
 - `false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -197,6 +197,11 @@ Allows you to group set elements by their kind, determining whether spread value
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of sets into logical groups. This can help in organizing and maintaining large sets by creating partitions based on comments.
@@ -205,6 +210,7 @@ Allows you to use comments to separate the members of sets into logical groups. 
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -197,11 +197,6 @@ Allows you to group set elements by their kind, determining whether spread value
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of sets into logical groups. This can help in organizing and maintaining large sets by creating partitions based on comments.
@@ -210,7 +205,7 @@ Allows you to use comments to separate the members of sets into logical groups. 
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -154,11 +154,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of union types into logical groups. This can help in organizing and maintaining large union types by creating partitions based on comments.
@@ -167,7 +162,7 @@ Allows you to use comments to separate the members of union types into logical g
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -154,6 +154,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of union types into logical groups. This can help in organizing and maintaining large union types by creating partitions based on comments.
@@ -162,6 +167,7 @@ Allows you to use comments to separate the members of union types into logical g
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -138,6 +138,11 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
+<sub>
+  - type:
+    - `boolean | string | string[]` (`BaseType`)
+    - `{ block: BaseType; line: BaseType }`
+</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of variable declarations into logical groups. This can help in organizing and maintaining large variable declaration blocks by creating partitions based on comments.
@@ -146,6 +151,7 @@ Allows you to use comments to separate the members of variable declarations into
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -138,11 +138,6 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### partitionByComment
 
-<sub>
-  - type:
-    - `boolean | string | string[]` (`BaseType`)
-    - `{ block: BaseType; line: BaseType }`
-</sub>
 <sub>default: `false`</sub>
 
 Allows you to use comments to separate the members of variable declarations into logical groups. This can help in organizing and maintaining large variable declaration blocks by creating partitions based on comments.
@@ -151,7 +146,7 @@ Allows you to use comments to separate the members of variable declarations into
 -	`false` — Comments will not be used as delimiters.
 - `string` — A regexp pattern to specify which comments should act as delimiters.
 - `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: BaseType; line: BaseType }` — Specify which block and line comments should act as delimiters.
+- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -30,7 +30,7 @@ import { getMatchingContextOptions } from '../utils/get-matching-context-options
 import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/is-partition-comment'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
@@ -265,13 +265,13 @@ export let sortArray = <MessageIds extends string>({
 
       let lastSortingNode = accumulator.at(-1)?.at(-1)
       if (
-        hasPartitionComment(
-          options.partitionByComment,
-          getCommentsBefore({
+        hasPartitionComment({
+          comments: getCommentsBefore({
             node: element,
             sourceCode,
           }),
-        ) ||
+          partitionByComment: options.partitionByComment,
+        }) ||
         (options.partitionByNewLine &&
           lastSortingNode &&
           getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -6,6 +6,14 @@ import {
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
+  partitionByComment:
+    | {
+        block?: string[] | boolean | string
+        line?: string[] | boolean | string
+      }
+    | string[]
+    | boolean
+    | string
   type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
   useConfigurationIf: {
     allNamesMatchPattern?: string
@@ -14,7 +22,6 @@ export type Options = Partial<{
    * @deprecated for {@link `groups`}
    */
   groupKind: 'literals-first' | 'spreads-first' | 'mixed'
-  partitionByComment: string[] | boolean | string
   specialCharacters: 'remove' | 'trim' | 'keep'
   locales: NonNullable<Intl.LocalesArgument>
   customGroups: CustomGroup[]

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -39,7 +39,7 @@ import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
 import { doesCustomGroupMatch } from './sort-classes/does-custom-group-match'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/is-partition-comment'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
@@ -567,13 +567,13 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             (options.partitionByNewLine &&
               lastMember &&
               getLinesBetween(sourceCode, lastMember, sortingNode)) ||
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
+            hasPartitionComment({
+              comments: getCommentsBefore({
                 node: member,
                 sourceCode,
               }),
-            )
+              partitionByComment: options.partitionByComment,
+            })
           ) {
             accumulator.push([])
           }

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -10,8 +10,15 @@ import {
 
 export type SortClassesOptions = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     ignoreCallbackDependenciesPatterns: string[]

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -19,7 +19,7 @@ import { validateGroupsConfiguration } from '../utils/validate-groups-configurat
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { getDecoratorName } from './sort-decorators/get-decorator-name'
-import { hasPartitionComment } from '../utils/is-partition-comment'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
@@ -219,13 +219,13 @@ let sortDecorators = (
   let formattedMembers: SortDecoratorsSortingNode[][] = decorators.reduce(
     (accumulator: SortDecoratorsSortingNode[][], decorator) => {
       if (
-        hasPartitionComment(
-          options.partitionByComment,
-          getCommentsBefore({
+        hasPartitionComment({
+          comments: getCommentsBefore({
             node: decorator,
             sourceCode,
           }),
-        )
+          partitionByComment: options.partitionByComment,
+        })
       ) {
         accumulator.push([])
       }

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -38,9 +38,16 @@ import { pairwise } from '../utils/pairwise'
 
 export type Options<T extends string[]> = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     customGroups: Record<T[number], string[] | string>
-    partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -38,8 +38,15 @@ import { pairwise } from '../utils/pairwise'
 
 export type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -20,7 +20,7 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/is-partition-comment'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -153,13 +153,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
           }
 
           if (
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
+            hasPartitionComment({
+              comments: getCommentsBefore({
                 node: member,
                 sourceCode,
               }),
-            ) ||
+              partitionByComment: options.partitionByComment,
+            }) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -30,9 +30,16 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     groupKind: 'values-first' | 'types-first' | 'mixed'
-    partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -15,8 +15,8 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -95,13 +95,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let lastNode = parts.at(-1)?.at(-1)
       if (
         (partitionComment &&
-          hasPartitionComment(
-            partitionComment,
-            getCommentsBefore({
+          hasPartitionComment({
+            comments: getCommentsBefore({
               sourceCode,
               node,
             }),
-          )) ||
+            partitionByComment: options.partitionByComment,
+          })) ||
         (options.partitionByNewLine &&
           lastNode &&
           getLinesBetween(sourceCode, lastNode, sortingNode))

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -45,12 +45,19 @@ import { matches } from '../utils/matches'
 
 export type Options<T extends string[]> = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     customGroups: {
       value?: Record<T[number], string[] | string>
       type?: Record<T[number], string[] | string>
     }
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -24,8 +24,8 @@ import { getOptionsWithCleanGroups } from '../utils/get-options-with-clean-group
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { getTypescriptImport } from './sort-imports/get-typescript-import'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
@@ -472,13 +472,13 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
           let lastSortingNode = lastGroup?.at(-1)
 
           if (
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
+            hasPartitionComment({
+              comments: getCommentsBefore({
                 node: sortingNode.node,
                 sourceCode,
               }),
-            ) ||
+              partitionByComment: options.partitionByComment,
+            }) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode)) ||

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -37,8 +37,15 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -17,8 +17,8 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
@@ -190,14 +190,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
             node: type,
           }
           if (
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
+            hasPartitionComment({
+              comments: getCommentsBefore({
                 tokenValueToIgnoreBefore: '&',
                 node: type,
                 sourceCode,
               }),
-            ) ||
+              partitionByComment: options.partitionByComment,
+            }) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -15,8 +15,8 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -127,13 +127,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
           }
 
           if (
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
+            hasPartitionComment({
+              comments: getCommentsBefore({
                 node: element,
                 sourceCode,
               }),
-            ) ||
+              partitionByComment: options.partitionByComment,
+            }) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -32,8 +32,15 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -40,8 +40,8 @@ import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
 import { doesCustomGroupMatch } from './sort-modules/does-custom-group-match'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
@@ -357,13 +357,13 @@ let analyzeModule = ({
       (options.partitionByNewLine &&
         lastSortingNode &&
         getLinesBetween(sourceCode, lastSortingNode, sortingNode)) ||
-      hasPartitionComment(
-        options.partitionByComment,
-        getCommentsBefore({
+      hasPartitionComment({
+        comments: getCommentsBefore({
           sourceCode,
           node,
         }),
-      )
+        partitionByComment: options.partitionByComment,
+      })
     ) {
       formattedNodes.push([])
     }

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -10,8 +10,15 @@ import {
 
 export type SortModulesOptions = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -31,9 +31,16 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     groupKind: 'values-first' | 'types-first' | 'mixed'
-    partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -15,8 +15,8 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -104,13 +104,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
           name,
         }
         if (
-          hasPartitionComment(
-            options.partitionByComment,
-            getCommentsBefore({
+          hasPartitionComment({
+            comments: getCommentsBefore({
               node: specifier,
               sourceCode,
             }),
-          ) ||
+            partitionByComment: options.partitionByComment,
+          }) ||
           (options.partitionByNewLine &&
             lastSortingNode &&
             getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -31,9 +31,16 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     groupKind: 'values-first' | 'types-first' | 'mixed'
-    partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -15,8 +15,8 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -113,13 +113,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
         }
 
         if (
-          hasPartitionComment(
-            options.partitionByComment,
-            getCommentsBefore({
+          hasPartitionComment({
+            comments: getCommentsBefore({
               node: specifier,
               sourceCode,
             }),
-          ) ||
+            partitionByComment: options.partitionByComment,
+          }) ||
           (options.partitionByNewLine &&
             lastSortingNode &&
             getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -36,7 +36,7 @@ import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isMemberOptional } from './sort-object-types/is-member-optional'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/is-partition-comment'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { isNodeFunctionType } from '../utils/is-node-function-type'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
@@ -355,13 +355,13 @@ export let sortObjectTypeElements = <MessageIds extends string>({
 
       if (
         (options.partitionByComment &&
-          hasPartitionComment(
-            options.partitionByComment,
-            getCommentsBefore({
+          hasPartitionComment({
+            comments: getCommentsBefore({
               node: typeElement,
               sourceCode,
             }),
-          )) ||
+            partitionByComment: options.partitionByComment,
+          })) ||
         (options.partitionByNewLine &&
           lastSortingNode &&
           getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -9,6 +9,14 @@ import {
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
+  partitionByComment:
+    | {
+        block?: string[] | boolean | string
+        line?: string[] | boolean | string
+      }
+    | string[]
+    | boolean
+    | string
   useConfigurationIf: {
     declarationMatchesPattern?: string
     allNamesMatchPattern?: string
@@ -19,7 +27,6 @@ export type Options = Partial<{
    * @deprecated for {@link `groups`}
    */
   groupKind: 'required-first' | 'optional-first' | 'mixed'
-  partitionByComment: string[] | boolean | string
   newlinesBetween: 'ignore' | 'always' | 'never'
   specialCharacters: 'remove' | 'trim' | 'keep'
   locales: NonNullable<Intl.LocalesArgument>

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -48,6 +48,14 @@ import { pairwise } from '../utils/pairwise'
 import { matches } from '../utils/matches'
 
 type Options = Partial<{
+  partitionByComment:
+    | {
+        block?: string[] | boolean | string
+        line?: string[] | boolean | string
+      }
+    | string[]
+    | boolean
+    | string
   useConfigurationIf: {
     callingFunctionNamePattern?: string
     allNamesMatchPattern?: string
@@ -55,7 +63,6 @@ type Options = Partial<{
   type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
   destructuredObjects: { groups: boolean } | boolean
   customGroups: Record<string, string[] | string>
-  partitionByComment: string[] | boolean | string
   newlinesBetween: 'ignore' | 'always' | 'never'
   specialCharacters: 'remove' | 'trim' | 'keep'
   locales: NonNullable<Intl.LocalesArgument>

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -27,8 +27,8 @@ import { validateGroupsConfiguration } from '../utils/validate-groups-configurat
 import { getMatchingContextOptions } from '../utils/get-matching-context-options'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
@@ -370,13 +370,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   lastProperty,
                   propertySortingNode,
                 )) ||
-              hasPartitionComment(
-                options.partitionByComment,
-                getCommentsBefore({
+              hasPartitionComment({
+                comments: getCommentsBefore({
                   node: property,
                   sourceCode,
                 }),
-              )
+                partitionByComment: options.partitionByComment,
+              })
             ) {
               accumulator.push([])
             }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -17,8 +17,8 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { makeNewlinesFixes } from '../utils/make-newlines-fixes'
@@ -190,14 +190,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
             node: type,
           }
           if (
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
+            hasPartitionComment({
+              comments: getCommentsBefore({
                 tokenValueToIgnoreBefore: '|',
                 node: type,
                 sourceCode,
               }),
-            ) ||
+              partitionByComment: options.partitionByComment,
+            }) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -37,8 +37,15 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -36,8 +36,15 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    partitionByComment: string[] | boolean | string
     specialCharacters: 'remove' | 'trim' | 'keep'
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -19,8 +19,8 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { hasPartitionComment } from '../utils/is-partition-comment'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
@@ -201,13 +201,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
             name,
           }
           if (
-            hasPartitionComment(
-              options.partitionByComment,
-              getCommentsBefore({
+            hasPartitionComment({
+              comments: getCommentsBefore({
                 node: declaration,
                 sourceCode,
               }),
-            ) ||
+              partitionByComment: options.partitionByComment,
+            }) ||
             (options.partitionByNewLine &&
               lastSortingNode &&
               getLinesBetween(sourceCode, lastSortingNode, sortingNode))

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -620,6 +620,254 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedArrayIncludesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                [
+                  /* Comment */
+                  'a',
+                  'b'
+                ].includes(value)
+              `,
+              code: dedent`
+                [
+                  'b',
+                  /* Comment */
+                  'a'
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  [
+                    'b',
+                    // Comment
+                    'a'
+                  ].includes(value)
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  [
+                    'c',
+                    // b
+                    'b',
+                    // a
+                    'a'
+                  ].includes(value)
+                  `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  [
+                    'b',
+                    // I am a partition comment because I don't have f o o
+                    'a'
+                  ].includes(value)
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedArrayIncludesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+              [
+                // Comment
+                'a',
+                'b'
+              ].includes(value)
+            `,
+              code: dedent`
+              [
+                'b',
+                // Comment
+                'a'
+              ].includes(value)
+            `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  [
+                    'b',
+                    /* Comment */
+                    'a'
+                  ].includes(value)
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  [
+                    'c',
+                    /* b */
+                    'b',
+                    /* a */
+                    'a'
+                  ].includes(value)
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                [
+                  'b',
+                  /* I am a partition comment because I don't have f o o */
+                  'a'
+                ].includes(value)
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(`${ruleName}(${type}): allows to use regex`, rule, {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -8393,6 +8393,246 @@ describe(ruleName, () => {
             invalid: [],
           },
         )
+
+        describe(`${ruleName}: allows to use "partitionByComment.line"`, () => {
+          ruleTester.run(`${ruleName}: ignores block comments`, rule, {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      right: 'a',
+                      left: 'b',
+                    },
+                    messageId: 'unexpectedClassesOrder',
+                  },
+                ],
+                output: dedent`
+                  class Class {
+                    /* Comment */
+                    a() {}
+                    b() {}
+                  }
+                `,
+                code: dedent`
+                  class Class {
+                    b() {}
+                    /* Comment */
+                    a() {}
+                  }
+                `,
+                options: [
+                  {
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          })
+
+          ruleTester.run(
+            `${ruleName}: allows to use all comments as parts`,
+            rule,
+            {
+              valid: [
+                {
+                  options: [
+                    {
+                      partitionByComment: {
+                        line: true,
+                      },
+                    },
+                  ],
+                  code: dedent`
+                    class Class {
+                      b() {}
+                      // Comment
+                      a() {}
+                    }
+                  `,
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use multiple partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  code: dedent`
+                    class Class {
+                      c() {}
+                      // b
+                      b() {}
+                      // a
+                      a() {}
+                    }
+                  `,
+                  options: [
+                    {
+                      partitionByComment: {
+                        line: ['a', 'b'],
+                      },
+                    },
+                  ],
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use regex for partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  code: dedent`
+                    class Class {
+                      b() {}
+                      // I am a partition comment because I don't have f o o
+                      a() {}
+                    }
+                  `,
+                  options: [
+                    {
+                      partitionByComment: {
+                        line: ['^(?!.*foo).*$'],
+                      },
+                    },
+                  ],
+                },
+              ],
+              invalid: [],
+            },
+          )
+        })
+
+        describe(`${ruleName}: allows to use "partitionByComment.block"`, () => {
+          ruleTester.run(`${ruleName}: ignores line comments`, rule, {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      right: 'a',
+                      left: 'b',
+                    },
+                    messageId: 'unexpectedClassesOrder',
+                  },
+                ],
+                output: dedent`
+                  class Class {
+                    // Comment
+                    a() {}
+                    b() {}
+                  }
+                `,
+                options: [
+                  {
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  class Class {
+                    b() {}
+                    // Comment
+                    a() {}
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          })
+
+          ruleTester.run(
+            `${ruleName}: allows to use all comments as parts`,
+            rule,
+            {
+              valid: [
+                {
+                  code: dedent`
+                    class Class {
+                      b() {}
+                      /* Comment */
+                      a() {}
+                    }
+                  `,
+                  options: [
+                    {
+                      partitionByComment: {
+                        block: true,
+                      },
+                    },
+                  ],
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use multiple partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  code: dedent`
+                    class Class {
+                      c() {}
+                      /* b */
+                      b() {}
+                      /* a */
+                      a() {}
+                    }
+                  `,
+                  options: [
+                    {
+                      partitionByComment: {
+                        block: ['a', 'b'],
+                      },
+                    },
+                  ],
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use regex for partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  code: dedent`
+                    class Class {
+                      b() {}
+                      /* I am a partition comment because I don't have f o o */
+                      a() {}
+                    }
+                  `,
+                  options: [
+                    {
+                      partitionByComment: {
+                        block: ['^(?!.*foo).*$'],
+                      },
+                    },
+                  ],
+                },
+              ],
+              invalid: [],
+            },
+          )
+        })
       })
 
       ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {

--- a/test/rules/sort-decorators.test.ts
+++ b/test/rules/sort-decorators.test.ts
@@ -1060,6 +1060,460 @@ describe(ruleName, () => {
       },
     )
 
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+        invalid: [
+          {
+            output: dedent`
+              /* Comment */
+              @A
+              @B
+              class Class {
+
+                /* Comment */
+                @A
+                @B
+                property
+
+                /* Comment */
+                @A
+                @B
+                accessor field
+
+                /* Comment */
+                @A
+                @B
+                method(
+                  /* Comment */
+                  @A
+                  @B
+                  parameter) {}
+              }
+            `,
+            code: dedent`
+              @B
+              /* Comment */
+              @A
+              class Class {
+
+                @B
+                /* Comment */
+                @A
+                property
+
+                @B
+                /* Comment */
+                @A
+                accessor field
+
+                @B
+                /* Comment */
+                @A
+                method(
+                  @B
+                  /* Comment */
+                  @A
+                  parameter) {}
+              }
+            `,
+            errors: duplicate5Times([
+              {
+                data: {
+                  right: 'A',
+                  left: 'B',
+                },
+                messageId: 'unexpectedDecoratorsOrder',
+              },
+            ]),
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  line: true,
+                },
+              },
+            ],
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                @B
+                // Comment
+                @A
+                class Class {
+
+                  @B
+                  // Comment
+                  @A
+                  property
+
+                  @B
+                  // Comment
+                  @A
+                  accessor field
+
+                  @B
+                  // Comment
+                  @A
+                  method(
+                    @B
+                    // Comment
+                    @A
+                    parameter) {}
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                @C
+                // B
+                @B
+                // A
+                @A
+                class Class {
+
+                  @C
+                  // B
+                  @B
+                  // A
+                  @A
+                  property
+
+                  @C
+                  // B
+                  @B
+                  // A
+                  @A
+                  accessor field
+
+                  @C
+                  // B
+                  @B
+                  // A
+                  @A
+                  method(
+                    @C
+                    // B
+                    @B
+                    // A
+                    @A
+                    parameter) {}
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['A', 'B'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                @B
+                // I am a partition comment because I don't have f o o
+                @A
+                class Class {
+
+                  @B
+                  // I am a partition comment because I don't have f o o
+                  @A
+                  property
+
+                  @B
+                  // I am a partition comment because I don't have f o o
+                  @A
+                  accessor field
+
+                  @B
+                  // I am a partition comment because I don't have f o o
+                  @A
+                  method(
+                    @B
+                    // I am a partition comment because I don't have f o o
+                    @A
+                    parameter) {}
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+        invalid: [
+          {
+            output: dedent`
+              // Comment
+              @A
+              @B
+              class Class {
+
+                // Comment
+                @A
+                @B
+                property
+
+                // Comment
+                @A
+                @B
+                accessor field
+
+                // Comment
+                @A
+                @B
+                method(
+                  // Comment
+                  @A
+                  @B
+                  parameter) {}
+              }
+            `,
+            code: dedent`
+              @B
+              // Comment
+              @A
+              class Class {
+
+                @B
+                // Comment
+                @A
+                property
+
+                @B
+                // Comment
+                @A
+                accessor field
+
+                @B
+                // Comment
+                @A
+                method(
+                  @B
+                  // Comment
+                  @A
+                  parameter) {}
+              }
+            `,
+            errors: duplicate5Times([
+              {
+                data: {
+                  right: 'A',
+                  left: 'B',
+                },
+                messageId: 'unexpectedDecoratorsOrder',
+              },
+            ]),
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  block: true,
+                },
+              },
+            ],
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                @B
+                /* Comment */
+                @A
+                class Class {
+
+                  @B
+                  /* Comment */
+                  @A
+                  property
+
+                  @B
+                  /* Comment */
+                  @A
+                  accessor field
+
+                  @B
+                  /* Comment */
+                  @A
+                  method(
+                    @B
+                    /* Comment */
+                    @A
+                    parameter) {}
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                @C
+                /* B */
+                @B
+                /* A */
+                @A
+                class Class {
+
+                  @C
+                  /* B */
+                  @B
+                  /* A */
+                  @A
+                  property
+
+                  @C
+                  /* B */
+                  @B
+                  /* A */
+                  @A
+                  accessor field
+
+                  @C
+                  /* B */
+                  @B
+                  /* A */
+                  @A
+                  method(
+                    @C
+                    /* B */
+                    @B
+                    /* A */
+                    @A
+                    parameter) {}
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['A', 'B'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                @B
+                /* I am a partition comment because I don't have f o o */
+                @A
+                class Class {
+
+                  @B
+                  /* I am a partition comment because I don't have f o o */
+                  @A
+                  property
+
+                  @B
+                  /* I am a partition comment because I don't have f o o */
+                  @A
+                  accessor field
+
+                  @B
+                  /* I am a partition comment because I don't have f o o */
+                  @A
+                  method(
+                    @B
+                    /* I am a partition comment because I don't have f o o */
+                    @A
+                    parameter) {}
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): allows to trim special characters`,
       rule,

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -427,6 +427,254 @@ describe(ruleName, () => {
       },
     )
 
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'A',
+                  left: 'B',
+                },
+                messageId: 'unexpectedEnumsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  line: true,
+                },
+              },
+            ],
+            output: dedent`
+              enum Enum {
+                /* Comment */
+                A = "A",
+                B = "B",
+              }
+            `,
+            code: dedent`
+              enum Enum {
+                B = "B",
+                /* Comment */
+                A = "A",
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              code: dedent`
+                enum Enum {
+                  B = "B",
+                  // Comment
+                  A = "A",
+                }
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               enum Enum {
+                  C = "C",
+                  // B
+                  B = "B",
+                  // A
+                  A = "A",
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['A', 'B'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+              code: dedent`
+              enum Enum {
+                B = 'B',
+                // I am a partition comment because I don't have f o o
+                A = 'A',
+              }
+            `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'A',
+                  left: 'B',
+                },
+                messageId: 'unexpectedEnumsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  block: true,
+                },
+              },
+            ],
+            output: dedent`
+              enum Enum {
+                // Comment
+                A = "A",
+                B = "B",
+              }
+            `,
+            code: dedent`
+              enum Enum {
+                B = "B",
+                // Comment
+                A = "A",
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              code: dedent`
+                enum Enum {
+                  B = "B",
+                  /* Comment */
+                  A = "A",
+                }
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+               enum Enum {
+                  C = "C",
+                  /* B */
+                  B = "B",
+                  /* A */
+                  A = "A",
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['A', 'B'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                enum Enum {
+                  B = 'B',
+                  /* I am a partition comment because I don't have f o o */
+                  A = 'A',
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
     ruleTester.run(`${ruleName}: sort enum values correctly`, rule, {
       invalid: [
         {

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -376,6 +376,234 @@ describe(ruleName, () => {
       },
     )
 
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: './a',
+                  left: './b',
+                },
+                messageId: 'unexpectedExportsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  line: true,
+                },
+              },
+            ],
+            output: dedent`
+              /* Comment */
+              export * from './a'
+              export * from './b'
+              `,
+            code: dedent`
+              export * from './b'
+              /* Comment */
+              export * from './a'
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              code: dedent`
+                export * from './b'
+                // Comment
+                export * from './a'
+            `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['a', 'b'],
+                  },
+                },
+              ],
+              code: dedent`
+                export * from './c'
+                // b
+                export * from './b'
+                // a
+                export * from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+              code: dedent`
+                export * from './b'
+                // I am a partition comment because I don't have f o o
+                export * from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: './a',
+                  left: './b',
+                },
+                messageId: 'unexpectedExportsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  block: true,
+                },
+              },
+            ],
+            output: dedent`
+              // Comment
+              export * from './a'
+              export * from './b'
+            `,
+            code: dedent`
+              export * from './b'
+              // Comment
+              export * from './a'
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              code: dedent`
+                export * from './b'
+                /* Comment */
+                export * from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['a', 'b'],
+                  },
+                },
+              ],
+              code: dedent`
+                export * from './c'
+                /* b */
+                export * from './b'
+                /* a */
+                export * from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+              code: dedent`
+                export * from './b'
+                /* I am a partition comment because I don't have f o o */
+                export * from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
     ruleTester.run(`${ruleName}(${type}): sorts by group kind`, rule, {
       invalid: [
         {

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2292,6 +2292,234 @@ describe(ruleName, () => {
       },
     )
 
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: './a',
+                  left: './b',
+                },
+                messageId: 'unexpectedImportsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  line: true,
+                },
+              },
+            ],
+            output: dedent`
+              /* Comment */
+              import a from './a'
+              import b from './b'
+              `,
+            code: dedent`
+              import b from './b'
+              /* Comment */
+              import a from './a'
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              code: dedent`
+                import b from './b'
+                // Comment
+                import a from './a'
+            `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['a', 'b'],
+                  },
+                },
+              ],
+              code: dedent`
+                import c from './c'
+                // b
+                import b from './b'
+                // a
+                import a from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+              code: dedent`
+                import b from './b'
+                // I am a partition comment because I don't have f o o
+                import a from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: './a',
+                  left: './b',
+                },
+                messageId: 'unexpectedImportsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  block: true,
+                },
+              },
+            ],
+            output: dedent`
+              // Comment
+              import a from './a'
+              import b from './b'
+            `,
+            code: dedent`
+              import b from './b'
+              // Comment
+              import a from './a'
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              code: dedent`
+                import b from './b'
+                /* Comment */
+                import a from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['a', 'b'],
+                  },
+                },
+              ],
+              code: dedent`
+                import c from './c'
+                /* b */
+                import b from './b'
+                /* a */
+                import a from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+              code: dedent`
+                import b from './b'
+                /* I am a partition comment because I don't have f o o */
+                import a from './a'
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): supports style imports with optional chaining`,
       rule,

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1864,6 +1864,254 @@ describe(ruleName, () => {
       },
     )
 
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'a',
+                  left: 'b',
+                },
+                messageId: 'unexpectedInterfacePropertiesOrder',
+              },
+            ],
+            output: dedent`
+                interface Interface {
+                  /* Comment */
+                  a: string
+                  b: string
+                }
+              `,
+            code: dedent`
+                interface Interface {
+                  b: string
+                  /* Comment */
+                  a: string
+                }
+              `,
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  line: true,
+                },
+              },
+            ],
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              code: dedent`
+                  interface Interface {
+                    b: string
+                    // Comment
+                    a: string
+                  }
+                `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                  interface Interface {
+                    c: string
+                    // b
+                    b: string
+                    // a
+                    a: string
+                  }
+                  `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['a', 'b'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                  interface Interface {
+                    b: string
+                    // I am a partition comment because I don't have f o o
+                    a: string
+                  }
+                `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'a',
+                  left: 'b',
+                },
+                messageId: 'unexpectedInterfacePropertiesOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  block: true,
+                },
+              },
+            ],
+            output: dedent`
+                interface Interface {
+                  // Comment
+                  a: string
+                  b: string
+                }
+            `,
+            code: dedent`
+                interface Interface {
+                  b: string
+                  // Comment
+                  a: string
+                }
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              code: dedent`
+                  interface Interface {
+                    b: string
+                    /* Comment */
+                    a: string
+                  }
+                `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                  interface Interface {
+                    c: string
+                    /* b */
+                    b: string
+                    /* a */
+                    a: string
+                  }
+                `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['a', 'b'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                  interface Interface {
+                    b: string
+                    /* I am a partition comment because I don't have f o o */
+                    a: string
+                  }
+                `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): allows to remove special characters`,
       rule,

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -697,6 +697,244 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                type Type =
+                  /* Comment */
+                  A &
+                  B
+              `,
+              code: dedent`
+                type Type =
+                  B &
+                  /* Comment */
+                  A
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B &
+                    // Comment
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    C &
+                    // B
+                    B &
+                    // A
+                    A
+                  `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B &
+                    // I am a partition comment because I don't have f o o
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+                type Type =
+                  // Comment
+                  A &
+                  B
+              `,
+              code: dedent`
+                type Type =
+                  B &
+                  // Comment
+                  A
+             `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B &
+                    /* Comment */
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    C &
+                    /* B */
+                    B &
+                    /* A */
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B &
+                    /* I am a partition comment because I don't have f o o */
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -475,6 +475,254 @@ describe(ruleName, () => {
         ],
         invalid: [],
       })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: "'a'",
+                    left: "'b'",
+                  },
+                  messageId: 'unexpectedMapElementsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                new Map([
+                  /* Comment */
+                  ['a', 'a'],
+                  ['b', 'b'],
+                ])
+              `,
+              code: dedent`
+                new Map([
+                  ['b', 'b'],
+                  /* Comment */
+                  ['a', 'a'],
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  new Map([
+                    ['b', 'b'],
+                    // Comment
+                    ['a', 'a'],
+                  ])
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  new Map([
+                    ['c', 'c'],
+                    // b
+                    ['b', 'b'],
+                    // a
+                    ['a', 'a'],
+                  ])
+                  `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  new Map([
+                    ['b', 'b'],
+                    // I am a partition comment because I don't have f o o
+                    ['a', 'a'],
+                  ])
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: "'a'",
+                    left: "'b'",
+                  },
+                  messageId: 'unexpectedMapElementsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+                new Map([
+                  // Comment
+                  ['a', 'a'],
+                  ['b', 'b'],
+                ])
+              `,
+              code: dedent`
+                new Map([
+                  ['b', 'b'],
+                  // Comment
+                  ['a', 'a'],
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  new Map([
+                    ['b', 'b'],
+                    /* Comment */
+                    ['a', 'a'],
+                  ])
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  new Map([
+                    ['c', 'c'],
+                    /* b */
+                    ['b', 'b'],
+                    /* a */
+                    ['a', 'a'],
+                  ])
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  new Map([
+                    ['b', 'b'],
+                    /* I am a partition comment because I don't have f o o */
+                    ['a', 'a'],
+                  ])
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -3171,6 +3171,226 @@ describe(ruleName, () => {
             invalid: [],
           },
         )
+
+        describe(`${ruleName}: allows to use "partitionByComment.line"`, () => {
+          ruleTester.run(`${ruleName}: ignores block comments`, rule, {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      right: 'a',
+                      left: 'b',
+                    },
+                    messageId: 'unexpectedModulesOrder',
+                  },
+                ],
+                options: [
+                  {
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                output: dedent`
+                  /* Comment */
+                  function a() {}
+                  function b() {}
+                `,
+                code: dedent`
+                  function b() {}
+                  /* Comment */
+                  function a() {}
+                `,
+              },
+            ],
+            valid: [],
+          })
+
+          ruleTester.run(
+            `${ruleName}: allows to use all comments as parts`,
+            rule,
+            {
+              valid: [
+                {
+                  options: [
+                    {
+                      partitionByComment: {
+                        line: true,
+                      },
+                    },
+                  ],
+                  code: dedent`
+                    function b() {}
+                    // Comment
+                    function a() {}
+                  `,
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use multiple partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  code: dedent`
+                    function c() {}
+                    // b
+                    function b() {}
+                    // a
+                    function a() {}
+                  `,
+                  options: [
+                    {
+                      partitionByComment: {
+                        line: ['a', 'b'],
+                      },
+                    },
+                  ],
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use regex for partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  options: [
+                    {
+                      partitionByComment: {
+                        line: ['^(?!.*foo).*$'],
+                      },
+                    },
+                  ],
+                  code: dedent`
+                    function b() {}
+                    // I am a partition comment because I don't have f o o
+                    function a() {}
+                  `,
+                },
+              ],
+              invalid: [],
+            },
+          )
+        })
+
+        describe(`${ruleName}: allows to use "partitionByComment.block"`, () => {
+          ruleTester.run(`${ruleName}: ignores line comments`, rule, {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      right: 'a',
+                      left: 'b',
+                    },
+                    messageId: 'unexpectedModulesOrder',
+                  },
+                ],
+                options: [
+                  {
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                output: dedent`
+                  // Comment
+                  function a() {}
+                  function b() {}
+                `,
+                code: dedent`
+                  function b() {}
+                  // Comment
+                  function a() {}
+                `,
+              },
+            ],
+            valid: [],
+          })
+
+          ruleTester.run(
+            `${ruleName}: allows to use all comments as parts`,
+            rule,
+            {
+              valid: [
+                {
+                  options: [
+                    {
+                      partitionByComment: {
+                        block: true,
+                      },
+                    },
+                  ],
+                  code: dedent`
+                    function b() {}
+                    /* Comment */
+                    function a() {}
+                  `,
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use multiple partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  code: dedent`
+                    function c() {}
+                    /* b */
+                    function b() {}
+                    /* a */
+                    function a() {}
+                  `,
+                  options: [
+                    {
+                      partitionByComment: {
+                        block: ['a', 'b'],
+                      },
+                    },
+                  ],
+                },
+              ],
+              invalid: [],
+            },
+          )
+
+          ruleTester.run(
+            `${ruleName}: allows to use regex for partition comments`,
+            rule,
+            {
+              valid: [
+                {
+                  options: [
+                    {
+                      partitionByComment: {
+                        block: ['^(?!.*foo).*$'],
+                      },
+                    },
+                  ],
+                  code: dedent`
+                    function b() {}
+                    /* I am a partition comment because I don't have f o o */
+                    function a() {}
+                  `,
+                },
+              ],
+              invalid: [],
+            },
+          )
+        })
       })
 
       ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -390,6 +390,254 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedNamedExportsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                export {
+                  /* Comment */
+                  A,
+                  B,
+                }
+              `,
+              code: dedent`
+              export {
+                B,
+                /* Comment */
+                A,
+              }
+            `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                export {
+                  B,
+                  // Comment
+                  A,
+                }
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                export {
+                  C,
+                  // B
+                  B,
+                  // A
+                  A,
+                }
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                export {
+                  B,
+                  // I am a partition comment because I don't have f o o
+                  A,
+                }
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedNamedExportsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+              export {
+                // Comment
+                A,
+                B,
+              }
+            `,
+              code: dedent`
+              export {
+                B,
+                // Comment
+                A,
+              }
+            `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                export {
+                  B,
+                  /* Comment */
+                  A,
+                }
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                export {
+                  C,
+                  /* B */
+                  B,
+                  /* A */
+                  A,
+                }
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                export {
+                  B,
+                  /* I am a partition comment because I don't have f o o */
+                  A,
+                }
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -608,6 +608,254 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedNamedImportsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                import {
+                  /* Comment */
+                  A,
+                  B,
+                } from 'module'
+              `,
+              code: dedent`
+              import {
+                B,
+                /* Comment */
+                A,
+              } from 'module'
+            `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                import {
+                  B,
+                  // Comment
+                  A,
+                } from 'module'
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                import {
+                  C,
+                  // B
+                  B,
+                  // A
+                  A,
+                } from 'module'
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                import {
+                  B,
+                  // I am a partition comment because I don't have f o o
+                  A,
+                } from 'module'
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedNamedImportsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+              import {
+                // Comment
+                A,
+                B,
+              } from 'module'
+            `,
+              code: dedent`
+              import {
+                B,
+                // Comment
+                A,
+              } from 'module'
+            `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                import {
+                  B,
+                  /* Comment */
+                  A,
+                } from 'module'
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                import {
+                  C,
+                  /* B */
+                  B,
+                  /* A */
+                  A,
+                } from 'module'
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                import {
+                  B,
+                  /* I am a partition comment because I don't have f o o */
+                  A,
+                } from 'module'
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -1500,6 +1500,254 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedObjectTypesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                type Type = {
+                  /* Comment */
+                  a: string
+                  b: string
+                }
+              `,
+              code: dedent`
+                type Type = {
+                  b: string
+                  /* Comment */
+                  a: string
+                }
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type = {
+                    b: string
+                    // Comment
+                    a: string
+                  }
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  type Type = {
+                    c: string
+                    // b
+                    b: string
+                    // a
+                    a: string
+                  }
+                  `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  type Type = {
+                    b: string
+                    // I am a partition comment because I don't have f o o
+                    a: string
+                  }
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedObjectTypesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+                type Type = {
+                  // Comment
+                  a: string
+                  b: string
+                }
+            `,
+              code: dedent`
+                type Type = {
+                  b: string
+                  // Comment
+                  a: string
+                }
+            `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type = {
+                    b: string
+                    /* Comment */
+                    a: string
+                  }
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  type Type = {
+                    c: string
+                    /* b */
+                    b: string
+                    /* a */
+                    a: string
+                  }
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  type Type = {
+                    b: string
+                    /* I am a partition comment because I don't have f o o */
+                    a: string
+                  }
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1496,6 +1496,254 @@ describe(ruleName, () => {
       },
     )
 
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'a',
+                  left: 'b',
+                },
+                messageId: 'unexpectedObjectsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  line: true,
+                },
+              },
+            ],
+            output: dedent`
+              let Obj = {
+                /* Comment */
+                a: 'a',
+                b: 'b',
+              }
+            `,
+            code: dedent`
+              let Obj = {
+                b: 'b',
+                /* Comment */
+                a: 'a',
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              code: dedent`
+                let Obj = {
+                  b: 'b',
+                  // Comment
+                  a: 'a',
+                }
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                let Obj = {
+                  c: 'c',
+                  // b
+                  b: 'b',
+                  // a
+                  a: 'a',
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['a', 'b'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                let Obj = {
+                  b: 'b',
+                  // I am a partition comment because I don't have f o o
+                  a: 'a',
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'a',
+                  left: 'b',
+                },
+                messageId: 'unexpectedObjectsOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                partitionByComment: {
+                  block: true,
+                },
+              },
+            ],
+            output: dedent`
+              let Obj = {
+                // Comment
+                a: 'a',
+                b: 'b',
+              }
+            `,
+            code: dedent`
+              let Obj = {
+                b: 'b',
+                // Comment
+                a: 'a',
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              code: dedent`
+                let Obj = {
+                  b: 'b',
+                  /* Comment */
+                  a: 'a',
+                }
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                let Obj = {
+                  c: 'c',
+                  /* b */
+                  b: 'b',
+                  /* a */
+                  a: 'a',
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['a', 'b'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use regex for partition comments`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                let Obj = {
+                  b: 'b',
+                  /* I am a partition comment because I don't have f o o */
+                  a: 'a',
+                }
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: ['^(?!.*foo).*$'],
+                  },
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): allows to use new line as partition`,
       rule,

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -590,6 +590,254 @@ describe(ruleName, () => {
         ],
         invalid: [],
       })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedSetsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                new Set([
+                  /* Comment */
+                  'a',
+                  'b'
+                ])
+              `,
+              code: dedent`
+                new Set([
+                  'b',
+                  /* Comment */
+                  'a'
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  new Set([
+                    'b',
+                    // Comment
+                    'a'
+                  ])
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  new Set([
+                    'c',
+                    // b
+                    'b',
+                    // a
+                    'a'
+                  ])
+                  `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  new Set([
+                    'b',
+                    // I am a partition comment because I don't have f o o
+                    'a'
+                  ])
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedSetsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+                new Set([
+                  // Comment
+                  'a',
+                  'b'
+                ])
+            `,
+              code: dedent`
+                new Set([
+                  'b',
+                  // Comment
+                  'a'
+                ])
+            `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  new Set([
+                    'b',
+                    /* Comment */
+                    'a'
+                  ])
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                code: dedent`
+                  new Set([
+                    'c',
+                    /* b */
+                    'b',
+                    /* a */
+                    'a'
+                  ])
+                `,
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['a', 'b'],
+                    },
+                  },
+                ],
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                new Set([
+                  'b',
+                  /* I am a partition comment because I don't have f o o */
+                  'a'
+                ])
+              `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(
@@ -1498,7 +1746,7 @@ describe(ruleName, () => {
               'b',
               'c',
               'd',
-            ).includes(value)
+            )
           `,
           options: [options],
         },

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -700,6 +700,244 @@ describe(ruleName, () => {
           invalid: [],
         },
       )
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedUnionTypesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                type Type =
+                  /* Comment */
+                  A |
+                  B
+              `,
+              code: dedent`
+                type Type =
+                  B |
+                  /* Comment */
+                  A
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B |
+                    // Comment
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    C |
+                    // B
+                    B |
+                    // A
+                    A
+                  `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B |
+                    // I am a partition comment because I don't have f o o
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'A',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedUnionTypesOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+                type Type =
+                  // Comment
+                  A |
+                  B
+              `,
+              code: dedent`
+                type Type =
+                  B |
+                  // Comment
+                  A
+             `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B |
+                    /* Comment */
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['A', 'B'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    C |
+                    /* B */
+                    B |
+                    /* A */
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  type Type =
+                    B |
+                    /* I am a partition comment because I don't have f o o */
+                    A
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -871,6 +871,244 @@ describe(ruleName, () => {
         ],
         invalid: [],
       })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedVariableDeclarationsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    line: true,
+                  },
+                },
+              ],
+              output: dedent`
+                const
+                  /* Comment */
+                  a: 'a',
+                  b: 'b',
+              `,
+              code: dedent`
+                const
+                  b: 'b',
+                  /* Comment */
+                  a: 'a',
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  const
+                    b: 'b',
+                    // Comment
+                    a: 'a',
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['a', 'b'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  const
+                    c: 'c',
+                    // b
+                    b: 'b',
+                    // a
+                    a: 'a',
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      line: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  const
+                    b: 'b',
+                    // I am a partition comment because I don't have f o o
+                    a: 'a',
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
+        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedVariableDeclarationsOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  partitionByComment: {
+                    block: true,
+                  },
+                },
+              ],
+              output: dedent`
+                const
+                  // Comment
+                  a: 'a',
+                  b: 'b',
+              `,
+              code: dedent`
+                const
+                  b: 'b',
+                  // Comment
+                  a: 'a',
+              `,
+            },
+          ],
+          valid: [],
+        })
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use all comments as parts`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: true,
+                    },
+                  },
+                ],
+                code: dedent`
+                  const
+                    b: 'b',
+                    /* Comment */
+                    a: 'a',
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use multiple partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['a', 'b'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  const
+                    c: 'c',
+                    /* b */
+                    b: 'b',
+                    /* a */
+                    a: 'a',
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use regex for partition comments`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    partitionByComment: {
+                      block: ['^(?!.*foo).*$'],
+                    },
+                  },
+                ],
+                code: dedent`
+                  const
+                    b: 'b',
+                    /* I am a partition comment because I don't have f o o */
+                    a: 'a',
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
     })
 
     ruleTester.run(

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -89,19 +89,33 @@ export let customGroupsJsonSchema: JSONSchema4 = {
   type: 'object',
 }
 
-export let partitionByCommentJsonSchema: JSONSchema4 = {
-  anyOf: [
-    {
-      items: {
-        type: 'string',
-      },
-      type: 'array',
-    },
-    {
-      type: 'boolean',
-    },
-    {
+let allowedPartitionByCommentJsonSchemas: JSONSchema4[] = [
+  {
+    items: {
       type: 'string',
+    },
+    type: 'array',
+  },
+  {
+    type: 'boolean',
+  },
+  {
+    type: 'string',
+  },
+]
+export let partitionByCommentJsonSchema: JSONSchema4 = {
+  oneOf: [
+    ...allowedPartitionByCommentJsonSchemas,
+    {
+      properties: {
+        block: {
+          oneOf: allowedPartitionByCommentJsonSchemas,
+        },
+        line: {
+          oneOf: allowedPartitionByCommentJsonSchemas,
+        },
+      },
+      type: 'object',
     },
   ],
 }

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -57,7 +57,10 @@ export let getNodeRange = ({
 
     let eslintDisabledRules = getEslintDisabledRules(comment.value)
     if (
-      isPartitionComment(options?.partitionByComment ?? false, comment.value) ||
+      isPartitionComment({
+        partitionByComment: options?.partitionByComment ?? false,
+        comment,
+      }) ||
       eslintDisabledRules?.eslintDisableDirective === 'eslint-disable' ||
       eslintDisabledRules?.eslintDisableDirective === 'eslint-enable'
     ) {

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -9,7 +9,14 @@ import { getCommentsBefore } from './get-comments-before'
 
 interface GetNodeRangeParameters {
   options?: {
-    partitionByComment: string[] | boolean | string
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
   }
   ignoreHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -1,8 +1,15 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
 export type Settings = Partial<{
+  partitionByComment:
+    | {
+        block?: string[] | boolean | string
+        line?: string[] | boolean | string
+      }
+    | string[]
+    | boolean
+    | string
   type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-  partitionByComment: string[] | boolean | string
   specialCharacters: 'remove' | 'trim' | 'keep'
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean

--- a/utils/has-partition-comment.ts
+++ b/utils/has-partition-comment.ts
@@ -1,0 +1,26 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { isPartitionComment } from './is-partition-comment'
+
+interface HasPartitionCommentParameters {
+  partitionByComment:
+    | {
+        block?: string[] | boolean | string
+        line?: string[] | boolean | string
+      }
+    | string[]
+    | boolean
+    | string
+  comments: TSESTree.Comment[]
+}
+
+export let hasPartitionComment = ({
+  partitionByComment,
+  comments,
+}: HasPartitionCommentParameters): boolean =>
+  comments.some(comment =>
+    isPartitionComment({
+      partitionByComment,
+      comment,
+    }),
+  )

--- a/utils/is-partition-comment.ts
+++ b/utils/is-partition-comment.ts
@@ -3,24 +3,41 @@ import type { TSESTree } from '@typescript-eslint/types'
 import { getEslintDisabledRules } from './get-eslint-disabled-rules'
 import { matches } from './matches'
 
-export let isPartitionComment = (
-  partitionComment: string[] | boolean | string,
-  comment: string,
-): boolean => {
-  if (getEslintDisabledRules(comment) || !partitionComment) {
-    return false
-  }
-  return (
-    (Array.isArray(partitionComment) &&
-      partitionComment.some(pattern => matches(comment.trim(), pattern))) ||
-    (typeof partitionComment === 'string' &&
-      matches(comment.trim(), partitionComment)) ||
-    partitionComment === true
-  )
+interface IsPartitionCommentParameters {
+  partitionByComment: string[] | boolean | string
+  comment: TSESTree.Comment
 }
 
-export let hasPartitionComment = (
-  partitionComment: string[] | boolean | string,
-  comments: TSESTree.Comment[],
-): boolean =>
-  comments.some(comment => isPartitionComment(partitionComment, comment.value))
+export let isPartitionComment = ({
+  partitionByComment,
+  comment,
+}: IsPartitionCommentParameters): boolean => {
+  if (getEslintDisabledRules(comment.value) || !partitionByComment) {
+    return false
+  }
+
+  let trimmedComment = comment.value.trim()
+
+  return isTrimmedCommentPartitionComment({
+    partitionByComment,
+    trimmedComment,
+  })
+}
+
+let isTrimmedCommentPartitionComment = ({
+  partitionByComment,
+  trimmedComment,
+}: {
+  partitionByComment: string[] | boolean | string
+  trimmedComment: string
+}): boolean => {
+  if (typeof partitionByComment === 'boolean') {
+    return partitionByComment
+  }
+  if (typeof partitionByComment === 'string') {
+    return matches(trimmedComment.trim(), partitionByComment)
+  }
+  return partitionByComment.some(pattern =>
+    matches(trimmedComment.trim(), pattern),
+  )
+}

--- a/utils/is-partition-comment.ts
+++ b/utils/is-partition-comment.ts
@@ -1,10 +1,19 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import { AST_TOKEN_TYPES } from '@typescript-eslint/types'
+
 import { getEslintDisabledRules } from './get-eslint-disabled-rules'
 import { matches } from './matches'
 
 interface IsPartitionCommentParameters {
-  partitionByComment: string[] | boolean | string
+  partitionByComment:
+    | {
+        block?: string[] | boolean | string
+        line?: string[] | boolean | string
+      }
+    | string[]
+    | boolean
+    | string
   comment: TSESTree.Comment
 }
 
@@ -18,10 +27,30 @@ export let isPartitionComment = ({
 
   let trimmedComment = comment.value.trim()
 
-  return isTrimmedCommentPartitionComment({
-    partitionByComment,
-    trimmedComment,
-  })
+  if (
+    Array.isArray(partitionByComment) ||
+    typeof partitionByComment === 'boolean' ||
+    typeof partitionByComment === 'string'
+  ) {
+    return isTrimmedCommentPartitionComment({
+      partitionByComment,
+      trimmedComment,
+    })
+  }
+
+  let relevantPartitionByComment =
+    comment.type === AST_TOKEN_TYPES.Block
+      ? partitionByComment.block
+      : partitionByComment.line
+
+  return (
+    // eslint-disable-next-line no-undefined
+    relevantPartitionByComment !== undefined &&
+    isTrimmedCommentPartitionComment({
+      partitionByComment: relevantPartitionByComment,
+      trimmedComment,
+    })
+  )
 }
 
 let isTrimmedCommentPartitionComment = ({

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -7,7 +7,14 @@ import { getNodeRange } from './get-node-range'
 
 interface MakeFixesParameters {
   options?: {
-    partitionByComment: string[] | boolean | string
+    partitionByComment:
+      | {
+          block?: string[] | boolean | string
+          line?: string[] | boolean | string
+        }
+      | string[]
+      | boolean
+      | string
   }
   ignoreFirstNodeHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode


### PR DESCRIPTION
Resolves #432

Most of the lines added are tests and documentation.

### Description

Updates the `partitionByComment` option to support `block` and `line` filters:

```ts
type T = {
        block?: string[] | boolean | string;
        line?: string[] | boolean | string;
    }
    | string[]
    | boolean
    | string
```

### Affected rules

- `sort-enums`
- `sort-array-includes`
- `sort-sets`
- `sort-decorators`
- `sort-object-types`
- `sort-interfaces`
- `sort-modules`
- `sort-classes`
- `sort-variable-declarations`
- `sort-union-types`
- `sort-intersection-types`
- `sort-objects`
- `sort-named-imports`
- `sort-named-exports`
- `sort-maps`
- `sort-imports`
- `sort-exports`

### What is the purpose of this pull request?

- [x] New Feature
