### PR TITLE
fix: adds missing `}` in error messages

### DIFF
--- a/utils/report-errors.ts
+++ b/utils/report-errors.ts
@@ -13,15 +13,15 @@ export const LEFT = 'left'
 const LEFT_GROUP = 'leftGroup'
 
 export const ORDER_ERROR =
-  `Expected "{{${RIGHT}}" to come before "{{${LEFT}}".` as const
+  `Expected "{{${RIGHT}}}" to come before "{{${LEFT}}}".` as const
 export const DEPENDENCY_ORDER_ERROR =
-  `Expected dependency "{{${RIGHT}}" to come before "{{${NODE_DEPENDENT_ON_RIGHT}}}".` as const
+  `Expected dependency "{{${RIGHT}}}" to come before "{{${NODE_DEPENDENT_ON_RIGHT}}}".` as const
 export const GROUP_ORDER_ERROR =
-  `Expected "{{${RIGHT}}" ({{${RIGHT_GROUP}}) to come before "{{${LEFT}}" ({{${LEFT_GROUP}}).` as const
+  `Expected "{{${RIGHT}}}" ({{${RIGHT_GROUP}}}) to come before "{{${LEFT}}}" ({{${LEFT_GROUP}}}).` as const
 export const EXTRA_SPACING_ERROR =
-  `Extra spacing between "{{${LEFT}}" and "{{${RIGHT}}" objects.` as const
+  `Extra spacing between "{{${LEFT}}}" and "{{${RIGHT}}}" objects.` as const
 export const MISSED_SPACING_ERROR =
-  `Missed spacing between "{{${LEFT}}" and "{{${RIGHT}}".` as const
+  `Missed spacing between "{{${LEFT}}}" and "{{${RIGHT}}}".` as const
 
 interface ReportErrorsParameters<MessageIds extends string> {
   context: TSESLint.RuleContext<MessageIds, unknown[]>


### PR DESCRIPTION
Fixes an error from https://github.com/azat-io/eslint-plugin-perfectionist/pull/448.

### Description

Some `}` were missing, leading to incorrectly formatted error messages.

Unfortunately, it seems that the ESLint framework does not allow us to precisely test the error message that is returned, so there is no way to add tests to bulletproof this.

Result after:
![image](https://github.com/user-attachments/assets/be5d3a8d-8fc9-4024-89de-669d82643b5a)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix