### PR TITLE
feat: adds `newlines-between` to some rules

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -232,6 +232,22 @@ if ([
 
 Each group of elements (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between groups.
+
+- `ignore` — Do not report errors related to new lines.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed.
+
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
+This option is only applicable when `partitionByNewLine` is `false`.
+
 ### useConfigurationIf
 
 <sub>
@@ -300,6 +316,25 @@ Predefined groups are characterized by a selector.
 
 - `literal`: Array elements that are not spread values.
 - `spread`: Array elements that are spread values.
+
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
+}
+```
 
 ### customGroups
 
@@ -379,6 +414,7 @@ Custom groups have a higher priority than any predefined group.
                   specialCharacters: 'keep',
                   groupKind: 'literals-first',
                   partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   useConfigurationIf: {},
                   groups: [],
                   customGroups: [],
@@ -408,6 +444,7 @@ Custom groups have a higher priority than any predefined group.
                 specialCharacters: 'keep',
                 groupKind: 'literals-first',
                 partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 useConfigurationIf: {},
                 groups: [],
                 customGroups: [],

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -266,6 +266,10 @@ Specifies how new lines should be handled between class member groups.
 - `always` — Enforce one new line between each group, and forbid new lines inside a group.
 - `never` — No new lines are allowed in object types.
 
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
 This option is only applicable when `partitionByNewLine` is `false`.
 
 ### ignoreCallbackDependenciesPatterns
@@ -553,6 +557,25 @@ abstract class Example extends BaseExample {
 
   // private-function-property
   private functionProperty = function() {};
+}
+```
+
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
 }
 ```
 

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -248,6 +248,10 @@ Specifies how new lines should be handled between interface groups.
 - `always` — Enforce one new line between each group, and forbid new lines inside a group.
 - `never` — No new lines are allowed between interface members.
 
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
 This option is only applicable when `partitionByNewLine` is `false`.
 
 ### [DEPRECATED] groupKind
@@ -431,6 +435,25 @@ interface Interface {
   description?: string;
   // 'required-method'
   method(): string
+```
+
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
+}
 ```
 
 ### customGroups

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -176,6 +176,10 @@ Specifies how new lines should be handled between intersection type groups.
 - `always` — Enforce one new line between each group, and forbid new lines inside a group.
 - `never` — No new lines are allowed in intersection types.
 
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
 This option is only applicable when `partitionByNewLine` is `false`.
 
 ### groups
@@ -292,6 +296,25 @@ type Example =
     'named',
     ['intersection', 'union'],
     'unknown',
+  ]
+}
+```
+
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
   ]
 }
 ```

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -225,6 +225,25 @@ Within a given group, members will be sorted according to the `type`, `order`, `
 Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
 All members of the groups in the array will be sorted together as if they were part of a single group.
 
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
+}
+```
+
 ### customGroups
 
 <sub>
@@ -280,6 +299,7 @@ Custom group matching takes precedence over predefined group matching.
                   ignoreCase: true,
                   specialCharacters: 'keep',
                   ignorePattern: [],
+                  newlinesBetween: 'ignore',
                   groups: [],
                   customGroups: {},
                 },
@@ -307,6 +327,7 @@ Custom group matching takes precedence over predefined group matching.
                 ignoreCase: true,
                 specialCharacters: 'keep',
                 ignorePattern: [],
+                newlinesBetween: 'ignore',
                 groups: [],
                 customGroups: {},
               },

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -200,6 +200,12 @@ Allows you to specify names or patterns for JSX elements that should be ignored 
 
 You can specify their names or a regexp pattern to ignore, for example: `'^Table.+'` to ignore all object types whose names begin with the word Table.
 
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort members if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
 ### groups
 
 <sub>
@@ -299,6 +305,7 @@ Custom group matching takes precedence over predefined group matching.
                   ignoreCase: true,
                   specialCharacters: 'keep',
                   ignorePattern: [],
+                  partitionByNewLine: false,
                   newlinesBetween: 'ignore',
                   groups: [],
                   customGroups: {},
@@ -327,6 +334,7 @@ Custom group matching takes precedence over predefined group matching.
                 ignoreCase: true,
                 specialCharacters: 'keep',
                 ignorePattern: [],
+                partitionByNewLine: false,
                 newlinesBetween: 'ignore',
                 groups: [],
                 customGroups: {},

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -290,6 +290,10 @@ Specifies how new lines should be handled between module member groups.
 - `always` — Enforce one new line between each group, and forbid new lines inside a group.
 - `never` — No new lines are allowed in object types.
 
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
 This option is only applicable when `partitionByNewLine` is `false`.
 
 ### groups
@@ -496,6 +500,24 @@ Example:
  }
 ```
 
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
+}
+```
 
 ## Usage
 

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -213,6 +213,10 @@ Specifies how new lines should be handled between object type groups.
 - `always` — Enforce one new line between each group, and forbid new lines inside a group.
 - `never` — No new lines are allowed in object types.
 
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
 This option is only applicable when `partitionByNewLine` is `false`.
 
 ### [DEPRECATED] groupKind
@@ -527,6 +531,25 @@ type User = {
 +    }                                       // [!code ++]
 +  ]                                         // [!code ++]
  }
+```
+
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
+}
 ```
 
 ## Usage

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -235,6 +235,22 @@ let items = new Set([
 
 Each group of elements (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between groups.
+
+- `ignore` — Do not report errors related to new lines.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed.
+
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
+This option is only applicable when `partitionByNewLine` is `false`.
+
 ### groups
 
 <sub>
@@ -258,6 +274,25 @@ Predefined groups are characterized by a selector.
 
 - `literal`: Array elements that are not spread values.
 - `spread`: Array elements that are spread values.
+
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
+}
+```
 
 ### customGroups
 
@@ -337,6 +372,7 @@ Custom groups have a higher priority than any predefined group.
                   specialCharacters: 'keep',
                   groupKind: 'literals-first',
                   partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   useConfigurationIf: {},
                   groups: [],
                   customGroups: [],
@@ -366,6 +402,7 @@ Custom groups have a higher priority than any predefined group.
                 specialCharacters: 'keep',
                 groupKind: 'literals-first',
                 partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 useConfigurationIf: {},
                 groups: [],
                 customGroups: [],

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -196,6 +196,10 @@ Specifies how new lines should be handled between union type groups.
 - `always` — Enforce one new line between each group, and forbid new lines inside a group.
 - `never` — No new lines are allowed in union types.
 
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
 This option is only applicable when `partitionByNewLine` is `false`.
 
 ### groups
@@ -312,6 +316,25 @@ type Example =
     'named',
     ['intersection', 'union'],
     'unknown',
+  ]
+}
+```
+
+#### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
   ]
 }
 ```

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -12,6 +12,7 @@ import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
   specialCharactersJsonSchema,
+  newlinesBetweenJsonSchema,
   ignoreCaseJsonSchema,
   buildTypeJsonSchema,
   alphabetJsonSchema,
@@ -19,6 +20,7 @@ import {
   groupsJsonSchema,
   orderJsonSchema,
 } from '../utils/common-json-schemas'
+import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import {
@@ -35,6 +37,7 @@ import { hasPartitionComment } from '../utils/has-partition-comment'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
+import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -53,20 +56,23 @@ import { pairwise } from '../utils/pairwise'
  */
 let cachedGroupsByModifiersAndSelectors = new Map<string, string[]>()
 
+type MESSAGE_ID =
+  | 'missedSpacingBetweenArrayIncludesMembers'
+  | 'extraSpacingBetweenArrayIncludesMembers'
+  | 'unexpectedArrayIncludesGroupOrder'
+  | 'unexpectedArrayIncludesOrder'
+
 interface SortArrayIncludesSortingNode
   extends SortingNode<TSESTree.SpreadElement | TSESTree.Expression> {
   groupKind: 'literal' | 'spread'
 }
-
-type MESSAGE_ID =
-  | 'unexpectedArrayIncludesGroupOrder'
-  | 'unexpectedArrayIncludesOrder'
 
 export let defaultOptions: Required<Options[0]> = {
   groupKind: 'literals-first',
   specialCharacters: 'keep',
   partitionByComment: false,
   partitionByNewLine: false,
+  newlinesBetween: 'ignore',
   useConfigurationIf: {},
   type: 'alphabetical',
   ignoreCase: true,
@@ -97,6 +103,7 @@ export let jsonSchema: JSONSchema4 = {
       type: buildTypeJsonSchema({ withUnsorted: true }),
       partitionByNewLine: partitionByNewLineJsonSchema,
       specialCharacters: specialCharactersJsonSchema,
+      newlinesBetween: newlinesBetweenJsonSchema,
       ignoreCase: ignoreCaseJsonSchema,
       alphabet: alphabetJsonSchema,
       locales: localesJsonSchema,
@@ -125,6 +132,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             : node.object.arguments
         sortArray<MESSAGE_ID>({
           availableMessageIds: {
+            missedSpacingBetweenMembers:
+              'missedSpacingBetweenArrayIncludesMembers',
+            extraSpacingBetweenMembers:
+              'extraSpacingBetweenArrayIncludesMembers',
             unexpectedGroupOrder: 'unexpectedArrayIncludesGroupOrder',
             unexpectedOrder: 'unexpectedArrayIncludesOrder',
           },
@@ -138,6 +149,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
     messages: {
       unexpectedArrayIncludesGroupOrder:
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+      missedSpacingBetweenArrayIncludesMembers:
+        'Missed spacing between "{{left}}" and "{{right}}" members.',
+      extraSpacingBetweenArrayIncludesMembers:
+        'Extra spacing between "{{left}}" and "{{right}}" members.',
       unexpectedArrayIncludesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },
@@ -160,6 +175,8 @@ export let sortArray = <MessageIds extends string>({
   context,
 }: {
   availableMessageIds: {
+    missedSpacingBetweenMembers: MessageIds
+    extraSpacingBetweenMembers: MessageIds
     unexpectedGroupOrder: MessageIds
     unexpectedOrder: MessageIds
   }
@@ -200,6 +217,7 @@ export let sortArray = <MessageIds extends string>({
     groups: options.groups,
     modifiers: [],
   })
+  validateNewlinesAndPartitionConfiguration(options)
 
   let eslintDisabledLines = getEslintDisabledLines({
     ruleName: context.id,
@@ -331,34 +349,54 @@ export let sortArray = <MessageIds extends string>({
 
       let indexOfRightExcludingEslintDisabled =
         sortedNodesExcludingEslintDisabled.indexOf(right)
-      if (
-        leftIndex < rightIndex &&
-        leftIndex < indexOfRightExcludingEslintDisabled
-      ) {
-        return
-      }
 
-      context.report({
-        fix: fixer =>
-          makeFixes({
-            sortedNodes: sortedNodesExcludingEslintDisabled,
-            sourceCode,
-            options,
-            fixer,
-            nodes,
-          }),
-        data: {
-          right: toSingleLine(right.name),
-          left: toSingleLine(left.name),
-          rightGroup: right.group,
-          leftGroup: left.group,
-        },
-        messageId:
+      let messageIds: MessageIds[] = []
+
+      if (
+        leftIndex > rightIndex ||
+        leftIndex >= indexOfRightExcludingEslintDisabled
+      ) {
+        messageIds.push(
           leftNumber === rightNumber
             ? availableMessageIds.unexpectedOrder
             : availableMessageIds.unexpectedGroupOrder,
-        node: right.node,
-      })
+        )
+      }
+
+      messageIds = [
+        ...messageIds,
+        ...getNewlinesErrors({
+          missedSpacingError: availableMessageIds.missedSpacingBetweenMembers,
+          extraSpacingError: availableMessageIds.extraSpacingBetweenMembers,
+          rightNum: rightNumber,
+          leftNum: leftNumber,
+          sourceCode,
+          options,
+          right,
+          left,
+        }),
+      ]
+
+      for (let messageId of messageIds) {
+        context.report({
+          fix: fixer =>
+            makeFixes({
+              sortedNodes: sortedNodesExcludingEslintDisabled,
+              sourceCode,
+              options,
+              fixer,
+              nodes,
+            }),
+          data: {
+            right: toSingleLine(right.name),
+            left: toSingleLine(left.name),
+            rightGroup: right.group,
+            leftGroup: left.group,
+          },
+          node: right.node,
+          messageId,
+        })
+      }
     })
   }
 }

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -20,6 +20,7 @@ import {
   orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
+import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import {
   singleCustomGroupJsonSchema,
   allSelectors,
@@ -192,6 +193,7 @@ export let sortArray = <MessageIds extends string>({
     ...completeOptions,
     type,
   }
+  validateCustomSortConfiguration(options)
   validateGeneratedGroupsConfiguration({
     customGroups: options.customGroups,
     selectors: allSelectors,

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -14,6 +14,11 @@ export type Options = Partial<{
     | string[]
     | boolean
     | string
+  groups: (
+    | { newlinesBetween: 'ignore' | 'always' | 'never' }
+    | Group[]
+    | Group
+  )[]
   type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
   useConfigurationIf: {
     allNamesMatchPattern?: string
@@ -22,11 +27,11 @@ export type Options = Partial<{
    * @deprecated for {@link `groups`}
    */
   groupKind: 'literals-first' | 'spreads-first' | 'mixed'
+  newlinesBetween: 'ignore' | 'always' | 'never'
   specialCharacters: 'remove' | 'trim' | 'keep'
   locales: NonNullable<Intl.LocalesArgument>
   customGroups: CustomGroup[]
   partitionByNewLine: boolean
-  groups: (Group[] | Group)[]
   order: 'desc' | 'asc'
   ignoreCase: boolean
   alphabet: string

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -34,9 +34,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       unexpectedInterfacePropertiesGroupOrder:
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       missedSpacingBetweenInterfaceMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" interfaces.',
+        'Missed spacing between "{{left}}" and "{{right}}" properties.',
       extraSpacingBetweenInterfaceMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" interfaces.',
+        'Extra spacing between "{{left}}" and "{{right}}" properties.',
       unexpectedInterfacePropertiesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -145,9 +145,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       unexpectedObjectTypesGroupOrder:
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
       missedSpacingBetweenObjectTypeMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" types.',
+        'Missed spacing between "{{left}}" and "{{right}}" properties.',
       extraSpacingBetweenObjectTypeMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" types.',
+        'Extra spacing between "{{left}}" and "{{right}}" properties.',
       unexpectedObjectTypesOrder:
         'Expected "{{right}}" to come before "{{left}}".',
     },

--- a/rules/sort-sets.ts
+++ b/rules/sort-sets.ts
@@ -3,7 +3,11 @@ import type { Options } from './sort-array-includes/types'
 import { defaultOptions, jsonSchema, sortArray } from './sort-array-includes'
 import { createEslintRule } from '../utils/create-eslint-rule'
 
-type MESSAGE_ID = 'unexpectedSetsGroupOrder' | 'unexpectedSetsOrder'
+type MESSAGE_ID =
+  | 'missedSpacingBetweenSetsMembers'
+  | 'extraSpacingBetweenSetsMembers'
+  | 'unexpectedSetsGroupOrder'
+  | 'unexpectedSetsOrder'
 
 export default createEslintRule<Options, MESSAGE_ID>({
   create: context => ({
@@ -23,6 +27,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
             : node.arguments[0].arguments
         sortArray<MESSAGE_ID>({
           availableMessageIds: {
+            missedSpacingBetweenMembers: 'missedSpacingBetweenSetsMembers',
+            extraSpacingBetweenMembers: 'extraSpacingBetweenSetsMembers',
             unexpectedGroupOrder: 'unexpectedSetsGroupOrder',
             unexpectedOrder: 'unexpectedSetsOrder',
           },
@@ -36,6 +42,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
     messages: {
       unexpectedSetsGroupOrder:
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
+      missedSpacingBetweenSetsMembers:
+        'Missed spacing between "{{left}}" and "{{right}}" members.',
+      extraSpacingBetweenSetsMembers:
+        'Extra spacing between "{{left}}" and "{{right}}" members.',
       unexpectedSetsOrder: 'Expected "{{right}}" to come before "{{left}}".',
     },
     docs: {

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1455,6 +1455,294 @@ describe(ruleName, () => {
         },
       )
     })
+
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'y',
+                    left: 'a',
+                  },
+                  messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                },
+                {
+                  data: {
+                    right: 'b',
+                    left: 'z',
+                  },
+                  messageId: 'unexpectedArrayIncludesOrder',
+                },
+                {
+                  data: {
+                    right: 'b',
+                    left: 'z',
+                  },
+                  messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                },
+              ],
+              code: dedent`
+                [
+                  'a',
+
+
+                 'y',
+                'z',
+
+                    'b'
+                ].includes(value)
+              `,
+              output: dedent`
+                [
+                  'a',
+                 'b',
+                'y',
+                    'z'
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'z',
+                    left: 'a',
+                  },
+                  messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                },
+                {
+                  data: {
+                    right: 'y',
+                    left: 'z',
+                  },
+                  messageId: 'unexpectedArrayIncludesOrder',
+                },
+                {
+                  data: {
+                    right: 'b',
+                    left: 'y',
+                  },
+                  messageId: 'missedSpacingBetweenArrayIncludesMembers',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                    {
+                      elementNamePattern: 'b',
+                      groupName: 'b',
+                    },
+                  ],
+                  groups: ['a', 'unknown', 'b'],
+                  newlinesBetween: 'always',
+                },
+              ],
+              output: dedent`
+                [
+                  'a',
+
+                 'y',
+                'z',
+
+                    'b',
+                ].includes(value)
+                `,
+              code: dedent`
+                [
+                  'a',
+
+
+                 'z',
+                'y',
+                    'b',
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    { elementNamePattern: 'a', groupName: 'a' },
+                    { elementNamePattern: 'b', groupName: 'b' },
+                    { elementNamePattern: 'c', groupName: 'c' },
+                    { elementNamePattern: 'd', groupName: 'd' },
+                    { elementNamePattern: 'e', groupName: 'e' },
+                  ],
+                  groups: [
+                    'a',
+                    { newlinesBetween: 'always' },
+                    'b',
+                    { newlinesBetween: 'always' },
+                    'c',
+                    { newlinesBetween: 'never' },
+                    'd',
+                    { newlinesBetween: 'ignore' },
+                    'e',
+                  ],
+                  newlinesBetween: 'always',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'missedSpacingBetweenArrayIncludesMembers',
+                },
+                {
+                  data: {
+                    right: 'c',
+                    left: 'b',
+                  },
+                  messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                },
+                {
+                  data: {
+                    right: 'd',
+                    left: 'c',
+                  },
+                  messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                },
+              ],
+              output: dedent`
+                [
+                  'a',
+
+                  'b',
+
+                  'c',
+                  'd',
+
+
+                  'e'
+                ].includes(value)
+              `,
+              code: dedent`
+                [
+                  'a',
+                  'b',
+
+
+                  'c',
+
+                  'd',
+
+
+                  'e'
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): handles newlines and comment after fixes`,
+        rule,
+        {
+          invalid: [
+            {
+              output: [
+                dedent`
+                  [
+                    'a', // Comment after
+                    'b',
+
+                    'c'
+                  ].includes(value)
+                `,
+                dedent`
+                  [
+                    'a', // Comment after
+
+                    'b',
+                    'c'
+                  ].includes(value)
+                `,
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      elementNamePattern: 'b|c',
+                      groupName: 'b|c',
+                    },
+                  ],
+                  groups: ['unknown', 'b|c'],
+                  newlinesBetween: 'always',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'unknown',
+                    leftGroup: 'b|c',
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedArrayIncludesGroupOrder',
+                },
+              ],
+              code: dedent`
+                [
+                  'b',
+                  'a', // Comment after
+
+                  'c'
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -591,6 +591,280 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    describe(`${ruleName}: newlinesBetween`, () => {
+      ruleTester.run(
+        `${ruleName}(${type}): removes newlines when never`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'y',
+                    left: 'a',
+                  },
+                  messageId: 'extraSpacingBetweenJSXPropsMembers',
+                },
+                {
+                  data: {
+                    right: 'b',
+                    left: 'z',
+                  },
+                  messageId: 'unexpectedJSXPropsOrder',
+                },
+                {
+                  data: {
+                    right: 'b',
+                    left: 'z',
+                  },
+                  messageId: 'extraSpacingBetweenJSXPropsMembers',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  customGroups: { a: 'a' },
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                },
+              ],
+              code: dedent`
+                <Component
+                  a
+
+
+                 y
+                z
+
+                    b
+                />
+              `,
+              output: dedent`
+                <Component
+                  a
+                 b
+                y
+                    z
+                />
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): keeps one newline when always`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'z',
+                    left: 'a',
+                  },
+                  messageId: 'extraSpacingBetweenJSXPropsMembers',
+                },
+                {
+                  data: {
+                    right: 'y',
+                    left: 'z',
+                  },
+                  messageId: 'unexpectedJSXPropsOrder',
+                },
+                {
+                  data: {
+                    right: 'b',
+                    left: 'y',
+                  },
+                  messageId: 'missedSpacingBetweenJSXPropsMembers',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  customGroups: {
+                    a: 'a',
+                    b: 'b',
+                  },
+                  groups: ['a', 'unknown', 'b'],
+                  newlinesBetween: 'always',
+                },
+              ],
+              output: dedent`
+                <Component
+                  a
+
+                 y
+                z
+
+                    b
+                />
+                `,
+              code: dedent`
+                <Component
+                  a
+
+
+                 z
+                y
+                    b
+                />
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  groups: [
+                    'a',
+                    { newlinesBetween: 'always' },
+                    'b',
+                    { newlinesBetween: 'always' },
+                    'c',
+                    { newlinesBetween: 'never' },
+                    'd',
+                    { newlinesBetween: 'ignore' },
+                    'e',
+                  ],
+                  customGroups: {
+                    a: 'a',
+                    b: 'b',
+                    c: 'c',
+                    d: 'd',
+                    e: 'e',
+                  },
+                  newlinesBetween: 'always',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'missedSpacingBetweenJSXPropsMembers',
+                },
+                {
+                  data: {
+                    right: 'c',
+                    left: 'b',
+                  },
+                  messageId: 'extraSpacingBetweenJSXPropsMembers',
+                },
+                {
+                  data: {
+                    right: 'd',
+                    left: 'c',
+                  },
+                  messageId: 'extraSpacingBetweenJSXPropsMembers',
+                },
+              ],
+              output: dedent`
+                <Component
+                  a
+
+                  b
+
+                  c
+                  d
+
+
+                  e
+                />
+              `,
+              code: dedent`
+                <Component
+                  a
+                  b
+
+
+                  c
+
+                  d
+
+
+                  e
+                />
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): handles newlines and comment after fixes`,
+        rule,
+        {
+          invalid: [
+            {
+              output: [
+                dedent`
+                  <Component
+                    a // Comment after
+                    b
+
+                    c
+                  />
+                `,
+                dedent`
+                  <Component
+                    a // Comment after
+
+                    b
+                    c
+                  />
+                `,
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'unknown',
+                    leftGroup: 'b|c',
+                    right: 'a',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedJSXPropsGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: {
+                    'b|c': 'b|c',
+                  },
+                  groups: ['unknown', 'b|c'],
+                  newlinesBetween: 'always',
+                },
+              ],
+              code: dedent`
+                <Component
+                  b
+                  a // Comment after
+
+                  c
+                />
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -592,6 +592,62 @@ describe(ruleName, () => {
       invalid: [],
     })
 
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use new line as partition`,
+      rule,
+      {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  right: 'a',
+                  left: 'd',
+                },
+                messageId: 'unexpectedJSXPropsOrder',
+              },
+              {
+                data: {
+                  right: 'b',
+                  left: 'e',
+                },
+                messageId: 'unexpectedJSXPropsOrder',
+              },
+            ],
+            output: dedent`
+                <Component
+                  a
+                  d
+
+                  c
+
+                  b
+                  e
+                />
+              `,
+            code: dedent`
+                <Component
+                  d
+                  a
+
+                  c
+
+                  e
+                  b
+                />
+              `,
+            options: [
+              {
+                ...options,
+                partitionByNewLine: true,
+              },
+            ],
+          },
+        ],
+        valid: [],
+      },
+    )
+
     describe(`${ruleName}: newlinesBetween`, () => {
       ruleTester.run(
         `${ruleName}(${type}): removes newlines when never`,


### PR DESCRIPTION
Most lines added are documentation and tests.

### Description

This PR adds the following:
- `sort-array-includes`: `newlines-between`.
- `sort-sets`: `netwlines-between`.
- `sort-jsx-props`: `netwlines-between` and `partition-by-newlines`.

Bonus:
- Adds missing documentation in other rules.

### What is the purpose of this pull request?

- [x] New Feature
