### PR TITLE
refactor: creates additional common options

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -195,10 +195,9 @@ export let sortArray = <MessageIds extends string>({
   }
   validateCustomSortConfiguration(options)
   validateGeneratedGroupsConfiguration({
-    customGroups: options.customGroups,
     selectors: allSelectors,
-    groups: options.groups,
     modifiers: [],
+    options,
   })
   validateNewlinesAndPartitionConfiguration(options)
 

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -16,6 +16,12 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
@@ -128,14 +134,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
   }),
   meta: {
     messages: {
-      unexpectedArrayIncludesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenArrayIncludesMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" members.',
-      extraSpacingBetweenArrayIncludesMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" members.',
-      unexpectedArrayIncludesOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
+      missedSpacingBetweenArrayIncludesMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenArrayIncludesMembers: EXTRA_SPACING_ERROR,
+      unexpectedArrayIncludesGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedArrayIncludesOrder: ORDER_ERROR,
     },
     docs: {
       description: 'Enforce sorted arrays before include method.',

--- a/rules/sort-array-includes/does-custom-group-match.ts
+++ b/rules/sort-array-includes/does-custom-group-match.ts
@@ -1,9 +1,10 @@
-import type { SingleCustomGroup, AnyOfCustomGroup, Selector } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
+import type { SingleCustomGroup, Selector } from './types'
 
 import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchParameters {
-  customGroup: SingleCustomGroup | AnyOfCustomGroup
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
   selectors: Selector[]
   elementName: string
 }

--- a/rules/sort-array-includes/does-custom-group-match.ts
+++ b/rules/sort-array-includes/does-custom-group-match.ts
@@ -2,7 +2,7 @@ import type { SingleCustomGroup, AnyOfCustomGroup, Selector } from './types'
 
 import { matches } from '../../utils/matches'
 
-interface DoesCustomGroupMatchProps {
+interface DoesCustomGroupMatchParameters {
   customGroup: SingleCustomGroup | AnyOfCustomGroup
   selectors: Selector[]
   elementName: string
@@ -10,13 +10,13 @@ interface DoesCustomGroupMatchProps {
 
 /**
  * Determines whether a custom group matches the given properties.
- * @param {DoesCustomGroupMatchProps} props - The properties to compare with the
- * custom group, including selectors, modifiers, and element name.
+ * @param {DoesCustomGroupMatchParameters} props - The properties to compare
+ * with the custom group, including selectors, modifiers, and element name.
  * @returns {boolean} `true` if the custom group matches the properties;
  * otherwise, `false`.
  */
 export let doesCustomGroupMatch = (
-  props: DoesCustomGroupMatchProps,
+  props: DoesCustomGroupMatchParameters,
 ): boolean => {
   if ('anyOf' in props.customGroup) {
     // At least one subgroup must match

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -5,6 +5,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../../types/common-options'
 
 import {
@@ -14,7 +15,6 @@ import {
 
 export type Options = Partial<
   {
-    type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
     useConfigurationIf: {
       allNamesMatchPattern?: string
     }
@@ -24,6 +24,7 @@ export type Options = Partial<
     groupKind: 'literals-first' | 'spreads-first' | 'mixed'
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
+    type: TypeOption | 'unsorted'
     groups: GroupsOptions<Group>
     customGroups: CustomGroup[]
     partitionByNewLine: boolean

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../../types/common-options'
@@ -21,8 +22,8 @@ export type Options = Partial<
      * @deprecated for {@link `groups`}
      */
     groupKind: 'literals-first' | 'spreads-first' | 'mixed'
-    newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     customGroups: CustomGroup[]
     partitionByNewLine: boolean

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -3,6 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   TypeOption,
@@ -22,11 +23,11 @@ export type Options = Partial<
      * @deprecated for {@link `groups`}
      */
     groupKind: 'literals-first' | 'spreads-first' | 'mixed'
+    customGroups: CustomGroupsOption<SingleCustomGroup>
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
     type: TypeOption | 'unsorted'
     groups: GroupsOptions<Group>
-    customGroups: CustomGroup[]
     partitionByNewLine: boolean
   } & CommonOptions
 >[]
@@ -36,24 +37,7 @@ export interface SingleCustomGroup {
   selector?: Selector
 }
 
-export interface AnyOfCustomGroup {
-  anyOf: SingleCustomGroup[]
-}
-
 export type Selector = LiteralSelector | SpreadSelector
-
-type CustomGroup = (
-  | {
-      order?: Options[0]['order']
-      type?: Options[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) &
-  (SingleCustomGroup | AnyOfCustomGroup) & {
-    groupName: string
-  }
 
 type LiteralSelector = 'literal'
 

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -112,10 +112,9 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
       let options = complete(context.options.at(0), settings, defaultOptions)
       validateCustomSortConfiguration(options)
       validateGeneratedGroupsConfiguration({
-        customGroups: options.customGroups,
         modifiers: allModifiers,
         selectors: allSelectors,
-        groups: options.groups,
+        options,
       })
       validateNewlinesAndPartitionConfiguration(options)
 

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -16,6 +16,13 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  DEPENDENCY_ORDER_ERROR,
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import {
@@ -655,15 +662,11 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
       },
     ],
     messages: {
-      unexpectedClassesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      unexpectedClassesDependencyOrder:
-        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
-      missedSpacingBetweenClassMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" objects.',
-      extraSpacingBetweenClassMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" objects.',
-      unexpectedClassesOrder: 'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedClassesDependencyOrder: DEPENDENCY_ORDER_ERROR,
+      missedSpacingBetweenClassMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenClassMembers: EXTRA_SPACING_ERROR,
+      unexpectedClassesGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedClassesOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-classes',

--- a/rules/sort-classes/does-custom-group-match.ts
+++ b/rules/sort-classes/does-custom-group-match.ts
@@ -1,14 +1,10 @@
-import type {
-  SingleCustomGroup,
-  AnyOfCustomGroup,
-  Modifier,
-  Selector,
-} from './types'
+import type { SingleCustomGroup, Modifier, Selector } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
 
 import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchParameters {
-  customGroup: SingleCustomGroup | AnyOfCustomGroup
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
   elementValue: undefined | string
   selectors: Selector[]
   modifiers: Modifier[]

--- a/rules/sort-classes/does-custom-group-match.ts
+++ b/rules/sort-classes/does-custom-group-match.ts
@@ -7,7 +7,7 @@ import type {
 
 import { matches } from '../../utils/matches'
 
-interface DoesCustomGroupMatchProps {
+interface DoesCustomGroupMatchParameters {
   customGroup: SingleCustomGroup | AnyOfCustomGroup
   elementValue: undefined | string
   selectors: Selector[]
@@ -18,14 +18,14 @@ interface DoesCustomGroupMatchProps {
 
 /**
  * Determines whether a custom group matches the given properties.
- * @param {DoesCustomGroupMatchProps} props - The properties to match against
- * the custom group, including selectors, modifiers, decorators, and element
- * names.
+ * @param {DoesCustomGroupMatchParameters} props - The properties to match
+ * against the custom group, including selectors, modifiers, decorators, and
+ * element names.
  * @returns {boolean} `true` if the custom group matches the properties;
  * otherwise, `false`.
  */
 export let doesCustomGroupMatch = (
-  props: DoesCustomGroupMatchProps,
+  props: DoesCustomGroupMatchParameters,
 ): boolean => {
   if ('anyOf' in props.customGroup) {
     // At least one subgroup must match.

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../../types/common-options'
@@ -29,9 +30,9 @@ export type SortClassesOptions = [
   Partial<
     {
       type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-      newlinesBetween: 'ignore' | 'always' | 'never'
       partitionByComment: PartitionByCommentOption
       ignoreCallbackDependenciesPatterns: string[]
+      newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group>
       partitionByNewLine: boolean
       customGroups: CustomGroup[]

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -3,6 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   TypeOption,
@@ -30,29 +31,16 @@ export type SingleCustomGroup =
 export type SortClassesOptions = [
   Partial<
     {
+      customGroups: CustomGroupsOption<SingleCustomGroup>
       partitionByComment: PartitionByCommentOption
       ignoreCallbackDependenciesPatterns: string[]
       newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group>
       partitionByNewLine: boolean
-      customGroups: CustomGroup[]
       type: TypeOption
     } & CommonOptions
   >,
 ]
-
-export type CustomGroup = (
-  | {
-      order?: SortClassesOptions[0]['order']
-      type?: SortClassesOptions[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) & {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
-} & (SingleCustomGroup | AnyOfCustomGroup)
 
 export type NonDeclarePropertyGroup = JoinWithDash<
   [
@@ -150,10 +138,6 @@ export type IndexSignatureGroup = JoinWithDash<
 export type ConstructorGroup = JoinWithDash<
   [PublicOrProtectedOrPrivateModifier, ConstructorSelector]
 >
-
-export interface AnyOfCustomGroup {
-  anyOf: SingleCustomGroup[]
-}
 
 /**
  * Only used in code as well

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -5,6 +5,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -29,13 +30,13 @@ export type SingleCustomGroup =
 export type SortClassesOptions = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       partitionByComment: PartitionByCommentOption
       ignoreCallbackDependenciesPatterns: string[]
       newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group>
       partitionByNewLine: boolean
       customGroups: CustomGroup[]
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -19,6 +19,7 @@ import { validateGroupsConfiguration } from '../utils/validate-groups-configurat
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { getDecoratorName } from './sort-decorators/get-decorator-name'
+import { GROUP_ORDER_ERROR, ORDER_ERROR } from '../utils/report-errors'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { getNodeDecorators } from '../utils/get-node-decorators'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -71,59 +72,6 @@ let defaultOptions: Required<Options[0]> = {
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
-  meta: {
-    schema: [
-      {
-        properties: {
-          ...commonJsonSchemas,
-          sortOnParameters: {
-            description:
-              'Controls whether sorting should be enabled for method parameter decorators.',
-            type: 'boolean',
-          },
-          sortOnProperties: {
-            description:
-              'Controls whether sorting should be enabled for class property decorators.',
-            type: 'boolean',
-          },
-          sortOnAccessors: {
-            description:
-              'Controls whether sorting should be enabled for class accessor decorators.',
-            type: 'boolean',
-          },
-          sortOnMethods: {
-            description:
-              'Controls whether sorting should be enabled for class method decorators.',
-            type: 'boolean',
-          },
-          sortOnClasses: {
-            description:
-              'Controls whether sorting should be enabled for class decorators.',
-            type: 'boolean',
-          },
-          partitionByComment: partitionByCommentJsonSchema,
-          customGroups: customGroupsJsonSchema,
-          type: buildTypeJsonSchema(),
-          groups: groupsJsonSchema,
-        },
-        additionalProperties: false,
-        type: 'object',
-      },
-    ],
-    messages: {
-      unexpectedDecoratorsGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      unexpectedDecoratorsOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
-    },
-    docs: {
-      url: 'https://perfectionist.dev/rules/sort-decorators',
-      description: 'Enforce sorted decorators.',
-      recommended: true,
-    },
-    type: 'suggestion',
-    fixable: 'code',
-  },
   create: context => {
     let settings = getSettings(context.settings)
 
@@ -181,6 +129,57 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ? sortDecorators(context, options, getNodeDecorators(declaration))
           : null,
     }
+  },
+  meta: {
+    schema: [
+      {
+        properties: {
+          ...commonJsonSchemas,
+          sortOnParameters: {
+            description:
+              'Controls whether sorting should be enabled for method parameter decorators.',
+            type: 'boolean',
+          },
+          sortOnProperties: {
+            description:
+              'Controls whether sorting should be enabled for class property decorators.',
+            type: 'boolean',
+          },
+          sortOnAccessors: {
+            description:
+              'Controls whether sorting should be enabled for class accessor decorators.',
+            type: 'boolean',
+          },
+          sortOnMethods: {
+            description:
+              'Controls whether sorting should be enabled for class method decorators.',
+            type: 'boolean',
+          },
+          sortOnClasses: {
+            description:
+              'Controls whether sorting should be enabled for class decorators.',
+            type: 'boolean',
+          },
+          partitionByComment: partitionByCommentJsonSchema,
+          customGroups: customGroupsJsonSchema,
+          type: buildTypeJsonSchema(),
+          groups: groupsJsonSchema,
+        },
+        additionalProperties: false,
+        type: 'object',
+      },
+    ],
+    docs: {
+      url: 'https://perfectionist.dev/rules/sort-decorators',
+      description: 'Enforce sorted decorators.',
+      recommended: true,
+    },
+    messages: {
+      unexpectedDecoratorsGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedDecoratorsOrder: ORDER_ERROR,
+    },
+    type: 'suggestion',
+    fixable: 'code',
   },
   defaultOptions: [defaultOptions],
   name: 'sort-decorators',

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -4,6 +4,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type {
   PartitionByCommentOption,
   CommonOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -35,7 +36,6 @@ import { complete } from '../utils/complete'
 export type Options<T extends string = string> = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       partitionByComment: PartitionByCommentOption
       customGroups: Record<T, string[] | string>
       groups: (Group<T>[] | Group<T>)[]
@@ -44,6 +44,7 @@ export type Options<T extends string = string> = [
       sortOnAccessors: boolean
       sortOnMethods: boolean
       sortOnClasses: boolean
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -85,10 +85,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let options = complete(context.options.at(0), settings, defaultOptions)
       validateCustomSortConfiguration(options)
       validateGeneratedGroupsConfiguration({
-        customGroups: options.customGroups,
-        groups: options.groups,
         selectors: [],
         modifiers: [],
+        options,
       })
       validateNewlinesAndPartitionConfiguration(options)
 

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -14,6 +14,13 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  DEPENDENCY_ORDER_ERROR,
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
@@ -289,15 +296,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
-      unexpectedEnumsGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      unexpectedEnumsDependencyOrder:
-        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
-      missedSpacingBetweenEnumsMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" members.',
-      extraSpacingBetweenEnumsMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" members.',
-      unexpectedEnumsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedEnumsDependencyOrder: DEPENDENCY_ORDER_ERROR,
+      missedSpacingBetweenEnumsMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenEnumsMembers: EXTRA_SPACING_ERROR,
+      unexpectedEnumsGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedEnumsOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-enums',

--- a/rules/sort-enums/does-custom-group-match.ts
+++ b/rules/sort-enums/does-custom-group-match.ts
@@ -1,9 +1,10 @@
-import type { SingleCustomGroup, AnyOfCustomGroup } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
+import type { SingleCustomGroup } from './types'
 
 import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchProps {
-  customGroup: SingleCustomGroup | AnyOfCustomGroup
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
   elementValue: string
   elementName: string
 }

--- a/rules/sort-enums/types.ts
+++ b/rules/sort-enums/types.ts
@@ -3,6 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   TypeOption,
@@ -15,11 +16,11 @@ import {
 
 export type Options = Partial<
   {
+    customGroups: CustomGroupsOption<SingleCustomGroup>
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
-    customGroups: CustomGroup[]
     forceNumericSort: boolean
     sortByValue: boolean
     type: TypeOption
@@ -30,23 +31,6 @@ export interface SingleCustomGroup {
   elementValuePattern?: string
   elementNamePattern?: string
 }
-
-export interface AnyOfCustomGroup {
-  anyOf: SingleCustomGroup[]
-}
-
-type CustomGroup = (
-  | {
-      order?: Options[0]['order']
-      type?: Options[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) &
-  (SingleCustomGroup | AnyOfCustomGroup) & {
-    groupName: string
-  }
 
 type Group = 'unknown' | string
 

--- a/rules/sort-enums/types.ts
+++ b/rules/sort-enums/types.ts
@@ -5,6 +5,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../../types/common-options'
 
 import {
@@ -14,7 +15,6 @@ import {
 
 export type Options = Partial<
   {
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
@@ -22,6 +22,7 @@ export type Options = Partial<
     customGroups: CustomGroup[]
     forceNumericSort: boolean
     sortByValue: boolean
+    type: TypeOption
   } & CommonOptions
 >[]
 

--- a/rules/sort-enums/types.ts
+++ b/rules/sort-enums/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../../types/common-options'
@@ -14,8 +15,8 @@ import {
 export type Options = Partial<
   {
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     customGroups: CustomGroup[]

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type {
   PartitionByCommentOption,
   CommonOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -28,10 +29,10 @@ import { complete } from '../utils/complete'
 type Options = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       groupKind: 'values-first' | 'types-first' | 'mixed'
       partitionByComment: PartitionByCommentOption
       partitionByNewLine: boolean
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -20,6 +20,7 @@ import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { ORDER_ERROR } from '../utils/report-errors'
 import { getSettings } from '../utils/get-settings'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
@@ -171,7 +172,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       recommended: true,
     },
     messages: {
-      unexpectedExportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedExportsOrder: ORDER_ERROR,
     },
     type: 'suggestion',
     fixable: 'code',

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -14,6 +14,7 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { GROUP_ORDER_ERROR, ORDER_ERROR } from '../utils/report-errors'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
@@ -65,16 +66,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
         type: 'object',
       },
     ],
-    messages: {
-      unexpectedHeritageClausesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      unexpectedHeritageClausesOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
-    },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-heritage-clauses',
       description: 'Enforce sorted heritage clauses.',
       recommended: true,
+    },
+    messages: {
+      unexpectedHeritageClausesGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedHeritageClausesOrder: ORDER_ERROR,
     },
     type: 'suggestion',
     fixable: 'code',

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -1,7 +1,7 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { CommonOptions } from '../types/common-options'
+import type { CommonOptions, TypeOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -28,9 +28,9 @@ import { complete } from '../utils/complete'
 export type Options<T extends string = string> = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       customGroups: Record<T, string[] | string>
       groups: (Group<T>[] | Group<T>)[]
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -7,6 +7,7 @@ import type {
   SpecialCharactersOption,
   NewlinesBetweenOption,
   GroupsOptions,
+  OrderOption,
   TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -62,8 +63,8 @@ export type Options<T extends string = string> = [
     sortSideEffects: boolean
     tsconfigRootDir?: string
     maxLineLength?: number
-    order: 'desc' | 'asc'
     ignoreCase: boolean
+    order: OrderOption
     type: TypeOption
     alphabet: string
   }>,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -7,6 +7,7 @@ import type {
   SpecialCharactersOption,
   NewlinesBetweenOption,
   GroupsOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -50,7 +51,6 @@ export type Options<T extends string = string> = [
       value?: Record<T, string[] | string>
       type?: Record<T, string[] | string>
     }
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     partitionByComment: PartitionByCommentOption
     specialCharacters: SpecialCharactersOption
     locales: NonNullable<Intl.LocalesArgument>
@@ -64,6 +64,7 @@ export type Options<T extends string = string> = [
     maxLineLength?: number
     order: 'desc' | 'asc'
     ignoreCase: boolean
+    type: TypeOption
     alphabet: string
   }>,
 ]

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -16,6 +16,12 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { readClosestTsConfigByPath } from './sort-imports/read-closest-ts-config-by-path'
@@ -623,13 +629,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
-      unexpectedImportsGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenImports:
-        'Missed spacing between "{{left}}" and "{{right}}" imports.',
-      extraSpacingBetweenImports:
-        'Extra spacing between "{{left}}" and "{{right}}" imports.',
-      unexpectedImportsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+      missedSpacingBetweenImports: MISSED_SPACING_ERROR,
+      extraSpacingBetweenImports: EXTRA_SPACING_ERROR,
+      unexpectedImportsGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedImportsOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-imports',

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -4,6 +4,7 @@ import { builtinModules } from 'node:module'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -49,10 +50,10 @@ export type Options<T extends string = string> = [
       type?: Record<T, string[] | string>
     }
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    newlinesBetween: 'ignore' | 'always' | 'never'
     specialCharacters: 'remove' | 'trim' | 'keep'
     partitionByComment: PartitionByCommentOption
     locales: NonNullable<Intl.LocalesArgument>
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group<T>>
     environment: 'node' | 'bun'
     partitionByNewLine: boolean
@@ -170,7 +171,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
     let isSideEffectOnlyGroup = (
       group:
-        | { newlinesBetween: 'ignore' | 'always' | 'never' }
+        | { newlinesBetween: NewlinesBetweenOption }
         | undefined
         | string[]
         | string,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -4,6 +4,7 @@ import { builtinModules } from 'node:module'
 
 import type {
   PartitionByCommentOption,
+  SpecialCharactersOption,
   NewlinesBetweenOption,
   GroupsOptions,
 } from '../types/common-options'
@@ -50,8 +51,8 @@ export type Options<T extends string = string> = [
       type?: Record<T, string[] | string>
     }
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    specialCharacters: 'remove' | 'trim' | 'keep'
     partitionByComment: PartitionByCommentOption
+    specialCharacters: SpecialCharactersOption
     locales: NonNullable<Intl.LocalesArgument>
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group<T>>

--- a/rules/sort-imports/read-closest-ts-config-by-path.ts
+++ b/rules/sort-imports/read-closest-ts-config-by-path.ts
@@ -10,23 +10,26 @@ import { getTypescriptImport } from './get-typescript-import'
  * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
  */
 
-interface OutputProps {
+interface ReadClosestTsConfigByPathValue {
   compilerOptions: ts.CompilerOptions
   cache: ts.ModuleResolutionCache
 }
 
-interface InputProps {
+interface ReadClosestTsConfigByPathParameters {
   tsconfigRootDir: string
   contextCwd: string
   filePath: string
 }
 
 export let directoryCacheByPath = new Map<string, string>()
-export let contentCacheByPath = new Map<string, OutputProps>()
+export let contentCacheByPath = new Map<
+  string,
+  ReadClosestTsConfigByPathValue
+>()
 
 export let readClosestTsConfigByPath = (
-  input: InputProps,
-): OutputProps | null => {
+  input: ReadClosestTsConfigByPathParameters,
+): ReadClosestTsConfigByPathValue | null => {
   let typescriptImport = getTypescriptImport()
   if (!typescriptImport) {
     return null
@@ -69,7 +72,7 @@ let getCompilerOptions = (
   typescriptImport: typeof ts,
   contextCwd: string,
   filePath: string,
-): OutputProps => {
+): ReadClosestTsConfigByPathValue => {
   if (contentCacheByPath.has(filePath)) {
     return contentCacheByPath.get(filePath)!
   }
@@ -105,7 +108,7 @@ let getCompilerOptions = (
     fileName => typescriptImport.sys.resolvePath(fileName),
     compilerOptionsConverted.options,
   )
-  let output: OutputProps = {
+  let output: ReadClosestTsConfigByPathValue = {
     compilerOptions: compilerOptionsConverted.options,
     cache,
   }

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -1,5 +1,11 @@
 import type { Options as SortObjectTypesOptions } from './sort-object-types/types'
 
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { sortObjectTypeElements, jsonSchema } from './sort-object-types'
 import { createEslintRule } from '../utils/create-eslint-rule'
 
@@ -29,26 +35,6 @@ let defaultOptions: Required<Options[0]> = {
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
-  meta: {
-    messages: {
-      unexpectedInterfacePropertiesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenInterfaceMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" properties.',
-      extraSpacingBetweenInterfaceMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" properties.',
-      unexpectedInterfacePropertiesOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
-    },
-    docs: {
-      url: 'https://perfectionist.dev/rules/sort-interfaces',
-      description: 'Enforce sorted interface properties.',
-      recommended: true,
-    },
-    schema: jsonSchema,
-    type: 'suggestion',
-    fixable: 'code',
-  },
   create: context => ({
     TSInterfaceDeclaration: node =>
       sortObjectTypeElements<MESSAGE_ID>({
@@ -63,6 +49,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
         context,
       }),
   }),
+  meta: {
+    messages: {
+      unexpectedInterfacePropertiesGroupOrder: GROUP_ORDER_ERROR,
+      missedSpacingBetweenInterfaceMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenInterfaceMembers: EXTRA_SPACING_ERROR,
+      unexpectedInterfacePropertiesOrder: ORDER_ERROR,
+    },
+    docs: {
+      url: 'https://perfectionist.dev/rules/sort-interfaces',
+      description: 'Enforce sorted interface properties.',
+      recommended: true,
+    },
+    schema: jsonSchema,
+    type: 'suggestion',
+    fixable: 'code',
+  },
   defaultOptions: [defaultOptions],
   name: 'sort-interfaces',
 })

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -1,5 +1,11 @@
 import type { Options as SortUnionTypesOptions } from './sort-union-types'
 
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { sortUnionOrIntersectionTypes } from './sort-union-types'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { jsonSchema } from './sort-union-types'
@@ -28,14 +34,10 @@ let defaultOptions: Required<Options[0]> = {
 export default createEslintRule<Options, MESSAGE_ID>({
   meta: {
     messages: {
-      unexpectedIntersectionTypesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenIntersectionTypes:
-        'Missed spacing between "{{left}}" and "{{right}}" types.',
-      extraSpacingBetweenIntersectionTypes:
-        'Extra spacing between "{{left}}" and "{{right}}" types.',
-      unexpectedIntersectionTypesOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
+      missedSpacingBetweenIntersectionTypes: MISSED_SPACING_ERROR,
+      extraSpacingBetweenIntersectionTypes: EXTRA_SPACING_ERROR,
+      unexpectedIntersectionTypesGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedIntersectionTypesOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-intersection-types',

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -11,6 +11,12 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
@@ -200,14 +206,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
       },
     ],
     messages: {
-      unexpectedJSXPropsGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenJSXPropsMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" props.',
-      extraSpacingBetweenJSXPropsMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" props.',
-      unexpectedJSXPropsOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
+      missedSpacingBetweenJSXPropsMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenJSXPropsMembers: EXTRA_SPACING_ERROR,
+      unexpectedJSXPropsGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedJSXPropsOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-jsx-props',

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -1,6 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { CommonOptions, GroupsOptions } from '../types/common-options'
+import type {
+  NewlinesBetweenOption,
+  CommonOptions,
+  GroupsOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import {
@@ -38,8 +42,8 @@ type Options<T extends string = string> = [
   Partial<
     {
       type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-      newlinesBetween: 'ignore' | 'always' | 'never'
       customGroups: Record<T, string[] | string>
+      newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group<T>>
       partitionByNewLine: boolean
       ignorePattern: string[]

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -4,6 +4,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -41,12 +42,12 @@ import { matches } from '../utils/matches'
 type Options<T extends string = string> = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       customGroups: Record<T, string[] | string>
       newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group<T>>
       partitionByNewLine: boolean
       ignorePattern: string[]
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -15,6 +15,12 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getCustomGroupsCompareOptions } from '../utils/get-custom-groups-compare-options'
@@ -218,14 +224,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'array',
     },
     messages: {
-      unexpectedMapElementsGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenMapElementsMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" members.',
-      extraSpacingBetweenMapElementsMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" members.',
-      unexpectedMapElementsOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
+      missedSpacingBetweenMapElementsMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenMapElementsMembers: EXTRA_SPACING_ERROR,
+      unexpectedMapElementsGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedMapElementsOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-maps',

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -94,10 +94,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let options = complete(matchedContextOptions[0], settings, defaultOptions)
       validateCustomSortConfiguration(options)
       validateGeneratedGroupsConfiguration({
-        customGroups: options.customGroups,
-        groups: options.groups,
         selectors: [],
         modifiers: [],
+        options,
       })
 
       let eslintDisabledLines = getEslintDisabledLines({

--- a/rules/sort-maps/does-custom-group-match.ts
+++ b/rules/sort-maps/does-custom-group-match.ts
@@ -2,13 +2,13 @@ import type { SingleCustomGroup, AnyOfCustomGroup } from './types'
 
 import { matches } from '../../utils/matches'
 
-interface DoesCustomGroupMatchProps {
+interface DoesCustomGroupMatchParameters {
   customGroup: SingleCustomGroup | AnyOfCustomGroup
   elementName: string
 }
 
 export let doesCustomGroupMatch = (
-  props: DoesCustomGroupMatchProps,
+  props: DoesCustomGroupMatchParameters,
 ): boolean => {
   if ('anyOf' in props.customGroup) {
     // At least one subgroup must match

--- a/rules/sort-maps/does-custom-group-match.ts
+++ b/rules/sort-maps/does-custom-group-match.ts
@@ -1,9 +1,10 @@
-import type { SingleCustomGroup, AnyOfCustomGroup } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
+import type { SingleCustomGroup } from './types'
 
 import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchParameters {
-  customGroup: SingleCustomGroup | AnyOfCustomGroup
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
   elementName: string
 }
 

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../../types/common-options'
@@ -14,8 +15,8 @@ export type Options = Partial<
       allNamesMatchPattern?: string
     }
     type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     customGroups: CustomGroup[]

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -5,6 +5,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../../types/common-options'
 
 import { elementNamePatternJsonSchema } from '../../utils/common-json-schemas'
@@ -14,12 +15,12 @@ export type Options = Partial<
     useConfigurationIf: {
       allNamesMatchPattern?: string
     }
-    type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     customGroups: CustomGroup[]
+    type: TypeOption
   } & CommonOptions
 >[]
 

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -3,6 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   TypeOption,
@@ -15,11 +16,11 @@ export type Options = Partial<
     useConfigurationIf: {
       allNamesMatchPattern?: string
     }
+    customGroups: CustomGroupsOption<SingleCustomGroup>
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
-    customGroups: CustomGroup[]
     type: TypeOption
   } & CommonOptions
 >[]
@@ -27,23 +28,6 @@ export type Options = Partial<
 export interface SingleCustomGroup {
   elementNamePattern?: string
 }
-
-export interface AnyOfCustomGroup {
-  anyOf: SingleCustomGroup[]
-}
-
-type CustomGroup = (
-  | {
-      order?: Options[0]['order']
-      type?: Options[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) &
-  (SingleCustomGroup | AnyOfCustomGroup) & {
-    groupName: string
-  }
 
 type Group = 'unknown' | string
 

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -132,10 +132,9 @@ export default createEslintRule<SortModulesOptions, MESSAGE_ID>({
     let options = complete(context.options.at(0), settings, defaultOptions)
     validateCustomSortConfiguration(options)
     validateGeneratedGroupsConfiguration({
-      customGroups: options.customGroups,
       modifiers: allModifiers,
       selectors: allSelectors,
-      groups: options.groups,
+      options,
     })
     validateNewlinesAndPartitionConfiguration(options)
 

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -19,6 +19,13 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  DEPENDENCY_ORDER_ERROR,
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import {
@@ -88,17 +95,6 @@ let defaultOptions: Required<SortModulesOptions[0]> = {
 
 export default createEslintRule<SortModulesOptions, MESSAGE_ID>({
   meta: {
-    messages: {
-      unexpectedModulesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      unexpectedModulesDependencyOrder:
-        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
-      missedSpacingBetweenModulesMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" objects.',
-      extraSpacingBetweenModulesMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" objects.',
-      unexpectedModulesOrder: 'Expected "{{right}}" to come before "{{left}}".',
-    },
     schema: [
       {
         properties: {
@@ -116,6 +112,13 @@ export default createEslintRule<SortModulesOptions, MESSAGE_ID>({
         type: 'object',
       },
     ],
+    messages: {
+      unexpectedModulesDependencyOrder: DEPENDENCY_ORDER_ERROR,
+      missedSpacingBetweenModulesMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenModulesMembers: EXTRA_SPACING_ERROR,
+      unexpectedModulesGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedModulesOrder: ORDER_ERROR,
+    },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-modules',
       description: 'Enforce sorted modules.',

--- a/rules/sort-modules/does-custom-group-match.ts
+++ b/rules/sort-modules/does-custom-group-match.ts
@@ -7,7 +7,7 @@ import type {
 
 import { matches } from '../../utils/matches'
 
-interface DoesCustomGroupMatchProps {
+interface DoesCustomGroupMatchParameters {
   customGroup: SingleCustomGroup | AnyOfCustomGroup
   selectors: Selector[]
   modifiers: Modifier[]
@@ -17,13 +17,13 @@ interface DoesCustomGroupMatchProps {
 
 /**
  * Determines whether a custom group matches the given properties.
- * @param {DoesCustomGroupMatchProps} props - The properties to compare with the
- * custom group, including selectors, modifiers, decorators, and element name.
+ * @param {DoesCustomGroupMatchParameters} props - The properties to compare
+ * with the custom group, including selectors, modifiers, decorators, and element name.
  * @returns {boolean} `true` if the custom group matches the properties;
  * otherwise, `false`.
  */
 export let doesCustomGroupMatch = (
-  props: DoesCustomGroupMatchProps,
+  props: DoesCustomGroupMatchParameters,
 ): boolean => {
   if ('anyOf' in props.customGroup) {
     // At least one subgroup must match.

--- a/rules/sort-modules/does-custom-group-match.ts
+++ b/rules/sort-modules/does-custom-group-match.ts
@@ -1,14 +1,10 @@
-import type {
-  SingleCustomGroup,
-  AnyOfCustomGroup,
-  Modifier,
-  Selector,
-} from './types'
+import type { SingleCustomGroup, Modifier, Selector } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
 
 import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchParameters {
-  customGroup: SingleCustomGroup | AnyOfCustomGroup
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
   selectors: Selector[]
   modifiers: Modifier[]
   decorators: string[]

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../../types/common-options'
@@ -17,8 +18,8 @@ export type SortModulesOptions = [
   Partial<
     {
       type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-      newlinesBetween: 'ignore' | 'always' | 'never'
       partitionByComment: PartitionByCommentOption
+      newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group>
       customGroups: CustomGroup[]
       partitionByNewLine: boolean

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -3,6 +3,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type {
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   TypeOption,
@@ -28,10 +29,10 @@ export type SingleCustomGroup = (
 export type SortModulesOptions = [
   Partial<
     {
+      customGroups: CustomGroupsOption<SingleCustomGroup>
       partitionByComment: PartitionByCommentOption
       newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group>
-      customGroups: CustomGroup[]
       partitionByNewLine: boolean
       type: TypeOption
     } & CommonOptions
@@ -54,10 +55,6 @@ export type Modifier =
   | ExportModifier
   | AsyncModifier
 
-export interface AnyOfCustomGroup {
-  anyOf: SingleCustomGroup[]
-}
-
 /**
  * Only used in code as well
  */
@@ -71,18 +68,6 @@ interface AllowedModifiersPerSelector {
   type: DeclareModifier | ExportModifier
 }
 
-type CustomGroup = (
-  | {
-      order?: SortModulesOptions[0]['order']
-      type?: SortModulesOptions[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) & {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
-} & (SingleCustomGroup | AnyOfCustomGroup)
 /**
  * Only used in code, so I don't know if it's worth maintaining this.
  */

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -5,6 +5,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -13,19 +14,6 @@ import {
   buildCustomGroupSelectorJsonSchema,
   elementNamePatternJsonSchema,
 } from '../../utils/common-json-schemas'
-
-export type SortModulesOptions = [
-  Partial<
-    {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-      partitionByComment: PartitionByCommentOption
-      newlinesBetween: NewlinesBetweenOption
-      groups: GroupsOptions<Group>
-      customGroups: CustomGroup[]
-      partitionByNewLine: boolean
-    } & CommonOptions
-  >,
-]
 
 export type SingleCustomGroup = (
   | (DecoratorNamePatternFilterCustomGroup &
@@ -36,6 +24,19 @@ export type SingleCustomGroup = (
   | BaseSingleCustomGroup<TypeSelector>
 ) &
   ElementNamePatternFilterCustomGroup
+
+export type SortModulesOptions = [
+  Partial<
+    {
+      partitionByComment: PartitionByCommentOption
+      newlinesBetween: NewlinesBetweenOption
+      groups: GroupsOptions<Group>
+      customGroups: CustomGroup[]
+      partitionByNewLine: boolean
+      type: TypeOption
+    } & CommonOptions
+  >,
+]
 
 export type Selector =
   // | NamespaceSelector

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type {
   PartitionByCommentOption,
   CommonOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -29,10 +30,10 @@ import { complete } from '../utils/complete'
 type Options = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       groupKind: 'values-first' | 'types-first' | 'mixed'
       partitionByComment: PartitionByCommentOption
       partitionByNewLine: boolean
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -20,6 +20,7 @@ import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { ORDER_ERROR } from '../utils/report-errors'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { sortNodes } from '../utils/sort-nodes'
@@ -173,8 +174,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       recommended: true,
     },
     messages: {
-      unexpectedNamedExportsOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedNamedExportsOrder: ORDER_ERROR,
     },
     type: 'suggestion',
     fixable: 'code',

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type {
   PartitionByCommentOption,
   CommonOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -29,11 +30,11 @@ import { complete } from '../utils/complete'
 type Options = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       groupKind: 'values-first' | 'types-first' | 'mixed'
       partitionByComment: PartitionByCommentOption
       partitionByNewLine: boolean
       ignoreAlias: boolean
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -20,6 +20,7 @@ import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
+import { ORDER_ERROR } from '../utils/report-errors'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
 import { sortNodes } from '../utils/sort-nodes'
@@ -185,8 +186,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       recommended: true,
     },
     messages: {
-      unexpectedNamedImportsOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedNamedImportsOrder: ORDER_ERROR,
     },
     type: 'suggestion',
     fixable: 'code',

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -218,10 +218,9 @@ export let sortObjectTypeElements = <MessageIds extends string>({
   }
   validateCustomSortConfiguration(options)
   validateGeneratedGroupsConfiguration({
-    customGroups: options.customGroups,
     selectors: allSelectors,
     modifiers: allModifiers,
-    groups: options.groups,
+    options,
   })
   validateNewlinesAndPartitionConfiguration(options)
 

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -17,6 +17,12 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import {
   singleCustomGroupJsonSchema,
@@ -121,26 +127,6 @@ export let jsonSchema: JSONSchema4 = {
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
-  meta: {
-    messages: {
-      unexpectedObjectTypesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenObjectTypeMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" properties.',
-      extraSpacingBetweenObjectTypeMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" properties.',
-      unexpectedObjectTypesOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
-    },
-    docs: {
-      url: 'https://perfectionist.dev/rules/sort-object-types',
-      description: 'Enforce sorted object types.',
-      recommended: true,
-    },
-    schema: jsonSchema,
-    type: 'suggestion',
-    fixable: 'code',
-  },
   create: context => ({
     TSTypeLiteral: node =>
       sortObjectTypeElements<MESSAGE_ID>({
@@ -158,6 +144,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
         context,
       }),
   }),
+  meta: {
+    messages: {
+      missedSpacingBetweenObjectTypeMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenObjectTypeMembers: EXTRA_SPACING_ERROR,
+      unexpectedObjectTypesGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedObjectTypesOrder: ORDER_ERROR,
+    },
+    docs: {
+      url: 'https://perfectionist.dev/rules/sort-object-types',
+      description: 'Enforce sorted object types.',
+      recommended: true,
+    },
+    schema: jsonSchema,
+    type: 'suggestion',
+    fixable: 'code',
+  },
   defaultOptions: [defaultOptions],
   name: 'sort-object-types',
 })

--- a/rules/sort-object-types/does-custom-group-match.ts
+++ b/rules/sort-object-types/does-custom-group-match.ts
@@ -7,7 +7,7 @@ import type {
 
 import { matches } from '../../utils/matches'
 
-interface DoesCustomGroupMatchProps {
+interface DoesCustomGroupMatchParameters {
   customGroup: SingleCustomGroup | AnyOfCustomGroup
   selectors: Selector[]
   modifiers: Modifier[]
@@ -16,13 +16,13 @@ interface DoesCustomGroupMatchProps {
 
 /**
  * Determines whether a custom group matches the given properties.
- * @param {DoesCustomGroupMatchProps} props - The properties to compare with the
- * custom group, including selectors, modifiers, and element name.
+ * @param {DoesCustomGroupMatchParameters} props - The properties to compare
+ * with the custom group, including selectors, modifiers, and element name.
  * @returns {boolean} `true` if the custom group matches the properties;
  * otherwise, `false`.
  */
 export let doesCustomGroupMatch = (
-  props: DoesCustomGroupMatchProps,
+  props: DoesCustomGroupMatchParameters,
 ): boolean => {
   if ('anyOf' in props.customGroup) {
     // At least one subgroup must match.

--- a/rules/sort-object-types/does-custom-group-match.ts
+++ b/rules/sort-object-types/does-custom-group-match.ts
@@ -1,14 +1,10 @@
-import type {
-  SingleCustomGroup,
-  AnyOfCustomGroup,
-  Modifier,
-  Selector,
-} from './types'
+import type { SingleCustomGroup, Modifier, Selector } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
 
 import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchParameters {
-  customGroup: SingleCustomGroup | AnyOfCustomGroup
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
   selectors: Selector[]
   modifiers: Modifier[]
   elementName: string

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -5,6 +5,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -20,7 +21,6 @@ export type Options = Partial<
       declarationMatchesPattern?: string
       allNamesMatchPattern?: string
     }
-    type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
     customGroups: Record<string, string[] | string> | CustomGroup[]
     /**
      * @deprecated for {@link `groups`}
@@ -28,6 +28,7 @@ export type Options = Partial<
     groupKind: 'required-first' | 'optional-first' | 'mixed'
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
+    type: TypeOption | 'unsorted'
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     /**

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -1,8 +1,10 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
+  DeprecatedCustomGroupsOption,
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   TypeOption,
@@ -21,7 +23,9 @@ export type Options = Partial<
       declarationMatchesPattern?: string
       allNamesMatchPattern?: string
     }
-    customGroups: Record<string, string[] | string> | CustomGroup[]
+    customGroups:
+      | CustomGroupsOption<SingleCustomGroup>
+      | DeprecatedCustomGroupsOption
     /**
      * @deprecated for {@link `groups`}
      */
@@ -56,10 +60,6 @@ export type Selector =
 
 export type Modifier = MultilineModifier | RequiredModifier | OptionalModifier
 
-export interface AnyOfCustomGroup {
-  anyOf: SingleCustomGroup[]
-}
-
 /**
  * Only used in code as well
  */
@@ -70,19 +70,6 @@ interface AllowedModifiersPerSelector {
   multiline: OptionalModifier | RequiredModifier
   'index-signature': never
 }
-
-type CustomGroup = (
-  | {
-      order?: Options[0]['order']
-      type?: Options[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) & {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
-} & (SingleCustomGroup | AnyOfCustomGroup)
 
 type IndexSignatureGroup = JoinWithDash<
   [

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../../types/common-options'
@@ -25,8 +26,8 @@ export type Options = Partial<
      * @deprecated for {@link `groups`}
      */
     groupKind: 'required-first' | 'optional-first' | 'mixed'
-    newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     /**

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -136,10 +136,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       }
       validateCustomSortConfiguration(options)
       validateGeneratedGroupsConfiguration({
-        customGroups: options.customGroups,
         selectors: allSelectors,
         modifiers: allModifiers,
-        groups: options.groups,
+        options,
       })
       validateNewlinesAndPartitionConfiguration(options)
 

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -15,6 +15,13 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  DEPENDENCY_ORDER_ERROR,
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
@@ -515,15 +522,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       type: 'array',
     },
     messages: {
-      unexpectedObjectsGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      unexpectedObjectsDependencyOrder:
-        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
-      missedSpacingBetweenObjectMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" objects.',
-      extraSpacingBetweenObjectMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" objects.',
-      unexpectedObjectsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedObjectsDependencyOrder: DEPENDENCY_ORDER_ERROR,
+      missedSpacingBetweenObjectMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenObjectMembers: EXTRA_SPACING_ERROR,
+      unexpectedObjectsGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedObjectsOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-objects',

--- a/rules/sort-objects/does-custom-group-match.ts
+++ b/rules/sort-objects/does-custom-group-match.ts
@@ -7,7 +7,7 @@ import type {
 
 import { matches } from '../../utils/matches'
 
-interface DoesCustomGroupMatchProps {
+interface DoesCustomGroupMatchParameters {
   customGroup: SingleCustomGroup | AnyOfCustomGroup
   elementValue: string | null
   selectors: Selector[]
@@ -17,13 +17,13 @@ interface DoesCustomGroupMatchProps {
 
 /**
  * Determines whether a custom group matches the given properties.
- * @param {DoesCustomGroupMatchProps} props - The properties to compare with the
- * custom group, including selectors, modifiers, and element name.
+ * @param {DoesCustomGroupMatchParameters} props - The properties to compare
+ * with the custom group, including selectors, modifiers, and element name.
  * @returns {boolean} `true` if the custom group matches the properties;
  * otherwise, `false`.
  */
 export let doesCustomGroupMatch = (
-  props: DoesCustomGroupMatchProps,
+  props: DoesCustomGroupMatchParameters,
 ): boolean => {
   if ('anyOf' in props.customGroup) {
     // At least one subgroup must match.

--- a/rules/sort-objects/does-custom-group-match.ts
+++ b/rules/sort-objects/does-custom-group-match.ts
@@ -1,14 +1,10 @@
-import type {
-  SingleCustomGroup,
-  AnyOfCustomGroup,
-  Modifier,
-  Selector,
-} from './types'
+import type { SingleCustomGroup, Modifier, Selector } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
 
 import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchParameters {
-  customGroup: SingleCustomGroup | AnyOfCustomGroup
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
   elementValue: string | null
   selectors: Selector[]
   modifiers: Modifier[]

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../../types/common-options'
@@ -23,8 +24,8 @@ export type Options = Partial<
     type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
     customGroups: Record<string, string[] | string> | CustomGroup[]
     destructuredObjects: { groups: boolean } | boolean
-    newlinesBetween: 'ignore' | 'always' | 'never'
     partitionByComment: PartitionByCommentOption
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     objectDeclarations: boolean

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -5,6 +5,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
@@ -21,11 +22,11 @@ export type Options = Partial<
       callingFunctionNamePattern?: string
       allNamesMatchPattern?: string
     }
-    type: 'alphabetical' | 'line-length' | 'unsorted' | 'natural' | 'custom'
     customGroups: Record<string, string[] | string> | CustomGroup[]
     destructuredObjects: { groups: boolean } | boolean
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
+    type: TypeOption | 'unsorted'
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     objectDeclarations: boolean

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -1,8 +1,10 @@
 import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
+  DeprecatedCustomGroupsOption,
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   TypeOption,
@@ -22,7 +24,9 @@ export type Options = Partial<
       callingFunctionNamePattern?: string
       allNamesMatchPattern?: string
     }
-    customGroups: Record<string, string[] | string> | CustomGroup[]
+    customGroups:
+      | CustomGroupsOption<SingleCustomGroup>
+      | DeprecatedCustomGroupsOption
     destructuredObjects: { groups: boolean } | boolean
     partitionByComment: PartitionByCommentOption
     newlinesBetween: NewlinesBetweenOption
@@ -57,10 +61,6 @@ export type Selector =
 
 export type Modifier = MultilineModifier | RequiredModifier | OptionalModifier
 
-export interface AnyOfCustomGroup {
-  anyOf: SingleCustomGroup[]
-}
-
 /**
  * Only used in code as well
  */
@@ -71,19 +71,6 @@ interface AllowedModifiersPerSelector {
   multiline: OptionalModifier | RequiredModifier
   'index-signature': never
 }
-
-type CustomGroup = (
-  | {
-      order?: Options[0]['order']
-      type?: Options[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) & {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
-} & (SingleCustomGroup | AnyOfCustomGroup)
 
 interface BaseSingleCustomGroup<T extends Selector> {
   modifiers?: AllowedModifiersPerSelector[T][]

--- a/rules/sort-sets.ts
+++ b/rules/sort-sets.ts
@@ -1,5 +1,11 @@
 import type { Options } from './sort-array-includes/types'
 
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { defaultOptions, jsonSchema, sortArray } from './sort-array-includes'
 import { createEslintRule } from '../utils/create-eslint-rule'
 
@@ -40,13 +46,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
   }),
   meta: {
     messages: {
-      unexpectedSetsGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenSetsMembers:
-        'Missed spacing between "{{left}}" and "{{right}}" members.',
-      extraSpacingBetweenSetsMembers:
-        'Extra spacing between "{{left}}" and "{{right}}" members.',
-      unexpectedSetsOrder: 'Expected "{{right}}" to come before "{{left}}".',
+      missedSpacingBetweenSetsMembers: MISSED_SPACING_ERROR,
+      extraSpacingBetweenSetsMembers: EXTRA_SPACING_ERROR,
+      unexpectedSetsGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedSetsOrder: ORDER_ERROR,
     },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-sets',

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { CommonOptions } from '../types/common-options'
+import type { CommonOptions, TypeOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { makeSingleNodeCommentAfterFixes } from '../utils/make-single-node-comment-after-fixes'
@@ -23,17 +23,17 @@ import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
 import { compare } from '../utils/compare'
 
-type Options = [
-  Partial<
-    {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-    } & CommonOptions
-  >,
-]
-
 interface SortSwitchCaseSortingNode extends SortingNode<TSESTree.SwitchCase> {
   isDefaultClause: boolean
 }
+
+type Options = [
+  Partial<
+    {
+      type: TypeOption
+    } & CommonOptions
+  >,
+]
 
 type MESSAGE_ID = 'unexpectedSwitchCaseOrder'
 

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -11,9 +11,9 @@ import {
   commonJsonSchemas,
 } from '../utils/common-json-schemas'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
+import { reportErrors, ORDER_ERROR } from '../utils/report-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
-import { reportErrors } from '../utils/report-errors'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -276,8 +276,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       recommended: true,
     },
     messages: {
-      unexpectedSwitchCaseOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
+      unexpectedSwitchCaseOrder: ORDER_ERROR,
     },
     type: 'suggestion',
     fixable: 'code',

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -10,8 +10,8 @@ import {
   buildTypeJsonSchema,
   commonJsonSchemas,
 } from '../utils/common-json-schemas'
+import { reportErrors, ORDER_ERROR, RIGHT, LEFT } from '../utils/report-errors'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
-import { reportErrors, ORDER_ERROR } from '../utils/report-errors'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
@@ -186,8 +186,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ]
           },
           data: {
-            left: defaultCase.name,
-            right: lastCase.name,
+            [LEFT]: defaultCase.name,
+            [RIGHT]: lastCase.name,
           },
           messageId: 'unexpectedSwitchCaseOrder',
           node: defaultCase.node,
@@ -250,8 +250,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
                   fixer,
                 }),
           data: {
-            right: right.name,
-            left: left.name,
+            [RIGHT]: right.name,
+            [LEFT]: left.name,
           },
           messageId: 'unexpectedSwitchCaseOrder',
           node: right.node,

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -17,6 +17,12 @@ import {
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
+import {
+  MISSED_SPACING_ERROR,
+  EXTRA_SPACING_ERROR,
+  GROUP_ORDER_ERROR,
+  ORDER_ERROR,
+} from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
@@ -92,26 +98,6 @@ export let jsonSchema: JSONSchema4 = {
 }
 
 export default createEslintRule<Options, MESSAGE_ID>({
-  meta: {
-    messages: {
-      unexpectedUnionTypesGroupOrder:
-        'Expected "{{right}}" ({{rightGroup}}) to come before "{{left}}" ({{leftGroup}}).',
-      missedSpacingBetweenUnionTypes:
-        'Missed spacing between "{{left}}" and "{{right}}" types.',
-      extraSpacingBetweenUnionTypes:
-        'Extra spacing between "{{left}}" and "{{right}}" types.',
-      unexpectedUnionTypesOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
-    },
-    docs: {
-      url: 'https://perfectionist.dev/rules/sort-union-types',
-      description: 'Enforce sorted union types.',
-      recommended: true,
-    },
-    schema: [jsonSchema],
-    type: 'suggestion',
-    fixable: 'code',
-  },
   create: context => ({
     TSUnionType: node => {
       sortUnionOrIntersectionTypes({
@@ -127,6 +113,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
       })
     },
   }),
+  meta: {
+    messages: {
+      missedSpacingBetweenUnionTypes: MISSED_SPACING_ERROR,
+      extraSpacingBetweenUnionTypes: EXTRA_SPACING_ERROR,
+      unexpectedUnionTypesGroupOrder: GROUP_ORDER_ERROR,
+      unexpectedUnionTypesOrder: ORDER_ERROR,
+    },
+    docs: {
+      url: 'https://perfectionist.dev/rules/sort-union-types',
+      description: 'Enforce sorted union types.',
+      recommended: true,
+    },
+    schema: [jsonSchema],
+    type: 'suggestion',
+    fixable: 'code',
+  },
   defaultOptions: [defaultOptions],
   name: 'sort-union-types',
 })

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -4,6 +4,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
 } from '../types/common-options'
@@ -42,8 +43,8 @@ export type Options = [
   Partial<
     {
       type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-      newlinesBetween: 'ignore' | 'always' | 'never'
       partitionByComment: PartitionByCommentOption
+      newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group>
       partitionByNewLine: boolean
     } & CommonOptions

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -7,6 +7,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
@@ -42,11 +43,11 @@ import { complete } from '../utils/complete'
 export type Options = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       partitionByComment: PartitionByCommentOption
       newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group>
       partitionByNewLine: boolean
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/common-json-schemas'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
+import { DEPENDENCY_ORDER_ERROR, ORDER_ERROR } from '../utils/report-errors'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -251,16 +252,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
         type: 'object',
       },
     ],
-    messages: {
-      unexpectedVariableDeclarationsDependencyOrder:
-        'Expected dependency "{{right}}" to come before "{{nodeDependentOnRight}}".',
-      unexpectedVariableDeclarationsOrder:
-        'Expected "{{right}}" to come before "{{left}}".',
-    },
     docs: {
       url: 'https://perfectionist.dev/rules/sort-variable-declarations',
       description: 'Enforce sorted variable declarations.',
       recommended: true,
+    },
+    messages: {
+      unexpectedVariableDeclarationsDependencyOrder: DEPENDENCY_ORDER_ERROR,
+      unexpectedVariableDeclarationsOrder: ORDER_ERROR,
     },
     type: 'suggestion',
     fixable: 'code',

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type {
   PartitionByCommentOption,
   CommonOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
 
@@ -30,9 +31,9 @@ import { complete } from '../utils/complete'
 type Options = [
   Partial<
     {
-      type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       partitionByComment: PartitionByCommentOption
       partitionByNewLine: boolean
+      type: TypeOption
     } & CommonOptions
   >,
 ]

--- a/test/utils/validate-generated-groups-configuration.test.ts
+++ b/test/utils/validate-generated-groups-configuration.test.ts
@@ -18,10 +18,12 @@ describe('validate-generated-groups-configuration', () => {
     ]
     expect(() =>
       validateGeneratedGroupsConfiguration({
-        groups: allPredefinedGroups,
+        options: {
+          groups: allPredefinedGroups,
+          customGroups: [],
+        },
         selectors: allSelectors,
         modifiers: allModifiers,
-        customGroups: [],
       }),
     ).not.toThrow()
   })
@@ -29,12 +31,14 @@ describe('validate-generated-groups-configuration', () => {
   it('allows custom groups', () => {
     expect(() =>
       validateGeneratedGroupsConfiguration({
-        customGroups: [
-          {
-            groupName: 'myCustomGroup',
-          },
-        ],
-        groups: ['static-property', 'myCustomGroup'],
+        options: {
+          customGroups: [
+            {
+              groupName: 'myCustomGroup',
+            },
+          ],
+          groups: ['static-property', 'myCustomGroup'],
+        },
         selectors: allSelectors,
         modifiers: allModifiers,
       }),
@@ -44,10 +48,12 @@ describe('validate-generated-groups-configuration', () => {
   it('throws an error with predefined groups with duplicate modifiers', () => {
     expect(() =>
       validateGeneratedGroupsConfiguration({
-        groups: ['static-static-property'],
+        options: {
+          groups: ['static-static-property'],
+          customGroups: [],
+        },
         selectors: allSelectors,
         modifiers: allModifiers,
-        customGroups: [],
       }),
     ).toThrow('Invalid group(s): static-static-property')
   })
@@ -55,10 +61,12 @@ describe('validate-generated-groups-configuration', () => {
   it('throws an error if a duplicate group is provided', () => {
     expect(() =>
       validateGeneratedGroupsConfiguration({
-        groups: ['static-property', 'static-property'],
+        options: {
+          groups: ['static-property', 'static-property'],
+          customGroups: [],
+        },
         selectors: allSelectors,
         modifiers: allModifiers,
-        customGroups: [],
       }),
     ).toThrow('Duplicated group(s): static-property')
   })
@@ -66,12 +74,14 @@ describe('validate-generated-groups-configuration', () => {
   it('throws an error if invalid groups are provided', () => {
     expect(() =>
       validateGeneratedGroupsConfiguration({
-        customGroups: [
-          {
-            groupName: 'myCustomGroupNotReferenced',
-          },
-        ],
-        groups: ['static-property', 'myCustomGroup', ''],
+        options: {
+          customGroups: [
+            {
+              groupName: 'myCustomGroupNotReferenced',
+            },
+          ],
+          groups: ['static-property', 'myCustomGroup', ''],
+        },
         selectors: allSelectors,
         modifiers: allModifiers,
       }),

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -1,5 +1,5 @@
 export interface CommonOptions {
-  specialCharacters: 'remove' | 'trim' | 'keep'
+  specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   order: 'desc' | 'asc'
   ignoreCase: boolean
@@ -22,3 +22,5 @@ export type GroupsOptions<T> = (
 )[]
 
 export type NewlinesBetweenOption = 'ignore' | 'always' | 'never'
+
+export type SpecialCharactersOption = 'remove' | 'trim' | 'keep'

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -1,3 +1,16 @@
+export type CustomGroupsOption<SingleCustomGroup = object> = ((
+  | {
+      type?: TypeOption | 'unsorted'
+      order?: OrderOption
+    }
+  | {
+      type?: 'unsorted'
+    }
+) & {
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+} & (AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup))[]
+
 export interface CommonOptions {
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
@@ -21,7 +34,13 @@ export type GroupsOptions<T> = (
   | T
 )[]
 
+export interface AnyOfCustomGroup<SingleCustomGroup> {
+  anyOf: SingleCustomGroup[]
+}
+
 export type TypeOption = 'alphabetical' | 'line-length' | 'natural' | 'custom'
+
+export type DeprecatedCustomGroupsOption = Record<string, string[] | string>
 
 export type NewlinesBetweenOption = 'ignore' | 'always' | 'never'
 

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -16,7 +16,9 @@ export type PartitionByCommentOption =
   | string
 
 export type GroupsOptions<T> = (
-  | { newlinesBetween: 'ignore' | 'always' | 'never' }
+  | { newlinesBetween: NewlinesBetweenOption }
   | T[]
   | T
 )[]
+
+export type NewlinesBetweenOption = 'ignore' | 'always' | 'never'

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -21,6 +21,8 @@ export type GroupsOptions<T> = (
   | T
 )[]
 
+export type TypeOption = 'alphabetical' | 'line-length' | 'natural' | 'custom'
+
 export type NewlinesBetweenOption = 'ignore' | 'always' | 'never'
 
 export type SpecialCharactersOption = 'remove' | 'trim' | 'keep'

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -1,8 +1,8 @@
 export interface CommonOptions {
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
-  order: 'desc' | 'asc'
   ignoreCase: boolean
+  order: OrderOption
   alphabet: string
 }
 
@@ -26,3 +26,5 @@ export type TypeOption = 'alphabetical' | 'line-length' | 'natural' | 'custom'
 export type NewlinesBetweenOption = 'ignore' | 'always' | 'never'
 
 export type SpecialCharactersOption = 'remove' | 'trim' | 'keep'
+
+export type OrderOption = 'desc' | 'asc'

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -1,6 +1,9 @@
 import { compare as createNaturalCompare } from 'natural-orderby'
 
-import type { SpecialCharactersOption } from '../types/common-options'
+import type {
+  SpecialCharactersOption,
+  OrderOption,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { convertBooleanToSign } from './convert-boolean-to-sign'
@@ -17,7 +20,7 @@ interface BaseCompareOptions<T extends SortingNode> {
    * node's name.
    */
   nodeValueGetter?: ((node: T) => string) | null
-  order: 'desc' | 'asc'
+  order: OrderOption
 }
 
 interface AlphabeticalCompareOptions<T extends SortingNode>

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -1,5 +1,6 @@
 import { compare as createNaturalCompare } from 'natural-orderby'
 
+import type { SpecialCharactersOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { convertBooleanToSign } from './convert-boolean-to-sign'
@@ -21,7 +22,7 @@ interface BaseCompareOptions<T extends SortingNode> {
 
 interface AlphabeticalCompareOptions<T extends SortingNode>
   extends BaseCompareOptions<T> {
-  specialCharacters: 'remove' | 'trim' | 'keep'
+  specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   type: 'alphabetical'
   ignoreCase: boolean
@@ -29,7 +30,7 @@ interface AlphabeticalCompareOptions<T extends SortingNode>
 
 interface NaturalCompareOptions<T extends SortingNode>
   extends BaseCompareOptions<T> {
-  specialCharacters: 'remove' | 'trim' | 'keep'
+  specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   ignoreCase: boolean
   type: 'natural'
@@ -37,7 +38,7 @@ interface NaturalCompareOptions<T extends SortingNode>
 
 interface CustomCompareOptions<T extends SortingNode>
   extends BaseCompareOptions<T> {
-  specialCharacters: 'remove' | 'trim' | 'keep'
+  specialCharacters: SpecialCharactersOption
   ignoreCase: boolean
   alphabet: string
   type: 'custom'
@@ -168,7 +169,7 @@ let getLineLengthSortingFunction =
   }
 
 let getFormatStringFunction =
-  (ignoreCase: boolean, specialCharacters: 'remove' | 'trim' | 'keep') =>
+  (ignoreCase: boolean, specialCharacters: SpecialCharactersOption) =>
   (value: string) => {
     let valueToCompare = value
     if (ignoreCase) {

--- a/utils/generate-predefined-groups.ts
+++ b/utils/generate-predefined-groups.ts
@@ -1,6 +1,6 @@
 import { getArrayCombinations } from './get-array-combinations'
 
-interface Props {
+interface GeneratePredefinedGroupsParameters {
   cache: Map<string, string[]>
   modifiers: string[]
   selectors: string[]
@@ -13,7 +13,7 @@ interface Props {
  * prioritized over the quantity of modifiers. For example,
  * `protected abstract override get fields();` should prioritize the
  * `'get-method'` group over the `'protected-abstract-override-method'` group.
- * @param {Props} props - The properties including selectors, modifiers, and
+ * @param {GeneratePredefinedGroupsParameters} props - The properties including selectors, modifiers, and
  * cache.
  * @param {string[]} props.selectors - The list of selectors.
  * @param {string[]} props.modifiers - The list of modifiers.
@@ -24,7 +24,7 @@ export let generatePredefinedGroups = ({
   selectors,
   modifiers,
   cache,
-}: Props): string[] => {
+}: GeneratePredefinedGroupsParameters): string[] => {
   let modifiersAndSelectorsKey = `${modifiers.join('&')}/${selectors.join('&')}`
   let cachedValue = cache.get(modifiersAndSelectorsKey)
   if (cachedValue) {

--- a/utils/get-custom-groups-compare-options.ts
+++ b/utils/get-custom-groups-compare-options.ts
@@ -1,6 +1,7 @@
 import type {
   SpecialCharactersOption,
   GroupsOptions,
+  OrderOption,
   TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -11,15 +12,15 @@ interface Options {
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   groups: GroupsOptions<string>
-  order: 'desc' | 'asc'
   ignoreCase: boolean
+  order: OrderOption
   type: TypeOption
   alphabet: string
 }
 
 type CustomGroup = (
   | {
-      order?: 'desc' | 'asc'
+      order?: OrderOption
       type?: TypeOption
     }
   | {

--- a/utils/get-custom-groups-compare-options.ts
+++ b/utils/get-custom-groups-compare-options.ts
@@ -1,25 +1,26 @@
 import type {
   SpecialCharactersOption,
   GroupsOptions,
+  TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 import type { CompareOptions } from './compare'
 
 interface Options {
   customGroups: Record<string, string[] | string> | CustomGroup[]
-  type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   groups: GroupsOptions<string>
   order: 'desc' | 'asc'
   ignoreCase: boolean
+  type: TypeOption
   alphabet: string
 }
 
 type CustomGroup = (
   | {
-      type?: 'alphabetical' | 'line-length' | 'natural' | 'custom'
       order?: 'desc' | 'asc'
+      type?: TypeOption
     }
   | {
       type?: 'unsorted'

--- a/utils/get-custom-groups-compare-options.ts
+++ b/utils/get-custom-groups-compare-options.ts
@@ -1,5 +1,7 @@
 import type {
+  DeprecatedCustomGroupsOption,
   SpecialCharactersOption,
+  CustomGroupsOption,
   GroupsOptions,
   OrderOption,
   TypeOption,
@@ -8,7 +10,7 @@ import type { SortingNode } from '../types/sorting-node'
 import type { CompareOptions } from './compare'
 
 interface Options {
-  customGroups: Record<string, string[] | string> | CustomGroup[]
+  customGroups: DeprecatedCustomGroupsOption | CustomGroupsOption
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   groups: GroupsOptions<string>
@@ -16,18 +18,6 @@ interface Options {
   order: OrderOption
   type: TypeOption
   alphabet: string
-}
-
-type CustomGroup = (
-  | {
-      order?: OrderOption
-      type?: TypeOption
-    }
-  | {
-      type?: 'unsorted'
-    }
-) & {
-  groupName: string
 }
 
 /**

--- a/utils/get-custom-groups-compare-options.ts
+++ b/utils/get-custom-groups-compare-options.ts
@@ -1,11 +1,14 @@
-import type { GroupsOptions } from '../types/common-options'
+import type {
+  SpecialCharactersOption,
+  GroupsOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 import type { CompareOptions } from './compare'
 
 interface Options {
   customGroups: Record<string, string[] | string> | CustomGroup[]
   type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-  specialCharacters: 'remove' | 'trim' | 'keep'
+  specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   groups: GroupsOptions<string>
   order: 'desc' | 'asc'

--- a/utils/get-group-number.ts
+++ b/utils/get-group-number.ts
@@ -1,9 +1,7 @@
+import type { NewlinesBetweenOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
-type Group =
-  | { newlinesBetween: 'ignore' | 'always' | 'never' }
-  | string[]
-  | string
+type Group = { newlinesBetween: NewlinesBetweenOption } | string[] | string
 
 export let getGroupNumber = (groups: Group[], node: SortingNode): number => {
   for (let max = groups.length, i = 0; i < max; i++) {

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -1,4 +1,7 @@
-import type { GroupsOptions } from '../types/common-options'
+import type {
+  NewlinesBetweenOption,
+  GroupsOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getGroupNumber } from './get-group-number'
@@ -11,7 +14,7 @@ export interface GetNewlinesBetweenOptionParameters {
 
 interface Options {
   customGroups?: Record<string, string[] | string> | CustomGroup[]
-  newlinesBetween: 'ignore' | 'always' | 'never'
+  newlinesBetween: NewlinesBetweenOption
   groups: GroupsOptions<string>
 }
 
@@ -30,14 +33,14 @@ interface CustomGroup {
  * @param {SortingNode} props.nextSortingNode - The next node to sort
  * @param {SortingNode} props.sortingNode - The current node to sort
  * @param {Options} props.options - Newlines between related options
- * @returns {'ignore' | 'always' | 'never'} - The `newlinesBetween` option to
+ * @returns {NewlinesBetweenOption} - The `newlinesBetween` option to
  * use
  */
 export let getNewlinesBetweenOption = ({
   nextSortingNode,
   sortingNode,
   options,
-}: GetNewlinesBetweenOptionParameters): 'ignore' | 'always' | 'never' => {
+}: GetNewlinesBetweenOptionParameters): NewlinesBetweenOption => {
   let nodeGroupNumber = getGroupNumber(options.groups, sortingNode)
   let nextNodeGroupNumber = getGroupNumber(options.groups, nextSortingNode)
   let globalNewlinesBetweenOption = getGlobalNewlinesBetweenOption({
@@ -88,7 +91,7 @@ let getGlobalNewlinesBetweenOption = ({
   newlinesBetween,
   nodeGroupNumber,
 }: {
-  newlinesBetween: 'ignore' | 'always' | 'never'
+  newlinesBetween: NewlinesBetweenOption
   nextNodeGroupNumber: number
   nodeGroupNumber: number
 }): 'always' | 'ignore' | 'never' => {

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -1,5 +1,7 @@
 import type {
+  DeprecatedCustomGroupsOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -7,20 +9,13 @@ import type { SortingNode } from '../types/sorting-node'
 import { getGroupNumber } from './get-group-number'
 
 export interface GetNewlinesBetweenOptionParameters {
+  options: {
+    customGroups?: DeprecatedCustomGroupsOption | CustomGroupsOption
+    newlinesBetween: NewlinesBetweenOption
+    groups: GroupsOptions<string>
+  }
   nextSortingNode: SortingNode
   sortingNode: SortingNode
-  options: Options
-}
-
-interface Options {
-  customGroups?: Record<string, string[] | string> | CustomGroup[]
-  newlinesBetween: NewlinesBetweenOption
-  groups: GroupsOptions<string>
-}
-
-interface CustomGroup {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
 }
 
 /**
@@ -32,7 +27,7 @@ interface CustomGroup {
  * @param {GetNewlinesBetweenOptionParameters} props - The function arguments
  * @param {SortingNode} props.nextSortingNode - The next node to sort
  * @param {SortingNode} props.sortingNode - The current node to sort
- * @param {Options} props.options - Newlines between related options
+ * @param {GetNewlinesBetweenOptionParameters['options']} props.options - Newlines between related options
  * @returns {NewlinesBetweenOption} - The `newlinesBetween` option to
  * use
  */

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -1,7 +1,9 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
 import type {
+  DeprecatedCustomGroupsOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -11,7 +13,7 @@ import { getLinesBetween } from './get-lines-between'
 
 interface GetNewlinesErrorsParameters<T extends string> {
   options: {
-    customGroups?: Record<string, string[] | string> | CustomGroup[]
+    customGroups?: DeprecatedCustomGroupsOption | CustomGroupsOption
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<string>
   }
@@ -22,11 +24,6 @@ interface GetNewlinesErrorsParameters<T extends string> {
   left: SortingNode
   rightNum: number
   leftNum: number
-}
-
-interface CustomGroup {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
 }
 
 export let getNewlinesErrors = <T extends string>({

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -1,6 +1,9 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { GroupsOptions } from '../types/common-options'
+import type {
+  NewlinesBetweenOption,
+  GroupsOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getNewlinesBetweenOption } from './get-newlines-between-option'
@@ -9,7 +12,7 @@ import { getLinesBetween } from './get-lines-between'
 interface GetNewlinesErrorsParameters<T extends string> {
   options: {
     customGroups?: Record<string, string[] | string> | CustomGroup[]
-    newlinesBetween: 'ignore' | 'always' | 'never'
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<string>
   }
   sourceCode: TSESLint.SourceCode

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -1,5 +1,7 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
+import type { SpecialCharactersOption } from '../types/common-options'
+
 export type Settings = Partial<{
   partitionByComment:
     | {
@@ -10,7 +12,7 @@ export type Settings = Partial<{
     | boolean
     | string
   type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
-  specialCharacters: 'remove' | 'trim' | 'keep'
+  specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
   ignorePattern: string[]

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -2,6 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import type {
   SpecialCharactersOption,
+  OrderOption,
   TypeOption,
 } from '../types/common-options'
 
@@ -18,8 +19,8 @@ export type Settings = Partial<{
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
   ignorePattern: string[]
-  order: 'desc' | 'asc'
   ignoreCase: boolean
+  order: OrderOption
   type: TypeOption
   alphabet: string
 }>

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -1,6 +1,9 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { SpecialCharactersOption } from '../types/common-options'
+import type {
+  SpecialCharactersOption,
+  TypeOption,
+} from '../types/common-options'
 
 export type Settings = Partial<{
   partitionByComment:
@@ -11,13 +14,13 @@ export type Settings = Partial<{
     | string[]
     | boolean
     | string
-  type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
   ignorePattern: string[]
   order: 'desc' | 'asc'
   ignoreCase: boolean
+  type: TypeOption
   alphabet: string
 }>
 

--- a/utils/is-positive.ts
+++ b/utils/is-positive.ts
@@ -1,1 +1,0 @@
-export let isPositive = (number: number): boolean => number > 0

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -1,8 +1,10 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
 import type {
+  DeprecatedCustomGroupsOption,
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -13,7 +15,7 @@ import { makeOrderFixes } from './make-order-fixes'
 
 export interface MakeFixesParameters {
   options?: {
-    customGroups?: Record<string, string[] | string> | CustomGroup[]
+    customGroups?: DeprecatedCustomGroupsOption | CustomGroupsOption
     partitionByComment?: PartitionByCommentOption
     newlinesBetween?: NewlinesBetweenOption
     groups?: GroupsOptions<string>
@@ -23,11 +25,6 @@ export interface MakeFixesParameters {
   sortedNodes: SortingNode[]
   fixer: TSESLint.RuleFixer
   nodes: SortingNode[]
-}
-
-interface CustomGroup {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
 }
 
 export let makeFixes = ({

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -2,6 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   GroupsOptions,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -13,8 +14,8 @@ import { makeOrderFixes } from './make-order-fixes'
 export interface MakeFixesParameters {
   options?: {
     customGroups?: Record<string, string[] | string> | CustomGroup[]
-    newlinesBetween?: 'ignore' | 'always' | 'never'
     partitionByComment?: PartitionByCommentOption
+    newlinesBetween?: NewlinesBetweenOption
     groups?: GroupsOptions<string>
   }
   ignoreFirstNodeHighestBlockComment?: boolean

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -1,5 +1,6 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
+import type { NewlinesBetweenOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getNewlinesBetweenOption } from './get-newlines-between-option'
@@ -7,13 +8,9 @@ import { getLinesBetween } from './get-lines-between'
 import { getNodeRange } from './get-node-range'
 
 interface Options {
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | string[]
-    | string
-  )[]
+  groups: ({ newlinesBetween: NewlinesBetweenOption } | string[] | string)[]
   customGroups?: Record<string, string[] | string> | CustomGroup[]
-  newlinesBetween: 'ignore' | 'always' | 'never'
+  newlinesBetween: NewlinesBetweenOption
 }
 
 interface MakeNewlinesFixesParameters {

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -1,29 +1,27 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { NewlinesBetweenOption } from '../types/common-options'
+import type {
+  DeprecatedCustomGroupsOption,
+  NewlinesBetweenOption,
+  CustomGroupsOption,
+  GroupsOptions,
+} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
 import { getNewlinesBetweenOption } from './get-newlines-between-option'
 import { getLinesBetween } from './get-lines-between'
 import { getNodeRange } from './get-node-range'
 
-interface Options {
-  groups: ({ newlinesBetween: NewlinesBetweenOption } | string[] | string)[]
-  customGroups?: Record<string, string[] | string> | CustomGroup[]
-  newlinesBetween: NewlinesBetweenOption
-}
-
 interface MakeNewlinesFixesParameters {
+  options: {
+    customGroups?: DeprecatedCustomGroupsOption | CustomGroupsOption
+    newlinesBetween: NewlinesBetweenOption
+    groups: GroupsOptions<string>
+  }
   sourceCode: TSESLint.SourceCode
   sortedNodes: SortingNode[]
   fixer: TSESLint.RuleFixer
   nodes: SortingNode[]
-  options: Options
-}
-
-interface CustomGroup {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
 }
 
 export let makeNewlinesFixes = ({

--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -23,7 +23,7 @@ interface ReportAllErrorsParameters<MessageIds extends string> {
   sortNodesExcludingEslintDisabled(
     ignoreEslintDisabledNodes: boolean,
   ): SortingNode[]
-  options?: {
+  options: {
     groups?: GroupsOptions<string>
   } & MakeFixesParameters['options']
   context: TSESLint.RuleContext<MessageIds, unknown[]>
@@ -47,10 +47,8 @@ export let reportAllErrors = <MessageIds extends string>({
   let nodeIndexMap = createNodeIndexMap(sortedNodes)
 
   pairwise(nodes, (left, right) => {
-    let leftNumber = options?.groups ? getGroupNumber(options.groups, left) : 0
-    let rightNumber = options?.groups
-      ? getGroupNumber(options.groups, right)
-      : 0
+    let leftNumber = options.groups ? getGroupNumber(options.groups, left) : 0
+    let rightNumber = options.groups ? getGroupNumber(options.groups, right) : 0
 
     let leftIndex = nodeIndexMap.get(left)!
     let rightIndex = nodeIndexMap.get(right)!
@@ -88,7 +86,7 @@ export let reportAllErrors = <MessageIds extends string>({
     }
 
     if (
-      options?.newlinesBetween &&
+      options.newlinesBetween &&
       options.groups &&
       availableMessageIds.missedSpacingBetweenMembers &&
       availableMessageIds.extraSpacingBetweenMembers

--- a/utils/report-errors.ts
+++ b/utils/report-errors.ts
@@ -7,9 +7,9 @@ import { toSingleLine } from './to-single-line'
 import { makeFixes } from './make-fixes'
 
 const NODE_DEPENDENT_ON_RIGHT = 'nodeDependentOnRight'
-const RIGHT = 'right'
+export const RIGHT = 'right'
 const RIGHT_GROUP = 'rightGroup'
-const LEFT = 'left'
+export const LEFT = 'left'
 const LEFT_GROUP = 'leftGroup'
 
 export const ORDER_ERROR =

--- a/utils/report-errors.ts
+++ b/utils/report-errors.ts
@@ -6,6 +6,23 @@ import type { MakeFixesParameters } from './make-fixes'
 import { toSingleLine } from './to-single-line'
 import { makeFixes } from './make-fixes'
 
+const NODE_DEPENDENT_ON_RIGHT = 'nodeDependentOnRight'
+const RIGHT = 'right'
+const RIGHT_GROUP = 'rightGroup'
+const LEFT = 'left'
+const LEFT_GROUP = 'leftGroup'
+
+export const ORDER_ERROR =
+  `Expected "{{${RIGHT}}" to come before "{{${LEFT}}".` as const
+export const DEPENDENCY_ORDER_ERROR =
+  `Expected dependency "{{${RIGHT}}" to come before "{{${NODE_DEPENDENT_ON_RIGHT}}}".` as const
+export const GROUP_ORDER_ERROR =
+  `Expected "{{${RIGHT}}" ({{${RIGHT_GROUP}}) to come before "{{${LEFT}}" ({{${LEFT_GROUP}}).` as const
+export const EXTRA_SPACING_ERROR =
+  `Extra spacing between "{{${LEFT}}" and "{{${RIGHT}}" objects.` as const
+export const MISSED_SPACING_ERROR =
+  `Missed spacing between "{{${LEFT}}" and "{{${RIGHT}}".` as const
+
 interface ReportErrorsParameters<MessageIds extends string> {
   context: TSESLint.RuleContext<MessageIds, unknown[]>
   firstUnorderedNodeDependentOnRight?: SortingNode
@@ -34,11 +51,11 @@ export let reportErrors = <MessageIds extends string>({
   for (let messageId of messageIds) {
     context.report({
       data: {
-        nodeDependentOnRight: firstUnorderedNodeDependentOnRight?.name,
-        right: toSingleLine(right.name),
-        left: toSingleLine(left.name),
-        rightGroup: right.group,
-        leftGroup: left.group,
+        [NODE_DEPENDENT_ON_RIGHT]: firstUnorderedNodeDependentOnRight?.name,
+        [RIGHT]: toSingleLine(right.name),
+        [LEFT]: toSingleLine(left.name),
+        [RIGHT_GROUP]: right.group,
+        [LEFT_GROUP]: left.group,
       },
       fix: (fixer: TSESLint.RuleFixer) =>
         makeFixes({

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -15,7 +15,7 @@ export interface SortingNodeWithDependencies<
 }
 
 interface ExtraOptions {
-  ignoreEslintDisabledNodes?: boolean
+  ignoreEslintDisabledNodes: boolean
 }
 
 /**
@@ -27,7 +27,7 @@ interface ExtraOptions {
  */
 export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
   nodes: T[],
-  extraOptions?: ExtraOptions,
+  extraOptions: ExtraOptions,
 ): T[] => {
   let result: T[] = []
   let visitedNodes = new Set<T>()
@@ -48,7 +48,7 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
     )
     for (let dependentNode of dependentNodes) {
       if (
-        !extraOptions?.ignoreEslintDisabledNodes ||
+        !extraOptions.ignoreEslintDisabledNodes ||
         !dependentNode.isEslintDisabled
       ) {
         visitNode(dependentNode)

--- a/utils/sort-nodes-by-groups.ts
+++ b/utils/sort-nodes-by-groups.ts
@@ -11,7 +11,7 @@ interface ExtraOptions<T extends SortingNode> {
    * will not be sorted within the group.
    */
   getGroupCompareOptions?(groupNumber: number): CompareOptions<T> | null
-  ignoreEslintDisabledNodes?: boolean
+  ignoreEslintDisabledNodes: boolean
   isNodeIgnored?(node: T): boolean
 }
 

--- a/utils/sort-nodes.ts
+++ b/utils/sort-nodes.ts
@@ -4,7 +4,7 @@ import type { CompareOptions } from './compare'
 import { compare } from './compare'
 
 interface ExtraOptions {
-  ignoreEslintDisabledNodes?: boolean
+  ignoreEslintDisabledNodes: boolean
 }
 
 export let sortNodes = <T extends SortingNode>(

--- a/utils/use-groups.ts
+++ b/utils/use-groups.ts
@@ -1,3 +1,5 @@
+import type { NewlinesBetweenOption } from '../types/common-options'
+
 import { matches } from './matches'
 
 interface UseGroupsValue {
@@ -13,11 +15,7 @@ interface UseGroupsValue {
 }
 
 interface UseGroupProps {
-  groups: (
-    | { newlinesBetween: 'ignore' | 'always' | 'never' }
-    | string[]
-    | string
-  )[]
+  groups: ({ newlinesBetween: NewlinesBetweenOption } | string[] | string)[]
 }
 
 export let useGroups = ({ groups }: UseGroupProps): UseGroupsValue => {

--- a/utils/use-groups.ts
+++ b/utils/use-groups.ts
@@ -1,10 +1,13 @@
-import type { NewlinesBetweenOption } from '../types/common-options'
+import type {
+  DeprecatedCustomGroupsOption,
+  NewlinesBetweenOption,
+} from '../types/common-options'
 
 import { matches } from './matches'
 
 interface UseGroupsValue {
   setCustomGroups(
-    customGroups: Record<string, string[] | string> | undefined,
+    customGroups: DeprecatedCustomGroupsOption | undefined,
     name: string,
     parameters?: {
       override?: boolean
@@ -30,7 +33,7 @@ export let useGroups = ({ groups }: UseGroupParameters): UseGroupsValue => {
   }
 
   let setCustomGroups = (
-    customGroups: Record<string, string[] | string> | undefined,
+    customGroups: DeprecatedCustomGroupsOption | undefined,
     name: string,
     parameters: { override?: boolean } = {},
   ): void => {

--- a/utils/use-groups.ts
+++ b/utils/use-groups.ts
@@ -14,11 +14,11 @@ interface UseGroupsValue {
   getGroup(): string
 }
 
-interface UseGroupProps {
+interface UseGroupParameters {
   groups: ({ newlinesBetween: NewlinesBetweenOption } | string[] | string)[]
 }
 
-export let useGroups = ({ groups }: UseGroupProps): UseGroupsValue => {
+export let useGroups = ({ groups }: UseGroupParameters): UseGroupsValue => {
   let group: undefined | string
   // For lookup performance.
   let groupsSet = new Set(groups.flat())

--- a/utils/validate-custom-sort-configuration.ts
+++ b/utils/validate-custom-sort-configuration.ts
@@ -1,5 +1,7 @@
+import type { TypeOption } from '../types/common-options'
+
 interface Options {
-  type: 'alphabetical' | 'line-length' | 'natural' | 'custom'
+  type: TypeOption
   alphabet: string
 }
 

--- a/utils/validate-generated-groups-configuration.ts
+++ b/utils/validate-generated-groups-configuration.ts
@@ -1,3 +1,5 @@
+import type { NewlinesBetweenOption } from '../types/common-options'
+
 import { validateNoDuplicatedGroups } from './validate-groups-configuration'
 
 interface ValidateGenerateGroupsConfigurationParameters {
@@ -7,10 +9,7 @@ interface ValidateGenerateGroupsConfigurationParameters {
   groups: Group[]
 }
 
-type Group =
-  | { newlinesBetween: 'ignore' | 'always' | 'never' }
-  | string[]
-  | string
+type Group = { newlinesBetween: NewlinesBetweenOption } | string[] | string
 
 interface BaseCustomGroup {
   groupName: string

--- a/utils/validate-generated-groups-configuration.ts
+++ b/utils/validate-generated-groups-configuration.ts
@@ -1,32 +1,31 @@
-import type { NewlinesBetweenOption } from '../types/common-options'
+import type {
+  DeprecatedCustomGroupsOption,
+  CustomGroupsOption,
+  GroupsOptions,
+} from '../types/common-options'
 
 import { validateNoDuplicatedGroups } from './validate-groups-configuration'
 
 interface ValidateGenerateGroupsConfigurationParameters {
-  customGroups: Record<string, string[] | string> | BaseCustomGroup[]
+  options: {
+    customGroups: DeprecatedCustomGroupsOption | CustomGroupsOption
+    groups: GroupsOptions<string>
+  }
   selectors: string[]
   modifiers: string[]
-  groups: Group[]
-}
-
-type Group = { newlinesBetween: NewlinesBetweenOption } | string[] | string
-
-interface BaseCustomGroup {
-  groupName: string
 }
 
 export let validateGeneratedGroupsConfiguration = ({
-  customGroups,
   selectors,
   modifiers,
-  groups,
+  options,
 }: ValidateGenerateGroupsConfigurationParameters): void => {
   let availableCustomGroupNames = new Set(
-    Array.isArray(customGroups)
-      ? customGroups.map(customGroup => customGroup.groupName)
-      : Object.keys(customGroups),
+    Array.isArray(options.customGroups)
+      ? options.customGroups.map(customGroup => customGroup.groupName)
+      : Object.keys(options.customGroups),
   )
-  let invalidGroups = groups
+  let invalidGroups = options.groups
     .flat()
     .filter(group => typeof group === 'string')
     .filter(
@@ -37,7 +36,7 @@ export let validateGeneratedGroupsConfiguration = ({
   if (invalidGroups.length > 0) {
     throw new Error(`Invalid group(s): ${invalidGroups.join(', ')}`)
   }
-  validateNoDuplicatedGroups(groups)
+  validateNoDuplicatedGroups(options.groups)
 }
 
 let isPredefinedGroup = (

--- a/utils/validate-groups-configuration.ts
+++ b/utils/validate-groups-configuration.ts
@@ -1,7 +1,6 @@
-type Group =
-  | { newlinesBetween: 'ignore' | 'always' | 'never' }
-  | string[]
-  | string
+import type { NewlinesBetweenOption } from '../types/common-options'
+
+type Group = { newlinesBetween: NewlinesBetweenOption } | string[] | string
 
 /**
  * Throws an error if one of the following conditions is met:

--- a/utils/validate-newlines-and-partition-configuration.ts
+++ b/utils/validate-newlines-and-partition-configuration.ts
@@ -1,7 +1,10 @@
-import type { GroupsOptions } from '../types/common-options'
+import type {
+  NewlinesBetweenOption,
+  GroupsOptions,
+} from '../types/common-options'
 
 interface Options {
-  newlinesBetween: 'ignore' | 'always' | 'never'
+  newlinesBetween: NewlinesBetweenOption
   groups: GroupsOptions<string>
   partitionByNewLine: boolean
 }


### PR DESCRIPTION
### Description

This PR:
- Puts all error messages in common in the same file.
- Refactors types to avoid duplicating them in the codebase.
  - `NewlinesBetweenOption`
  - `SpecialCharacterOption`
  - `TypeOption`
  - `OrderOption`
  - `CustomGroupsOption`


### What is the purpose of this pull request?

- [x] Other
