### PR TITLE
refactor: reduces code duplication (2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:astro": "astro check",
     "test:css": "stylelint \"docs/**/*.{astro,svelte,css}\"",
     "test:format": "prettier --check \"**/*.{astro,svelte,js,ts,json,md,yml}\"",
-    "test:js": "eslint --flag unstable_ts_config .",
+    "test:js": "eslint --fix --flag unstable_ts_config .",
     "test:spelling": "cspell \"**/*\"",
     "test:svelte": "svelte-check",
     "test:types": "tsc --noEmit --pretty",

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -29,12 +29,10 @@ import { getMatchingContextOptions } from '../utils/get-matching-context-options
 import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -268,16 +266,12 @@ export let sortArray = <MessageIds extends string>({
 
       let lastSortingNode = accumulator.at(-1)?.at(-1)
       if (
-        hasPartitionComment({
-          comments: getCommentsBefore({
-            node: element,
-            sourceCode,
-          }),
-          partitionByComment: options.partitionByComment,
-        }) ||
-        (options.partitionByNewLine &&
-          lastSortingNode &&
-          getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+        shouldPartition({
+          lastSortingNode,
+          sortingNode,
+          sourceCode,
+          options,
+        })
       ) {
         accumulator.push([])
       }

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -30,21 +30,17 @@ import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
-import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
-import { getGroupNumber } from '../utils/get-group-number'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 
 /**
  * Cache computed groups by modifiers and selectors for performance
@@ -310,7 +306,7 @@ export let sortArray = <MessageIds extends string>({
       ),
     )
 
-    let sortNodesIgnoringEslintDisabledNodes = (
+    let sortNodesExcludingEslintDisabled = (
       ignoreEslintDisabledNodes: boolean,
     ): SortArrayIncludesSortingNode[] =>
       filteredGroupKindNodes.flatMap(groupedNodes =>
@@ -321,59 +317,13 @@ export let sortArray = <MessageIds extends string>({
         }),
       )
 
-    let sortedNodes = sortNodesIgnoringEslintDisabledNodes(false)
-    let sortedNodesExcludingEslintDisabled =
-      sortNodesIgnoringEslintDisabledNodes(true)
-
-    let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-    pairwise(nodes, (left, right) => {
-      let leftIndex = nodeIndexMap.get(left)!
-      let rightIndex = nodeIndexMap.get(right)!
-
-      let leftNumber = getGroupNumber(options.groups, left)
-      let rightNumber = getGroupNumber(options.groups, right)
-
-      let indexOfRightExcludingEslintDisabled =
-        sortedNodesExcludingEslintDisabled.indexOf(right)
-
-      let messageIds: MessageIds[] = []
-
-      if (
-        leftIndex > rightIndex ||
-        leftIndex >= indexOfRightExcludingEslintDisabled
-      ) {
-        messageIds.push(
-          leftNumber === rightNumber
-            ? availableMessageIds.unexpectedOrder
-            : availableMessageIds.unexpectedGroupOrder,
-        )
-      }
-
-      messageIds = [
-        ...messageIds,
-        ...getNewlinesErrors({
-          missedSpacingError: availableMessageIds.missedSpacingBetweenMembers,
-          extraSpacingError: availableMessageIds.extraSpacingBetweenMembers,
-          rightNum: rightNumber,
-          leftNum: leftNumber,
-          sourceCode,
-          options,
-          right,
-          left,
-        }),
-      ]
-
-      reportErrors({
-        sortedNodes: sortedNodesExcludingEslintDisabled,
-        sourceCode,
-        messageIds,
-        options,
-        context,
-        nodes,
-        right,
-        left,
-      })
+    reportAllErrors<MessageIds>({
+      sortNodesExcludingEslintDisabled,
+      availableMessageIds,
+      sourceCode,
+      options,
+      context,
+      nodes,
     })
   }
 }

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -31,12 +31,10 @@ import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { doesCustomGroupMatch } from './sort-classes/does-custom-group-match'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -549,18 +547,14 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             name,
           }
 
-          let lastMember = accumulator.at(-1)?.at(-1)
+          let lastSortingNode = accumulator.at(-1)?.at(-1)
 
           if (
-            (options.partitionByNewLine &&
-              lastMember &&
-              getLinesBetween(sourceCode, lastMember, sortingNode)) ||
-            hasPartitionComment({
-              comments: getCommentsBefore({
-                node: member,
-                sourceCode,
-              }),
-              partitionByComment: options.partitionByComment,
+            shouldPartition({
+              lastSortingNode,
+              sortingNode,
+              sourceCode,
+              options,
             })
           ) {
             accumulator.push([])

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -20,20 +20,17 @@ import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { getDecoratorName } from './sort-decorators/get-decorator-name'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { getNodeDecorators } from '../utils/get-node-decorators'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getGroupNumber } from '../utils/get-group-number'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 
 export type Options<T extends string = string> = [
   Partial<
@@ -244,42 +241,18 @@ let sortDecorators = (
     formattedMembers.flatMap(nodes =>
       sortNodesByGroups(nodes, options, { ignoreEslintDisabledNodes }),
     )
-  let sortedNodes = sortNodesExcludingEslintDisabled(false)
-  let sortedNodesExcludingEslintDisabled =
-    sortNodesExcludingEslintDisabled(true)
-
   let nodes = formattedMembers.flat()
 
-  let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-  pairwise(nodes, (left, right) => {
-    let leftIndex = nodeIndexMap.get(left)!
-    let rightIndex = nodeIndexMap.get(right)!
-    let indexOfRightExcludingEslintDisabled =
-      sortedNodesExcludingEslintDisabled.indexOf(right)
-    if (
-      leftIndex < rightIndex &&
-      leftIndex < indexOfRightExcludingEslintDisabled
-    ) {
-      return
-    }
-    let leftNumber = getGroupNumber(options.groups, left)
-    let rightNumber = getGroupNumber(options.groups, right)
-
-    reportErrors({
-      messageIds: [
-        leftNumber === rightNumber
-          ? 'unexpectedDecoratorsOrder'
-          : 'unexpectedDecoratorsGroupOrder',
-      ],
-      sortedNodes: sortedNodesExcludingEslintDisabled,
-      ignoreFirstNodeHighestBlockComment: true,
-      sourceCode,
-      options,
-      context,
-      nodes,
-      right,
-      left,
-    })
+  reportAllErrors<MESSAGE_ID>({
+    availableMessageIds: {
+      unexpectedGroupOrder: 'unexpectedDecoratorsGroupOrder',
+      unexpectedOrder: 'unexpectedDecoratorsOrder',
+    },
+    ignoreFirstNodeHighestBlockComment: true,
+    sortNodesExcludingEslintDisabled,
+    sourceCode,
+    options,
+    context,
+    nodes,
   })
 }

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -17,11 +17,9 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getEnumMembers } from '../utils/get-enum-members'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -144,16 +142,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
           }
 
           if (
-            hasPartitionComment({
-              comments: getCommentsBefore({
-                node: member,
-                sourceCode,
-              }),
-              partitionByComment: options.partitionByComment,
-            }) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            shouldPartition({
+              lastSortingNode,
+              sortingNode,
+              sourceCode,
+              options,
+            })
           ) {
             accumulator.push([])
           }

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -15,11 +15,9 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -66,7 +64,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
     validateCustomSortConfiguration(options)
 
     let sourceCode = getSourceCode(context)
-    let partitionComment = options.partitionByComment
     let eslintDisabledLines = getEslintDisabledLines({
       ruleName: context.id,
       sourceCode,
@@ -88,21 +85,18 @@ export default createEslintRule<Options, MESSAGE_ID>({
         node,
       }
       let lastNode = parts.at(-1)?.at(-1)
+
       if (
-        (partitionComment &&
-          hasPartitionComment({
-            comments: getCommentsBefore({
-              sourceCode,
-              node,
-            }),
-            partitionByComment: options.partitionByComment,
-          })) ||
-        (options.partitionByNewLine &&
-          lastNode &&
-          getLinesBetween(sourceCode, lastNode, sortingNode))
+        shouldPartition({
+          lastSortingNode: lastNode,
+          sortingNode,
+          sourceCode,
+          options,
+        })
       ) {
         parts.push([])
       }
+
       parts.at(-1)!.push(sortingNode)
     }
 

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -16,17 +16,15 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<
@@ -135,35 +133,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
               }),
             )
 
-          let sortedNodes = sortNodesExcludingEslintDisabled(false)
-          let sortedNodesExcludingEslintDisabled =
-            sortNodesExcludingEslintDisabled(true)
-
-          let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-          pairwise(nodes, (left, right) => {
-            let leftIndex = nodeIndexMap.get(left)!
-            let rightIndex = nodeIndexMap.get(right)!
-
-            let indexOfRightExcludingEslintDisabled =
-              sortedNodesExcludingEslintDisabled.indexOf(right)
-            if (
-              leftIndex < rightIndex &&
-              leftIndex < indexOfRightExcludingEslintDisabled
-            ) {
-              return
-            }
-
-            reportErrors({
-              sortedNodes: sortedNodesExcludingEslintDisabled,
-              messageIds: ['unexpectedExportsOrder'],
-              sourceCode,
-              options,
-              context,
-              nodes,
-              right,
-              left,
-            })
+          reportAllErrors<MESSAGE_ID>({
+            availableMessageIds: {
+              unexpectedOrder: 'unexpectedExportsOrder',
+            },
+            sortNodesExcludingEslintDisabled,
+            sourceCode,
+            options,
+            context,
+            nodes,
           })
         }
       },

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -24,12 +24,10 @@ import { getOptionsWithCleanGroups } from '../utils/get-options-with-clean-group
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { getTypescriptImport } from './sort-imports/get-typescript-import'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -471,16 +469,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let lastSortingNode = lastGroup?.at(-1)
 
           if (
-            hasPartitionComment({
-              comments: getCommentsBefore({
-                node: sortingNode.node,
-                sourceCode,
-              }),
-              partitionByComment: options.partitionByComment,
+            shouldPartition({
+              lastSortingNode,
+              sortingNode,
+              sourceCode,
+              options,
             }) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode)) ||
             (lastSortingNode &&
               hasContentBetweenNodes(lastSortingNode, sortingNode))
           ) {

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -25,21 +25,17 @@ import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { getTypescriptImport } from './sort-imports/get-typescript-import'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
-import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
-import { getGroupNumber } from '../utils/get-group-number'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 import { matches } from '../utils/matches'
 
 export type Options<T extends string = string> = [
@@ -511,65 +507,21 @@ export default createEslintRule<Options, MESSAGE_ID>({
               ignoreEslintDisabledNodes,
             })
 
-          let sortedNodes = sortNodesExcludingEslintDisabled(false)
-          let sortedNodesExcludingEslintDisabled =
-            sortNodesExcludingEslintDisabled(true)
-
-          let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-          pairwise(nodes, (left, right) => {
-            let leftNumber = getGroupNumber(options.groups, left)
-            let rightNumber = getGroupNumber(options.groups, right)
-
-            let leftIndex = nodeIndexMap.get(left)!
-            let rightIndex = nodeIndexMap.get(right)!
-
-            let indexOfRightExcludingEslintDisabled =
-              sortedNodesExcludingEslintDisabled.indexOf(right)
-
-            let messageIds: MESSAGE_ID[] = []
-
-            if (
-              leftIndex > rightIndex ||
-              leftIndex >= indexOfRightExcludingEslintDisabled
-            ) {
-              messageIds.push(
-                leftNumber === rightNumber
-                  ? 'unexpectedImportsOrder'
-                  : 'unexpectedImportsGroupOrder',
-              )
-            }
-
-            messageIds = [
-              ...messageIds,
-              ...getNewlinesErrors({
-                options: {
-                  ...options,
-                  customGroups: [],
-                },
-                missedSpacingError: 'missedSpacingBetweenImports',
-                extraSpacingError: 'extraSpacingBetweenImports',
-                rightNum: rightNumber,
-                leftNum: leftNumber,
-                sourceCode,
-                right,
-                left,
-              }),
-            ]
-
-            reportErrors({
-              options: {
-                ...options,
-                customGroups: [],
-              },
-              sortedNodes: sortedNodesExcludingEslintDisabled,
-              sourceCode,
-              messageIds,
-              context,
-              nodes,
-              right,
-              left,
-            })
+          reportAllErrors<MESSAGE_ID>({
+            availableMessageIds: {
+              missedSpacingBetweenMembers: 'missedSpacingBetweenImports',
+              extraSpacingBetweenMembers: 'extraSpacingBetweenImports',
+              unexpectedGroupOrder: 'unexpectedImportsGroupOrder',
+              unexpectedOrder: 'unexpectedImportsOrder',
+            },
+            options: {
+              ...options,
+              customGroups: [],
+            },
+            sortNodesExcludingEslintDisabled,
+            sourceCode,
+            context,
+            nodes,
           })
         }
       },

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -18,8 +18,8 @@ import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -137,9 +137,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
             let lastSortingNode = accumulator.at(-1)?.at(-1)
             if (
-              options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode)
+              shouldPartition({
+                lastSortingNode,
+                sortingNode,
+                sourceCode,
+                options,
+              })
             ) {
               accumulator.push([])
             }

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -16,19 +16,15 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
-import { getGroupNumber } from '../utils/get-group-number'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
-import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
 import { matches } from '../utils/matches'
 
@@ -160,59 +156,19 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreEslintDisabledNodes: boolean,
         ): SortingNode[] =>
           sortNodesByGroups(nodes, options, { ignoreEslintDisabledNodes })
-        let sortedNodes = sortNodesExcludingEslintDisabled(false)
-        let sortedNodesExcludingEslintDisabled =
-          sortNodesExcludingEslintDisabled(true)
 
-        let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-        pairwise(nodes, (left, right) => {
-          let leftIndex = nodeIndexMap.get(left)!
-          let rightIndex = nodeIndexMap.get(right)!
-
-          let indexOfRightExcludingEslintDisabled =
-            sortedNodesExcludingEslintDisabled.indexOf(right)
-
-          let leftNumber = getGroupNumber(options.groups, left)
-          let rightNumber = getGroupNumber(options.groups, right)
-
-          let messageIds: MESSAGE_ID[] = []
-
-          if (
-            leftIndex > rightIndex ||
-            leftIndex >= indexOfRightExcludingEslintDisabled
-          ) {
-            messageIds.push(
-              leftNumber === rightNumber
-                ? 'unexpectedJSXPropsOrder'
-                : 'unexpectedJSXPropsGroupOrder',
-            )
-          }
-
-          messageIds = [
-            ...messageIds,
-            ...getNewlinesErrors({
-              missedSpacingError: 'missedSpacingBetweenJSXPropsMembers',
-              extraSpacingError: 'extraSpacingBetweenJSXPropsMembers',
-              rightNum: rightNumber,
-              leftNum: leftNumber,
-              sourceCode,
-              options,
-              right,
-              left,
-            }),
-          ]
-
-          reportErrors({
-            sortedNodes: sortedNodesExcludingEslintDisabled,
-            sourceCode,
-            messageIds,
-            options,
-            context,
-            nodes,
-            right,
-            left,
-          })
+        reportAllErrors<MESSAGE_ID>({
+          availableMessageIds: {
+            missedSpacingBetweenMembers: 'missedSpacingBetweenJSXPropsMembers',
+            extraSpacingBetweenMembers: 'extraSpacingBetweenJSXPropsMembers',
+            unexpectedGroupOrder: 'unexpectedJSXPropsGroupOrder',
+            unexpectedOrder: 'unexpectedJSXPropsOrder',
+          },
+          sortNodesExcludingEslintDisabled,
+          sourceCode,
+          options,
+          context,
+          nodes,
         })
       }
     },

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -22,13 +22,11 @@ import { getMatchingContextOptions } from '../utils/get-matching-context-options
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { doesCustomGroupMatch } from './sort-maps/does-custom-group-match'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { singleCustomGroupJsonSchema } from './sort-maps/types'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -156,16 +154,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
           }
 
           if (
-            hasPartitionComment({
-              comments: getCommentsBefore({
-                node: element,
-                sourceCode,
-              }),
-              partitionByComment: options.partitionByComment,
-            }) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            shouldPartition({
+              lastSortingNode,
+              sortingNode,
+              sourceCode,
+              options,
+            })
           ) {
             formattedMembers.push([])
           }

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -23,22 +23,18 @@ import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { doesCustomGroupMatch } from './sort-maps/does-custom-group-match'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
-import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { singleCustomGroupJsonSchema } from './sort-maps/types'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
-import { getGroupNumber } from '../utils/get-group-number'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 
 type MESSAGE_ID =
   | 'missedSpacingBetweenMapElementsMembers'
@@ -186,59 +182,21 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 getCustomGroupsCompareOptions(options, groupNumber),
               ignoreEslintDisabledNodes,
             })
-          let sortedNodes = sortNodesExcludingEslintDisabled(false)
-          let sortedNodesExcludingEslintDisabled =
-            sortNodesExcludingEslintDisabled(true)
 
-          let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-          pairwise(nodes, (left, right) => {
-            let leftIndex = nodeIndexMap.get(left)!
-            let rightIndex = nodeIndexMap.get(right)!
-
-            let leftNumber = getGroupNumber(options.groups, left)
-            let rightNumber = getGroupNumber(options.groups, right)
-
-            let indexOfRightExcludingEslintDisabled =
-              sortedNodesExcludingEslintDisabled.indexOf(right)
-
-            let messageIds: MESSAGE_ID[] = []
-
-            if (
-              leftIndex > rightIndex ||
-              leftIndex >= indexOfRightExcludingEslintDisabled
-            ) {
-              messageIds.push(
-                leftNumber === rightNumber
-                  ? 'unexpectedMapElementsOrder'
-                  : 'unexpectedMapElementsGroupOrder',
-              )
-            }
-
-            messageIds = [
-              ...messageIds,
-              ...getNewlinesErrors({
-                missedSpacingError: 'missedSpacingBetweenMapElementsMembers',
-                extraSpacingError: 'extraSpacingBetweenMapElementsMembers',
-                rightNum: rightNumber,
-                leftNum: leftNumber,
-                sourceCode,
-                options,
-                right,
-                left,
-              }),
-            ]
-
-            reportErrors({
-              sortedNodes: sortedNodesExcludingEslintDisabled,
-              sourceCode,
-              messageIds,
-              options,
-              context,
-              nodes,
-              right,
-              left,
-            })
+          reportAllErrors<MESSAGE_ID>({
+            availableMessageIds: {
+              missedSpacingBetweenMembers:
+                'missedSpacingBetweenMapElementsMembers',
+              extraSpacingBetweenMembers:
+                'extraSpacingBetweenMapElementsMembers',
+              unexpectedGroupOrder: 'unexpectedMapElementsGroupOrder',
+              unexpectedOrder: 'unexpectedMapElementsOrder',
+            },
+            sortNodesExcludingEslintDisabled,
+            sourceCode,
+            options,
+            context,
+            nodes,
           })
         }
       }

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -33,13 +33,11 @@ import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { doesCustomGroupMatch } from './sort-modules/does-custom-group-match'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { getNodeDecorators } from '../utils/get-node-decorators'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getEnumMembers } from '../utils/get-enum-members'
 import { getSourceCode } from '../utils/get-source-code'
@@ -332,21 +330,19 @@ let analyzeModule = ({
       name,
       node,
     }
+
     let lastSortingNode = formattedNodes.at(-1)?.at(-1)
     if (
-      (options.partitionByNewLine &&
-        lastSortingNode &&
-        getLinesBetween(sourceCode, lastSortingNode, sortingNode)) ||
-      hasPartitionComment({
-        comments: getCommentsBefore({
-          sourceCode,
-          node,
-        }),
-        partitionByComment: options.partitionByComment,
+      shouldPartition({
+        lastSortingNode,
+        sortingNode,
+        sourceCode,
+        options,
       })
     ) {
       formattedNodes.push([])
     }
+
     formattedNodes.at(-1)?.push(sortingNode)
   }
 

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -16,18 +16,16 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<
@@ -143,35 +141,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             }),
           )
 
-        let sortedNodes = sortNodesExcludingEslintDisabled(false)
-        let sortedNodesExcludingEslintDisabled =
-          sortNodesExcludingEslintDisabled(true)
-
-        let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-        pairwise(nodes, (left, right) => {
-          let leftIndex = nodeIndexMap.get(left)!
-          let rightIndex = nodeIndexMap.get(right)!
-
-          let indexOfRightExcludingEslintDisabled =
-            sortedNodesExcludingEslintDisabled.indexOf(right)
-          if (
-            leftIndex < rightIndex &&
-            leftIndex < indexOfRightExcludingEslintDisabled
-          ) {
-            return
-          }
-
-          reportErrors({
-            sortedNodes: sortedNodesExcludingEslintDisabled,
-            messageIds: ['unexpectedNamedExportsOrder'],
-            sourceCode,
-            options,
-            context,
-            nodes,
-            right,
-            left,
-          })
+        reportAllErrors<MESSAGE_ID>({
+          availableMessageIds: {
+            unexpectedOrder: 'unexpectedNamedExportsOrder',
+          },
+          sortNodesExcludingEslintDisabled,
+          sourceCode,
+          options,
+          context,
+          nodes,
         })
       }
     },

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -15,11 +15,9 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -98,17 +96,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
           groupKind,
           name,
         }
+
         if (
-          hasPartitionComment({
-            comments: getCommentsBefore({
-              node: specifier,
-              sourceCode,
-            }),
-            partitionByComment: options.partitionByComment,
-          }) ||
-          (options.partitionByNewLine &&
-            lastSortingNode &&
-            getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+          shouldPartition({
+            lastSortingNode,
+            sortingNode,
+            sourceCode,
+            options,
+          })
         ) {
           formattedMembers.push([])
         }

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -16,18 +16,16 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<
@@ -152,35 +150,15 @@ export default createEslintRule<Options, MESSAGE_ID>({
             }),
           )
 
-        let sortedNodes = sortNodesExcludingEslintDisabled(false)
-        let sortedNodesExcludingEslintDisabled =
-          sortNodesExcludingEslintDisabled(true)
-
-        let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-        pairwise(nodes, (left, right) => {
-          let leftIndex = nodeIndexMap.get(left)!
-          let rightIndex = nodeIndexMap.get(right)!
-
-          let indexOfRightExcludingEslintDisabled =
-            sortedNodesExcludingEslintDisabled.indexOf(right)
-          if (
-            leftIndex < rightIndex &&
-            leftIndex < indexOfRightExcludingEslintDisabled
-          ) {
-            return
-          }
-
-          reportErrors({
-            sortedNodes: sortedNodesExcludingEslintDisabled,
-            messageIds: ['unexpectedNamedImportsOrder'],
-            sourceCode,
-            options,
-            context,
-            nodes,
-            right,
-            left,
-          })
+        reportAllErrors<MESSAGE_ID>({
+          availableMessageIds: {
+            unexpectedOrder: 'unexpectedNamedImportsOrder',
+          },
+          sortNodesExcludingEslintDisabled,
+          sourceCode,
+          options,
+          context,
+          nodes,
         })
       }
     },

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -15,11 +15,9 @@ import {
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -108,16 +106,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
         }
 
         if (
-          hasPartitionComment({
-            comments: getCommentsBefore({
-              node: specifier,
-              sourceCode,
-            }),
-            partitionByComment: options.partitionByComment,
-          }) ||
-          (options.partitionByNewLine &&
-            lastSortingNode &&
-            getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+          shouldPartition({
+            lastSortingNode,
+            sortingNode,
+            sourceCode,
+            options,
+          })
         ) {
           formattedMembers.push([])
         }

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -32,13 +32,11 @@ import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isMemberOptional } from './sort-object-types/is-member-optional'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
 import { isNodeFunctionType } from '../utils/is-node-function-type'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -336,17 +334,12 @@ export let sortObjectTypeElements = <MessageIds extends string>({
       }
 
       if (
-        (options.partitionByComment &&
-          hasPartitionComment({
-            comments: getCommentsBefore({
-              node: typeElement,
-              sourceCode,
-            }),
-            partitionByComment: options.partitionByComment,
-          })) ||
-        (options.partitionByNewLine &&
-          lastSortingNode &&
-          getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+        shouldPartition({
+          lastSortingNode,
+          sortingNode,
+          sourceCode,
+          options,
+        })
       ) {
         lastGroup = []
         accumulator.push(lastGroup)

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -34,21 +34,17 @@ import { isMemberOptional } from './sort-object-types/is-member-optional'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
 import { isNodeFunctionType } from '../utils/is-node-function-type'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getCommentsBefore } from '../utils/get-comments-before'
-import { getNewlinesErrors } from '../utils/get-newlines-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
-import { getGroupNumber } from '../utils/get-group-number'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 import { matches } from '../utils/matches'
 
 /**
@@ -388,59 +384,14 @@ export let sortObjectTypeElements = <MessageIds extends string>({
           ignoreEslintDisabledNodes,
         }),
       )
-    let sortedNodes = sortNodesExcludingEslintDisabled(false)
-    let sortedNodesExcludingEslintDisabled =
-      sortNodesExcludingEslintDisabled(true)
 
-    let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-    pairwise(nodes, (left, right) => {
-      let leftNumber = getGroupNumber(options.groups, left)
-      let rightNumber = getGroupNumber(options.groups, right)
-
-      let leftIndex = nodeIndexMap.get(left)!
-      let rightIndex = nodeIndexMap.get(right)!
-
-      let indexOfRightExcludingEslintDisabled =
-        sortedNodesExcludingEslintDisabled.indexOf(right)
-
-      let messageIds: MessageIds[] = []
-
-      if (
-        leftIndex > rightIndex ||
-        leftIndex >= indexOfRightExcludingEslintDisabled
-      ) {
-        messageIds.push(
-          leftNumber === rightNumber
-            ? availableMessageIds.unexpectedOrder
-            : availableMessageIds.unexpectedGroupOrder,
-        )
-      }
-
-      messageIds = [
-        ...messageIds,
-        ...getNewlinesErrors({
-          missedSpacingError: availableMessageIds.missedSpacingBetweenMembers,
-          extraSpacingError: availableMessageIds.extraSpacingBetweenMembers,
-          rightNum: rightNumber,
-          leftNum: leftNumber,
-          sourceCode,
-          options,
-          right,
-          left,
-        }),
-      ]
-
-      reportErrors({
-        sortedNodes: sortedNodesExcludingEslintDisabled,
-        messageIds,
-        sourceCode,
-        options,
-        context,
-        nodes,
-        right,
-        left,
-      })
+    reportAllErrors<MessageIds>({
+      sortNodesExcludingEslintDisabled,
+      availableMessageIds,
+      sourceCode,
+      options,
+      context,
+      nodes,
     })
   }
 }

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -22,12 +22,10 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -251,18 +249,15 @@ export let sortUnionOrIntersectionTypes = <MessageIds extends string>({
         group: getGroup(),
         node: type,
       }
+
       if (
-        hasPartitionComment({
-          comments: getCommentsBefore({
-            tokenValueToIgnoreBefore,
-            node: type,
-            sourceCode,
-          }),
-          partitionByComment: options.partitionByComment,
-        }) ||
-        (options.partitionByNewLine &&
-          lastSortingNode &&
-          getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+        shouldPartition({
+          tokenValueToIgnoreBefore,
+          lastSortingNode,
+          sortingNode,
+          sourceCode,
+          options,
+        })
       ) {
         lastGroup = []
         accumulator.push(lastGroup)

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -16,11 +16,9 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
-import { hasPartitionComment } from '../utils/has-partition-comment'
-import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getLinesBetween } from '../utils/get-lines-between'
 import { reportAllErrors } from '../utils/report-all-errors'
+import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
@@ -191,17 +189,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
             dependencies,
             name,
           }
+
           if (
-            hasPartitionComment({
-              comments: getCommentsBefore({
-                node: declaration,
-                sourceCode,
-              }),
-              partitionByComment: options.partitionByComment,
-            }) ||
-            (options.partitionByNewLine &&
-              lastSortingNode &&
-              getLinesBetween(sourceCode, lastSortingNode, sortingNode))
+            shouldPartition({
+              lastSortingNode,
+              sortingNode,
+              sourceCode,
+              options,
+            })
           ) {
             accumulator.push([])
           }

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -12,26 +12,21 @@ import {
   buildTypeJsonSchema,
   commonJsonSchemas,
 } from '../utils/common-json-schemas'
-import {
-  getFirstUnorderedNodeDependentOn,
-  sortNodesByDependencies,
-} from '../utils/sort-nodes-by-dependencies'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
+import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { hasPartitionComment } from '../utils/has-partition-comment'
-import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
+import { reportAllErrors } from '../utils/report-all-errors'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
-import { pairwise } from '../utils/pairwise'
 
 type Options = [
   Partial<
@@ -218,7 +213,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         [[]],
       )
 
-      let sortNodesIgnoringEslintDisabledNodes = (
+      let sortNodesExcludingEslintDisabled = (
         ignoreEslintDisabledNodes: boolean,
       ): SortingNodeWithDependencies[] =>
         sortNodesByDependencies(
@@ -231,45 +226,20 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ignoreEslintDisabledNodes,
           },
         )
-      let sortedNodes = sortNodesIgnoringEslintDisabledNodes(false)
-      let sortedNodesExcludingEslintDisabled =
-        sortNodesIgnoringEslintDisabledNodes(true)
 
       let nodes = formattedMembers.flat()
 
-      let nodeIndexMap = createNodeIndexMap(sortedNodes)
-
-      pairwise(nodes, (left, right) => {
-        let leftIndex = nodeIndexMap.get(left)!
-        let rightIndex = nodeIndexMap.get(right)!
-
-        let indexOfRightExcludingEslintDisabled =
-          sortedNodesExcludingEslintDisabled.indexOf(right)
-        if (
-          leftIndex < rightIndex &&
-          leftIndex < indexOfRightExcludingEslintDisabled
-        ) {
-          return
-        }
-
-        let firstUnorderedNodeDependentOnRight =
-          getFirstUnorderedNodeDependentOn(right, nodes)
-
-        reportErrors({
-          messageIds: [
-            firstUnorderedNodeDependentOnRight
-              ? 'unexpectedVariableDeclarationsDependencyOrder'
-              : 'unexpectedVariableDeclarationsOrder',
-          ],
-          sortedNodes: sortedNodesExcludingEslintDisabled,
-          firstUnorderedNodeDependentOnRight,
-          sourceCode,
-          options,
-          context,
-          nodes,
-          right,
-          left,
-        })
+      reportAllErrors<MESSAGE_ID>({
+        availableMessageIds: {
+          unexpectedDependencyOrder:
+            'unexpectedVariableDeclarationsDependencyOrder',
+          unexpectedOrder: 'unexpectedVariableDeclarationsOrder',
+        },
+        sortNodesExcludingEslintDisabled,
+        sourceCode,
+        options,
+        context,
+        nodes,
       })
     },
   }),

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -529,6 +529,13 @@ describe(ruleName, () => {
                   },
                   messageId: 'unexpectedObjectsDependencyOrder',
                 },
+                {
+                  data: {
+                    nodeDependentOnRight: 'b',
+                    right: 'd',
+                  },
+                  messageId: 'unexpectedObjectsDependencyOrder',
+                },
               ],
               output: dedent`
                 let Func = ({
@@ -590,6 +597,13 @@ describe(ruleName, () => {
                   data: {
                     nodeDependentOnRight: 'b',
                     right: 'c',
+                  },
+                  messageId: 'unexpectedObjectsDependencyOrder',
+                },
+                {
+                  data: {
+                    nodeDependentOnRight: 'b',
+                    right: 'd',
                   },
                   messageId: 'unexpectedObjectsDependencyOrder',
                 },
@@ -1029,7 +1043,7 @@ describe(ruleName, () => {
             {
               code: dedent`
                 let Func = ({
-                  b = a,
+                  b = 'b',
                   a = b as any,
                 }) => {
                   // ...
@@ -1054,7 +1068,7 @@ describe(ruleName, () => {
             {
               code: dedent`
                 let Func = ({
-                  b = a,
+                  b = 'b',
                   a = <any>b,
                 }) => {
                   // ...
@@ -1079,7 +1093,7 @@ describe(ruleName, () => {
             {
               code: dedent`
                 let Func = ({
-                  b = a,
+                  b = 'b',
                   a = \`\${b}\`,
                 }) => {
                   // ...
@@ -3555,6 +3569,13 @@ describe(ruleName, () => {
                 },
                 messageId: 'unexpectedObjectsDependencyOrder',
               },
+              {
+                data: {
+                  nodeDependentOnRight: 'b',
+                  right: 'd',
+                },
+                messageId: 'unexpectedObjectsDependencyOrder',
+              },
             ],
             output: dedent`
               let Func = ({
@@ -3616,6 +3637,13 @@ describe(ruleName, () => {
                 data: {
                   nodeDependentOnRight: 'b',
                   right: 'c',
+                },
+                messageId: 'unexpectedObjectsDependencyOrder',
+              },
+              {
+                data: {
+                  nodeDependentOnRight: 'b',
+                  right: 'd',
                 },
                 messageId: 'unexpectedObjectsDependencyOrder',
               },
@@ -4453,6 +4481,13 @@ describe(ruleName, () => {
                 },
                 messageId: 'unexpectedObjectsDependencyOrder',
               },
+              {
+                data: {
+                  nodeDependentOnRight: 'b',
+                  right: 'd',
+                },
+                messageId: 'unexpectedObjectsDependencyOrder',
+              },
             ],
             output: dedent`
               let Func = ({
@@ -4514,6 +4549,13 @@ describe(ruleName, () => {
                 data: {
                   nodeDependentOnRight: 'b',
                   right: 'c',
+                },
+                messageId: 'unexpectedObjectsDependencyOrder',
+              },
+              {
+                data: {
+                  nodeDependentOnRight: 'b',
+                  right: 'd',
                 },
                 messageId: 'unexpectedObjectsDependencyOrder',
               },

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -561,7 +561,7 @@ describe(ruleName, () => {
               },
             ],
             code: dedent`
-              let b = a,
+              let b = 'b',
               a = b as any;
             `,
           },
@@ -582,7 +582,7 @@ describe(ruleName, () => {
               },
             ],
             code: dedent`
-              let b = a,
+              let b = 'b',
               a = <any>b;
             `,
           },
@@ -603,7 +603,7 @@ describe(ruleName, () => {
               },
             ],
             code: dedent`
-              let b = a,
+              let b = 'b',
               a = \`\${b}\`
             `,
           },

--- a/utils/get-custom-groups-compare-options.ts
+++ b/utils/get-custom-groups-compare-options.ts
@@ -1,16 +1,13 @@
+import type { GroupsOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 import type { CompareOptions } from './compare'
 
 interface Options {
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | string[]
-    | string
-  )[]
   customGroups: Record<string, string[] | string> | CustomGroup[]
   type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
   specialCharacters: 'remove' | 'trim' | 'keep'
   locales: NonNullable<Intl.LocalesArgument>
+  groups: GroupsOptions<string>
   order: 'desc' | 'asc'
   ignoreCase: boolean
   alphabet: string
@@ -40,7 +37,7 @@ type CustomGroup = (
  * if the group should not be sorted.
  */
 export let getCustomGroupsCompareOptions = <T extends SortingNode>(
-  options: Required<Options>,
+  options: Options,
   groupNumber: number,
 ): CompareOptions<T> | null => {
   if (!Array.isArray(options.customGroups)) {

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -1,3 +1,4 @@
+import type { GroupsOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getGroupNumber } from './get-group-number'
@@ -9,13 +10,9 @@ export interface GetNewlinesBetweenOptionParameters {
 }
 
 interface Options {
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | string[]
-    | string
-  )[]
   customGroups?: Record<string, string[] | string> | CustomGroup[]
   newlinesBetween: 'ignore' | 'always' | 'never'
+  groups: GroupsOptions<string>
 }
 
 interface CustomGroup {

--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -1,0 +1,128 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { SortingNodeWithDependencies } from './sort-nodes-by-dependencies'
+import type { GroupsOptions } from '../types/common-options'
+import type { SortingNode } from '../types/sorting-node'
+import type { MakeFixesParameters } from './make-fixes'
+
+import { getFirstUnorderedNodeDependentOn } from './sort-nodes-by-dependencies'
+import { createNodeIndexMap } from './create-node-index-map'
+import { getNewlinesErrors } from './get-newlines-errors'
+import { getGroupNumber } from './get-group-number'
+import { reportErrors } from './report-errors'
+import { pairwise } from './pairwise'
+
+interface ReportAllErrorsParameters<MessageIds extends string> {
+  availableMessageIds: {
+    missedSpacingBetweenMembers?: MessageIds
+    extraSpacingBetweenMembers?: MessageIds
+    unexpectedDependencyOrder?: MessageIds
+    unexpectedGroupOrder?: MessageIds
+    unexpectedOrder: MessageIds
+  }
+  sortNodesExcludingEslintDisabled(
+    ignoreEslintDisabledNodes: boolean,
+  ): SortingNode[]
+  options?: {
+    groups?: GroupsOptions<string>
+  } & MakeFixesParameters['options']
+  context: TSESLint.RuleContext<MessageIds, unknown[]>
+  ignoreFirstNodeHighestBlockComment?: boolean
+  sourceCode: TSESLint.SourceCode
+  nodes: SortingNode[]
+}
+
+export let reportAllErrors = <MessageIds extends string>({
+  ignoreFirstNodeHighestBlockComment,
+  sortNodesExcludingEslintDisabled,
+  availableMessageIds,
+  sourceCode,
+  context,
+  options,
+  nodes,
+}: ReportAllErrorsParameters<MessageIds>): void => {
+  let sortedNodes = sortNodesExcludingEslintDisabled(false)
+  let sortedNodesExcludingEslintDisabled =
+    sortNodesExcludingEslintDisabled(true)
+  let nodeIndexMap = createNodeIndexMap(sortedNodes)
+
+  pairwise(nodes, (left, right) => {
+    let leftNumber = options?.groups ? getGroupNumber(options.groups, left) : 0
+    let rightNumber = options?.groups
+      ? getGroupNumber(options.groups, right)
+      : 0
+
+    let leftIndex = nodeIndexMap.get(left)!
+    let rightIndex = nodeIndexMap.get(right)!
+
+    let indexOfRightExcludingEslintDisabled =
+      sortedNodesExcludingEslintDisabled.indexOf(right)
+
+    let messageIds: MessageIds[] = []
+
+    let firstUnorderedNodeDependentOnRight:
+      | SortingNodeWithDependencies
+      | undefined
+    if (availableMessageIds.unexpectedDependencyOrder) {
+      firstUnorderedNodeDependentOnRight = getFirstUnorderedNodeDependentOn(
+        right as SortingNodeWithDependencies,
+        nodes as SortingNodeWithDependencies[],
+      )
+    }
+
+    if (
+      firstUnorderedNodeDependentOnRight ||
+      leftIndex > rightIndex ||
+      leftIndex >= indexOfRightExcludingEslintDisabled
+    ) {
+      if (firstUnorderedNodeDependentOnRight) {
+        messageIds.push(availableMessageIds.unexpectedDependencyOrder!)
+      } else {
+        messageIds.push(
+          leftNumber === rightNumber ||
+            !availableMessageIds.unexpectedGroupOrder
+            ? availableMessageIds.unexpectedOrder
+            : availableMessageIds.unexpectedGroupOrder,
+        )
+      }
+    }
+
+    if (
+      options?.newlinesBetween &&
+      options.groups &&
+      availableMessageIds.missedSpacingBetweenMembers &&
+      availableMessageIds.extraSpacingBetweenMembers
+    ) {
+      messageIds = [
+        ...messageIds,
+        ...getNewlinesErrors({
+          options: {
+            ...options,
+            newlinesBetween: options.newlinesBetween,
+            groups: options.groups,
+          },
+          missedSpacingError: availableMessageIds.missedSpacingBetweenMembers,
+          extraSpacingError: availableMessageIds.extraSpacingBetweenMembers,
+          rightNum: rightNumber,
+          leftNum: leftNumber,
+          sourceCode,
+          right,
+          left,
+        }),
+      ]
+    }
+
+    reportErrors({
+      sortedNodes: sortedNodesExcludingEslintDisabled,
+      ignoreFirstNodeHighestBlockComment,
+      firstUnorderedNodeDependentOnRight,
+      messageIds,
+      sourceCode,
+      options,
+      context,
+      nodes,
+      right,
+      left,
+    })
+  })
+}

--- a/utils/should-partition.ts
+++ b/utils/should-partition.ts
@@ -1,0 +1,47 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { PartitionByCommentOption } from '../types/common-options'
+import type { SortingNode } from '../types/sorting-node'
+
+import { hasPartitionComment } from './has-partition-comment'
+import { getCommentsBefore } from './get-comments-before'
+import { getLinesBetween } from './get-lines-between'
+
+interface ShouldPartitionParameters {
+  options: {
+    partitionByComment?: PartitionByCommentOption
+    partitionByNewLine?: boolean
+  }
+  lastSortingNode: SortingNode | undefined
+  tokenValueToIgnoreBefore?: string
+  sourceCode: TSESLint.SourceCode
+  sortingNode: SortingNode
+}
+
+export let shouldPartition = ({
+  tokenValueToIgnoreBefore,
+  lastSortingNode,
+  sortingNode,
+  sourceCode,
+  options,
+}: ShouldPartitionParameters): boolean => {
+  let shouldPartitionByComment =
+    options.partitionByComment &&
+    hasPartitionComment({
+      comments: getCommentsBefore({
+        tokenValueToIgnoreBefore,
+        node: sortingNode.node,
+        sourceCode,
+      }),
+      partitionByComment: options.partitionByComment,
+    })
+  if (shouldPartitionByComment) {
+    return true
+  }
+
+  return !!(
+    options.partitionByNewLine &&
+    lastSortingNode &&
+    getLinesBetween(sourceCode, lastSortingNode, sortingNode)
+  )
+}

--- a/utils/sort-nodes-by-groups.ts
+++ b/utils/sort-nodes-by-groups.ts
@@ -1,3 +1,4 @@
+import type { GroupsOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 import type { CompareOptions } from './compare'
 
@@ -14,17 +15,13 @@ interface ExtraOptions<T extends SortingNode> {
   isNodeIgnored?(node: T): boolean
 }
 
-interface GroupsOptions {
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | string[]
-    | string
-  )[]
+interface GroupsOption {
+  groups: GroupsOptions<string>
 }
 
 export let sortNodesByGroups = <T extends SortingNode>(
   nodes: T[],
-  options: CompareOptions<T> & GroupsOptions,
+  options: CompareOptions<T> & GroupsOption,
   extraOptions?: ExtraOptions<T>,
 ): T[] => {
   let nodesByNonIgnoredGroupNumber: Record<number, T[]> = {}

--- a/utils/validate-newlines-and-partition-configuration.ts
+++ b/utils/validate-newlines-and-partition-configuration.ts
@@ -1,10 +1,8 @@
+import type { GroupsOptions } from '../types/common-options'
+
 interface Options {
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | string[]
-    | string
-  )[]
   newlinesBetween: 'ignore' | 'always' | 'never'
+  groups: GroupsOptions<string>
   partitionByNewLine: boolean
 }
 


### PR DESCRIPTION
Continuation of https://github.com/azat-io/eslint-plugin-perfectionist/pull/445.

# Description

This PR further decreases code duplication by putting the error and fixes generation behind a `reportAllErrors` function.
It also creates a `shouldPartitionFunction` that checks both `partitionByComment` and `partitionByNewLine`.

# Tests updated

A couple of tests were updated:

## `sort-variables`

Some tests were making a circular dependency:

```ts
  let b = a,
  a = <any>b;
```
(`b` references `a` and `a` references `b`)

=>

```ts
  let b = 'b',
  a = <any>b;
```

Commit: [`ee0a819` (#446)](https://github.com/azat-io/eslint-plugin-perfectionist/pull/446/commits/ee0a8196a5be59f90f2002980b0618f2c07829eb#diff-f1654584a631196a4910bc61ab25073e4192b2a755673993e9f45eed2f49464d)

## `sort-objects`

There is a minor difference between how dependency errors were raised in `sort-objects` in comparison to `reportAllErrors`, leading to a few additional errors being raised. Outputs were not changed.

Commit: [`22adc71` (#446)](https://github.com/azat-io/eslint-plugin-perfectionist/pull/446/commits/22adc7168d3077e60f0143ea464614aa96752bfe#diff-b0cd59a5f8f908bc7e013e0403f96568fdfe19dd641f32083b1d5aae6db3e0ebL529)

### Explanation of the difference

#### Before in `sort-objects`

```ts
        if (
          leftIndex > rightIndex ||
          leftIndex >= indexOfRightExcludingEslintDisabled
        ) {
          firstUnorderedNodeDependentOnRight = getFirstUnorderedNodeDependentOn(
            right,
            nodes,
          )
          if (firstUnorderedNodeDependentOnRight) {
            messageIds.push('unexpectedObjectsDependencyOrder')
          } else {
            messageIds.push(
              leftNumber === rightNumber
                ? 'unexpectedObjectsOrder'
                : 'unexpectedObjectsGroupOrder',
            )
          }
        }
```

#### After in `sort-objects` (implementation of `reportAllErrors`)

```ts
          firstUnorderedNodeDependentOnRight = getFirstUnorderedNodeDependentOn(
            right,
            nodes,
          )

        if (
          firstUnorderedNodeDependentOnRight ||
          leftIndex > rightIndex ||
          leftIndex >= indexOfRightExcludingEslintDisabled
        ) {
          if (firstUnorderedNodeDependentOnRight) {
            messageIds.push('unexpectedObjectsDependencyOrder')
          } else {
            messageIds.push(
              leftNumber === rightNumber
                ? 'unexpectedObjectsOrder'
                : 'unexpectedObjectsGroupOrder',
            )
          }
        }
```

### What is the purpose of this pull request?

- [x] Other
