### PR TITLE
refactor: reduces code duplication

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -86,11 +86,6 @@ export let defaultOptions: Required<Options[0]> = {
 export let jsonSchema: JSONSchema4 = {
   items: {
     properties: {
-      partitionByComment: {
-        ...partitionByCommentJsonSchema,
-        description:
-          'Allows you to use comments to separate the array members into logical groups.',
-      },
       groupKind: {
         enum: ['mixed', 'literals-first', 'spreads-first'],
         description: 'Specifies top-level groups.',
@@ -101,6 +96,7 @@ export let jsonSchema: JSONSchema4 = {
       }),
       useConfigurationIf: buildUseConfigurationIfJsonSchema(),
       type: buildTypeJsonSchema({ withUnsorted: true }),
+      partitionByComment: partitionByCommentJsonSchema,
       partitionByNewLine: partitionByNewLineJsonSchema,
       specialCharacters: specialCharactersJsonSchema,
       newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -38,11 +38,10 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -365,26 +364,16 @@ export let sortArray = <MessageIds extends string>({
         }),
       ]
 
-      for (let messageId of messageIds) {
-        context.report({
-          fix: fixer =>
-            makeFixes({
-              sortedNodes: sortedNodesExcludingEslintDisabled,
-              sourceCode,
-              options,
-              fixer,
-              nodes,
-            }),
-          data: {
-            right: toSingleLine(right.name),
-            left: toSingleLine(left.name),
-            rightGroup: right.group,
-            leftGroup: left.group,
-          },
-          node: right.node,
-          messageId,
-        })
-      }
+      reportErrors({
+        sortedNodes: sortedNodesExcludingEslintDisabled,
+        sourceCode,
+        messageIds,
+        options,
+        context,
+        nodes,
+        right,
+        left,
+      })
     })
   }
 }

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -11,14 +11,10 @@ import {
   buildCustomGroupsArrayJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
@@ -86,6 +82,7 @@ export let defaultOptions: Required<Options[0]> = {
 export let jsonSchema: JSONSchema4 = {
   items: {
     properties: {
+      ...commonJsonSchemas,
       groupKind: {
         enum: ['mixed', 'literals-first', 'spreads-first'],
         description: 'Specifies top-level groups.',
@@ -98,13 +95,8 @@ export let jsonSchema: JSONSchema4 = {
       type: buildTypeJsonSchema({ withUnsorted: true }),
       partitionByComment: partitionByCommentJsonSchema,
       partitionByNewLine: partitionByNewLineJsonSchema,
-      specialCharacters: specialCharactersJsonSchema,
       newlinesBetween: newlinesBetweenJsonSchema,
-      ignoreCase: ignoreCaseJsonSchema,
-      alphabet: alphabetJsonSchema,
-      locales: localesJsonSchema,
       groups: groupsJsonSchema,
-      order: orderJsonSchema,
     },
     additionalProperties: false,
     type: 'object',

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  CommonOptions,
   GroupOptions,
 } from '../../types/common-options'
 
@@ -10,26 +11,23 @@ import {
   elementNamePatternJsonSchema,
 } from '../../utils/common-json-schemas'
 
-export type Options = Partial<{
-  type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
-  useConfigurationIf: {
-    allNamesMatchPattern?: string
-  }
-  /**
-   * @deprecated for {@link `groups`}
-   */
-  groupKind: 'literals-first' | 'spreads-first' | 'mixed'
-  newlinesBetween: 'ignore' | 'always' | 'never'
-  specialCharacters: 'remove' | 'trim' | 'keep'
-  partitionByComment: PartitionByCommentOption
-  locales: NonNullable<Intl.LocalesArgument>
-  groups: GroupOptions<Group>
-  customGroups: CustomGroup[]
-  partitionByNewLine: boolean
-  order: 'desc' | 'asc'
-  ignoreCase: boolean
-  alphabet: string
-}>[]
+export type Options = Partial<
+  {
+    type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
+    useConfigurationIf: {
+      allNamesMatchPattern?: string
+    }
+    /**
+     * @deprecated for {@link `groups`}
+     */
+    groupKind: 'literals-first' | 'spreads-first' | 'mixed'
+    newlinesBetween: 'ignore' | 'always' | 'never'
+    partitionByComment: PartitionByCommentOption
+    groups: GroupOptions<Group>
+    customGroups: CustomGroup[]
+    partitionByNewLine: boolean
+  } & CommonOptions
+>[]
 
 export interface SingleCustomGroup {
   elementNamePattern?: string

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -1,19 +1,13 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { PartitionByCommentOption } from '../../types/common-options'
+
 import {
   buildCustomGroupSelectorJsonSchema,
   elementNamePatternJsonSchema,
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
-  partitionByComment:
-    | {
-        block?: string[] | boolean | string
-        line?: string[] | boolean | string
-      }
-    | string[]
-    | boolean
-    | string
   groups: (
     | { newlinesBetween: 'ignore' | 'always' | 'never' }
     | Group[]
@@ -29,6 +23,7 @@ export type Options = Partial<{
   groupKind: 'literals-first' | 'spreads-first' | 'mixed'
   newlinesBetween: 'ignore' | 'always' | 'never'
   specialCharacters: 'remove' | 'trim' | 'keep'
+  partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
   customGroups: CustomGroup[]
   partitionByNewLine: boolean

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -1,6 +1,9 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { PartitionByCommentOption } from '../../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../../types/common-options'
 
 import {
   buildCustomGroupSelectorJsonSchema,
@@ -8,11 +11,6 @@ import {
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | Group[]
-    | Group
-  )[]
   type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
   useConfigurationIf: {
     allNamesMatchPattern?: string
@@ -25,6 +23,7 @@ export type Options = Partial<{
   specialCharacters: 'remove' | 'trim' | 'keep'
   partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
+  groups: GroupOptions<Group>
   customGroups: CustomGroup[]
   partitionByNewLine: boolean
   order: 'desc' | 'asc'

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -3,7 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   CommonOptions,
-  GroupOptions,
+  GroupsOptions,
 } from '../../types/common-options'
 
 import {
@@ -23,7 +23,7 @@ export type Options = Partial<
     groupKind: 'literals-first' | 'spreads-first' | 'mixed'
     newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
-    groups: GroupOptions<Group>
+    groups: GroupsOptions<Group>
     customGroups: CustomGroup[]
     partitionByNewLine: boolean
   } & CommonOptions

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -1,5 +1,4 @@
 import type { TSESTree } from '@typescript-eslint/types'
-import type { TSESLint } from '@typescript-eslint/utils'
 
 import type {
   SortClassesOptions,
@@ -43,11 +42,10 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -645,27 +643,17 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           }),
         ]
 
-        for (let messageId of messageIds) {
-          context.report({
-            data: {
-              nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
-              right: toSingleLine(right.name),
-              left: toSingleLine(left.name),
-              rightGroup: right.group,
-              leftGroup: left.group,
-            },
-            fix: (fixer: TSESLint.RuleFixer) =>
-              makeFixes({
-                sortedNodes: sortedNodesExcludingEslintDisabled,
-                sourceCode,
-                options,
-                fixer,
-                nodes,
-              }),
-            node: right.node,
-            messageId,
-          })
-        }
+        reportErrors({
+          sortedNodes: sortedNodesExcludingEslintDisabled,
+          firstUnorderedNodeDependentOnRight,
+          sourceCode,
+          messageIds,
+          options,
+          context,
+          nodes,
+          right,
+          left,
+        })
       })
     },
   }),

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -685,14 +685,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             },
             type: 'array',
           },
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows to use comments to separate the class members into logical groups.',
-          },
           customGroups: buildCustomGroupsArrayJsonSchema({
             singleCustomGroupJsonSchema,
           }),
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -12,14 +12,10 @@ import {
   buildCustomGroupsArrayJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import {
   getFirstUnorderedNodeDependentOn,
@@ -677,6 +673,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           ignoreCallbackDependenciesPatterns: {
             description:
               'Patterns that should be ignored when detecting dependencies in method callbacks.',
@@ -690,14 +687,9 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           }),
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
           groups: groupsJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -1,6 +1,9 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { PartitionByCommentOption } from '../../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -12,17 +15,13 @@ import {
 
 export type SortClassesOptions = [
   Partial<{
-    groups: (
-      | { newlinesBetween: 'ignore' | 'always' | 'never' }
-      | Group[]
-      | Group
-    )[]
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     partitionByComment: PartitionByCommentOption
     ignoreCallbackDependenciesPatterns: string[]
     locales: NonNullable<Intl.LocalesArgument>
+    groups: GroupOptions<Group>
     partitionByNewLine: boolean
     customGroups: CustomGroup[]
     order: 'desc' | 'asc'

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { PartitionByCommentOption } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -11,14 +12,6 @@ import {
 
 export type SortClassesOptions = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     groups: (
       | { newlinesBetween: 'ignore' | 'always' | 'never' }
       | Group[]
@@ -27,6 +20,7 @@ export type SortClassesOptions = [
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     ignoreCallbackDependenciesPatterns: string[]
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  CommonOptions,
   GroupOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -13,23 +14,6 @@ import {
   elementNamePatternJsonSchema,
 } from '../../utils/common-json-schemas'
 
-export type SortClassesOptions = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    newlinesBetween: 'ignore' | 'always' | 'never'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    ignoreCallbackDependenciesPatterns: string[]
-    locales: NonNullable<Intl.LocalesArgument>
-    groups: GroupOptions<Group>
-    partitionByNewLine: boolean
-    customGroups: CustomGroup[]
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
-]
-
 export type SingleCustomGroup =
   | AdvancedSingleCustomGroup<FunctionPropertySelector>
   | AdvancedSingleCustomGroup<AccessorPropertySelector>
@@ -40,6 +24,20 @@ export type SingleCustomGroup =
   | BaseSingleCustomGroup<StaticBlockSelector>
   | BaseSingleCustomGroup<ConstructorSelector>
   | AdvancedSingleCustomGroup<MethodSelector>
+
+export type SortClassesOptions = [
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      newlinesBetween: 'ignore' | 'always' | 'never'
+      partitionByComment: PartitionByCommentOption
+      ignoreCallbackDependenciesPatterns: string[]
+      groups: GroupOptions<Group>
+      partitionByNewLine: boolean
+      customGroups: CustomGroup[]
+    } & CommonOptions
+  >,
+]
 
 export type CustomGroup = (
   | {

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -3,7 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   CommonOptions,
-  GroupOptions,
+  GroupsOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -32,7 +32,7 @@ export type SortClassesOptions = [
       newlinesBetween: 'ignore' | 'always' | 'never'
       partitionByComment: PartitionByCommentOption
       ignoreCallbackDependenciesPatterns: string[]
-      groups: GroupOptions<Group>
+      groups: GroupsOptions<Group>
       partitionByNewLine: boolean
       customGroups: CustomGroup[]
     } & CommonOptions

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -36,7 +36,7 @@ import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
-export type Options<T extends string[]> = [
+export type Options<T extends string = string> = [
   Partial<{
     partitionByComment:
       | {
@@ -47,8 +47,8 @@ export type Options<T extends string[]> = [
       | boolean
       | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    customGroups: Record<T[number], string[] | string>
     specialCharacters: 'remove' | 'trim' | 'keep'
+    customGroups: Record<T, string[] | string>
     locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     sortOnParameters: boolean
@@ -66,9 +66,9 @@ type MESSAGE_ID = 'unexpectedDecoratorsGroupOrder' | 'unexpectedDecoratorsOrder'
 
 type SortDecoratorsSortingNode = SortingNode<TSESTree.Decorator>
 
-type Group<T extends string[]> = 'unknown' | T[number]
+type Group<T extends string> = 'unknown' | T
 
-let defaultOptions: Required<Options<string[]>[0]> = {
+let defaultOptions: Required<Options[0]> = {
   specialCharacters: 'keep',
   partitionByComment: false,
   sortOnProperties: true,
@@ -85,7 +85,7 @@ let defaultOptions: Required<Options<string[]>[0]> = {
   groups: [],
 }
 
-export default createEslintRule<Options<string[]>, MESSAGE_ID>({
+export default createEslintRule<Options, MESSAGE_ID>({
   meta: {
     schema: [
       {
@@ -210,8 +210,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 })
 
 let sortDecorators = (
-  context: Readonly<RuleContext<MESSAGE_ID, Options<string[]>>>,
-  options: Required<Options<string[]>[0]>,
+  context: Readonly<RuleContext<MESSAGE_ID, Options>>,
+  options: Required<Options[0]>,
   decorators: TSESTree.Decorator[],
 ): void => {
   if (!isSortable(decorators)) {

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -84,11 +84,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the decorators into logical groups.',
-          },
           sortOnParameters: {
             description:
               'Controls whether sorting should be enabled for method parameter decorators.',
@@ -114,6 +109,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               'Controls whether sorting should be enabled for class decorators.',
             type: 'boolean',
           },
+          partitionByComment: partitionByCommentJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           customGroups: customGroupsJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -27,11 +27,10 @@ import { getNodeDecorators } from '../utils/get-node-decorators'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -266,27 +265,21 @@ let sortDecorators = (
     }
     let leftNumber = getGroupNumber(options.groups, left)
     let rightNumber = getGroupNumber(options.groups, right)
-    context.report({
-      fix: fixer =>
-        makeFixes({
-          sortedNodes: sortedNodesExcludingEslintDisabled,
-          ignoreFirstNodeHighestBlockComment: true,
-          sourceCode,
-          options,
-          fixer,
-          nodes,
-        }),
-      data: {
-        right: toSingleLine(right.name),
-        left: toSingleLine(left.name),
-        rightGroup: right.group,
-        leftGroup: left.group,
-      },
-      messageId:
+
+    reportErrors({
+      messageIds: [
         leftNumber === rightNumber
           ? 'unexpectedDecoratorsOrder'
           : 'unexpectedDecoratorsGroupOrder',
-      node: right.node,
+      ],
+      sortedNodes: sortedNodesExcludingEslintDisabled,
+      ignoreFirstNodeHighestBlockComment: true,
+      sourceCode,
+      options,
+      context,
+      nodes,
+      right,
+      left,
     })
   })
 }

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -1,6 +1,7 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -38,16 +39,9 @@ import { pairwise } from '../utils/pairwise'
 
 export type Options<T extends string = string> = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     customGroups: Record<T, string[] | string>
     locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -9,14 +9,10 @@ import type { SortingNode } from '../types/sorting-node'
 
 import {
   partitionByCommentJsonSchema,
-  specialCharactersJsonSchema,
   customGroupsJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
@@ -84,6 +80,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           sortOnParameters: {
             description:
               'Controls whether sorting should be enabled for method parameter decorators.',
@@ -110,14 +107,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'boolean',
           },
           partitionByComment: partitionByCommentJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
           customGroups: customGroupsJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
           groups: groupsJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -1,7 +1,10 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { PartitionByCommentOption } from '../types/common-options'
+import type {
+  PartitionByCommentOption,
+  CommonOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -38,22 +41,19 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 export type Options<T extends string = string> = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    customGroups: Record<T, string[] | string>
-    locales: NonNullable<Intl.LocalesArgument>
-    groups: (Group<T>[] | Group<T>)[]
-    sortOnParameters: boolean
-    sortOnProperties: boolean
-    sortOnAccessors: boolean
-    sortOnMethods: boolean
-    sortOnClasses: boolean
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      partitionByComment: PartitionByCommentOption
+      customGroups: Record<T, string[] | string>
+      groups: (Group<T>[] | Group<T>)[]
+      sortOnParameters: boolean
+      sortOnProperties: boolean
+      sortOnAccessors: boolean
+      sortOnMethods: boolean
+      sortOnClasses: boolean
+    } & CommonOptions
+  >,
 ]
 
 type MESSAGE_ID = 'unexpectedDecoratorsGroupOrder' | 'unexpectedDecoratorsOrder'

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -272,11 +272,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the members of enums into logical groups.',
-          },
           forceNumericSort: {
             description:
               'Will always sort numeric enums by their value regardless of the sort type specified.',
@@ -286,6 +281,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description: 'Compare enum values instead of names.',
             type: 'boolean',
           },
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -10,12 +10,8 @@ import type { CompareOptions } from '../utils/compare'
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
-  orderJsonSchema,
+  commonJsonSchemas,
 } from '../utils/common-json-schemas'
 import {
   getFirstUnorderedNodeDependentOn,
@@ -272,6 +268,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           forceNumericSort: {
             description:
               'Will always sort numeric enums by their value regardless of the sort type specified.',
@@ -283,12 +280,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           },
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -1,7 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type {
+  PartitionByCommentOption,
+  CommonOptions,
+} from '../types/common-options'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
-import type { PartitionByCommentOption } from '../types/common-options'
 import type { CompareOptions } from '../utils/compare'
 
 import {
@@ -38,18 +41,15 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 export type Options = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
-    forceNumericSort: boolean
-    order: 'desc' | 'asc'
-    sortByValue: boolean
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      partitionByComment: PartitionByCommentOption
+      partitionByNewLine: boolean
+      forceNumericSort: boolean
+      sortByValue: boolean
+    } & CommonOptions
+  >,
 ]
 
 interface SortEnumsSortingNode

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { CompareOptions } from '../utils/compare'
 
 import {
@@ -38,16 +39,9 @@ import { pairwise } from '../utils/pairwise'
 
 export type Options = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     forceNumericSort: boolean

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -1,6 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { PartitionByCommentOption } from '../types/common-options'
+import type {
+  PartitionByCommentOption,
+  CommonOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -30,17 +33,14 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 type Options = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    groupKind: 'values-first' | 'types-first' | 'mixed'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      groupKind: 'values-first' | 'types-first' | 'mixed'
+      partitionByComment: PartitionByCommentOption
+      partitionByNewLine: boolean
+    } & CommonOptions
+  >,
 ]
 
 interface SortExportsSortingNode

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -189,16 +189,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the exports into logical groups.',
-          },
           groupKind: {
             enum: ['mixed', 'values-first', 'types-first'],
             description: 'Specifies top-level groups.',
             type: 'string',
           },
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -1,5 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -30,17 +31,10 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     groupKind: 'values-first' | 'types-first' | 'mixed'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -21,9 +21,9 @@ import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { makeFixes } from '../utils/make-fixes'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -154,21 +154,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
               return
             }
 
-            context.report({
-              fix: fixer =>
-                makeFixes({
-                  sortedNodes: sortedNodesExcludingEslintDisabled,
-                  sourceCode,
-                  options,
-                  fixer,
-                  nodes,
-                }),
-              data: {
-                right: right.name,
-                left: left.name,
-              },
-              messageId: 'unexpectedExportsOrder',
-              node: right.node,
+            reportErrors({
+              sortedNodes: sortedNodesExcludingEslintDisabled,
+              messageIds: ['unexpectedExportsOrder'],
+              sourceCode,
+              options,
+              context,
+              nodes,
+              right,
+              left,
             })
           })
         }

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -9,12 +9,8 @@ import type { SortingNode } from '../types/sorting-node'
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
-  orderJsonSchema,
+  commonJsonSchemas,
 } from '../utils/common-json-schemas'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
@@ -189,6 +185,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           groupKind: {
             enum: ['mixed', 'values-first', 'types-first'],
             description: 'Specifies top-level groups.',
@@ -196,12 +193,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           },
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -31,11 +31,11 @@ import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
-export type Options<T extends string[]> = [
+export type Options<T extends string = string> = [
   Partial<{
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    customGroups: Record<T[number], string[] | string>
     specialCharacters: 'remove' | 'trim' | 'keep'
+    customGroups: Record<T, string[] | string>
     locales: NonNullable<Intl.LocalesArgument>
     groups: (Group<T>[] | Group<T>)[]
     order: 'desc' | 'asc'
@@ -48,9 +48,9 @@ type MESSAGE_ID =
   | 'unexpectedHeritageClausesGroupOrder'
   | 'unexpectedHeritageClausesOrder'
 
-type Group<T extends string[]> = 'unknown' | T[number]
+type Group<T extends string> = 'unknown' | T
 
-let defaultOptions: Required<Options<string[]>[0]> = {
+let defaultOptions: Required<Options[0]> = {
   specialCharacters: 'keep',
   type: 'alphabetical',
   ignoreCase: true,
@@ -61,7 +61,7 @@ let defaultOptions: Required<Options<string[]>[0]> = {
   groups: [],
 }
 
-export default createEslintRule<Options<string[]>, MESSAGE_ID>({
+export default createEslintRule<Options, MESSAGE_ID>({
   meta: {
     schema: [
       {
@@ -116,8 +116,8 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 })
 
 let sortHeritageClauses = (
-  context: Readonly<RuleContext<MESSAGE_ID, Options<string[]>>>,
-  options: Required<Options<string[]>[0]>,
+  context: Readonly<RuleContext<MESSAGE_ID, Options>>,
+  options: Required<Options[0]>,
   heritageClauses:
     | TSESTree.TSInterfaceHeritage[]
     | TSESTree.TSClassImplements[]

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -19,11 +19,10 @@ import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -165,25 +164,20 @@ let sortHeritageClauses = (
     }
     let leftNumber = getGroupNumber(options.groups, left)
     let rightNumber = getGroupNumber(options.groups, right)
-    context.report({
-      fix: fixer =>
-        makeFixes({
-          sortedNodes: sortedNodesExcludingEslintDisabled,
-          sourceCode,
-          fixer,
-          nodes,
-        }),
-      data: {
-        right: toSingleLine(right.name),
-        left: toSingleLine(left.name),
-        rightGroup: right.group,
-        leftGroup: left.group,
-      },
-      messageId:
+
+    reportErrors({
+      messageIds: [
         leftNumber === rightNumber
           ? 'unexpectedHeritageClausesOrder'
           : 'unexpectedHeritageClausesGroupOrder',
-      node: right.node,
+      ],
+      sortedNodes: sortedNodesExcludingEslintDisabled,
+      sourceCode,
+      options,
+      context,
+      nodes,
+      right,
+      left,
     })
   })
 }

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -1,6 +1,7 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { CommonOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -32,16 +33,13 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 export type Options<T extends string = string> = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    customGroups: Record<T, string[] | string>
-    locales: NonNullable<Intl.LocalesArgument>
-    groups: (Group<T>[] | Group<T>)[]
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      customGroups: Record<T, string[] | string>
+      groups: (Group<T>[] | Group<T>)[]
+    } & CommonOptions
+  >,
 ]
 
 type MESSAGE_ID =

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -5,14 +5,10 @@ import type { CommonOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
-  specialCharactersJsonSchema,
   customGroupsJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
@@ -64,14 +60,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          specialCharacters: specialCharactersJsonSchema,
+          ...commonJsonSchemas,
           customGroups: customGroupsJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
           groups: groupsJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -42,7 +42,7 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 import { matches } from '../utils/matches'
 
-export type Options<T extends string[]> = [
+export type Options<T extends string = string> = [
   Partial<{
     partitionByComment:
       | {
@@ -52,15 +52,15 @@ export type Options<T extends string[]> = [
       | string[]
       | boolean
       | string
-    customGroups: {
-      value?: Record<T[number], string[] | string>
-      type?: Record<T[number], string[] | string>
-    }
     groups: (
       | { newlinesBetween: 'ignore' | 'always' | 'never' }
       | Group<T>[]
       | Group<T>
     )[]
+    customGroups: {
+      value?: Record<T, string[] | string>
+      type?: Record<T, string[] | string>
+    }
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
@@ -83,7 +83,7 @@ export type MESSAGE_ID =
   | 'extraSpacingBetweenImports'
   | 'unexpectedImportsOrder'
 
-type Group<T extends string[]> =
+type Group<T extends string> =
   | 'side-effect-style'
   | 'external-type'
   | 'internal-type'
@@ -94,7 +94,6 @@ type Group<T extends string[]> =
   | 'index-type'
   | 'internal'
   | 'external'
-  | T[number]
   | 'sibling'
   | 'unknown'
   | 'builtin'
@@ -103,12 +102,13 @@ type Group<T extends string[]> =
   | 'index'
   | 'style'
   | 'type'
+  | T
 
 interface SortImportsSortingNode extends SortingNode {
   isIgnored: boolean
 }
 
-export default createEslintRule<Options<string[]>, MESSAGE_ID>({
+export default createEslintRule<Options, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -621,11 +621,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
             additionalProperties: false,
             type: 'object',
           },
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the interface properties into logical groups.',
-          },
           internalPattern: {
             description: 'Specifies the pattern for internal modules.',
             items: {
@@ -653,6 +648,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description: 'Specifies the tsConfig root directory.',
             type: 'string',
           },
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -2,7 +2,10 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { builtinModules } from 'node:module'
 
-import type { PartitionByCommentOption } from '../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -45,11 +48,6 @@ import { matches } from '../utils/matches'
 
 export type Options<T extends string = string> = [
   Partial<{
-    groups: (
-      | { newlinesBetween: 'ignore' | 'always' | 'never' }
-      | Group<T>[]
-      | Group<T>
-    )[]
     customGroups: {
       value?: Record<T, string[] | string>
       type?: Record<T, string[] | string>
@@ -59,6 +57,7 @@ export type Options<T extends string = string> = [
     specialCharacters: 'remove' | 'trim' | 'keep'
     partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
+    groups: GroupOptions<Group<T>>
     environment: 'node' | 'bun'
     partitionByNewLine: boolean
     internalPattern: string[]

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -4,7 +4,7 @@ import { builtinModules } from 'node:module'
 
 import type {
   PartitionByCommentOption,
-  GroupOptions,
+  GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -53,7 +53,7 @@ export type Options<T extends string = string> = [
     specialCharacters: 'remove' | 'trim' | 'keep'
     partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
-    groups: GroupOptions<Group<T>>
+    groups: GroupsOptions<Group<T>>
     environment: 'node' | 'bun'
     partitionByNewLine: boolean
     internalPattern: string[]

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -2,6 +2,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { builtinModules } from 'node:module'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -44,14 +45,6 @@ import { matches } from '../utils/matches'
 
 export type Options<T extends string = string> = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     groups: (
       | { newlinesBetween: 'ignore' | 'always' | 'never' }
       | Group<T>[]
@@ -64,6 +57,7 @@ export type Options<T extends string = string> = [
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     environment: 'node' | 'bun'
     partitionByNewLine: boolean

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -11,14 +11,10 @@ import type { SortingNode } from '../types/sorting-node'
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
@@ -606,6 +602,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           customGroups: {
             properties: {
               value: {
@@ -650,14 +647,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
           },
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
           groups: groupsJsonSchema,
-          order: orderJsonSchema,
         },
         definitions: {
           'max-line-length-requires-line-length-type': {

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -5,15 +5,11 @@ import type { SortingNode } from '../types/sorting-node'
 
 import {
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
   customGroupsJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
@@ -235,6 +231,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           ignorePattern: {
             description:
               'Specifies names or patterns for nodes that should be ignored by rule.',
@@ -244,15 +241,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'array',
           },
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
           customGroups: customGroupsJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
           groups: groupsJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { GroupOptions } from '../types/common-options'
+import type { CommonOptions, GroupOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -37,19 +37,16 @@ import { complete } from '../utils/complete'
 import { matches } from '../utils/matches'
 
 type Options<T extends string = string> = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    newlinesBetween: 'ignore' | 'always' | 'never'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    customGroups: Record<T, string[] | string>
-    locales: NonNullable<Intl.LocalesArgument>
-    groups: GroupOptions<Group<T>>
-    partitionByNewLine: boolean
-    ignorePattern: string[]
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      newlinesBetween: 'ignore' | 'always' | 'never'
+      customGroups: Record<T, string[] | string>
+      groups: GroupOptions<Group<T>>
+      partitionByNewLine: boolean
+      ignorePattern: string[]
+    } & CommonOptions
+  >,
 ]
 
 type MESSAGE_ID =

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { CommonOptions, GroupOptions } from '../types/common-options'
+import type { CommonOptions, GroupsOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -38,7 +38,7 @@ type Options<T extends string = string> = [
       type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       newlinesBetween: 'ignore' | 'always' | 'never'
       customGroups: Record<T, string[] | string>
-      groups: GroupOptions<Group<T>>
+      groups: GroupsOptions<Group<T>>
       partitionByNewLine: boolean
       ignorePattern: string[]
     } & CommonOptions

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -1,5 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { GroupOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -37,16 +38,12 @@ import { matches } from '../utils/matches'
 
 type Options<T extends string = string> = [
   Partial<{
-    groups: (
-      | { newlinesBetween: 'ignore' | 'always' | 'never' }
-      | Group<T>[]
-      | Group<T>
-    )[]
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     customGroups: Record<T, string[] | string>
     locales: NonNullable<Intl.LocalesArgument>
+    groups: GroupOptions<Group<T>>
     partitionByNewLine: boolean
     ignorePattern: string[]
     order: 'desc' | 'asc'

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -23,10 +23,10 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
@@ -203,26 +203,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
             }),
           ]
 
-          for (let messageId of messageIds) {
-            context.report({
-              fix: fixer =>
-                makeFixes({
-                  sortedNodes: sortedNodesExcludingEslintDisabled,
-                  sourceCode,
-                  options,
-                  fixer,
-                  nodes,
-                }),
-              data: {
-                rightGroup: right.group,
-                leftGroup: left.group,
-                right: right.name,
-                left: left.name,
-              },
-              node: right.node,
-              messageId,
-            })
-          }
+          reportErrors({
+            sortedNodes: sortedNodesExcludingEslintDisabled,
+            sourceCode,
+            messageIds,
+            options,
+            context,
+            nodes,
+            right,
+            left,
+          })
         })
       }
     },

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -35,7 +35,7 @@ import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
 import { matches } from '../utils/matches'
 
-type Options<T extends string[]> = [
+type Options<T extends string = string> = [
   Partial<{
     groups: (
       | { newlinesBetween: 'ignore' | 'always' | 'never' }
@@ -43,9 +43,9 @@ type Options<T extends string[]> = [
       | Group<T>
     )[]
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    customGroups: Record<T[number], string[] | string>
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    customGroups: Record<T, string[] | string>
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     ignorePattern: string[]
@@ -61,13 +61,9 @@ type MESSAGE_ID =
   | 'unexpectedJSXPropsGroupOrder'
   | 'unexpectedJSXPropsOrder'
 
-type Group<T extends string[]> =
-  | 'multiline'
-  | 'shorthand'
-  | 'unknown'
-  | T[number]
+type Group<T extends string> = 'multiline' | 'shorthand' | 'unknown' | T
 
-let defaultOptions: Required<Options<string[]>[0]> = {
+let defaultOptions: Required<Options[0]> = {
   specialCharacters: 'keep',
   newlinesBetween: 'ignore',
   partitionByNewLine: false,
@@ -81,7 +77,7 @@ let defaultOptions: Required<Options<string[]>[0]> = {
   groups: [],
 }
 
-export default createEslintRule<Options<string[]>, MESSAGE_ID>({
+export default createEslintRule<Options, MESSAGE_ID>({
   create: context => ({
     JSXElement: node => {
       if (!isSortable(node.openingElement.attributes)) {

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -263,15 +263,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: {
       items: {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the maps members into logical groups.',
-          },
           customGroups: buildCustomGroupsArrayJsonSchema({
             singleCustomGroupJsonSchema,
           }),
           useConfigurationIf: buildUseConfigurationIfJsonSchema(),
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -10,14 +10,10 @@ import {
   buildCustomGroupsArrayJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
@@ -263,20 +259,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: {
       items: {
         properties: {
+          ...commonJsonSchemas,
           customGroups: buildCustomGroupsArrayJsonSchema({
             singleCustomGroupJsonSchema,
           }),
           useConfigurationIf: buildUseConfigurationIfJsonSchema(),
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
           groups: groupsJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -32,11 +32,10 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -230,26 +229,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
               }),
             ]
 
-            for (let messageId of messageIds) {
-              context.report({
-                fix: fixer =>
-                  makeFixes({
-                    sortedNodes: sortedNodesExcludingEslintDisabled,
-                    sourceCode,
-                    options,
-                    fixer,
-                    nodes,
-                  }),
-                data: {
-                  right: toSingleLine(right.name),
-                  left: toSingleLine(left.name),
-                  rightGroup: right.group,
-                  leftGroup: left.group,
-                },
-                node: right.node,
-                messageId,
-              })
-            }
+            reportErrors({
+              sortedNodes: sortedNodesExcludingEslintDisabled,
+              sourceCode,
+              messageIds,
+              options,
+              context,
+              nodes,
+              right,
+              left,
+            })
           })
         }
       }

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -3,7 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   CommonOptions,
-  GroupOptions,
+  GroupsOptions,
 } from '../../types/common-options'
 
 import { elementNamePatternJsonSchema } from '../../utils/common-json-schemas'
@@ -16,7 +16,7 @@ export type Options = Partial<
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
-    groups: GroupOptions<Group>
+    groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     customGroups: CustomGroup[]
   } & CommonOptions

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -1,16 +1,10 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { PartitionByCommentOption } from '../../types/common-options'
+
 import { elementNamePatternJsonSchema } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
-  partitionByComment:
-    | {
-        block?: string[] | boolean | string
-        line?: string[] | boolean | string
-      }
-    | string[]
-    | boolean
-    | string
   groups: (
     | { newlinesBetween: 'ignore' | 'always' | 'never' }
     | Group[]
@@ -22,6 +16,7 @@ export type Options = Partial<{
   type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
   newlinesBetween: 'ignore' | 'always' | 'never'
   specialCharacters: 'remove' | 'trim' | 'keep'
+  partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
   customGroups: CustomGroup[]

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -2,27 +2,25 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  CommonOptions,
   GroupOptions,
 } from '../../types/common-options'
 
 import { elementNamePatternJsonSchema } from '../../utils/common-json-schemas'
 
-export type Options = Partial<{
-  useConfigurationIf: {
-    allNamesMatchPattern?: string
-  }
-  type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-  newlinesBetween: 'ignore' | 'always' | 'never'
-  specialCharacters: 'remove' | 'trim' | 'keep'
-  partitionByComment: PartitionByCommentOption
-  locales: NonNullable<Intl.LocalesArgument>
-  groups: GroupOptions<Group>
-  partitionByNewLine: boolean
-  customGroups: CustomGroup[]
-  order: 'desc' | 'asc'
-  ignoreCase: boolean
-  alphabet: string
-}>[]
+export type Options = Partial<
+  {
+    useConfigurationIf: {
+      allNamesMatchPattern?: string
+    }
+    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+    newlinesBetween: 'ignore' | 'always' | 'never'
+    partitionByComment: PartitionByCommentOption
+    groups: GroupOptions<Group>
+    partitionByNewLine: boolean
+    customGroups: CustomGroup[]
+  } & CommonOptions
+>[]
 
 export interface SingleCustomGroup {
   elementNamePattern?: string

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -1,15 +1,13 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { PartitionByCommentOption } from '../../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../../types/common-options'
 
 import { elementNamePatternJsonSchema } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | Group[]
-    | Group
-  )[]
   useConfigurationIf: {
     allNamesMatchPattern?: string
   }
@@ -18,6 +16,7 @@ export type Options = Partial<{
   specialCharacters: 'remove' | 'trim' | 'keep'
   partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
+  groups: GroupOptions<Group>
   partitionByNewLine: boolean
   customGroups: CustomGroup[]
   order: 'desc' | 'asc'

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -104,14 +104,10 @@ export default createEslintRule<SortModulesOptions, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows to use comments to separate the modules members into logical groups.',
-          },
           customGroups: buildCustomGroupsArrayJsonSchema({
             singleCustomGroupJsonSchema,
           }),
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -47,11 +47,10 @@ import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getEnumMembers } from '../utils/get-enum-members'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -427,27 +426,17 @@ let analyzeModule = ({
       }),
     ]
 
-    for (let messageId of messageIds) {
-      context.report({
-        data: {
-          nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
-          right: toSingleLine(right.name),
-          left: toSingleLine(left.name),
-          rightGroup: right.group,
-          leftGroup: left.group,
-        },
-        fix: (fixer: TSESLint.RuleFixer) =>
-          makeFixes({
-            sortedNodes: sortedNodesExcludingEslintDisabled,
-            sourceCode,
-            options,
-            fixer,
-            nodes,
-          }),
-        node: right.node,
-        messageId,
-      })
-    }
+    reportErrors({
+      sortedNodes: sortedNodesExcludingEslintDisabled,
+      firstUnorderedNodeDependentOnRight,
+      sourceCode,
+      messageIds,
+      options,
+      context,
+      nodes,
+      right,
+      left,
+    })
   })
 }
 

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -14,14 +14,10 @@ import {
   buildCustomGroupsArrayJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import {
   getFirstUnorderedNodeDependentOn,
@@ -101,27 +97,6 @@ let defaultOptions: Required<SortModulesOptions[0]> = {
 
 export default createEslintRule<SortModulesOptions, MESSAGE_ID>({
   meta: {
-    schema: [
-      {
-        properties: {
-          customGroups: buildCustomGroupsArrayJsonSchema({
-            singleCustomGroupJsonSchema,
-          }),
-          partitionByComment: partitionByCommentJsonSchema,
-          partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
-          newlinesBetween: newlinesBetweenJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
-          type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
-          groups: groupsJsonSchema,
-          order: orderJsonSchema,
-        },
-        additionalProperties: false,
-        type: 'object',
-      },
-    ],
     messages: {
       unexpectedModulesGroupOrder:
         'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
@@ -133,6 +108,23 @@ export default createEslintRule<SortModulesOptions, MESSAGE_ID>({
         'Extra spacing between "{{left}}" and "{{right}}" objects.',
       unexpectedModulesOrder: 'Expected "{{right}}" to come before "{{left}}".',
     },
+    schema: [
+      {
+        properties: {
+          ...commonJsonSchemas,
+          customGroups: buildCustomGroupsArrayJsonSchema({
+            singleCustomGroupJsonSchema,
+          }),
+          partitionByComment: partitionByCommentJsonSchema,
+          partitionByNewLine: partitionByNewLineJsonSchema,
+          newlinesBetween: newlinesBetweenJsonSchema,
+          type: buildTypeJsonSchema(),
+          groups: groupsJsonSchema,
+        },
+        additionalProperties: false,
+        type: 'object',
+      },
+    ],
     docs: {
       url: 'https://perfectionist.dev/rules/sort-modules',
       description: 'Enforce sorted modules.',

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { PartitionByCommentOption } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -10,14 +11,6 @@ import {
 
 export type SortModulesOptions = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     groups: (
       | { newlinesBetween: 'ignore' | 'always' | 'never' }
       | Group[]
@@ -26,6 +19,7 @@ export type SortModulesOptions = [
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     customGroups: CustomGroup[]
     partitionByNewLine: boolean

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  CommonOptions,
   GroupOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -13,19 +14,16 @@ import {
 } from '../../utils/common-json-schemas'
 
 export type SortModulesOptions = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    newlinesBetween: 'ignore' | 'always' | 'never'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    locales: NonNullable<Intl.LocalesArgument>
-    groups: GroupOptions<Group>
-    customGroups: CustomGroup[]
-    partitionByNewLine: boolean
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      newlinesBetween: 'ignore' | 'always' | 'never'
+      partitionByComment: PartitionByCommentOption
+      groups: GroupOptions<Group>
+      customGroups: CustomGroup[]
+      partitionByNewLine: boolean
+    } & CommonOptions
+  >,
 ]
 
 export type SingleCustomGroup = (

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -1,6 +1,9 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { PartitionByCommentOption } from '../../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -11,16 +14,12 @@ import {
 
 export type SortModulesOptions = [
   Partial<{
-    groups: (
-      | { newlinesBetween: 'ignore' | 'always' | 'never' }
-      | Group[]
-      | Group
-    )[]
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
+    groups: GroupOptions<Group>
     customGroups: CustomGroup[]
     partitionByNewLine: boolean
     order: 'desc' | 'asc'

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -3,7 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   CommonOptions,
-  GroupOptions,
+  GroupsOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -19,7 +19,7 @@ export type SortModulesOptions = [
       type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       newlinesBetween: 'ignore' | 'always' | 'never'
       partitionByComment: PartitionByCommentOption
-      groups: GroupOptions<Group>
+      groups: GroupsOptions<Group>
       customGroups: CustomGroup[]
       partitionByNewLine: boolean
     } & CommonOptions

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -1,5 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -31,17 +32,10 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     groupKind: 'values-first' | 'types-first' | 'mixed'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -1,6 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { PartitionByCommentOption } from '../types/common-options'
+import type {
+  PartitionByCommentOption,
+  CommonOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -31,17 +34,14 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 type Options = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    groupKind: 'values-first' | 'types-first' | 'mixed'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      groupKind: 'values-first' | 'types-first' | 'mixed'
+      partitionByComment: PartitionByCommentOption
+      partitionByNewLine: boolean
+    } & CommonOptions
+  >,
 ]
 
 interface SortNamedExportsSortingNode

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -190,16 +190,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the named exports members into logical groups.',
-          },
           groupKind: {
             enum: ['mixed', 'values-first', 'types-first'],
             description: 'Specifies top-level groups.',
             type: 'string',
           },
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -9,12 +9,8 @@ import type { SortingNode } from '../types/sorting-node'
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
-  orderJsonSchema,
+  commonJsonSchemas,
 } from '../utils/common-json-schemas'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
@@ -190,6 +186,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           groupKind: {
             enum: ['mixed', 'values-first', 'types-first'],
             description: 'Specifies top-level groups.',
@@ -197,12 +194,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           },
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -21,10 +21,10 @@ import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -162,21 +162,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             return
           }
 
-          context.report({
-            fix: fixer =>
-              makeFixes({
-                sortedNodes: sortedNodesExcludingEslintDisabled,
-                sourceCode,
-                options,
-                fixer,
-                nodes,
-              }),
-            data: {
-              right: right.name,
-              left: left.name,
-            },
-            messageId: 'unexpectedNamedExportsOrder',
-            node: right.node,
+          reportErrors({
+            sortedNodes: sortedNodesExcludingEslintDisabled,
+            messageIds: ['unexpectedNamedExportsOrder'],
+            sourceCode,
+            options,
+            context,
+            nodes,
+            right,
+            left,
           })
         })
       }

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -199,11 +199,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the named imports members into logical groups.',
-          },
           groupKind: {
             enum: ['mixed', 'values-first', 'types-first'],
             description: 'Specifies top-level groups.',
@@ -213,6 +208,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             description: 'Controls whether to ignore alias names.',
             type: 'boolean',
           },
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -1,5 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -31,17 +32,10 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     groupKind: 'values-first' | 'types-first' | 'mixed'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -21,10 +21,10 @@ import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -171,21 +171,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             return
           }
 
-          context.report({
-            fix: fixer =>
-              makeFixes({
-                sortedNodes: sortedNodesExcludingEslintDisabled,
-                sourceCode,
-                options,
-                fixer,
-                nodes,
-              }),
-            data: {
-              right: right.name,
-              left: left.name,
-            },
-            messageId: 'unexpectedNamedImportsOrder',
-            node: right.node,
+          reportErrors({
+            sortedNodes: sortedNodesExcludingEslintDisabled,
+            messageIds: ['unexpectedNamedImportsOrder'],
+            sourceCode,
+            options,
+            context,
+            nodes,
+            right,
+            left,
           })
         })
       }

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -9,12 +9,8 @@ import type { SortingNode } from '../types/sorting-node'
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
-  orderJsonSchema,
+  commonJsonSchemas,
 } from '../utils/common-json-schemas'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
@@ -199,6 +195,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           groupKind: {
             enum: ['mixed', 'values-first', 'types-first'],
             description: 'Specifies top-level groups.',
@@ -210,12 +207,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           },
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -1,6 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { PartitionByCommentOption } from '../types/common-options'
+import type {
+  PartitionByCommentOption,
+  CommonOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -31,18 +34,15 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 type Options = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    groupKind: 'values-first' | 'types-first' | 'mixed'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
-    order: 'desc' | 'asc'
-    ignoreAlias: boolean
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      groupKind: 'values-first' | 'types-first' | 'mixed'
+      partitionByComment: PartitionByCommentOption
+      partitionByNewLine: boolean
+      ignoreAlias: boolean
+    } & CommonOptions
+  >,
 ]
 
 interface SortNamedImportsSortingNode

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -106,11 +106,6 @@ export let jsonSchema: JSONSchema4 = {
           },
         },
       }),
-      partitionByComment: {
-        ...partitionByCommentJsonSchema,
-        description:
-          'Allows you to use comments to separate members into logical groups.',
-      },
       customGroups: {
         oneOf: [
           customGroupsJsonSchema,
@@ -123,6 +118,7 @@ export let jsonSchema: JSONSchema4 = {
         type: 'string',
       },
       type: buildTypeJsonSchema({ withUnsorted: true }),
+      partitionByComment: partitionByCommentJsonSchema,
       partitionByNewLine: partitionByNewLineJsonSchema,
       specialCharacters: specialCharactersJsonSchema,
       newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -11,15 +11,11 @@ import {
   buildCustomGroupsArrayJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
   customGroupsJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import {
@@ -91,6 +87,7 @@ let defaultOptions: Required<Options[0]> = {
 export let jsonSchema: JSONSchema4 = {
   items: {
     properties: {
+      ...commonJsonSchemas,
       ignorePattern: {
         description:
           'Specifies names or patterns for nodes that should be ignored by rule.',
@@ -120,13 +117,8 @@ export let jsonSchema: JSONSchema4 = {
       type: buildTypeJsonSchema({ withUnsorted: true }),
       partitionByComment: partitionByCommentJsonSchema,
       partitionByNewLine: partitionByNewLineJsonSchema,
-      specialCharacters: specialCharactersJsonSchema,
       newlinesBetween: newlinesBetweenJsonSchema,
-      ignoreCase: ignoreCaseJsonSchema,
-      alphabet: alphabetJsonSchema,
-      locales: localesJsonSchema,
       groups: groupsJsonSchema,
-      order: orderJsonSchema,
     },
     additionalProperties: false,
     type: 'object',

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -42,11 +42,10 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -432,26 +431,16 @@ export let sortObjectTypeElements = <MessageIds extends string>({
         }),
       ]
 
-      for (let messageId of messageIds) {
-        context.report({
-          fix: fixer =>
-            makeFixes({
-              sortedNodes: sortedNodesExcludingEslintDisabled,
-              sourceCode,
-              options,
-              fixer,
-              nodes,
-            }),
-          data: {
-            right: toSingleLine(right.name),
-            left: toSingleLine(left.name),
-            rightGroup: right.group,
-            leftGroup: left.group,
-          },
-          node: right.node,
-          messageId,
-        })
-      }
+      reportErrors({
+        sortedNodes: sortedNodesExcludingEslintDisabled,
+        messageIds,
+        sourceCode,
+        options,
+        context,
+        nodes,
+        right,
+        left,
+      })
     })
   }
 }

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  CommonOptions,
   GroupOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -12,31 +13,28 @@ import {
   elementNamePatternJsonSchema,
 } from '../../utils/common-json-schemas'
 
-export type Options = Partial<{
-  useConfigurationIf: {
-    declarationMatchesPattern?: string
-    allNamesMatchPattern?: string
-  }
-  type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
-  customGroups: Record<string, string[] | string> | CustomGroup[]
-  /**
-   * @deprecated for {@link `groups`}
-   */
-  groupKind: 'required-first' | 'optional-first' | 'mixed'
-  newlinesBetween: 'ignore' | 'always' | 'never'
-  specialCharacters: 'remove' | 'trim' | 'keep'
-  partitionByComment: PartitionByCommentOption
-  locales: NonNullable<Intl.LocalesArgument>
-  groups: GroupOptions<Group>
-  partitionByNewLine: boolean
-  /**
-   * @deprecated for {@link `useConfigurationIf.declarationMatchesPattern`}
-   */
-  ignorePattern: string[]
-  order: 'desc' | 'asc'
-  ignoreCase: boolean
-  alphabet: string
-}>[]
+export type Options = Partial<
+  {
+    useConfigurationIf: {
+      declarationMatchesPattern?: string
+      allNamesMatchPattern?: string
+    }
+    type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
+    customGroups: Record<string, string[] | string> | CustomGroup[]
+    /**
+     * @deprecated for {@link `groups`}
+     */
+    groupKind: 'required-first' | 'optional-first' | 'mixed'
+    newlinesBetween: 'ignore' | 'always' | 'never'
+    partitionByComment: PartitionByCommentOption
+    groups: GroupOptions<Group>
+    partitionByNewLine: boolean
+    /**
+     * @deprecated for {@link `useConfigurationIf.declarationMatchesPattern`}
+     */
+    ignorePattern: string[]
+  } & CommonOptions
+>[]
 
 export type SingleCustomGroup = (
   | BaseSingleCustomGroup<IndexSignatureSelector>

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { PartitionByCommentOption } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -9,14 +10,6 @@ import {
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
-  partitionByComment:
-    | {
-        block?: string[] | boolean | string
-        line?: string[] | boolean | string
-      }
-    | string[]
-    | boolean
-    | string
   useConfigurationIf: {
     declarationMatchesPattern?: string
     allNamesMatchPattern?: string
@@ -34,6 +27,7 @@ export type Options = Partial<{
   groupKind: 'required-first' | 'optional-first' | 'mixed'
   newlinesBetween: 'ignore' | 'always' | 'never'
   specialCharacters: 'remove' | 'trim' | 'keep'
+  partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
   /**

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -3,7 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   CommonOptions,
-  GroupOptions,
+  GroupsOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -27,7 +27,7 @@ export type Options = Partial<
     groupKind: 'required-first' | 'optional-first' | 'mixed'
     newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
-    groups: GroupOptions<Group>
+    groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     /**
      * @deprecated for {@link `useConfigurationIf.declarationMatchesPattern`}

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -1,6 +1,9 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { PartitionByCommentOption } from '../../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -14,11 +17,6 @@ export type Options = Partial<{
     declarationMatchesPattern?: string
     allNamesMatchPattern?: string
   }
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | Group[]
-    | Group
-  )[]
   type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
   customGroups: Record<string, string[] | string> | CustomGroup[]
   /**
@@ -29,6 +27,7 @@ export type Options = Partial<{
   specialCharacters: 'remove' | 'trim' | 'keep'
   partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
+  groups: GroupOptions<Group>
   partitionByNewLine: boolean
   /**
    * @deprecated for {@link `useConfigurationIf.declarationMatchesPattern`}

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -40,10 +40,10 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
@@ -495,27 +495,17 @@ export default createEslintRule<Options, MESSAGE_ID>({
           }),
         ]
 
-        for (let messageId of messageIds) {
-          context.report({
-            data: {
-              nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
-              rightGroup: right.group,
-              leftGroup: left.group,
-              right: right.name,
-              left: left.name,
-            },
-            fix: fixer =>
-              makeFixes({
-                sortedNodes: sortedNodesExcludingEslintDisabled,
-                sourceCode,
-                options,
-                fixer,
-                nodes,
-              }),
-            node: right.node,
-            messageId,
-          })
-        }
+        reportErrors({
+          sortedNodes: sortedNodesExcludingEslintDisabled,
+          firstUnorderedNodeDependentOnRight,
+          messageIds,
+          sourceCode,
+          options,
+          context,
+          nodes,
+          right,
+          left,
+        })
       })
     }
 

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -566,11 +566,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
               },
             },
           }),
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the keys of objects into logical groups.',
-          },
           customGroups: {
             oneOf: [
               customGroupsJsonSchema,
@@ -590,6 +585,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'boolean',
           },
           type: buildTypeJsonSchema({ withUnsorted: true }),
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -9,15 +9,11 @@ import {
   buildCustomGroupsArrayJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
   customGroupsJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import {
   getFirstUnorderedNodeDependentOn,
@@ -532,6 +528,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: {
       items: {
         properties: {
+          ...commonJsonSchemas,
           destructuredObjects: {
             oneOf: [
               {
@@ -587,13 +584,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
           type: buildTypeJsonSchema({ withUnsorted: true }),
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
-          locales: localesJsonSchema,
           groups: groupsJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  CommonOptions,
   GroupOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -13,31 +14,28 @@ import {
   elementNamePatternJsonSchema,
 } from '../../utils/common-json-schemas'
 
-export type Options = Partial<{
-  useConfigurationIf: {
-    callingFunctionNamePattern?: string
-    allNamesMatchPattern?: string
-  }
-  type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
-  customGroups: Record<string, string[] | string> | CustomGroup[]
-  destructuredObjects: { groups: boolean } | boolean
-  newlinesBetween: 'ignore' | 'always' | 'never'
-  specialCharacters: 'remove' | 'trim' | 'keep'
-  partitionByComment: PartitionByCommentOption
-  locales: NonNullable<Intl.LocalesArgument>
-  groups: GroupOptions<Group>
-  partitionByNewLine: boolean
-  objectDeclarations: boolean
-  styledComponents: boolean
-  /**
-   * @deprecated for {@link `destructuredObjects`} and {@link `objectDeclarations`}
-   */
-  destructureOnly: boolean
-  ignorePattern: string[]
-  order: 'desc' | 'asc'
-  ignoreCase: boolean
-  alphabet: string
-}>[]
+export type Options = Partial<
+  {
+    useConfigurationIf: {
+      callingFunctionNamePattern?: string
+      allNamesMatchPattern?: string
+    }
+    type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
+    customGroups: Record<string, string[] | string> | CustomGroup[]
+    destructuredObjects: { groups: boolean } | boolean
+    newlinesBetween: 'ignore' | 'always' | 'never'
+    partitionByComment: PartitionByCommentOption
+    groups: GroupOptions<Group>
+    partitionByNewLine: boolean
+    objectDeclarations: boolean
+    styledComponents: boolean
+    /**
+     * @deprecated for {@link `destructuredObjects`} and {@link `objectDeclarations`}
+     */
+    destructureOnly: boolean
+    ignorePattern: string[]
+  } & CommonOptions
+>[]
 
 export type SingleCustomGroup = (
   | BaseSingleCustomGroup<MultilineSelector>

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
+import type { PartitionByCommentOption } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -10,14 +11,6 @@ import {
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<{
-  partitionByComment:
-    | {
-        block?: string[] | boolean | string
-        line?: string[] | boolean | string
-      }
-    | string[]
-    | boolean
-    | string
   useConfigurationIf: {
     callingFunctionNamePattern?: string
     allNamesMatchPattern?: string
@@ -32,6 +25,7 @@ export type Options = Partial<{
   destructuredObjects: { groups: boolean } | boolean
   newlinesBetween: 'ignore' | 'always' | 'never'
   specialCharacters: 'remove' | 'trim' | 'keep'
+  partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
   objectDeclarations: boolean

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -3,7 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   CommonOptions,
-  GroupOptions,
+  GroupsOptions,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -25,7 +25,7 @@ export type Options = Partial<
     destructuredObjects: { groups: boolean } | boolean
     newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
-    groups: GroupOptions<Group>
+    groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     objectDeclarations: boolean
     styledComponents: boolean

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -1,6 +1,9 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
-import type { PartitionByCommentOption } from '../../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
 import {
@@ -15,11 +18,6 @@ export type Options = Partial<{
     callingFunctionNamePattern?: string
     allNamesMatchPattern?: string
   }
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | Group[]
-    | Group
-  )[]
   type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
   customGroups: Record<string, string[] | string> | CustomGroup[]
   destructuredObjects: { groups: boolean } | boolean
@@ -27,6 +25,7 @@ export type Options = Partial<{
   specialCharacters: 'remove' | 'trim' | 'keep'
   partitionByComment: PartitionByCommentOption
   locales: NonNullable<Intl.LocalesArgument>
+  groups: GroupOptions<Group>
   partitionByNewLine: boolean
   objectDeclarations: boolean
   styledComponents: boolean

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
+import type { CommonOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -26,14 +27,11 @@ import { complete } from '../utils/complete'
 import { compare } from '../utils/compare'
 
 type Options = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    locales: NonNullable<Intl.LocalesArgument>
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+    } & CommonOptions
+  >,
 ]
 
 interface SortSwitchCaseSortingNode extends SortingNode<TSESTree.SwitchCase> {

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -4,16 +4,12 @@ import type { TSESLint } from '@typescript-eslint/utils'
 import type { CommonOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
-import {
-  specialCharactersJsonSchema,
-  ignoreCaseJsonSchema,
-  buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
-  orderJsonSchema,
-} from '../utils/common-json-schemas'
 import { makeSingleNodeCommentAfterFixes } from '../utils/make-single-node-comment-after-fixes'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
+import {
+  buildTypeJsonSchema,
+  commonJsonSchemas,
+} from '../utils/common-json-schemas'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
@@ -272,12 +268,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          specialCharacters: specialCharactersJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
+          ...commonJsonSchemas,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -13,6 +13,7 @@ import {
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -111,20 +112,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
             return
           }
 
-          context.report({
-            fix: fixer =>
-              makeFixes({
-                sortedNodes: sortedCaseNameSortingNodes,
-                nodes: caseNodesSortingNodeGroup,
-                sourceCode,
-                fixer,
-              }),
-            data: {
-              right: right.name,
-              left: left.name,
-            },
-            messageId: 'unexpectedSwitchCaseOrder',
-            node: right.node,
+          reportErrors({
+            messageIds: ['unexpectedSwitchCaseOrder'],
+            sortedNodes: sortedCaseNameSortingNodes,
+            nodes: caseNodesSortingNodeGroup,
+            sourceCode,
+            context,
+            right,
+            left,
           })
         })
       }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -31,10 +31,9 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
-import { makeFixes } from '../utils/make-fixes'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -327,26 +326,16 @@ export let sortUnionOrIntersectionTypes = <MessageIds extends string>({
         }),
       ]
 
-      for (let messageId of messageIds) {
-        context.report({
-          fix: fixer =>
-            makeFixes({
-              sortedNodes: sortedNodesExcludingEslintDisabled,
-              sourceCode,
-              options,
-              fixer,
-              nodes,
-            }),
-          data: {
-            right: toSingleLine(right.name),
-            left: toSingleLine(left.name),
-            rightGroup: right.group,
-            leftGroup: left.group,
-          },
-          node: right.node,
-          messageId,
-        })
-      }
+      reportErrors({
+        sortedNodes: sortedNodesExcludingEslintDisabled,
+        messageIds,
+        sourceCode,
+        options,
+        context,
+        nodes,
+        right,
+        left,
+      })
     })
   }
 }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -12,14 +12,10 @@ import type { SortingNode } from '../types/sorting-node'
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
   newlinesBetweenJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
+  commonJsonSchemas,
   groupsJsonSchema,
-  orderJsonSchema,
 } from '../utils/common-json-schemas'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
@@ -91,16 +87,12 @@ let defaultOptions: Required<Options[0]> = {
 
 export let jsonSchema: JSONSchema4 = {
   properties: {
+    ...commonJsonSchemas,
     partitionByComment: partitionByCommentJsonSchema,
     partitionByNewLine: partitionByNewLineJsonSchema,
-    specialCharacters: specialCharactersJsonSchema,
     newlinesBetween: newlinesBetweenJsonSchema,
-    ignoreCase: ignoreCaseJsonSchema,
-    alphabet: alphabetJsonSchema,
     type: buildTypeJsonSchema(),
-    locales: localesJsonSchema,
     groups: groupsJsonSchema,
-    order: orderJsonSchema,
   },
   additionalProperties: false,
   type: 'object',

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -91,11 +91,7 @@ let defaultOptions: Required<Options[0]> = {
 
 export let jsonSchema: JSONSchema4 = {
   properties: {
-    partitionByComment: {
-      ...partitionByCommentJsonSchema,
-      description:
-        'Allows you to use comments to separate the union types into logical groups.',
-    },
+    partitionByComment: partitionByCommentJsonSchema,
     partitionByNewLine: partitionByNewLineJsonSchema,
     specialCharacters: specialCharactersJsonSchema,
     newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -4,6 +4,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type {
   PartitionByCommentOption,
+  CommonOptions,
   GroupOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -43,18 +44,15 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 export type Options = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    newlinesBetween: 'ignore' | 'always' | 'never'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    locales: NonNullable<Intl.LocalesArgument>
-    groups: GroupOptions<Group>
-    partitionByNewLine: boolean
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      newlinesBetween: 'ignore' | 'always' | 'never'
+      partitionByComment: PartitionByCommentOption
+      groups: GroupOptions<Group>
+      partitionByNewLine: boolean
+    } & CommonOptions
+  >,
 ]
 
 type Group =

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -2,7 +2,10 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { PartitionByCommentOption } from '../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -41,16 +44,12 @@ import { pairwise } from '../utils/pairwise'
 
 export type Options = [
   Partial<{
-    groups: (
-      | { newlinesBetween: 'ignore' | 'always' | 'never' }
-      | Group[]
-      | Group
-    )[]
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
+    groups: GroupOptions<Group>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -5,7 +5,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type {
   PartitionByCommentOption,
   CommonOptions,
-  GroupOptions,
+  GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -44,7 +44,7 @@ export type Options = [
       type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       newlinesBetween: 'ignore' | 'always' | 'never'
       partitionByComment: PartitionByCommentOption
-      groups: GroupOptions<Group>
+      groups: GroupsOptions<Group>
       partitionByNewLine: boolean
     } & CommonOptions
   >,

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -40,14 +41,6 @@ import { pairwise } from '../utils/pairwise'
 
 export type Options = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     groups: (
       | { newlinesBetween: 'ignore' | 'always' | 'never' }
       | Group[]
@@ -56,6 +49,7 @@ export type Options = [
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -1,7 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type {
+  PartitionByCommentOption,
+  CommonOptions,
+} from '../types/common-options'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
-import type { PartitionByCommentOption } from '../types/common-options'
 
 import {
   partitionByCommentJsonSchema,
@@ -36,16 +39,13 @@ import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
 
 type Options = [
-  Partial<{
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    specialCharacters: 'remove' | 'trim' | 'keep'
-    partitionByComment: PartitionByCommentOption
-    locales: NonNullable<Intl.LocalesArgument>
-    partitionByNewLine: boolean
-    order: 'desc' | 'asc'
-    ignoreCase: boolean
-    alphabet: string
-  }>,
+  Partial<
+    {
+      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+      partitionByComment: PartitionByCommentOption
+      partitionByNewLine: boolean
+    } & CommonOptions
+  >,
 ]
 
 type MESSAGE_ID =

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -9,12 +9,8 @@ import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-depende
 import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
-  specialCharactersJsonSchema,
-  ignoreCaseJsonSchema,
   buildTypeJsonSchema,
-  alphabetJsonSchema,
-  localesJsonSchema,
-  orderJsonSchema,
+  commonJsonSchemas,
 } from '../utils/common-json-schemas'
 import {
   getFirstUnorderedNodeDependentOn,
@@ -285,14 +281,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
+          ...commonJsonSchemas,
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
-          specialCharacters: specialCharactersJsonSchema,
-          ignoreCase: ignoreCaseJsonSchema,
-          alphabet: alphabetJsonSchema,
           type: buildTypeJsonSchema(),
-          locales: localesJsonSchema,
-          order: orderJsonSchema,
         },
         additionalProperties: false,
         type: 'object',

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -285,11 +285,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     schema: [
       {
         properties: {
-          partitionByComment: {
-            ...partitionByCommentJsonSchema,
-            description:
-              'Allows you to use comments to separate the variable declarations into logical groups.',
-          },
+          partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           specialCharacters: specialCharactersJsonSchema,
           ignoreCase: ignoreCaseJsonSchema,

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -25,11 +25,10 @@ import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getSourceCode } from '../utils/get-source-code'
-import { toSingleLine } from '../utils/to-single-line'
+import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
 import { pairwise } from '../utils/pairwise'
@@ -255,24 +254,21 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
         let firstUnorderedNodeDependentOnRight =
           getFirstUnorderedNodeDependentOn(right, nodes)
-        context.report({
-          fix: fixer =>
-            makeFixes({
-              sortedNodes: sortedNodesExcludingEslintDisabled,
-              sourceCode,
-              options,
-              fixer,
-              nodes,
-            }),
-          data: {
-            nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
-            right: toSingleLine(right.name),
-            left: toSingleLine(left.name),
-          },
-          messageId: firstUnorderedNodeDependentOnRight
-            ? 'unexpectedVariableDeclarationsDependencyOrder'
-            : 'unexpectedVariableDeclarationsOrder',
-          node: right.node,
+
+        reportErrors({
+          messageIds: [
+            firstUnorderedNodeDependentOnRight
+              ? 'unexpectedVariableDeclarationsDependencyOrder'
+              : 'unexpectedVariableDeclarationsOrder',
+          ],
+          sortedNodes: sortedNodesExcludingEslintDisabled,
+          firstUnorderedNodeDependentOnRight,
+          sourceCode,
+          options,
+          context,
+          nodes,
+          right,
+          left,
         })
       })
     },

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
+import type { PartitionByCommentOption } from '../types/common-options'
 
 import {
   partitionByCommentJsonSchema,
@@ -36,16 +37,9 @@ import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<{
-    partitionByComment:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     specialCharacters: 'remove' | 'trim' | 'keep'
+    partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
     partitionByNewLine: boolean
     order: 'desc' | 'asc'

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -6382,7 +6382,7 @@ describe(ruleName, () => {
 
     describe(`${ruleName}: checks compatibility between 'sortSideEffects' and 'groups'`, () => {
       let createRule = (
-        groups: Options<string[]>[0]['groups'],
+        groups: Options[0]['groups'],
         sortSideEffects: boolean = false,
       ): RuleListener =>
         rule.create({
@@ -6392,7 +6392,7 @@ describe(ruleName, () => {
               groups,
             },
           ],
-        } as Readonly<RuleContext<MESSAGE_ID, Options<string[]>>>)
+        } as Readonly<RuleContext<MESSAGE_ID, Options>>)
       let expectedThrownError =
         "Side effect groups cannot be nested with non side effect groups when 'sortSideEffects' is 'false'."
 

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -1,3 +1,11 @@
+export interface CommonOptions {
+  specialCharacters: 'remove' | 'trim' | 'keep'
+  locales: NonNullable<Intl.LocalesArgument>
+  order: 'desc' | 'asc'
+  ignoreCase: boolean
+  alphabet: string
+}
+
 export type PartitionByCommentOption =
   | {
       block?: string[] | boolean | string

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -15,7 +15,7 @@ export type PartitionByCommentOption =
   | boolean
   | string
 
-export type GroupOptions<T> = (
+export type GroupsOptions<T> = (
   | { newlinesBetween: 'ignore' | 'always' | 'never' }
   | T[]
   | T

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -6,3 +6,9 @@ export type PartitionByCommentOption =
   | string[]
   | boolean
   | string
+
+export type GroupOptions<T> = (
+  | { newlinesBetween: 'ignore' | 'always' | 'never' }
+  | T[]
+  | T
+)[]

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -1,0 +1,8 @@
+export type PartitionByCommentOption =
+  | {
+      block?: string[] | boolean | string
+      line?: string[] | boolean | string
+    }
+  | string[]
+  | boolean
+  | string

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -130,6 +130,8 @@ export let partitionByCommentJsonSchema: JSONSchema4 = {
       type: 'object',
     },
   ],
+  description:
+    'Allows to use comments to separate members into logical groups.',
 }
 
 export let partitionByNewLineJsonSchema: JSONSchema4 = {

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -14,19 +14,19 @@ export let buildTypeJsonSchema = ({
   }
 }
 
-export let orderJsonSchema: JSONSchema4 = {
+let orderJsonSchema: JSONSchema4 = {
   description:
     'Determines whether the sorted items should be in ascending or descending order.',
   enum: ['asc', 'desc'],
   type: 'string',
 }
 
-export let alphabetJsonSchema: JSONSchema4 = {
+let alphabetJsonSchema: JSONSchema4 = {
   description: 'Alphabet to use for the `custom` sort type.',
   type: 'string',
 }
 
-export let localesJsonSchema: JSONSchema4 = {
+let localesJsonSchema: JSONSchema4 = {
   oneOf: [
     {
       type: 'string',
@@ -41,16 +41,24 @@ export let localesJsonSchema: JSONSchema4 = {
   description: 'Specifies the sorting locales.',
 }
 
-export let ignoreCaseJsonSchema: JSONSchema4 = {
+let ignoreCaseJsonSchema: JSONSchema4 = {
   description: 'Controls whether sorting should be case-sensitive or not.',
   type: 'boolean',
 }
 
-export let specialCharactersJsonSchema: JSONSchema4 = {
+let specialCharactersJsonSchema: JSONSchema4 = {
   description:
     'Controls how special characters should be handled before sorting.',
   enum: ['remove', 'trim', 'keep'],
   type: 'string',
+}
+
+export let commonJsonSchemas: Record<string, JSONSchema4> = {
+  specialCharacters: specialCharactersJsonSchema,
+  ignoreCase: ignoreCaseJsonSchema,
+  alphabet: alphabetJsonSchema,
+  locales: localesJsonSchema,
+  order: orderJsonSchema,
 }
 
 export let newlinesBetweenJsonSchema: JSONSchema4 = {

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -1,6 +1,6 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { GroupOptions } from '../types/common-options'
+import type { GroupsOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getNewlinesBetweenOption } from './get-newlines-between-option'
@@ -10,7 +10,7 @@ interface GetNewlinesErrorsParameters<T extends string> {
   options: {
     customGroups?: Record<string, string[] | string> | CustomGroup[]
     newlinesBetween: 'ignore' | 'always' | 'never'
-    groups: GroupOptions<string>
+    groups: GroupsOptions<string>
   }
   sourceCode: TSESLint.SourceCode
   missedSpacingError: T

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -1,5 +1,6 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
+import type { GroupOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getNewlinesBetweenOption } from './get-newlines-between-option'
@@ -7,13 +8,9 @@ import { getLinesBetween } from './get-lines-between'
 
 interface GetNewlinesErrorsParameters<T extends string> {
   options: {
-    groups: (
-      | { newlinesBetween: 'ignore' | 'always' | 'never' }
-      | string[]
-      | string
-    )[]
     customGroups?: Record<string, string[] | string> | CustomGroup[]
     newlinesBetween: 'ignore' | 'always' | 'never'
+    groups: GroupOptions<string>
   }
   sourceCode: TSESLint.SourceCode
   missedSpacingError: T

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -3,20 +3,15 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import { ASTUtils } from '@typescript-eslint/utils'
 
+import type { PartitionByCommentOption } from '../types/common-options'
+
 import { getEslintDisabledRules } from './get-eslint-disabled-rules'
 import { isPartitionComment } from './is-partition-comment'
 import { getCommentsBefore } from './get-comments-before'
 
 interface GetNodeRangeParameters {
   options?: {
-    partitionByComment?:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
+    partitionByComment?: PartitionByCommentOption
   }
   ignoreHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode

--- a/utils/get-options-with-clean-groups.ts
+++ b/utils/get-options-with-clean-groups.ts
@@ -1,12 +1,12 @@
-interface GroupOptions {
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | string[]
-    | string
-  )[]
+import type { GroupsOptions } from '../types/common-options'
+
+interface GetOptionsWithCleanGroupsParameters {
+  groups: GroupsOptions<string>
 }
 
-export let getOptionsWithCleanGroups = <T extends GroupOptions>(
+export let getOptionsWithCleanGroups = <
+  T extends GetOptionsWithCleanGroupsParameters,
+>(
   options: T,
 ): T => ({
   ...options,

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -10,7 +10,7 @@ import { makeCommentAfterFixes } from './make-comment-after-fixes'
 import { makeNewlinesFixes } from './make-newlines-fixes'
 import { makeOrderFixes } from './make-order-fixes'
 
-interface MakeFixesParameters {
+export interface MakeFixesParameters {
   options?: {
     customGroups?: Record<string, string[] | string> | CustomGroup[]
     newlinesBetween?: 'ignore' | 'always' | 'never'

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -1,6 +1,9 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { PartitionByCommentOption } from '../types/common-options'
+import type {
+  PartitionByCommentOption,
+  GroupOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { makeCommentAfterFixes } from './make-comment-after-fixes'
@@ -9,14 +12,10 @@ import { makeOrderFixes } from './make-order-fixes'
 
 interface MakeFixesParameters {
   options?: {
-    groups?: (
-      | { newlinesBetween: 'ignore' | 'always' | 'never' }
-      | string[]
-      | string
-    )[]
     customGroups?: Record<string, string[] | string> | CustomGroup[]
     newlinesBetween?: 'ignore' | 'always' | 'never'
     partitionByComment?: PartitionByCommentOption
+    groups?: GroupOptions<string>
   }
   ignoreFirstNodeHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -2,7 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import type {
   PartitionByCommentOption,
-  GroupOptions,
+  GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -15,7 +15,7 @@ export interface MakeFixesParameters {
     customGroups?: Record<string, string[] | string> | CustomGroup[]
     newlinesBetween?: 'ignore' | 'always' | 'never'
     partitionByComment?: PartitionByCommentOption
-    groups?: GroupOptions<string>
+    groups?: GroupsOptions<string>
   }
   ignoreFirstNodeHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -1,5 +1,6 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { makeCommentAfterFixes } from './make-comment-after-fixes'
@@ -8,14 +9,6 @@ import { makeOrderFixes } from './make-order-fixes'
 
 interface MakeFixesParameters {
   options?: {
-    partitionByComment?:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
     groups?: (
       | { newlinesBetween: 'ignore' | 'always' | 'never' }
       | string[]
@@ -23,6 +16,7 @@ interface MakeFixesParameters {
     )[]
     customGroups?: Record<string, string[] | string> | CustomGroup[]
     newlinesBetween?: 'ignore' | 'always' | 'never'
+    partitionByComment?: PartitionByCommentOption
   }
   ignoreFirstNodeHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode

--- a/utils/make-order-fixes.ts
+++ b/utils/make-order-fixes.ts
@@ -1,19 +1,13 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
+import type { PartitionByCommentOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getNodeRange } from './get-node-range'
 
 interface MakeOrderFixesParameters {
   options?: {
-    partitionByComment?:
-      | {
-          block?: string[] | boolean | string
-          line?: string[] | boolean | string
-        }
-      | string[]
-      | boolean
-      | string
+    partitionByComment?: PartitionByCommentOption
   }
   ignoreFirstNodeHighestBlockComment?: boolean
   sourceCode: TSESLint.SourceCode

--- a/utils/report-errors.ts
+++ b/utils/report-errors.ts
@@ -1,0 +1,56 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { SortingNode } from '../types/sorting-node'
+import type { MakeFixesParameters } from './make-fixes'
+
+import { toSingleLine } from './to-single-line'
+import { makeFixes } from './make-fixes'
+
+interface ReportErrorsParameters<MessageIds extends string> {
+  context: TSESLint.RuleContext<MessageIds, unknown[]>
+  firstUnorderedNodeDependentOnRight?: SortingNode
+  ignoreFirstNodeHighestBlockComment?: boolean
+  options?: MakeFixesParameters['options']
+  sourceCode: TSESLint.SourceCode
+  sortedNodes: SortingNode[]
+  messageIds: MessageIds[]
+  nodes: SortingNode[]
+  right: SortingNode
+  left: SortingNode
+}
+
+export let reportErrors = <MessageIds extends string>({
+  firstUnorderedNodeDependentOnRight,
+  ignoreFirstNodeHighestBlockComment,
+  sortedNodes,
+  messageIds,
+  sourceCode,
+  context,
+  options,
+  nodes,
+  right,
+  left,
+}: ReportErrorsParameters<MessageIds>): void => {
+  for (let messageId of messageIds) {
+    context.report({
+      data: {
+        nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
+        right: toSingleLine(right.name),
+        left: toSingleLine(left.name),
+        rightGroup: right.group,
+        leftGroup: left.group,
+      },
+      fix: (fixer: TSESLint.RuleFixer) =>
+        makeFixes({
+          ignoreFirstNodeHighestBlockComment,
+          sortedNodes,
+          sourceCode,
+          options,
+          fixer,
+          nodes,
+        }),
+      node: right.node,
+      messageId,
+    })
+  }
+}

--- a/utils/sort-nodes-by-groups.ts
+++ b/utils/sort-nodes-by-groups.ts
@@ -14,7 +14,7 @@ interface ExtraOptions<T extends SortingNode> {
   isNodeIgnored?(node: T): boolean
 }
 
-interface GroupOptions {
+interface GroupsOptions {
   groups: (
     | { newlinesBetween: 'ignore' | 'always' | 'never' }
     | string[]
@@ -24,7 +24,7 @@ interface GroupOptions {
 
 export let sortNodesByGroups = <T extends SortingNode>(
   nodes: T[],
-  options: CompareOptions<T> & GroupOptions,
+  options: CompareOptions<T> & GroupsOptions,
   extraOptions?: ExtraOptions<T>,
 ): T[] => {
   let nodesByNonIgnoredGroupNumber: Record<number, T[]> = {}


### PR DESCRIPTION
## Description

This PR focuses on reducing code duplication:
- Creates a `CommonOptions` interface (includes `type`, `locales`, `specialCharacters`, `ignoreCase`, `alphabet`).
  - Does not contain `type` yet, as some rules handle the `unsorted` type while others don't.
- Creates a `commonJsonSchema` variable regrouping common JSON schemas to all rules.
- Creates a `PartitionByCommentOption` interface.
- Creates a `GroupsOptions` interface.
- Creates a `reportErrors` function.

No test impacted.

### What is the purpose of this pull request?

- [x] Other