### PR TITLE
feat: improves `newlinesBetween` inside `groups` option behavior

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -31,6 +31,7 @@ import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-c
 import { readClosestTsConfigByPath } from './sort-imports/read-closest-ts-config-by-path'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getOptionsWithCleanGroups } from '../utils/get-options-with-clean-groups'
+import { isNewlinesBetweenOption } from '../utils/is-newlines-between-option'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { getTypescriptImport } from './sort-imports/get-typescript-import'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
@@ -179,7 +180,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         | string[]
         | string,
     ): boolean => {
-      if (!group || (typeof group === 'object' && 'newlinesBetween' in group)) {
+      if (!group || isNewlinesBetweenOption(group)) {
         return false
       }
       if (typeof group === 'string') {

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1596,91 +1596,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'a', groupName: 'a' },
-                    { elementNamePattern: 'b', groupName: 'b' },
-                    { elementNamePattern: 'c', groupName: 'c' },
-                    { elementNamePattern: 'd', groupName: 'd' },
-                    { elementNamePattern: 'e', groupName: 'e' },
-                  ],
-                  groups: [
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'a', groupName: 'a' },
+                      { elementNamePattern: 'b', groupName: 'b' },
+                      { elementNamePattern: 'c', groupName: 'c' },
+                      { elementNamePattern: 'd', groupName: 'd' },
+                      { elementNamePattern: 'e', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenArrayIncludesMembers',
+                  },
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                  },
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                  },
+                ],
+                output: dedent`
+                  [
                     'a',
-                    { newlinesBetween: 'always' },
+
                     'b',
-                    { newlinesBetween: 'always' },
+
                     'c',
-                    { newlinesBetween: 'never' },
                     'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'missedSpacingBetweenArrayIncludesMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
-                  },
-                  messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
-                  },
-                  messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                },
-              ],
-              output: dedent`
-                [
-                  'a',
-
-                  'b',
-
-                  'c',
-                  'd',
 
 
-                  'e'
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'a',
-                  'b',
+                    'e'
+                  ].includes(value)
+                `,
+                code: dedent`
+                  [
+                    'a',
+                    'b',
 
 
-                  'c',
+                    'c',
 
-                  'd',
+                    'd',
 
 
-                  'e'
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    'e'
+                  ].includes(value)
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1747,7 +1747,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1682,6 +1682,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenArrayIncludesMembers',
+                      },
+                    ],
+                    output: dedent`
+                      [
+                        a,
+
+                        b,
+                      ].includes(value)
+                    `,
+                    code: dedent`
+                      [
+                        a,
+                        b,
+                      ].includes(value)
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      [
+                        a,
+
+                        b,
+                      ].includes(value)
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      [
+                        a,
+                        b,
+                      ].includes(value)
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4520,6 +4520,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenClassMembers',
+                      },
+                    ],
+                    output: dedent`
+                      class Class {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                    code: dedent`
+                      class Class {
+                        a: string
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      class Class {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      class Class {
+                        a: string
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4585,7 +4585,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4434,91 +4434,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'a', groupName: 'a' },
-                    { elementNamePattern: 'b', groupName: 'b' },
-                    { elementNamePattern: 'c', groupName: 'c' },
-                    { elementNamePattern: 'd', groupName: 'd' },
-                    { elementNamePattern: 'e', groupName: 'e' },
-                  ],
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'a', groupName: 'a' },
+                      { elementNamePattern: 'b', groupName: 'b' },
+                      { elementNamePattern: 'c', groupName: 'c' },
+                      { elementNamePattern: 'd', groupName: 'd' },
+                      { elementNamePattern: 'e', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
                   },
-                  messageId: 'missedSpacingBetweenClassMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenClassMembers',
                   },
-                  messageId: 'extraSpacingBetweenClassMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenClassMembers',
                   },
-                  messageId: 'extraSpacingBetweenClassMembers',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  a: string
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenClassMembers',
+                  },
+                ],
+                output: dedent`
+                  class Class {
+                    a: string
 
-                  b: string
+                    b: string
 
-                  c: string
-                  d: string
-
-
-                  e: string
-                }
-              `,
-              code: dedent`
-                class Class {
-                  a: string
-                  b: string
+                    c: string
+                    d: string
 
 
-                  c: string
+                    e: string
+                  }
+                `,
+                code: dedent`
+                  class Class {
+                    a: string
+                    b: string
 
-                  d: string
+
+                    c: string
+
+                    d: string
 
 
-                  e: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    e: string
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1361,91 +1361,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'A', groupName: 'a' },
-                    { elementNamePattern: 'B', groupName: 'b' },
-                    { elementNamePattern: 'C', groupName: 'c' },
-                    { elementNamePattern: 'D', groupName: 'd' },
-                    { elementNamePattern: 'E', groupName: 'e' },
-                  ],
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'B',
-                    left: 'A',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'A', groupName: 'a' },
+                      { elementNamePattern: 'B', groupName: 'b' },
+                      { elementNamePattern: 'C', groupName: 'c' },
+                      { elementNamePattern: 'D', groupName: 'd' },
+                      { elementNamePattern: 'E', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
                   },
-                  messageId: 'missedSpacingBetweenEnumsMembers',
-                },
-                {
-                  data: {
-                    right: 'C',
-                    left: 'B',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'B',
+                      left: 'A',
+                    },
+                    messageId: 'missedSpacingBetweenEnumsMembers',
                   },
-                  messageId: 'extraSpacingBetweenEnumsMembers',
-                },
-                {
-                  data: {
-                    right: 'D',
-                    left: 'C',
+                  {
+                    data: {
+                      right: 'C',
+                      left: 'B',
+                    },
+                    messageId: 'extraSpacingBetweenEnumsMembers',
                   },
-                  messageId: 'extraSpacingBetweenEnumsMembers',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  A = null,
+                  {
+                    data: {
+                      right: 'D',
+                      left: 'C',
+                    },
+                    messageId: 'extraSpacingBetweenEnumsMembers',
+                  },
+                ],
+                output: dedent`
+                  enum Enum {
+                    A = null,
 
-                  B = null,
+                    B = null,
 
-                  C = null,
-                  D = null,
-
-
-                  E = null,
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  A = null,
-                  B = null,
+                    C = null,
+                    D = null,
 
 
-                  C = null,
+                    E = null,
+                  }
+                `,
+                code: dedent`
+                  enum Enum {
+                    A = null,
+                    B = null,
 
-                  D = null,
+
+                    C = null,
+
+                    D = null,
 
 
-                  E = null,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    E = null,
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1447,6 +1447,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'A', groupName: 'A' },
+                          { elementNamePattern: 'B', groupName: 'B' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'A',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'B',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'B',
+                          left: 'A',
+                        },
+                        messageId: 'missedSpacingBetweenEnumsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      enum Enum {
+                        A = 'A',
+
+                        B = 'B',
+                      }
+                    `,
+                    code: dedent`
+                      enum Enum {
+                        A = 'A',
+                        B = 'B',
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'A', groupName: 'A' },
+                          { elementNamePattern: 'B', groupName: 'B' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'A',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'B',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      enum Enum {
+                        A = 'A',
+
+                        B = 'B',
+                      }
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      enum Enum {
+                        A = 'A',
+                        B = 'B',
+                      }
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1512,7 +1512,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2116,6 +2116,130 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: {
+                          value: {
+                            unusedGroup: 'X',
+                            a: 'a',
+                            b: 'b',
+                          },
+                        },
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenImports',
+                      },
+                    ],
+                    output: dedent`
+                      import { a } from 'a';
+
+                      import { b } from 'b';
+                    `,
+                    code: dedent`
+                      import { a } from 'a';
+                      import { b } from 'b';
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: {
+                          value: {
+                            unusedGroup: 'X',
+                            a: 'a',
+                            b: 'b',
+                          },
+                        },
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      import { a } from 'a';
+
+                      import { b } from 'b';
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: {
+                          value: {
+                            unusedGroup: 'X',
+                            a: 'a',
+                            b: 'b',
+                          },
+                        },
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      import { a } from 'a';
+                      import { b } from 'b';
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2179,7 +2179,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2032,89 +2032,91 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  customGroups: {
-                    value: {
-                      a: 'a',
-                      b: 'b',
-                      c: 'c',
-                      d: 'd',
-                      e: 'e',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: {
+                      value: {
+                        a: 'a',
+                        b: 'b',
+                        c: 'c',
+                        d: 'd',
+                        e: 'e',
+                      },
                     },
+                    newlinesBetween: 'always',
                   },
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenImports',
                   },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenImports',
                   },
-                  messageId: 'extraSpacingBetweenImports',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenImports',
                   },
-                  messageId: 'extraSpacingBetweenImports',
-                },
-              ],
-              output: dedent`
-                import { A } from 'a'
+                ],
+                output: dedent`
+                  import { A } from 'a'
 
-                import { B } from 'b'
+                  import { B } from 'b'
 
-                import { C } from 'c'
-                import { D } from 'd'
+                  import { C } from 'c'
+                  import { D } from 'd'
 
 
-                import { E } from 'e'
-              `,
-              code: dedent`
-                import { A } from 'a'
-                import { B } from 'b'
+                  import { E } from 'e'
+                `,
+                code: dedent`
+                  import { A } from 'a'
+                  import { B } from 'b'
 
 
-                import { C } from 'c'
+                  import { C } from 'c'
 
-                import { D } from 'd'
+                  import { D } from 'd'
 
 
-                import { E } from 'e'
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                  import { E } from 'e'
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -2305,91 +2305,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'a', groupName: 'a' },
-                    { elementNamePattern: 'b', groupName: 'b' },
-                    { elementNamePattern: 'c', groupName: 'c' },
-                    { elementNamePattern: 'd', groupName: 'd' },
-                    { elementNamePattern: 'e', groupName: 'e' },
-                  ],
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'a', groupName: 'a' },
+                      { elementNamePattern: 'b', groupName: 'b' },
+                      { elementNamePattern: 'c', groupName: 'c' },
+                      { elementNamePattern: 'd', groupName: 'd' },
+                      { elementNamePattern: 'e', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
                   },
-                  messageId: 'missedSpacingBetweenInterfaceMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenInterfaceMembers',
                   },
-                  messageId: 'extraSpacingBetweenInterfaceMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenInterfaceMembers',
                   },
-                  messageId: 'extraSpacingBetweenInterfaceMembers',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  a: string
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenInterfaceMembers',
+                  },
+                ],
+                output: dedent`
+                  interface Interface {
+                    a: string
 
-                  b: string
+                    b: string
 
-                  c: string
-                  d: string
-
-
-                  e: string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  a: string
-                  b: string
+                    c: string
+                    d: string
 
 
-                  c: string
+                    e: string
+                  }
+                `,
+                code: dedent`
+                  interface Interface {
+                    a: string
+                    b: string
 
-                  d: string
+
+                    c: string
+
+                    d: string
 
 
-                  e: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    e: string
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -2391,6 +2391,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenInterfaceMembers',
+                      },
+                    ],
+                    output: dedent`
+                      interface Interface {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                    code: dedent`
+                      interface Interface {
+                        a: string
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      interface Interface {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      interface Interface {
+                        a: string
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -2456,7 +2456,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1122,82 +1122,84 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '{ a: string }',
-                    left: '() => void',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      right: '{ a: string }',
+                      left: '() => void',
+                    },
+                    messageId: 'missedSpacingBetweenIntersectionTypes',
                   },
-                  messageId: 'missedSpacingBetweenIntersectionTypes',
-                },
-                {
-                  data: {
-                    left: '{ a: string }',
-                    right: 'A',
+                  {
+                    data: {
+                      left: '{ a: string }',
+                      right: 'A',
+                    },
+                    messageId: 'extraSpacingBetweenIntersectionTypes',
                   },
-                  messageId: 'extraSpacingBetweenIntersectionTypes',
-                },
-                {
-                  data: {
-                    right: '[A]',
-                    left: 'A',
+                  {
+                    data: {
+                      right: '[A]',
+                      left: 'A',
+                    },
+                    messageId: 'extraSpacingBetweenIntersectionTypes',
                   },
-                  messageId: 'extraSpacingBetweenIntersectionTypes',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'function',
-                    { newlinesBetween: 'always' },
-                    'object',
-                    { newlinesBetween: 'always' },
-                    'named',
-                    { newlinesBetween: 'never' },
-                    'tuple',
-                    { newlinesBetween: 'ignore' },
-                    'nullish',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              output: dedent`
-                type Type =
-                  (() => void) &
+                ],
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'function',
+                      { newlinesBetween: 'always' },
+                      'object',
+                      { newlinesBetween: 'always' },
+                      'named',
+                      { newlinesBetween: 'never' },
+                      'tuple',
+                      { newlinesBetween: 'ignore' },
+                      'nullish',
+                    ],
+                    newlinesBetween: 'always',
+                  },
+                ],
+                output: dedent`
+                  type Type =
+                    (() => void) &
 
-                  { a: string } &
+                    { a: string } &
 
-                  A &
-                  [A] &
+                    A &
+                    [A] &
 
 
-                  null
-              `,
-              code: dedent`
-                type Type =
-                  (() => void) &
-                  { a: string } &
+                    null
+                `,
+                code: dedent`
+                  type Type =
+                    (() => void) &
+                    { a: string } &
 
 
-                  A &
+                    A &
 
-                  [A] &
+                    [A] &
 
 
-                  null
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    null
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1199,6 +1199,113 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          'tuple',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'null',
+                          left: 'A',
+                        },
+                        messageId: 'missedSpacingBetweenIntersectionTypes',
+                      },
+                    ],
+                    output: dedent`
+                      type T =
+                        A &
+
+                        null
+                    `,
+                    code: dedent`
+                      type T =
+                        A &
+                        null
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          'tuple',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      type T =
+                        A &
+
+                        null
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          'tuple',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      type T =
+                        A &
+                        null
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1257,7 +1257,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -928,7 +928,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -777,91 +777,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  customGroups: {
-                    a: 'a',
-                    b: 'b',
-                    c: 'c',
-                    d: 'd',
-                    e: 'e',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: {
+                      a: 'a',
+                      b: 'b',
+                      c: 'c',
+                      d: 'd',
+                      e: 'e',
+                    },
+                    newlinesBetween: 'always',
                   },
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenJSXPropsMembers',
                   },
-                  messageId: 'missedSpacingBetweenJSXPropsMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenJSXPropsMembers',
                   },
-                  messageId: 'extraSpacingBetweenJSXPropsMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenJSXPropsMembers',
                   },
-                  messageId: 'extraSpacingBetweenJSXPropsMembers',
-                },
-              ],
-              output: dedent`
-                <Component
-                  a
+                ],
+                output: dedent`
+                  <Component
+                    a
 
-                  b
+                    b
 
-                  c
-                  d
+                    c
+                    d
 
 
-                  e
-                />
-              `,
-              code: dedent`
-                <Component
-                  a
-                  b
+                    e
+                  />
+                `,
+                code: dedent`
+                  <Component
+                    a
+                    b
 
 
-                  c
+                    c
 
-                  d
+                    d
 
 
-                  e
-                />
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    e
+                  />
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -863,6 +863,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        customGroups: {
+                          unusedGroup: 'X',
+                          a: 'a',
+                          b: 'b',
+                        },
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenJSXPropsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      <Component
+                        a
+
+                        b
+                      />
+                    `,
+                    code: dedent`
+                      <Component
+                        a
+                        b
+                      />
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        customGroups: {
+                          unusedGroup: 'X',
+                          a: 'a',
+                          b: 'b',
+                        },
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      <Component
+                        a
+
+                        b
+                      />
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        customGroups: {
+                          unusedGroup: 'X',
+                          a: 'a',
+                          b: 'b',
+                        },
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      <Component
+                        a
+                        b
+                      />
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1355,7 +1355,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1204,91 +1204,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'a', groupName: 'a' },
-                    { elementNamePattern: 'b', groupName: 'b' },
-                    { elementNamePattern: 'c', groupName: 'c' },
-                    { elementNamePattern: 'd', groupName: 'd' },
-                    { elementNamePattern: 'e', groupName: 'e' },
-                  ],
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'a', groupName: 'a' },
+                      { elementNamePattern: 'b', groupName: 'b' },
+                      { elementNamePattern: 'c', groupName: 'c' },
+                      { elementNamePattern: 'd', groupName: 'd' },
+                      { elementNamePattern: 'e', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
                   },
-                  messageId: 'missedSpacingBetweenMapElementsMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenMapElementsMembers',
                   },
-                  messageId: 'extraSpacingBetweenMapElementsMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenMapElementsMembers',
                   },
-                  messageId: 'extraSpacingBetweenMapElementsMembers',
-                },
-              ],
-              output: dedent`
-                new Map([
-                  [a, null],
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenMapElementsMembers',
+                  },
+                ],
+                output: dedent`
+                  new Map([
+                    [a, null],
 
-                  [b, null],
+                    [b, null],
 
-                  [c, null],
-                  [d, null],
-
-
-                  [e, null]
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  [a, null],
-                  [b, null],
+                    [c, null],
+                    [d, null],
 
 
-                  [c, null],
+                    [e, null]
+                  ])
+                `,
+                code: dedent`
+                  new Map([
+                    [a, null],
+                    [b, null],
 
-                  [d, null],
+
+                    [c, null],
+
+                    [d, null],
 
 
-                  [e, null]
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    [e, null]
+                  ])
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1290,6 +1290,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenMapElementsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      new Map([
+                        [a, 'a'],
+
+                        [b, 'b'],
+                      ])
+                    `,
+                    code: dedent`
+                      new Map([
+                        [a, 'a'],
+                        [b, 'b'],
+                      ])
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      new Map([
+                        [a, 'a'],
+
+                        [b, 'b'],
+                      ])
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      new Map([
+                        [a, 'a'],
+                        [b, 'b'],
+                      ])
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -2188,6 +2188,124 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenModulesMembers',
+                      },
+                    ],
+                    output: dedent`
+                      function a() {}
+
+                      function b() {}
+                    `,
+                    code: dedent`
+                      function a() {}
+                      function b() {}
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      function a() {}
+
+                      function b() {}
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      function a() {}
+                      function b() {}
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -2249,7 +2249,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -2106,87 +2106,89 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'a', groupName: 'a' },
-                    { elementNamePattern: 'b', groupName: 'b' },
-                    { elementNamePattern: 'c', groupName: 'c' },
-                    { elementNamePattern: 'd', groupName: 'd' },
-                    { elementNamePattern: 'e', groupName: 'e' },
-                  ],
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'a', groupName: 'a' },
+                      { elementNamePattern: 'b', groupName: 'b' },
+                      { elementNamePattern: 'c', groupName: 'c' },
+                      { elementNamePattern: 'd', groupName: 'd' },
+                      { elementNamePattern: 'e', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
                   },
-                  messageId: 'missedSpacingBetweenModulesMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenModulesMembers',
                   },
-                  messageId: 'extraSpacingBetweenModulesMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenModulesMembers',
                   },
-                  messageId: 'extraSpacingBetweenModulesMembers',
-                },
-              ],
-              output: dedent`
-                function a() {}
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenModulesMembers',
+                  },
+                ],
+                output: dedent`
+                  function a() {}
 
-                function b() {}
+                  function b() {}
 
-                function c() {}
-                function d() {}
-
-
-                function e() {}
-              `,
-              code: dedent`
-                function a() {}
-                function b() {}
+                  function c() {}
+                  function d() {}
 
 
-                function c() {}
+                  function e() {}
+                `,
+                code: dedent`
+                  function a() {}
+                  function b() {}
 
-                function d() {}
+
+                  function c() {}
+
+                  function d() {}
 
 
-                function e() {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                  function e() {}
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2252,7 +2252,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2187,6 +2187,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenObjectTypeMembers',
+                      },
+                    ],
+                    output: dedent`
+                      type Type = {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                    code: dedent`
+                      type Type = {
+                        a: string
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      type Type = {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      type Type = {
+                        a: string
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2101,91 +2101,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'a', groupName: 'a' },
-                    { elementNamePattern: 'b', groupName: 'b' },
-                    { elementNamePattern: 'c', groupName: 'c' },
-                    { elementNamePattern: 'd', groupName: 'd' },
-                    { elementNamePattern: 'e', groupName: 'e' },
-                  ],
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'a', groupName: 'a' },
+                      { elementNamePattern: 'b', groupName: 'b' },
+                      { elementNamePattern: 'c', groupName: 'c' },
+                      { elementNamePattern: 'd', groupName: 'd' },
+                      { elementNamePattern: 'e', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
                   },
-                  messageId: 'missedSpacingBetweenObjectTypeMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenObjectTypeMembers',
                   },
-                  messageId: 'extraSpacingBetweenObjectTypeMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenObjectTypeMembers',
                   },
-                  messageId: 'extraSpacingBetweenObjectTypeMembers',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  a: string
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenObjectTypeMembers',
+                  },
+                ],
+                output: dedent`
+                  type Type = {
+                    a: string
 
-                  b: string
+                    b: string
 
-                  c: string
-                  d: string
-
-
-                  e: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  a: string
-                  b: string
+                    c: string
+                    d: string
 
 
-                  c: string
+                    e: string
+                  }
+                `,
+                code: dedent`
+                  type Type = {
+                    a: string
+                    b: string
 
-                  d: string
+
+                    c: string
+
+                    d: string
 
 
-                  e: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    e: string
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2343,7 +2343,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2278,6 +2278,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenObjectMembers',
+                      },
+                    ],
+                    output: dedent`
+                      let obj = {
+                        a: null,
+
+                        b: null,
+                      }
+                    `,
+                    code: dedent`
+                      let obj = {
+                        a: null,
+                        b: null,
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      let obj = {
+                        a: null,
+
+                        b: null,
+                      }
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      let obj = {
+                        a: null,
+                        b: null,
+                      }
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2192,91 +2192,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'a',
-                    { newlinesBetween: 'always' },
-                    'b',
-                    { newlinesBetween: 'always' },
-                    'c',
-                    { newlinesBetween: 'never' },
-                    'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  customGroups: {
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: {
+                      a: 'a',
+                      b: 'b',
+                      c: 'c',
+                      d: 'd',
+                      e: 'e',
+                    },
+                    newlinesBetween: 'always',
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenObjectMembers',
+                  },
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenObjectMembers',
+                  },
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenObjectMembers',
+                  },
+                ],
+                output: dedent`
+                  let obj = {
                     a: 'a',
+
                     b: 'b',
+
                     c: 'c',
                     d: 'd',
+
+
                     e: 'e',
-                  },
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'missedSpacingBetweenObjectMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
-                  },
-                  messageId: 'extraSpacingBetweenObjectMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
-                  },
-                  messageId: 'extraSpacingBetweenObjectMembers',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  a: 'a',
-
-                  b: 'b',
-
-                  c: 'c',
-                  d: 'd',
+                  }
+                `,
+                code: dedent`
+                  let obj = {
+                    a: 'a',
+                    b: 'b',
 
 
-                  e: 'e',
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  a: 'a',
-                  b: 'b',
+                    c: 'c',
+
+                    d: 'd',
 
 
-                  c: 'c',
-
-                  d: 'd',
-
-
-                  e: 'e',
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    e: 'e',
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1694,7 +1694,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1543,91 +1543,93 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    { elementNamePattern: 'a', groupName: 'a' },
-                    { elementNamePattern: 'b', groupName: 'b' },
-                    { elementNamePattern: 'c', groupName: 'c' },
-                    { elementNamePattern: 'd', groupName: 'd' },
-                    { elementNamePattern: 'e', groupName: 'e' },
-                  ],
-                  groups: [
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'a',
+                      { newlinesBetween: 'always' },
+                      'b',
+                      { newlinesBetween: 'always' },
+                      'c',
+                      { newlinesBetween: 'never' },
+                      'd',
+                      { newlinesBetween: 'ignore' },
+                      'e',
+                    ],
+                    customGroups: [
+                      { elementNamePattern: 'a', groupName: 'a' },
+                      { elementNamePattern: 'b', groupName: 'b' },
+                      { elementNamePattern: 'c', groupName: 'c' },
+                      { elementNamePattern: 'd', groupName: 'd' },
+                      { elementNamePattern: 'e', groupName: 'e' },
+                    ],
+                    newlinesBetween: 'always',
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      right: 'b',
+                      left: 'a',
+                    },
+                    messageId: 'missedSpacingBetweenSetsMembers',
+                  },
+                  {
+                    data: {
+                      right: 'c',
+                      left: 'b',
+                    },
+                    messageId: 'extraSpacingBetweenSetsMembers',
+                  },
+                  {
+                    data: {
+                      right: 'd',
+                      left: 'c',
+                    },
+                    messageId: 'extraSpacingBetweenSetsMembers',
+                  },
+                ],
+                output: dedent`
+                  new Set([
                     'a',
-                    { newlinesBetween: 'always' },
+
                     'b',
-                    { newlinesBetween: 'always' },
+
                     'c',
-                    { newlinesBetween: 'never' },
                     'd',
-                    { newlinesBetween: 'ignore' },
-                    'e',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'missedSpacingBetweenSetsMembers',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'b',
-                  },
-                  messageId: 'extraSpacingBetweenSetsMembers',
-                },
-                {
-                  data: {
-                    right: 'd',
-                    left: 'c',
-                  },
-                  messageId: 'extraSpacingBetweenSetsMembers',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  'a',
-
-                  'b',
-
-                  'c',
-                  'd',
 
 
-                  'e'
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'a',
-                  'b',
+                    'e'
+                  ])
+                `,
+                code: dedent`
+                  new Set([
+                    'a',
+                    'b',
 
 
-                  'c',
+                    'c',
 
-                  'd',
+                    'd',
 
 
-                  'e'
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    'e'
+                  ])
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1629,6 +1629,132 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'missedSpacingBetweenSetsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      new Set([
+                        a,
+
+                        b,
+                      ])
+                    `,
+                    code: dedent`
+                      new Set([
+                        a,
+                        b,
+                      ])
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      new Set([
+                        a,
+
+                        b,
+                      ])
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        groups: [
+                          'a',
+                          'unusedGroup',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'b',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      new Set([
+                        a,
+                        b,
+                      ])
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1125,82 +1125,84 @@ describe(ruleName, () => {
         },
       )
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use "newlinesBetween" inside groups`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '{ a: string }',
-                    left: '() => void',
+      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
+        ruleTester.run(
+          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      right: '{ a: string }',
+                      left: '() => void',
+                    },
+                    messageId: 'missedSpacingBetweenUnionTypes',
                   },
-                  messageId: 'missedSpacingBetweenUnionTypes',
-                },
-                {
-                  data: {
-                    left: '{ a: string }',
-                    right: 'A',
+                  {
+                    data: {
+                      left: '{ a: string }',
+                      right: 'A',
+                    },
+                    messageId: 'extraSpacingBetweenUnionTypes',
                   },
-                  messageId: 'extraSpacingBetweenUnionTypes',
-                },
-                {
-                  data: {
-                    right: '[A]',
-                    left: 'A',
+                  {
+                    data: {
+                      right: '[A]',
+                      left: 'A',
+                    },
+                    messageId: 'extraSpacingBetweenUnionTypes',
                   },
-                  messageId: 'extraSpacingBetweenUnionTypes',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'function',
-                    { newlinesBetween: 'always' },
-                    'object',
-                    { newlinesBetween: 'always' },
-                    'named',
-                    { newlinesBetween: 'never' },
-                    'tuple',
-                    { newlinesBetween: 'ignore' },
-                    'nullish',
-                  ],
-                  newlinesBetween: 'always',
-                },
-              ],
-              output: dedent`
-                type Type =
-                  (() => void) |
+                ],
+                options: [
+                  {
+                    ...options,
+                    groups: [
+                      'function',
+                      { newlinesBetween: 'always' },
+                      'object',
+                      { newlinesBetween: 'always' },
+                      'named',
+                      { newlinesBetween: 'never' },
+                      'tuple',
+                      { newlinesBetween: 'ignore' },
+                      'nullish',
+                    ],
+                    newlinesBetween: 'always',
+                  },
+                ],
+                output: dedent`
+                  type Type =
+                    (() => void) |
 
-                  { a: string } |
+                    { a: string } |
 
-                  A |
-                  [A] |
+                    A |
+                    [A] |
 
 
-                  null
-              `,
-              code: dedent`
-                type Type =
-                  (() => void) |
-                  { a: string } |
+                    null
+                `,
+                code: dedent`
+                  type Type =
+                    (() => void) |
+                    { a: string } |
 
 
-                  A |
+                    A |
 
-                  [A] |
+                    [A] |
 
 
-                  null
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                    null
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
 
       ruleTester.run(
         `${ruleName}(${type}): handles newlines and comment after fixes`,

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1202,6 +1202,113 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['always', 'never'] as const,
+            ['always', 'ignore'] as const,
+            ['never', 'always'] as const,
+            ['ignore', 'always'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          'tuple',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'null',
+                          left: 'A',
+                        },
+                        messageId: 'missedSpacingBetweenUnionTypes',
+                      },
+                    ],
+                    output: dedent`
+                      type T =
+                        A |
+
+                        null
+                    `,
+                    code: dedent`
+                      type T =
+                        A |
+                        null
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
+          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
+            ['ignore', 'never'] as const,
+            ['never', 'ignore'] as const,
+          ]) {
+            ruleTester.run(
+              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              rule,
+              {
+                valid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          'tuple',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      type T =
+                        A |
+
+                        null
+                    `,
+                  },
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          'tuple',
+                          { newlinesBetween: groupNewlinesBetween },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    code: dedent`
+                      type T =
+                        A |
+                        null
+                    `,
+                  },
+                ],
+                invalid: [],
+              },
+            )
+          }
+        })
       })
 
       ruleTester.run(

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1260,7 +1260,7 @@ describe(ruleName, () => {
             ['never', 'ignore'] as const,
           ]) {
             ruleTester.run(
-              `${ruleName}(${type}): does not enforces a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
+              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
               rule,
               {
                 valid: [

--- a/test/utils/get-newlines-between-option.test.ts
+++ b/test/utils/get-newlines-between-option.test.ts
@@ -172,6 +172,93 @@ describe('get-newlines-between-option', () => {
         ).toBe('never')
       })
     })
+
+    describe('newlinesBetween option between two groups', () => {
+      it('should return the newlinesBetween option between two adjacent groups', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              groups: ['group1', { newlinesBetween: 'always' }, 'group2'],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      describe('non-adjacent groups', () => {
+        it('should return `always` if the global option is `always`', () => {
+          for (let newlinesBetween of ['always', 'ignore', 'never'] as const) {
+            expect(
+              getNewlinesBetweenOption(
+                buildParameters({
+                  groups: [
+                    'group1',
+                    'someOtherGroup',
+                    { newlinesBetween },
+                    'group2',
+                  ],
+                  newlinesBetween: 'always',
+                }),
+              ),
+            ).toBe('always')
+          }
+        })
+
+        it('should return `always` if `always` exists between the groups', () => {
+          expect(
+            getNewlinesBetweenOption(
+              buildParameters({
+                groups: [
+                  'group1',
+                  'someOtherGroup',
+                  { newlinesBetween: 'always' },
+                  'group2',
+                ],
+                newlinesBetween: 'never',
+              }),
+            ),
+          ).toBe('always')
+        })
+
+        it('should return `ignore` if `ignore` exists between the groups', () => {
+          expect(
+            getNewlinesBetweenOption(
+              buildParameters({
+                groups: [
+                  'group1',
+                  'someOtherGroup',
+                  { newlinesBetween: 'ignore' },
+                  'group2',
+                  { newlinesBetween: 'always' },
+                  'someOtherGroup2',
+                ],
+                newlinesBetween: 'never',
+              }),
+            ),
+          ).toBe('ignore')
+        })
+
+        it('should return the global option if no `ignore` or `always` exist', () => {
+          for (let newlinesBetween of ['always', 'ignore', 'never'] as const) {
+            expect(
+              getNewlinesBetweenOption(
+                buildParameters({
+                  groups: [
+                    'group1',
+                    'someOtherGroup',
+                    { newlinesBetween: 'never' },
+                    'group2',
+                    { newlinesBetween: 'always' },
+                    'someOtherGroup2',
+                  ],
+                  newlinesBetween,
+                }),
+              ),
+            ).toBe(newlinesBetween)
+          }
+        })
+      })
+    })
   })
 
   let buildParameters = ({

--- a/test/utils/is-newlines-between-option.test.ts
+++ b/test/utils/is-newlines-between-option.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { isNewlinesBetweenOption } from '../../utils/is-newlines-between-option'
+
+describe('is-newlines-between-option', () => {
+  it('should return `true` if the element is a newlines between option', () => {
+    expect(
+      isNewlinesBetweenOption({
+        newlinesBetween: 'ignore',
+      }),
+    ).toBeTruthy()
+  })
+
+  it('should return `false` if the element is not a newlines between option', () => {
+    expect(isNewlinesBetweenOption('group')).toBeFalsy()
+    expect(isNewlinesBetweenOption(['group'])).toBeFalsy()
+  })
+})

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -6,6 +6,7 @@ import type {
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
+import { isNewlinesBetweenOption } from './is-newlines-between-option'
 import { getGroupNumber } from './get-group-number'
 
 export interface GetNewlinesBetweenOptionParameters {
@@ -71,10 +72,25 @@ export let getNewlinesBetweenOption = ({
   }
 
   // Check if a specific newlinesBetween is defined between the two groups
-  if (nextNodeGroupNumber === nodeGroupNumber + 2) {
-    let groupBetween = options.groups[nodeGroupNumber + 1]
-    if (typeof groupBetween === 'object' && 'newlinesBetween' in groupBetween) {
-      return groupBetween.newlinesBetween
+  if (nextNodeGroupNumber >= nodeGroupNumber + 2) {
+    if (nextNodeGroupNumber === nodeGroupNumber + 2) {
+      let groupBetween = options.groups[nodeGroupNumber + 1]!
+      if (isNewlinesBetweenOption(groupBetween)) {
+        return groupBetween.newlinesBetween
+      }
+    } else {
+      if (globalNewlinesBetweenOption === 'always') {
+        return 'always'
+      }
+      for (let i = nodeGroupNumber + 2; i < nextNodeGroupNumber; i++) {
+        let groupBetween = options.groups[i]!
+        if (
+          isNewlinesBetweenOption(groupBetween) &&
+          groupBetween.newlinesBetween !== 'never'
+        ) {
+          return groupBetween.newlinesBetween
+        }
+      }
     }
   }
 

--- a/utils/is-newlines-between-option.ts
+++ b/utils/is-newlines-between-option.ts
@@ -1,0 +1,9 @@
+import type {
+  NewlinesBetweenOption,
+  GroupsOptions,
+} from '../types/common-options'
+
+export let isNewlinesBetweenOption = (
+  groupOption: GroupsOptions<string>[number],
+): groupOption is { newlinesBetween: NewlinesBetweenOption } =>
+  typeof groupOption === 'object' && 'newlinesBetween' in groupOption

--- a/utils/validate-groups-configuration.ts
+++ b/utils/validate-groups-configuration.ts
@@ -1,5 +1,7 @@
 import type { NewlinesBetweenOption } from '../types/common-options'
 
+import { isNewlinesBetweenOption } from './is-newlines-between-option'
+
 type Group = { newlinesBetween: NewlinesBetweenOption } | string[] | string
 
 /**
@@ -26,7 +28,7 @@ export let validateGroupsConfiguration = (
   let invalidGroups: string[] = []
   let isPreviousElementNewlinesBetween = false
   for (let groupElement of groups) {
-    if (typeof groupElement === 'object' && 'newlinesBetween' in groupElement) {
+    if (isNewlinesBetweenOption(groupElement)) {
       // There should not be two consecutive `newlinesBetween` objects
       if (isPreviousElementNewlinesBetween) {
         throw new Error("Consecutive 'newlinesBetween' objects are not allowed")
@@ -61,7 +63,7 @@ export let validateNoDuplicatedGroups = (groups: Group[]): void => {
   let duplicatedGroups = new Set<string>()
 
   for (let group of flattenGroups) {
-    if (typeof group === 'object' && 'newlinesBetween' in group) {
+    if (isNewlinesBetweenOption(group)) {
       continue
     }
     if (seenGroups.has(group)) {

--- a/utils/validate-newlines-and-partition-configuration.ts
+++ b/utils/validate-newlines-and-partition-configuration.ts
@@ -3,6 +3,8 @@ import type {
   GroupsOptions,
 } from '../types/common-options'
 
+import { isNewlinesBetweenOption } from './is-newlines-between-option'
+
 interface Options {
   newlinesBetween: NewlinesBetweenOption
   groups: GroupsOptions<string>
@@ -22,8 +24,8 @@ export let validateNewlinesAndPartitionConfiguration = ({
       "The 'partitionByNewLine' and 'newlinesBetween' options cannot be used together",
     )
   }
-  let hasNewlinesBetweenGroup = groups.some(
-    group => typeof group === 'object' && 'newlinesBetween' in group,
+  let hasNewlinesBetweenGroup = groups.some(group =>
+    isNewlinesBetweenOption(group),
   )
   if (hasNewlinesBetweenGroup) {
     throw new Error(


### PR DESCRIPTION
Resolves #449.

ℹ️ Don't be afraid of the lines changed: a `describe` wrapper has been added around existing tests in [this](https://github.com/azat-io/eslint-plugin-perfectionist/pull/450/commits/d984a553892b5d0ab07a235b6af229c89cc186b2) commit, changing their indentation. No actual test content is changed in this PR.

Most lines added are tests.

### Description

This PR improves the current behavior of the `newlinesBetween` option within `groups` between two groups that are **not** adjacent in the `groups` option.

See the [issue](https://github.com/azat-io/eslint-plugin-perfectionist/issues/449) for two examples of behavior that was incorrect.

![image](https://github.com/user-attachments/assets/7e0ce8f0-5d9e-435d-a1a7-4594c56ef1e8)

The commit with the fix is: [`2fcfb1f` (#450)](https://github.com/azat-io/eslint-plugin-perfectionist/pull/450/commits/a320d09f1b94a3538eafd49ddd3616f7a7dc05a8).
The one with the added tests is: [`821c7dc` (#450)](https://github.com/azat-io/eslint-plugin-perfectionist/pull/450/commits/188d0f340c8c20cd61eb8d497693317ae465850b)

### What is the purpose of this pull request?

- [x] New Feature
