### PR TITLE
feat: improves regex-related options

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -197,10 +197,10 @@ Allows you to group array elements by their kind, determining whether spread val
 Allows you to use comments to separate the members of arrays into logical groups. This can help in organizing and maintaining large arrays by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -251,7 +251,7 @@ This option is only applicable when `partitionByNewLine` is `false`.
 ### useConfigurationIf
 
 <sub>
-  type: `{ allNamesMatchPattern?: string }`
+  type: `{ allNamesMatchPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[] }`
 </sub>
 <sub>default: `{}`</sub>
 
@@ -353,7 +353,7 @@ interface CustomGroupDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   selector?: string
-  elementNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -368,7 +368,7 @@ interface CustomGroupAnyOfDefinition {
   order?: 'asc' | 'desc'
   anyOf: Array<{
       selector?: string
-      elementNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -219,9 +219,10 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 Allows you to use comments to separate the class members into logical groups. This can help in organizing and maintaining large classes by creating partitions within the class based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- string — A regexp pattern to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -626,9 +627,9 @@ interface CustomGroupDefinition {
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
-  elementNamePattern?: string
-  elementValuePattern?: string
-  decoratorNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  elementValuePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  decoratorNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 ```
 A class member will match a `CustomGroupDefinition` group if it matches all the filters of the custom group's definition.
@@ -644,9 +645,9 @@ interface CustomGroupAnyOfDefinition {
   anyOf: Array<{
       selector?: string
       modifiers?: string[]
-      elementNamePattern?: string
-      elementValuePattern?: string
-      decoratorNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+      elementValuePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+      decoratorNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-decorators.mdx
+++ b/docs/content/rules/sort-decorators.mdx
@@ -214,9 +214,9 @@ Allows you to use comments to separate class decorators into logical groups.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 - `false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### groups
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -169,10 +169,10 @@ Controls whether numeric enums should always be sorted numerically, regardless o
 Allows you to use comments to separate the members of enums into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -265,7 +265,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
-  elementNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -279,7 +279,7 @@ interface CustomGroupAnyOfDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   anyOf: Array<{
-      elementNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -143,10 +143,10 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 Allows you to use comments to separate the exports into logical groups. This can help in organizing and maintaining large export blocks by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -200,9 +200,9 @@ Allows you to use comments to separate imports into logical groups.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 - `false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -210,9 +210,9 @@ Allows you to use comments to separate the properties of interfaces into logical
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 - `false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -269,9 +269,14 @@ Specifies how optional and required members should be ordered in TypeScript inte
 ### useConfigurationIf
 
 <sub>
-  type: `{ allNamesMatchPattern?: string; declarationMatchesPattern?: string }`
+  type:
+  ```
+  {
+    allNamesMatchPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+    declarationMatchesPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+  }
+  ```
 </sub>
-<sub>default: `{}`</sub>
 
 Allows you to specify filters to match a particular options configuration for a given interface.
 
@@ -503,7 +508,7 @@ interface CustomGroupDefinition {
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
-  elementNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -520,7 +525,7 @@ interface CustomGroupAnyOfDefinition {
   anyOf: Array<{
       selector?: string
       modifiers?: string[]
-      elementNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -139,10 +139,10 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 Allows you to use comments to separate the members of intersection types into logical groups. This can help in organizing and maintaining large intersection types by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -194,6 +194,14 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 
 ### ignorePattern
 
+<sub>
+  type:
+  ```
+  {
+    allNamesMatchPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+  }
+  ```
+</sub>
 <sub>default: `[]`</sub>
 
 Allows you to specify names or patterns for JSX elements that should be ignored by this rule. This can be useful if you have specific components that you do not want to sort.

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -145,10 +145,10 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 Allows you to use comments to separate the members of maps into logical groups. This can help in organizing and maintaining large maps by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -197,7 +197,12 @@ This option is only applicable when `partitionByNewLine` is `false`.
 ### useConfigurationIf
 
 <sub>
-  type: `{ allNamesMatchPattern?: string }`
+  type:
+  ```
+  {
+    allNamesMatchPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+  }
+  ```
 </sub>
 <sub>default: `{}`</sub>
 
@@ -291,7 +296,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
-  elementNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -305,7 +310,7 @@ interface CustomGroupAnyOfDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   anyOf: Array<{
-      elementNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -242,9 +242,10 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 Allows you to use comments to separate the module members into logical groups. This can help in organizing and maintaining large modules by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- string — A regexp pattern to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -408,8 +409,8 @@ interface CustomGroupDefinition {
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
-  elementNamePattern?: string
-  decoratorNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  decoratorNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 ```
 A module member will match a `CustomGroupDefinition` group if it matches all the filters of the custom group's definition.
@@ -425,8 +426,8 @@ interface CustomGroupAnyOfDefinition {
   anyOf: Array<{
       selector?: string
       modifiers?: string[]
-      elementNamePattern?: string
-      decoratorNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+      decoratorNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -181,10 +181,10 @@ Allows you to group named exports by their kind, determining whether value expor
 Allows you to use comments to separate the members of named exports into logical groups. This can help in organizing and maintaining large named exports by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -182,10 +182,10 @@ Allows you to group named imports by their kind, determining whether value impor
 Allows you to use comments to separate the members of named imports into logical groups. This can help in organizing and maintaining large named imports by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -172,9 +172,9 @@ Allows you to use comments to separate the members of types into logical groups.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 - `false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -234,7 +234,13 @@ Allows you to group type object keys by their kind, determining whether required
 ### useConfigurationIf
 
 <sub>
-  type: `{ allNamesMatchPattern?: string; declarationMatchesPattern?: string }`
+  type:
+  ```
+  {
+    allNamesMatchPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+    declarationMatchesPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+  }
+  ```
 </sub>
 <sub>default: `{}`</sub>
 
@@ -449,7 +455,7 @@ interface CustomGroupDefinition {
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
-  elementNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -466,7 +472,7 @@ interface CustomGroupAnyOfDefinition {
   anyOf: Array<{
       selector?: string
       modifiers?: string[]
-      elementNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -220,9 +220,9 @@ Allows you to use comments to separate the keys of objects into logical groups. 
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 - `false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — An array of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -275,6 +275,14 @@ Determines whether this rule should be applied to styled-components like librari
 
 ### ignorePattern
 
+<sub>
+  type:
+  ```
+  {
+    allNamesMatchPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+  }
+  ```
+</sub>
 <sub>default: `[]`</sub>
 
 Allows you to specify names or patterns for object that should be ignored by this rule. This can be useful if you have specific objects that you do not want to sort.
@@ -308,7 +316,13 @@ The `groups` attribute allows you to specify whether to use groups to sort destr
 ### useConfigurationIf
 
 <sub>
-  type: `{ allNamesMatchPattern?: string; callingFunctionNamePattern?: string }`
+  type:
+  ```
+  {
+    allNamesMatchPattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+    callingFunctionNamePattern?: string | string[] | { pattern: string; flags: string } | { pattern: string; flags: string }[]
+  }
+  ```
 </sub>
 <sub>default: `{}`</sub>
 
@@ -516,8 +530,8 @@ interface CustomGroupDefinition {
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
-  elementNamePattern?: string
-  elementValuePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  elementValuePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -534,8 +548,8 @@ interface CustomGroupAnyOfDefinition {
   anyOf: Array<{
       selector?: string
       modifiers?: string[]
-      elementNamePattern?: string
-      elementValuePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+      elementValuePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -202,10 +202,10 @@ Allows you to group set elements by their kind, determining whether spread value
 Allows you to use comments to separate the members of sets into logical groups. This can help in organizing and maintaining large sets by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 
@@ -311,7 +311,7 @@ interface CustomGroupDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   selector?: string
-  elementNamePattern?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -326,7 +326,7 @@ interface CustomGroupAnyOfDefinition {
   order?: 'asc' | 'desc'
   anyOf: Array<{
       selector?: string
-      elementNamePattern?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -159,10 +159,10 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 Allows you to use comments to separate the members of union types into logical groups. This can help in organizing and maintaining large union types by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -143,10 +143,10 @@ Specifies the sorting locales. See [String.prototype.localeCompare() - locales](
 Allows you to use comments to separate the members of variable declarations into logical groups. This can help in organizing and maintaining large variable declaration blocks by creating partitions based on comments.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
--	`false` — Comments will not be used as delimiters.
-- `string` — A regexp pattern to specify which comments should act as delimiters.
-- `string[]` — A list of regexp patterns to specify which comments should act as delimiters.
-- `{ block: boolean | string | string[]; line: boolean | string | string[] }` — Specify which block and line comments should act as delimiters.
+- `false` — Comments will not be used as delimiters.
+- `RegExpPattern = string | { pattern: string; flags: string}` — A regexp pattern to specify which comments should act as delimiters.
+- `RegExpPattern[]` — A list of regexp patterns to specify which comments should act as delimiters.
+- `{ block: boolean | RegExpPattern | RegExpPattern[]; line: boolean | RegExpPattern | RegExpPattern[] }` — Specify which block and line comments should act as delimiters.
 
 ### partitionByNewLine
 

--- a/readme.md
+++ b/readme.md
@@ -202,15 +202,15 @@ module.exports = {
 
 ### Can I automatically fix problems in the editor?
 
-Yes. To do this, you need to enable autofix in ESLint when you save the file in your editor. You may find instructions for your editor can be found [here](https://perfectionist.dev/guide/integrations).
+Yes. To do this, you need to enable autofix in ESLint when you save the file in your editor. You may find instructions for your editor [here](https://perfectionist.dev/guide/integrations).
 
 ### Is it safe?
 
 Overall, yes. We want to make sure that the work of the plugin does not negatively affect the behavior of the code. For example, the plugin takes into account spread operators in JSX and objects, comments to the code. Safety is our priority. If you encounter any problem, you can create an [issue](https://github.com/azat-io/eslint-plugin-perfectionist/issues/new/choose).
 
-### Why not Prettier?
+### Why not use Prettier?
 
-I love Prettier. However, this is not its area of responsibility. Prettier is used for formatting, and ESLint is also used for styling. For example, changing the order of imports can affect how the code works (console.log calls, fetch, style loading). Prettier should not change the AST. There is a cool article about this: ["The Blurry Line Between Formatting and Style"](https://blog.joshuakgoldberg.com/the-blurry-line-between-formatting-and-style) by **@joshuakgoldberg**.
+I love Prettier. However, this is not its area of responsibility. Prettier is used for formatting, and ESLint for styling. For example, changing the order of imports can affect how the code works (console.log calls, fetch, style loading). Prettier should not change the AST. There is a cool article about this: ["The Blurry Line Between Formatting and Style"](https://blog.joshuakgoldberg.com/the-blurry-line-between-formatting-and-style) by **@joshuakgoldberg**.
 
 ## Versioning Policy
 

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -6,18 +6,19 @@ import type {
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../../types/common-options'
 
 import {
   buildCustomGroupSelectorJsonSchema,
-  elementNamePatternJsonSchema,
+  regexJsonSchema,
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<
   {
     useConfigurationIf: {
-      allNamesMatchPattern?: string
+      allNamesMatchPattern?: RegexOption
     }
     /**
      * @deprecated for {@link `groups`}
@@ -33,7 +34,7 @@ export type Options = Partial<
 >[]
 
 export interface SingleCustomGroup {
-  elementNamePattern?: string
+  elementNamePattern?: RegexOption
   selector?: Selector
 }
 
@@ -49,5 +50,5 @@ export let allSelectors: Selector[] = ['literal', 'spread']
 
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   selector: buildCustomGroupSelectorJsonSchema(allSelectors),
-  elementNamePattern: elementNamePatternJsonSchema,
+  elementNamePattern: regexJsonSchema,
 }

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -6,6 +6,7 @@ import type {
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -13,8 +14,7 @@ import type { JoinWithDash } from '../../types/join-with-dash'
 import {
   buildCustomGroupModifiersJsonSchema,
   buildCustomGroupSelectorJsonSchema,
-  elementValuePatternJsonSchema,
-  elementNamePatternJsonSchema,
+  regexJsonSchema,
 } from '../../utils/common-json-schemas'
 
 export type SingleCustomGroup =
@@ -205,9 +205,9 @@ type Group =
   | string
 
 type AdvancedSingleCustomGroup<T extends Selector> = {
-  decoratorNamePattern?: string
-  elementValuePattern?: string
-  elementNamePattern?: string
+  decoratorNamePattern?: RegexOption
+  elementValuePattern?: RegexOption
+  elementNamePattern?: RegexOption
 } & BaseSingleCustomGroup<T>
 
 interface BaseSingleCustomGroup<T extends Selector> {
@@ -297,12 +297,9 @@ export let allModifiers: Modifier[] = [
  * that users do not enter invalid modifiers for a given selector
  */
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
-  decoratorNamePattern: {
-    description: 'Decorator name pattern filter.',
-    type: 'string',
-  },
   modifiers: buildCustomGroupModifiersJsonSchema(allModifiers),
   selector: buildCustomGroupSelectorJsonSchema(allSelectors),
-  elementValuePattern: elementValuePatternJsonSchema,
-  elementNamePattern: elementNamePatternJsonSchema,
+  decoratorNamePattern: regexJsonSchema,
+  elementValuePattern: regexJsonSchema,
+  elementNamePattern: regexJsonSchema,
 }

--- a/rules/sort-enums/types.ts
+++ b/rules/sort-enums/types.ts
@@ -6,13 +6,11 @@ import type {
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../../types/common-options'
 
-import {
-  elementValuePatternJsonSchema,
-  elementNamePatternJsonSchema,
-} from '../../utils/common-json-schemas'
+import { regexJsonSchema } from '../../utils/common-json-schemas'
 
 export type Options = Partial<
   {
@@ -28,13 +26,13 @@ export type Options = Partial<
 >[]
 
 export interface SingleCustomGroup {
-  elementValuePattern?: string
-  elementNamePattern?: string
+  elementValuePattern?: RegexOption
+  elementNamePattern?: RegexOption
 }
 
 type Group = 'unknown' | string
 
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
-  elementValuePattern: elementValuePatternJsonSchema,
-  elementNamePattern: elementNamePatternJsonSchema,
+  elementValuePattern: regexJsonSchema,
+  elementNamePattern: regexJsonSchema,
 }

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -8,6 +8,7 @@ import type {
   NewlinesBetweenOption,
   GroupsOptions,
   OrderOption,
+  RegexOption,
   TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -19,6 +20,7 @@ import {
   buildTypeJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
+  regexJsonSchema,
 } from '../utils/common-json-schemas'
 import {
   MISSED_SPACING_ERROR,
@@ -58,9 +60,9 @@ export type Options<T extends string = string> = [
     locales: NonNullable<Intl.LocalesArgument>
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group<T>>
+    internalPattern: RegexOption[]
     environment: 'node' | 'bun'
     partitionByNewLine: boolean
-    internalPattern: string[]
     sortSideEffects: boolean
     tsconfigRootDir?: string
     maxLineLength?: number
@@ -564,13 +566,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
             additionalProperties: false,
             type: 'object',
           },
-          internalPattern: {
-            description: 'Specifies the pattern for internal modules.',
-            items: {
-              type: 'string',
-            },
-            type: 'array',
-          },
           maxLineLength: {
             description: 'Specifies the maximum line length.',
             exclusiveMinimum: true,
@@ -594,6 +589,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
+          internalPattern: regexJsonSchema,
           type: buildTypeJsonSchema(),
           groups: groupsJsonSchema,
         },

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -4,6 +4,7 @@ import type {
   NewlinesBetweenOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
@@ -15,6 +16,7 @@ import {
   buildTypeJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
+  regexJsonSchema,
 } from '../utils/common-json-schemas'
 import {
   MISSED_SPACING_ERROR,
@@ -46,7 +48,7 @@ type Options<T extends string = string> = [
       newlinesBetween: NewlinesBetweenOption
       groups: GroupsOptions<Group<T>>
       partitionByNewLine: boolean
-      ignorePattern: string[]
+      ignorePattern: RegexOption
       type: TypeOption
     } & CommonOptions
   >,
@@ -93,13 +95,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
       let sourceCode = getSourceCode(context)
 
-      let shouldIgnore = false
-      if (options.ignorePattern.length > 0) {
-        let tagName = sourceCode.getText(node.openingElement.name)
-        shouldIgnore = options.ignorePattern.some(pattern =>
-          matches(tagName, pattern),
-        )
-      }
+      let shouldIgnore = matches(
+        sourceCode.getText(node.openingElement.name),
+        options.ignorePattern,
+      )
       if (shouldIgnore || !isSortable(node.openingElement.attributes)) {
         return
       }
@@ -192,17 +191,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         properties: {
           ...commonJsonSchemas,
-          ignorePattern: {
-            description:
-              'Specifies names or patterns for nodes that should be ignored by rule.',
-            items: {
-              type: 'string',
-            },
-            type: 'array',
-          },
           partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
           customGroups: customGroupsJsonSchema,
+          ignorePattern: regexJsonSchema,
           type: buildTypeJsonSchema(),
           groups: groupsJsonSchema,
         },

--- a/rules/sort-maps/types.ts
+++ b/rules/sort-maps/types.ts
@@ -6,15 +6,16 @@ import type {
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../../types/common-options'
 
-import { elementNamePatternJsonSchema } from '../../utils/common-json-schemas'
+import { regexJsonSchema } from '../../utils/common-json-schemas'
 
 export type Options = Partial<
   {
     useConfigurationIf: {
-      allNamesMatchPattern?: string
+      allNamesMatchPattern?: RegexOption
     }
     customGroups: CustomGroupsOption<SingleCustomGroup>
     partitionByComment: PartitionByCommentOption
@@ -26,11 +27,11 @@ export type Options = Partial<
 >[]
 
 export interface SingleCustomGroup {
-  elementNamePattern?: string
+  elementNamePattern?: RegexOption
 }
 
 type Group = 'unknown' | string
 
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
-  elementNamePattern: elementNamePatternJsonSchema,
+  elementNamePattern: regexJsonSchema,
 }

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -6,6 +6,7 @@ import type {
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -13,7 +14,7 @@ import type { JoinWithDash } from '../../types/join-with-dash'
 import {
   buildCustomGroupModifiersJsonSchema,
   buildCustomGroupSelectorJsonSchema,
-  elementNamePatternJsonSchema,
+  regexJsonSchema,
 } from '../../utils/common-json-schemas'
 
 export type SingleCustomGroup = (
@@ -113,11 +114,11 @@ type DefaultInterfaceGroup = JoinWithDash<
 >
 
 interface DecoratorNamePatternFilterCustomGroup {
-  decoratorNamePattern?: string
+  decoratorNamePattern?: RegexOption
 }
 
 interface ElementNamePatternFilterCustomGroup {
-  elementNamePattern?: string
+  elementNamePattern?: RegexOption
 }
 
 type TypeGroup = JoinWithDash<[ExportModifier, DeclareModifier, TypeSelector]>
@@ -167,11 +168,8 @@ export let allModifiers: Modifier[] = [
  * that users do not enter invalid modifiers for a given selector
  */
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
-  decoratorNamePattern: {
-    description: 'Decorator name pattern filter.',
-    type: 'string',
-  },
   modifiers: buildCustomGroupModifiersJsonSchema(allModifiers),
   selector: buildCustomGroupSelectorJsonSchema(allSelectors),
-  elementNamePattern: elementNamePatternJsonSchema,
+  decoratorNamePattern: regexJsonSchema,
+  elementNamePattern: regexJsonSchema,
 }

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -16,6 +16,7 @@ import {
   buildTypeJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
+  regexJsonSchema,
 } from '../utils/common-json-schemas'
 import {
   MISSED_SPACING_ERROR,
@@ -87,27 +88,17 @@ export let jsonSchema: JSONSchema4 = {
   items: {
     properties: {
       ...commonJsonSchemas,
-      ignorePattern: {
-        description:
-          'Specifies names or patterns for nodes that should be ignored by rule.',
-        items: {
-          type: 'string',
-        },
-        type: 'array',
-      },
-      useConfigurationIf: buildUseConfigurationIfJsonSchema({
-        additionalProperties: {
-          declarationMatchesPattern: {
-            type: 'string',
-          },
-        },
-      }),
       customGroups: {
         oneOf: [
           customGroupsJsonSchema,
           buildCustomGroupsArrayJsonSchema({ singleCustomGroupJsonSchema }),
         ],
       },
+      useConfigurationIf: buildUseConfigurationIfJsonSchema({
+        additionalProperties: {
+          declarationMatchesPattern: regexJsonSchema,
+        },
+      }),
       groupKind: {
         enum: ['mixed', 'required-first', 'optional-first'],
         description: 'Specifies top-level groups.',
@@ -117,6 +108,7 @@ export let jsonSchema: JSONSchema4 = {
       partitionByComment: partitionByCommentJsonSchema,
       partitionByNewLine: partitionByNewLineJsonSchema,
       newlinesBetween: newlinesBetweenJsonSchema,
+      ignorePattern: regexJsonSchema,
       groups: groupsJsonSchema,
     },
     additionalProperties: false,
@@ -224,11 +216,7 @@ export let sortObjectTypeElements = <MessageIds extends string>({
   })
   validateNewlinesAndPartitionConfiguration(options)
 
-  if (
-    options.ignorePattern.some(
-      pattern => parentNodeName && matches(parentNodeName, pattern),
-    )
-  ) {
+  if (parentNodeName && matches(parentNodeName, options.ignorePattern)) {
     return
   }
 

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -7,6 +7,7 @@ import type {
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -14,14 +15,14 @@ import type { JoinWithDash } from '../../types/join-with-dash'
 import {
   buildCustomGroupModifiersJsonSchema,
   buildCustomGroupSelectorJsonSchema,
-  elementNamePatternJsonSchema,
+  regexJsonSchema,
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<
   {
     useConfigurationIf: {
-      declarationMatchesPattern?: string
-      allNamesMatchPattern?: string
+      declarationMatchesPattern?: RegexOption
+      allNamesMatchPattern?: RegexOption
     }
     customGroups:
       | CustomGroupsOption<SingleCustomGroup>
@@ -38,7 +39,7 @@ export type Options = Partial<
     /**
      * @deprecated for {@link `useConfigurationIf.declarationMatchesPattern`}
      */
-    ignorePattern: string[]
+    ignorePattern: RegexOption
   } & CommonOptions
 >[]
 
@@ -117,7 +118,7 @@ type MultilineGroup = JoinWithDash<
 >
 
 interface ElementNamePatternFilterCustomGroup {
-  elementNamePattern?: string
+  elementNamePattern?: RegexOption
 }
 
 type IndexSignatureSelector = 'index-signature'
@@ -156,5 +157,5 @@ export let allModifiers: Modifier[] = ['optional', 'required', 'multiline']
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   modifiers: buildCustomGroupModifiersJsonSchema(allModifiers),
   selector: buildCustomGroupSelectorJsonSchema(allSelectors),
-  elementNamePattern: elementNamePatternJsonSchema,
+  elementNamePattern: regexJsonSchema,
 }

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -14,6 +14,7 @@ import {
   buildTypeJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
+  regexJsonSchema,
 } from '../utils/common-json-schemas'
 import {
   DEPENDENCY_ORDER_ERROR,
@@ -157,9 +158,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       })
       if (
         objectParentForIgnorePattern?.name &&
-        options.ignorePattern.some(pattern =>
-          matches(objectParentForIgnorePattern.name, pattern),
-        )
+        matches(objectParentForIgnorePattern.name, options.ignorePattern)
       ) {
         return
       }
@@ -475,27 +474,17 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ],
             description: 'Controls whether to sort destructured objects.',
           },
-          ignorePattern: {
-            description:
-              'Specifies names or patterns for nodes that should be ignored by rule.',
-            items: {
-              type: 'string',
-            },
-            type: 'array',
-          },
-          useConfigurationIf: buildUseConfigurationIfJsonSchema({
-            additionalProperties: {
-              callingFunctionNamePattern: {
-                type: 'string',
-              },
-            },
-          }),
           customGroups: {
             oneOf: [
               customGroupsJsonSchema,
               buildCustomGroupsArrayJsonSchema({ singleCustomGroupJsonSchema }),
             ],
           },
+          useConfigurationIf: buildUseConfigurationIfJsonSchema({
+            additionalProperties: {
+              callingFunctionNamePattern: regexJsonSchema,
+            },
+          }),
           destructureOnly: {
             description: 'Controls whether to sort only destructured objects.',
             type: 'boolean',
@@ -512,6 +501,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
+          ignorePattern: regexJsonSchema,
           groups: groupsJsonSchema,
         },
         additionalProperties: false,

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -7,6 +7,7 @@ import type {
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
   TypeOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
@@ -14,15 +15,14 @@ import type { JoinWithDash } from '../../types/join-with-dash'
 import {
   buildCustomGroupModifiersJsonSchema,
   buildCustomGroupSelectorJsonSchema,
-  elementValuePatternJsonSchema,
-  elementNamePatternJsonSchema,
+  regexJsonSchema,
 } from '../../utils/common-json-schemas'
 
 export type Options = Partial<
   {
     useConfigurationIf: {
-      callingFunctionNamePattern?: string
-      allNamesMatchPattern?: string
+      callingFunctionNamePattern?: RegexOption
+      allNamesMatchPattern?: RegexOption
     }
     customGroups:
       | CustomGroupsOption<SingleCustomGroup>
@@ -34,12 +34,12 @@ export type Options = Partial<
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
     objectDeclarations: boolean
+    ignorePattern: RegexOption
     styledComponents: boolean
     /**
      * @deprecated for {@link `destructuredObjects`} and {@link `objectDeclarations`}
      */
     destructureOnly: boolean
-    ignorePattern: string[]
   } & CommonOptions
 >[]
 
@@ -49,8 +49,8 @@ export type SingleCustomGroup = (
   | BaseSingleCustomGroup<MethodSelector>
   | BaseSingleCustomGroup<MemberSelector>
 ) & {
-  elementValuePattern?: string
-  elementNamePattern?: string
+  elementValuePattern?: RegexOption
+  elementNamePattern?: RegexOption
 }
 
 export type Selector =
@@ -140,6 +140,6 @@ export let allModifiers: Modifier[] = ['optional', 'required', 'multiline']
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   modifiers: buildCustomGroupModifiersJsonSchema(allModifiers),
   selector: buildCustomGroupSelectorJsonSchema(allSelectors),
-  elementValuePattern: elementValuePatternJsonSchema,
-  elementNamePattern: elementNamePatternJsonSchema,
+  elementValuePattern: regexJsonSchema,
+  elementNamePattern: regexJsonSchema,
 }

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -480,7 +480,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -559,7 +559,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },
@@ -611,7 +611,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part: *',
+                  partitionByComment: '^Part:',
                   groupKind: 'spreads-first',
                 },
               ],

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1103,51 +1103,58 @@ describe(ruleName, () => {
         valid: [],
       })
 
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'literalsStartingWithHello',
-                    elementNamePattern: 'hello*',
-                    selector: 'literal',
-                  },
-                ],
-                groups: ['literalsStartingWithHello', 'unknown'],
-                groupKind: 'mixed',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'literalsStartingWithHello',
-                  right: 'helloLiteral',
-                  leftGroup: 'unknown',
-                  left: 'b',
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'literalsStartingWithHello',
+                      selector: 'literal',
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['literalsStartingWithHello', 'unknown'],
+                  groupKind: 'mixed',
                 },
-                messageId: 'unexpectedArrayIncludesGroupOrder',
-              },
-            ],
-            output: dedent`
-              [
-                'helloLiteral',
-                'a',
-                'b',
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'a',
-                'b',
-                'helloLiteral',
-              ].includes(value)
-            `,
-          },
-        ],
-        valid: [],
-      })
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'literalsStartingWithHello',
+                    right: 'helloLiteral',
+                    leftGroup: 'unknown',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedArrayIncludesGroupOrder',
+                },
+              ],
+              output: dedent`
+                [
+                  'helloLiteral',
+                  'a',
+                  'b',
+                ].includes(value)
+              `,
+              code: dedent`
+                [
+                  'a',
+                  'b',
+                  'helloLiteral',
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
@@ -1380,80 +1387,87 @@ describe(ruleName, () => {
     })
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  useConfigurationIf: {
-                    allNamesMatchPattern: 'foo',
-                  },
-                },
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      elementNamePattern: '^r$',
-                      groupName: 'r',
+      for (let allNamesMatchPattern of [
+        'foo',
+        ['noMatch', 'foo'],
+        { pattern: 'FOO', flags: 'i' },
+        ['noMatch', { pattern: 'foo', flags: 'i' }],
+      ]) {
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    useConfigurationIf: {
+                      allNamesMatchPattern,
                     },
-                    {
-                      elementNamePattern: '^g$',
-                      groupName: 'g',
+                  },
+                  {
+                    ...options,
+                    customGroups: [
+                      {
+                        elementNamePattern: '^r$',
+                        groupName: 'r',
+                      },
+                      {
+                        elementNamePattern: '^g$',
+                        groupName: 'g',
+                      },
+                      {
+                        elementNamePattern: '^b$',
+                        groupName: 'b',
+                      },
+                    ],
+                    useConfigurationIf: {
+                      allNamesMatchPattern: '^r|g|b$',
                     },
-                    {
-                      elementNamePattern: '^b$',
-                      groupName: 'b',
+                    groups: ['r', 'g', 'b'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'g',
+                      leftGroup: 'b',
+                      right: 'g',
+                      left: 'b',
                     },
-                  ],
-                  useConfigurationIf: {
-                    allNamesMatchPattern: '^r|g|b$',
+                    messageId: 'unexpectedArrayIncludesGroupOrder',
                   },
-                  groups: ['r', 'g', 'b'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
+                  {
+                    data: {
+                      rightGroup: 'r',
+                      leftGroup: 'g',
+                      right: 'r',
+                      left: 'g',
+                    },
+                    messageId: 'unexpectedArrayIncludesGroupOrder',
                   },
-                  messageId: 'unexpectedArrayIncludesGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
-                  },
-                  messageId: 'unexpectedArrayIncludesGroupOrder',
-                },
-              ],
-              output: dedent`
-                [
-                  'r',
-                  'g',
-                  'b',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'b',
-                  'g',
-                  'r',
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                ],
+                output: dedent`
+                  [
+                    'r',
+                    'g',
+                    'b',
+                  ].includes(value)
+                `,
+                code: dedent`
+                  [
+                    'b',
+                    'g',
+                    'r',
+                  ].includes(value)
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      }
     })
 
     describe(`${ruleName}: newlinesBetween`, () => {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -7520,258 +7520,293 @@ describe(ruleName, () => {
       valid: [],
     })
 
-    ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'constructor',
-                leftGroup: 'unknown',
-                right: 'constructor',
-                left: 'b',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'propertiesStartingWithHello',
-                right: 'helloProperty',
-                leftGroup: 'unknown',
-                left: 'method',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'propertiesStartingWithHello',
-                  elementNamePattern: 'hello*',
-                  selector: 'property',
+    for (let elementNamePattern of [
+      'hello',
+      ['noMatch', 'hello'],
+      { pattern: 'HELLO', flags: 'i' },
+      ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+    ]) {
+      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  rightGroup: 'constructor',
+                  leftGroup: 'unknown',
+                  right: 'constructor',
+                  left: 'b',
                 },
-              ],
-              groups: ['propertiesStartingWithHello', 'constructor', 'unknown'],
-            },
-          ],
-          output: dedent`
-            class Class {
-              helloProperty;
-
-              constructor() {}
-
-              a;
-
-              b;
-
-              method() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              a;
-
-              b;
-
-              constructor() {}
-
-              method() {}
-
-              helloProperty;
-            }
-          `,
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              customGroups: [
-                {
-                  elementValuePattern: 'inject*',
-                  groupName: 'inject',
-                },
-                {
-                  elementValuePattern: 'computed*',
-                  groupName: 'computed',
-                },
-              ],
-              groups: ['computed', 'inject', 'unknown'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                rightGroup: 'computed',
-                leftGroup: 'inject',
-                right: 'z',
-                left: 'y',
+                messageId: 'unexpectedClassesGroupOrder',
               },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              a = computed(A)
-              z = computed(Z)
-              b = inject(B)
-              y = inject(Y)
-              c() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              a = computed(A)
-              b = inject(B)
-              y = inject(Y)
-              z = computed(Z)
-              c() {}
-            }
-          `,
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'constructor',
-                leftGroup: 'unknown',
-                right: 'constructor',
-                left: 'b',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'propertiesWithDecoratorStartingWithHello',
-                leftGroup: 'unknown',
-                right: 'property',
-                left: 'method',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                right: 'anotherProperty',
-                left: 'property',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'propertiesWithDecoratorStartingWithHello',
-                  decoratorNamePattern: 'Hello*',
-                  selector: 'property',
+              {
+                data: {
+                  rightGroup: 'propertiesStartingWithHello',
+                  right: 'helloProperty',
+                  leftGroup: 'unknown',
+                  left: 'method',
                 },
-              ],
-              groups: [
-                'propertiesWithDecoratorStartingWithHello',
-                'constructor',
-                'unknown',
-              ],
-            },
-          ],
-          output: dedent`
-            class Class {
-              @HelloDecorator()
-              anotherProperty;
-
-              @HelloDecorator
-              property;
-
-              constructor() {}
-
-              @Decorator
-              a;
-
-              b;
-
-              method() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              @Decorator
-              a;
-
-              b;
-
-              constructor() {}
-
-              method() {}
-
-              @HelloDecorator
-              property;
-
-              @HelloDecorator()
-              anotherProperty;
-            }
-          `,
-        },
-        {
-          options: [
-            {
-              customGroups: [
-                {
-                  decoratorNamePattern: 'B',
-                  groupName: 'B',
-                },
-                {
-                  decoratorNamePattern: 'A',
-                  groupName: 'A',
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['B', 'A'],
-              order: 'asc',
-            },
-          ],
-          errors: [
-            {
-              data: {
-                rightGroup: 'B',
-                leftGroup: 'A',
-                right: 'b',
-                left: 'a',
+                messageId: 'unexpectedClassesGroupOrder',
               },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              @B.B()
-              b() {}
+            ],
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'propertiesStartingWithHello',
+                    selector: 'property',
+                    elementNamePattern,
+                  },
+                ],
+                groups: [
+                  'propertiesStartingWithHello',
+                  'constructor',
+                  'unknown',
+                ],
+              },
+            ],
+            output: dedent`
+              class Class {
+                helloProperty;
 
-              @A.A.A(() => A)
-              a() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              @A.A.A(() => A)
-              a() {}
+                constructor() {}
 
-              @B.B()
-              b() {}
-            }
-          `,
-        },
-      ],
-      valid: [],
-    })
+                a;
+
+                b;
+
+                method() {}
+              }
+            `,
+            code: dedent`
+              class Class {
+                a;
+
+                b;
+
+                constructor() {}
+
+                method() {}
+
+                helloProperty;
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+    }
+
+    for (let injectElementValuePattern of [
+      'inject',
+      ['noMatch', 'inject'],
+      { pattern: 'INJECT', flags: 'i' },
+      ['noMatch', { pattern: 'INJECT', flags: 'i' }],
+    ]) {
+      ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    elementValuePattern: injectElementValuePattern,
+                    groupName: 'inject',
+                  },
+                  {
+                    elementValuePattern: 'computed',
+                    groupName: 'computed',
+                  },
+                ],
+                groups: ['computed', 'inject', 'unknown'],
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  rightGroup: 'computed',
+                  leftGroup: 'inject',
+                  right: 'z',
+                  left: 'y',
+                },
+                messageId: 'unexpectedClassesGroupOrder',
+              },
+            ],
+            output: dedent`
+              class Class {
+                a = computed(A)
+                z = computed(Z)
+                b = inject(B)
+                y = inject(Y)
+                c() {}
+              }
+            `,
+            code: dedent`
+              class Class {
+                a = computed(A)
+                b = inject(B)
+                y = inject(Y)
+                z = computed(Z)
+                c() {}
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+    }
+
+    for (let decoratorNamePattern of [
+      'Hello',
+      ['noMatch', 'Hello'],
+      { pattern: 'HELLO', flags: 'i' },
+      ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+    ]) {
+      ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  rightGroup: 'constructor',
+                  leftGroup: 'unknown',
+                  right: 'constructor',
+                  left: 'b',
+                },
+                messageId: 'unexpectedClassesGroupOrder',
+              },
+              {
+                data: {
+                  rightGroup: 'propertiesWithDecoratorStartingWithHello',
+                  leftGroup: 'unknown',
+                  right: 'property',
+                  left: 'method',
+                },
+                messageId: 'unexpectedClassesGroupOrder',
+              },
+              {
+                data: {
+                  right: 'anotherProperty',
+                  left: 'property',
+                },
+                messageId: 'unexpectedClassesOrder',
+              },
+            ],
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'propertiesWithDecoratorStartingWithHello',
+                    decoratorNamePattern,
+                    selector: 'property',
+                  },
+                ],
+                groups: [
+                  'propertiesWithDecoratorStartingWithHello',
+                  'constructor',
+                  'unknown',
+                ],
+              },
+            ],
+            output: dedent`
+              class Class {
+                @HelloDecorator()
+                anotherProperty;
+
+                @HelloDecorator
+                property;
+
+                constructor() {}
+
+                @Decorator
+                a;
+
+                b;
+
+                method() {}
+              }
+            `,
+            code: dedent`
+              class Class {
+                @Decorator
+                a;
+
+                b;
+
+                constructor() {}
+
+                method() {}
+
+                @HelloDecorator
+                property;
+
+                @HelloDecorator()
+                anotherProperty;
+              }
+            `,
+          },
+        ],
+        valid: [],
+      })
+    }
+
+    ruleTester.run(
+      `${ruleName}: filters on complex decoratorNamePattern`,
+      rule,
+      {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    decoratorNamePattern: 'B',
+                    groupName: 'B',
+                  },
+                  {
+                    decoratorNamePattern: 'A',
+                    groupName: 'A',
+                  },
+                ],
+                type: 'alphabetical',
+                groups: ['B', 'A'],
+                order: 'asc',
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  rightGroup: 'B',
+                  leftGroup: 'A',
+                  right: 'b',
+                  left: 'a',
+                },
+                messageId: 'unexpectedClassesGroupOrder',
+              },
+            ],
+            output: dedent`
+              class Class {
+                @B.B()
+                b() {}
+
+                @A.A.A(() => A)
+                a() {}
+              }
+            `,
+            code: dedent`
+              class Class {
+                @A.A.A(() => A)
+                a() {}
+
+                @B.B()
+                b() {}
+              }
+            `,
+          },
+        ],
+        valid: [],
+      },
+    )
 
     ruleTester.run(
       `${ruleName}: sort custom groups by overriding 'type' and 'order'`,

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -2442,7 +2442,7 @@ describe(ruleName, () => {
           options: [
             {
               ...options,
-              partitionByComment: 'Region:*',
+              partitionByComment: 'Region:',
             },
           ],
         },
@@ -2474,7 +2474,7 @@ describe(ruleName, () => {
           options: [
             {
               ...options,
-              partitionByComment: 'Region:*',
+              partitionByComment: 'Region:',
             },
           ],
         },
@@ -3983,7 +3983,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: 'Part*',
+                  partitionByComment: 'Part',
                 },
               ],
             },
@@ -5997,7 +5997,7 @@ describe(ruleName, () => {
           options: [
             {
               ...options,
-              partitionByComment: 'Region:*',
+              partitionByComment: 'Region:',
             },
           ],
         },
@@ -6029,7 +6029,7 @@ describe(ruleName, () => {
           options: [
             {
               ...options,
-              partitionByComment: 'Region:*',
+              partitionByComment: 'Region:',
             },
           ],
         },
@@ -7322,11 +7322,11 @@ describe(ruleName, () => {
               ],
               customGroups: [
                 {
-                  elementNamePattern: 'customFirst*',
+                  elementNamePattern: 'customFirst',
                   groupName: 'my-first-group',
                 },
                 {
-                  elementNamePattern: 'customLast*',
+                  elementNamePattern: 'customLast',
                   groupName: 'my-last-group',
                 },
               ],
@@ -8835,7 +8835,7 @@ describe(ruleName, () => {
               ],
               options: [
                 {
-                  partitionByComment: 'PartitionComment:*',
+                  partitionByComment: 'PartitionComment:',
                   type: 'alphabetical',
                 },
               ],

--- a/test/rules/sort-decorators.test.ts
+++ b/test/rules/sort-decorators.test.ts
@@ -873,7 +873,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -1064,7 +1064,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -2377,7 +2377,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -2568,7 +2568,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -3488,7 +3488,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -3679,7 +3679,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -312,7 +312,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -391,7 +391,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -1945,7 +1945,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -2024,7 +2024,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -2480,7 +2480,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -2559,7 +2559,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -3180,7 +3180,7 @@ describe(ruleName, () => {
               `,
               options: [
                 {
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                   type: 'alphabetical',
                 },
               ],
@@ -3365,7 +3365,7 @@ describe(ruleName, () => {
             ],
             options: [
               {
-                partitionByComment: 'PartitionComment:*',
+                partitionByComment: 'PartitionComment:',
                 type: 'alphabetical',
               },
             ],

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -907,93 +907,107 @@ describe(ruleName, () => {
     )
 
     describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'keysStartingWithHello',
-                  leftGroup: 'unknown',
-                  right: 'HELLO_KEY',
-                  left: 'B',
-                },
-                messageId: 'unexpectedEnumsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'keysStartingWithHello',
-                    elementNamePattern: 'HELLO*',
+      for (let elementNamePattern of [
+        'HELLO',
+        ['noMatch', 'HELLO'],
+        { pattern: 'hello', flags: 'i' },
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'keysStartingWithHello',
+                    leftGroup: 'unknown',
+                    right: 'HELLO_KEY',
+                    left: 'B',
                   },
-                ],
-                groups: ['keysStartingWithHello', 'unknown'],
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                HELLO_KEY = 3,
-                A = 1,
-                B = 2,
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                A = 1,
-                B = 2,
-                HELLO_KEY = 3,
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
+                  messageId: 'unexpectedEnumsGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'keysStartingWithHello',
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['keysStartingWithHello', 'unknown'],
+                },
+              ],
+              output: dedent`
+                enum Enum {
+                  HELLO_KEY = 3,
+                  A = 1,
+                  B = 2,
+                }
+              `,
+              code: dedent`
+                enum Enum {
+                  A = 1,
+                  B = 2,
+                  HELLO_KEY = 3,
+                }
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
-      ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'valuesStartingWithHello',
-                    elementValuePattern: 'HELLO*',
-                  },
-                ],
-                groups: ['valuesStartingWithHello', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'valuesStartingWithHello',
-                  leftGroup: 'unknown',
-                  right: 'Z',
-                  left: 'B',
+      for (let elementValuePattern of [
+        'HELLO',
+        ['noMatch', 'HELLO'],
+        { pattern: 'hello', flags: 'i' },
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'valuesStartingWithHello',
+                      elementValuePattern,
+                    },
+                  ],
+                  groups: ['valuesStartingWithHello', 'unknown'],
                 },
-                messageId: 'unexpectedEnumsGroupOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                Z = 'HELLO_KEY',
-                A = 'A',
-                B = 'B',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                A = 'A',
-                B = 'B',
-                Z = 'HELLO_KEY',
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'valuesStartingWithHello',
+                    leftGroup: 'unknown',
+                    right: 'Z',
+                    left: 'B',
+                  },
+                  messageId: 'unexpectedEnumsGroupOrder',
+                },
+              ],
+              output: dedent`
+                enum Enum {
+                  Z = 'HELLO_KEY',
+                  A = 'A',
+                  B = 'B',
+                }
+              `,
+              code: dedent`
+                enum Enum {
+                  A = 'A',
+                  B = 'B',
+                  Z = 'HELLO_KEY',
+                }
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -268,7 +268,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -341,7 +341,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2443,7 +2443,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -2516,7 +2516,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1056,52 +1056,59 @@ describe(ruleName, () => {
         valid: [],
       })
 
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'propertiesStartingWithHello',
-                    elementNamePattern: 'hello*',
-                    selector: 'property',
-                  },
-                ],
-                groups: ['propertiesStartingWithHello', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'propertiesStartingWithHello',
-                  right: 'helloProperty',
-                  leftGroup: 'unknown',
-                  left: 'method',
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'propertiesStartingWithHello',
+                      selector: 'property',
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['propertiesStartingWithHello', 'unknown'],
                 },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                helloProperty: string
-                a: string
-                b: string
-                method(): void
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string
-                b: string
-                method(): void
-                helloProperty: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'propertiesStartingWithHello',
+                    right: 'helloProperty',
+                    leftGroup: 'unknown',
+                    left: 'method',
+                  },
+                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
+                },
+              ],
+              output: dedent`
+                interface Interface {
+                  helloProperty: string
+                  a: string
+                  b: string
+                  method(): void
+                }
+              `,
+              code: dedent`
+                interface Interface {
+                  a: string
+                  b: string
+                  method(): void
+                  helloProperty: string
+                }
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
@@ -2652,71 +2659,78 @@ describe(ruleName, () => {
     )
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
+      for (let rgbAllNamesMatchPattern of [
+        '^r|g|b$',
+        ['noMatch', '^r|g|b$'],
+        { pattern: '^R|G|B$', flags: 'i' },
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ]) {
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'g',
+                      leftGroup: 'b',
+                      right: 'g',
+                      left: 'b',
+                    },
+                    messageId: 'unexpectedInterfacePropertiesGroupOrder',
                   },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
+                  {
+                    data: {
+                      rightGroup: 'r',
+                      leftGroup: 'g',
+                      right: 'r',
+                      left: 'g',
+                    },
+                    messageId: 'unexpectedInterfacePropertiesGroupOrder',
                   },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  useConfigurationIf: {
-                    allNamesMatchPattern: 'foo',
+                ],
+                options: [
+                  {
+                    ...options,
+                    useConfigurationIf: {
+                      allNamesMatchPattern: 'foo',
+                    },
                   },
-                },
-                {
-                  ...options,
-                  customGroups: {
-                    r: 'r',
-                    g: 'g',
-                    b: 'b',
+                  {
+                    ...options,
+                    customGroups: {
+                      r: 'r',
+                      g: 'g',
+                      b: 'b',
+                    },
+                    useConfigurationIf: {
+                      allNamesMatchPattern: rgbAllNamesMatchPattern,
+                    },
+                    groups: ['r', 'g', 'b'],
                   },
-                  useConfigurationIf: {
-                    allNamesMatchPattern: '^r|g|b$',
-                  },
-                  groups: ['r', 'g', 'b'],
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  r: string
-                  g: string
-                  b: string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  b: string
-                  g: string
-                  r: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                ],
+                output: dedent`
+                  interface Interface {
+                    r: string
+                    g: string
+                    b: string
+                  }
+                `,
+                code: dedent`
+                  interface Interface {
+                    b: string
+                    g: string
+                    r: string
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      }
 
       describe(`${ruleName}(${type}): allows to use 'declarationMatchesPattern'`, () => {
         ruleTester.run(

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1731,7 +1731,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -1810,7 +1810,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -3465,7 +3465,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -3544,7 +3544,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -4515,7 +4515,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -4594,7 +4594,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
               },
             ],
           },
@@ -4732,7 +4732,7 @@ describe(ruleName, () => {
         {
           options: [
             {
-              ignorePattern: ['Ignore*'],
+              ignorePattern: ['Ignore'],
               type: 'line-length',
               order: 'desc',
             },

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -533,7 +533,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -587,7 +587,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -663,7 +663,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -2143,31 +2143,38 @@ describe(ruleName, () => {
       invalid: [],
     })
 
-    ruleTester.run(
-      `${ruleName}: allow to disable rule for some JSX elements`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  c="c"
-                  b="bb"
-                  a="aaa"
-                />
-              )
-            `,
-            options: [
-              {
-                ignorePattern: ['Element'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
+    for (let ignorePattern of [
+      'Element',
+      ['noMatch', 'Element'],
+      { pattern: 'ELEMENT', flags: 'i' },
+      ['noMatch', { pattern: 'ELEMENT', flags: 'i' }],
+    ]) {
+      ruleTester.run(
+        `${ruleName}: allow to disable rule for some JSX elements`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+                let Component = () => (
+                  <Element
+                    c="c"
+                    b="bb"
+                    a="aaa"
+                  />
+                )
+              `,
+              options: [
+                {
+                  ignorePattern,
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+    }
 
     let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
     ruleTester.run(eslintDisableRuleTesterName, rule, {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -311,7 +311,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                customGroups: { callback: 'on*' },
+                customGroups: { callback: 'on' },
                 groups: ['unknown', 'callback'],
               },
             ],
@@ -336,7 +336,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                customGroups: { callback: 'on*' },
+                customGroups: { callback: 'on' },
                 groups: ['unknown', 'callback'],
               },
             ],
@@ -1331,7 +1331,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                customGroups: { callback: 'on*' },
+                customGroups: { callback: 'on' },
                 groups: ['unknown', 'callback'],
               },
             ],
@@ -1356,7 +1356,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                customGroups: { callback: 'on*' },
+                customGroups: { callback: 'on' },
                 groups: ['unknown', 'callback'],
               },
             ],
@@ -1863,7 +1863,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                customGroups: { callback: 'on*' },
+                customGroups: { callback: 'on' },
                 groups: ['unknown', 'callback'],
               },
             ],
@@ -1888,7 +1888,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                customGroups: { callback: 'on*' },
+                customGroups: { callback: 'on' },
                 groups: ['unknown', 'callback'],
               },
             ],

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -813,7 +813,7 @@ describe(ruleName, () => {
                 customGroups: [
                   {
                     groupName: 'keysStartingWithHello',
-                    elementNamePattern: 'hello*',
+                    elementNamePattern: 'hello',
                   },
                 ],
                 groups: ['keysStartingWithHello', 'unknown'],
@@ -1481,80 +1481,87 @@ describe(ruleName, () => {
     })
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  useConfigurationIf: {
-                    allNamesMatchPattern: 'foo',
-                  },
-                },
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      elementNamePattern: '^r$',
-                      groupName: 'r',
+      for (let allNamesMatchPattern of [
+        'foo',
+        ['noMatch', 'foo'],
+        { pattern: 'FOO', flags: 'i' },
+        ['noMatch', { pattern: 'FOO', flags: 'i' }],
+      ]) {
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    useConfigurationIf: {
+                      allNamesMatchPattern,
                     },
-                    {
-                      elementNamePattern: '^g$',
-                      groupName: 'g',
+                  },
+                  {
+                    ...options,
+                    customGroups: [
+                      {
+                        elementNamePattern: '^r$',
+                        groupName: 'r',
+                      },
+                      {
+                        elementNamePattern: '^g$',
+                        groupName: 'g',
+                      },
+                      {
+                        elementNamePattern: '^b$',
+                        groupName: 'b',
+                      },
+                    ],
+                    useConfigurationIf: {
+                      allNamesMatchPattern: '^r|g|b$',
                     },
-                    {
-                      elementNamePattern: '^b$',
-                      groupName: 'b',
+                    groups: ['r', 'g', 'b'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'g',
+                      leftGroup: 'b',
+                      right: 'g',
+                      left: 'b',
                     },
-                  ],
-                  useConfigurationIf: {
-                    allNamesMatchPattern: '^r|g|b$',
+                    messageId: 'unexpectedMapElementsGroupOrder',
                   },
-                  groups: ['r', 'g', 'b'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
+                  {
+                    data: {
+                      rightGroup: 'r',
+                      leftGroup: 'g',
+                      right: 'r',
+                      left: 'g',
+                    },
+                    messageId: 'unexpectedMapElementsGroupOrder',
                   },
-                  messageId: 'unexpectedMapElementsGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
-                  },
-                  messageId: 'unexpectedMapElementsGroupOrder',
-                },
-              ],
-              output: dedent`
-                new Map([
-                  [r, null],
-                  [g, null],
-                  [b, null]
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  [b, null],
-                  [g, null],
-                  [r, null]
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                ],
+                output: dedent`
+                  new Map([
+                    [r, null],
+                    [g, null],
+                    [b, null]
+                  ])
+                `,
+                code: dedent`
+                  new Map([
+                    [b, null],
+                    [g, null],
+                    [r, null]
+                  ])
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      }
     })
   })
 

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -365,7 +365,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -444,7 +444,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -384,158 +384,182 @@ describe(ruleName, () => {
         valid: [],
       })
 
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'functionsStartingWithHello',
-                    elementNamePattern: 'hello*',
-                    selector: 'function',
-                  },
-                ],
-                groups: ['functionsStartingWithHello', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'functionsStartingWithHello',
-                  right: 'helloFunction',
-                  leftGroup: 'unknown',
-                  left: 'func',
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'functionsStartingWithHello',
+                      selector: 'function',
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['functionsStartingWithHello', 'unknown'],
                 },
-                messageId: 'unexpectedModulesGroupOrder',
-              },
-            ],
-            output: dedent`
-              function helloFunction() {}
-              interface A {}
-              interface B {}
-              function func() {}
-            `,
-            code: dedent`
-              interface A {}
-              interface B {}
-              function func() {}
-              function helloFunction() {}
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'classesWithDecoratorStartingWithHello',
-                  leftGroup: 'unknown',
-                  left: 'func',
-                  right: 'C',
-                },
-                messageId: 'unexpectedModulesGroupOrder',
-              },
-              {
-                data: {
-                  right: 'AnotherClass',
-                  left: 'C',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'classesWithDecoratorStartingWithHello',
-                    decoratorNamePattern: 'Hello*',
-                    selector: 'class',
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'functionsStartingWithHello',
+                    right: 'helloFunction',
+                    leftGroup: 'unknown',
+                    left: 'func',
                   },
-                ],
-                groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
-              },
-            ],
-            output: dedent`
-              @HelloDecorator()
-              class AnotherClass {}
-
-              @HelloDecorator
-              class C {}
-
-              @Decorator
-              class A {}
-
-              class B {}
-
-              function func() {}
-            `,
-            code: dedent`
-              @Decorator
-              class A {}
-
-              class B {}
-
-              function func() {}
-
-              @HelloDecorator
-              class C {}
-
-              @HelloDecorator()
-              class AnotherClass {}
-            `,
-          },
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    decoratorNamePattern: 'B',
-                    groupName: 'B',
-                  },
-                  {
-                    decoratorNamePattern: 'A',
-                    groupName: 'A',
-                  },
-                ],
-                type: 'alphabetical',
-                groups: ['B', 'A'],
-                order: 'asc',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'B',
-                  leftGroup: 'A',
-                  right: 'B',
-                  left: 'A',
+                  messageId: 'unexpectedModulesGroupOrder',
                 },
-                messageId: 'unexpectedModulesGroupOrder',
-              },
-            ],
-            output: dedent`
-              @B.B()
-              class B {}
+              ],
+              output: dedent`
+                function helloFunction() {}
+                interface A {}
+                interface B {}
+                function func() {}
+              `,
+              code: dedent`
+                interface A {}
+                interface B {}
+                function func() {}
+                function helloFunction() {}
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
-              @A.A.A(() => A)
-              class A {}
-            `,
-            code: dedent`
-              @A.A.A(() => A)
-              class A {}
+      for (let decoratorNamePattern of [
+        'Hello',
+        ['noMatch', 'Hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'classesWithDecoratorStartingWithHello',
+                    leftGroup: 'unknown',
+                    left: 'func',
+                    right: 'C',
+                  },
+                  messageId: 'unexpectedModulesGroupOrder',
+                },
+                {
+                  data: {
+                    right: 'AnotherClass',
+                    left: 'C',
+                  },
+                  messageId: 'unexpectedModulesOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'classesWithDecoratorStartingWithHello',
+                      decoratorNamePattern,
+                      selector: 'class',
+                    },
+                  ],
+                  groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
+                },
+              ],
+              output: dedent`
+                @HelloDecorator()
+                class AnotherClass {}
 
-              @B.B()
-              class B {}
-            `,
-          },
-        ],
-        valid: [],
-      })
+                @HelloDecorator
+                class C {}
+
+                @Decorator
+                class A {}
+
+                class B {}
+
+                function func() {}
+              `,
+              code: dedent`
+                @Decorator
+                class A {}
+
+                class B {}
+
+                function func() {}
+
+                @HelloDecorator
+                class C {}
+
+                @HelloDecorator()
+                class AnotherClass {}
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
+
+      ruleTester.run(
+        `${ruleName}: filters on complex decoratorNamePattern`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      decoratorNamePattern: 'B',
+                      groupName: 'B',
+                    },
+                    {
+                      decoratorNamePattern: 'A',
+                      groupName: 'A',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['B', 'A'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'B',
+                    leftGroup: 'A',
+                    right: 'B',
+                    left: 'A',
+                  },
+                  messageId: 'unexpectedModulesGroupOrder',
+                },
+              ],
+              output: dedent`
+                @B.B()
+                class B {}
+
+                @A.A.A(() => A)
+                class A {}
+              `,
+              code: dedent`
+                @A.A.A(() => A)
+                class A {}
+
+                @B.B()
+                class B {}
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
 
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -1893,7 +1893,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: 'Part*',
+                  partitionByComment: 'Part',
                 },
               ],
               output: dedent`
@@ -3457,7 +3457,7 @@ describe(ruleName, () => {
               ],
               options: [
                 {
-                  partitionByComment: 'PartitionComment:*',
+                  partitionByComment: 'PartitionComment:',
                   type: 'alphabetical',
                 },
               ],

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -275,7 +275,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                   groupKind: 'types-first',
                 },
               ],
@@ -355,7 +355,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -520,7 +520,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                   groupKind: 'types-first',
                 },
               ],
@@ -600,7 +600,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -797,52 +797,59 @@ describe(ruleName, () => {
         valid: [],
       })
 
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'propertiesStartingWithHello',
-                    elementNamePattern: 'hello*',
-                    selector: 'property',
-                  },
-                ],
-                groups: ['propertiesStartingWithHello', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'propertiesStartingWithHello',
-                  right: 'helloProperty',
-                  leftGroup: 'unknown',
-                  left: 'method',
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'propertiesStartingWithHello',
+                      selector: 'property',
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['propertiesStartingWithHello', 'unknown'],
                 },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                helloProperty: string
-                a: string
-                b: string
-                method(): void
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a: string
-                b: string
-                method(): void
-                helloProperty: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'propertiesStartingWithHello',
+                    right: 'helloProperty',
+                    leftGroup: 'unknown',
+                    left: 'method',
+                  },
+                  messageId: 'unexpectedObjectTypesGroupOrder',
+                },
+              ],
+              output: dedent`
+                type Type = {
+                  helloProperty: string
+                  a: string
+                  b: string
+                  method(): void
+                }
+              `,
+              code: dedent`
+                type Type = {
+                  a: string
+                  b: string
+                  method(): void
+                  helloProperty: string
+                }
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
@@ -2499,71 +2506,78 @@ describe(ruleName, () => {
     )
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
+      for (let rgbAllNamesMatchPattern of [
+        '^r|g|b$',
+        ['noMatch', '^r|g|b$'],
+        { pattern: '^R|G|B$', flags: 'i' },
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ]) {
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'g',
+                      leftGroup: 'b',
+                      right: 'g',
+                      left: 'b',
+                    },
+                    messageId: 'unexpectedObjectTypesGroupOrder',
                   },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
+                  {
+                    data: {
+                      rightGroup: 'r',
+                      leftGroup: 'g',
+                      right: 'r',
+                      left: 'g',
+                    },
+                    messageId: 'unexpectedObjectTypesGroupOrder',
                   },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  useConfigurationIf: {
-                    allNamesMatchPattern: 'foo',
+                ],
+                options: [
+                  {
+                    ...options,
+                    useConfigurationIf: {
+                      allNamesMatchPattern: 'foo',
+                    },
                   },
-                },
-                {
-                  ...options,
-                  customGroups: {
-                    r: 'r',
-                    g: 'g',
-                    b: 'b',
+                  {
+                    ...options,
+                    customGroups: {
+                      r: 'r',
+                      g: 'g',
+                      b: 'b',
+                    },
+                    useConfigurationIf: {
+                      allNamesMatchPattern: rgbAllNamesMatchPattern,
+                    },
+                    groups: ['r', 'g', 'b'],
                   },
-                  useConfigurationIf: {
-                    allNamesMatchPattern: '^r|g|b$',
-                  },
-                  groups: ['r', 'g', 'b'],
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  r: string
-                  g: string
-                  b: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  b: string
-                  g: string
-                  r: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                ],
+                output: dedent`
+                  type Type = {
+                    r: string
+                    g: string
+                    b: string
+                  }
+                `,
+                code: dedent`
+                  type Type = {
+                    b: string
+                    g: string
+                    r: string
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      }
 
       describe(`${ruleName}(${type}): allows to use 'declarationMatchesPattern'`, () => {
         ruleTester.run(

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -1393,7 +1393,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -1472,7 +1472,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1287,7 +1287,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -1395,7 +1395,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -1474,7 +1474,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *'],
+                partitionByComment: ['Partition Comment', 'Part:'],
               },
             ],
           },
@@ -3946,7 +3946,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -4025,7 +4025,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *'],
+                partitionByComment: ['Partition Comment', 'Part:'],
               },
             ],
           },
@@ -4826,7 +4826,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: '^Part*',
+                partitionByComment: '^Part',
               },
             ],
           },
@@ -4905,7 +4905,7 @@ describe(ruleName, () => {
             options: [
               {
                 ...options,
-                partitionByComment: ['Partition Comment', 'Part: *'],
+                partitionByComment: ['Partition Comment', 'Part:'],
               },
             ],
           },
@@ -4941,7 +4941,7 @@ describe(ruleName, () => {
                 ...options,
                 partitionByComment: [
                   'Public Safety Bureau',
-                  'Crime Coefficient: *',
+                  'Crime Coefficient:',
                   'Victims',
                 ],
               },
@@ -5767,7 +5767,7 @@ describe(ruleName, () => {
             ],
             options: [
               {
-                partitionByComment: 'PartitionComment:*',
+                partitionByComment: 'PartitionComment:',
                 type: 'alphabetical',
               },
             ],

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2517,71 +2517,78 @@ describe(ruleName, () => {
     )
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
+      for (let rgbAllNamesMatchPattern of [
+        '^r|g|b$',
+        ['noMatch', '^r|g|b$'],
+        { pattern: '^R|G|B$', flags: 'i' },
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ]) {
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'g',
+                      leftGroup: 'b',
+                      right: 'g',
+                      left: 'b',
+                    },
+                    messageId: 'unexpectedObjectsGroupOrder',
                   },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
+                  {
+                    data: {
+                      rightGroup: 'r',
+                      leftGroup: 'g',
+                      right: 'r',
+                      left: 'g',
+                    },
+                    messageId: 'unexpectedObjectsGroupOrder',
                   },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  useConfigurationIf: {
-                    allNamesMatchPattern: 'foo',
+                ],
+                options: [
+                  {
+                    ...options,
+                    useConfigurationIf: {
+                      allNamesMatchPattern: 'foo',
+                    },
                   },
-                },
-                {
-                  ...options,
-                  customGroups: {
-                    r: 'r',
-                    g: 'g',
-                    b: 'b',
+                  {
+                    ...options,
+                    customGroups: {
+                      r: 'r',
+                      g: 'g',
+                      b: 'b',
+                    },
+                    useConfigurationIf: {
+                      allNamesMatchPattern: rgbAllNamesMatchPattern,
+                    },
+                    groups: ['r', 'g', 'b'],
                   },
-                  useConfigurationIf: {
-                    allNamesMatchPattern: '^r|g|b$',
-                  },
-                  groups: ['r', 'g', 'b'],
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  r: string,
-                  g: string,
-                  b: string
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  b: string,
-                  g: string,
-                  r: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                ],
+                output: dedent`
+                  let obj = {
+                    r: string,
+                    g: string,
+                    b: string
+                  }
+                `,
+                code: dedent`
+                  let obj = {
+                    b: string,
+                    g: string,
+                    r: string
+                  }
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      }
 
       ruleTester.run(
         `${ruleName}(${type}): allows to use 'callingFunctionNamePattern'`,
@@ -2755,104 +2762,118 @@ describe(ruleName, () => {
         valid: [],
       })
 
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'propertiesStartingWithHello',
-                    elementNamePattern: 'hello*',
-                    selector: 'property',
-                  },
-                ],
-                groups: ['propertiesStartingWithHello', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'propertiesStartingWithHello',
-                  right: 'helloProperty',
-                  leftGroup: 'unknown',
-                  left: 'method',
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'propertiesStartingWithHello',
+                      selector: 'property',
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['propertiesStartingWithHello', 'unknown'],
                 },
-                messageId: 'unexpectedObjectsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let obj = {
-                helloProperty,
-                a,
-                b,
-                method() {},
-              }
-            `,
-            code: dedent`
-              let obj = {
-                a,
-                b,
-                method() {},
-                helloProperty,
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'propertiesStartingWithHello',
+                    right: 'helloProperty',
+                    leftGroup: 'unknown',
+                    left: 'method',
+                  },
+                  messageId: 'unexpectedObjectsGroupOrder',
+                },
+              ],
+              output: dedent`
+                let obj = {
+                  helloProperty,
+                  a,
+                  b,
+                  method() {},
+                }
+              `,
+              code: dedent`
+                let obj = {
+                  a,
+                  b,
+                  method() {},
+                  helloProperty,
+                }
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
-      ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    elementValuePattern: 'inject*',
-                    groupName: 'inject',
-                  },
-                  {
-                    elementValuePattern: 'computed*',
-                    groupName: 'computed',
-                  },
-                ],
-                groups: ['computed', 'inject', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'computed',
-                  leftGroup: 'inject',
-                  right: 'z',
-                  left: 'y',
+      for (let injectElementValuePattern of [
+        'inject',
+        ['noMatch', 'inject'],
+        { pattern: 'INJECT', flags: 'i' },
+        ['noMatch', { pattern: 'INJECT', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      elementValuePattern: injectElementValuePattern,
+                      groupName: 'inject',
+                    },
+                    {
+                      elementValuePattern: 'computed',
+                      groupName: 'computed',
+                    },
+                  ],
+                  groups: ['computed', 'inject', 'unknown'],
                 },
-                messageId: 'unexpectedObjectsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let obj = {
-                a: computed(A),
-                z: computed(Z),
-                b: inject(B),
-                y: inject(Y),
-                c() {},
-              }
-            `,
-            code: dedent`
-              let obj = {
-                a: computed(A),
-                b: inject(B),
-                y: inject(Y),
-                z: computed(Z),
-                c() {},
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'computed',
+                    leftGroup: 'inject',
+                    right: 'z',
+                    left: 'y',
+                  },
+                  messageId: 'unexpectedObjectsGroupOrder',
+                },
+              ],
+              output: dedent`
+                let obj = {
+                  a: computed(A),
+                  z: computed(Z),
+                  b: inject(B),
+                  y: inject(Y),
+                  c() {},
+                }
+              `,
+              code: dedent`
+                let obj = {
+                  a: computed(A),
+                  b: inject(B),
+                  y: inject(Y),
+                  z: computed(Z),
+                  c() {},
+                }
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
@@ -5225,25 +5246,37 @@ describe(ruleName, () => {
           ],
         },
       ],
-      valid: [
-        {
-          code: dedent`
-            const buttonStyles = {
-              background: "red",
-              display: 'flex',
-              flexDirection: 'column',
-              width: "50px",
-              height: "50px",
-            }
-          `,
-          options: [
-            {
-              ignorePattern: ['Styles$'],
-            },
-          ],
-        },
-      ],
+      valid: [],
     })
+
+    for (let ignorePattern of [
+      'Styles$',
+      ['noMatch', 'Styles$'],
+      { pattern: 'STYLES$', flags: 'i' },
+      ['noMatch', { pattern: 'STYLES$', flags: 'i' }],
+    ]) {
+      ruleTester.run(`${ruleName}: allow to ignore pattern`, rule, {
+        valid: [
+          {
+            code: dedent`
+              const buttonStyles = {
+                background: "red",
+                display: 'flex',
+                flexDirection: 'column',
+                width: "50px",
+                height: "50px",
+              }
+            `,
+            options: [
+              {
+                ignorePattern,
+              },
+            ],
+          },
+        ],
+        invalid: [],
+      })
+    }
 
     ruleTester.run(`${ruleName}: allow to ignore pattern`, rule, {
       invalid: [

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -480,7 +480,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -559,7 +559,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1050,51 +1050,58 @@ describe(ruleName, () => {
         valid: [],
       })
 
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'literalsStartingWithHello',
-                    elementNamePattern: 'hello*',
-                    selector: 'literal',
-                  },
-                ],
-                groups: ['literalsStartingWithHello', 'unknown'],
-                groupKind: 'mixed',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'literalsStartingWithHello',
-                  right: 'helloLiteral',
-                  leftGroup: 'unknown',
-                  left: 'b',
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'literalsStartingWithHello',
+                      selector: 'literal',
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['literalsStartingWithHello', 'unknown'],
+                  groupKind: 'mixed',
                 },
-                messageId: 'unexpectedSetsGroupOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                'helloLiteral',
-                'a',
-                'b',
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'a',
-                'b',
-                'helloLiteral',
-              ])
-            `,
-          },
-        ],
-        valid: [],
-      })
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'literalsStartingWithHello',
+                    right: 'helloLiteral',
+                    leftGroup: 'unknown',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedSetsGroupOrder',
+                },
+              ],
+              output: dedent`
+                new Set([
+                  'helloLiteral',
+                  'a',
+                  'b',
+                ])
+              `,
+              code: dedent`
+                new Set([
+                  'a',
+                  'b',
+                  'helloLiteral',
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
 
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
@@ -1327,80 +1334,87 @@ describe(ruleName, () => {
     })
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  useConfigurationIf: {
-                    allNamesMatchPattern: 'foo',
-                  },
-                },
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      elementNamePattern: '^r$',
-                      groupName: 'r',
+      for (let allNamesMatchPattern of [
+        'foo',
+        ['noMatch', 'foo'],
+        { pattern: 'FOO', flags: 'i' },
+        ['noMatch', { pattern: 'foo', flags: 'i' }],
+      ]) {
+        ruleTester.run(
+          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
+          rule,
+          {
+            invalid: [
+              {
+                options: [
+                  {
+                    ...options,
+                    useConfigurationIf: {
+                      allNamesMatchPattern,
                     },
-                    {
-                      elementNamePattern: '^g$',
-                      groupName: 'g',
+                  },
+                  {
+                    ...options,
+                    customGroups: [
+                      {
+                        elementNamePattern: '^r$',
+                        groupName: 'r',
+                      },
+                      {
+                        elementNamePattern: '^g$',
+                        groupName: 'g',
+                      },
+                      {
+                        elementNamePattern: '^b$',
+                        groupName: 'b',
+                      },
+                    ],
+                    useConfigurationIf: {
+                      allNamesMatchPattern: '^r|g|b$',
                     },
-                    {
-                      elementNamePattern: '^b$',
-                      groupName: 'b',
+                    groups: ['r', 'g', 'b'],
+                  },
+                ],
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'g',
+                      leftGroup: 'b',
+                      right: 'g',
+                      left: 'b',
                     },
-                  ],
-                  useConfigurationIf: {
-                    allNamesMatchPattern: '^r|g|b$',
+                    messageId: 'unexpectedSetsGroupOrder',
                   },
-                  groups: ['r', 'g', 'b'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
+                  {
+                    data: {
+                      rightGroup: 'r',
+                      leftGroup: 'g',
+                      right: 'r',
+                      left: 'g',
+                    },
+                    messageId: 'unexpectedSetsGroupOrder',
                   },
-                  messageId: 'unexpectedSetsGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
-                  },
-                  messageId: 'unexpectedSetsGroupOrder',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  'r',
-                  'g',
-                  'b',
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'b',
-                  'g',
-                  'r',
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+                ],
+                output: dedent`
+                  new Set([
+                    'r',
+                    'g',
+                    'b',
+                  ])
+                `,
+                code: dedent`
+                  new Set([
+                    'b',
+                    'g',
+                    'r',
+                  ])
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      }
     })
 
     describe(`${ruleName}: newlinesBetween`, () => {

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -536,7 +536,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -590,7 +590,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -666,7 +666,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -765,7 +765,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: '^Part*',
+                  partitionByComment: '^Part',
                 },
               ],
             },
@@ -841,7 +841,7 @@ describe(ruleName, () => {
               options: [
                 {
                   ...options,
-                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
                 },
               ],
             },

--- a/test/utils/get-matching-context-options.test.ts
+++ b/test/utils/get-matching-context-options.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import type { RegexOption } from '../../types/common-options'
+
 import { getMatchingContextOptions } from '../../utils/get-matching-context-options'
 
 describe('get-matching-context-options', () => {
@@ -37,8 +39,8 @@ describe('get-matching-context-options', () => {
   })
 
   let buildContextOptions = (
-    allNamesMatchPattern?: string,
-  ): { useConfigurationIf: { allNamesMatchPattern?: string } } => ({
+    allNamesMatchPattern?: RegexOption,
+  ): { useConfigurationIf: { allNamesMatchPattern?: RegexOption } } => ({
     useConfigurationIf: {
       ...(allNamesMatchPattern ? { allNamesMatchPattern } : {}),
     },

--- a/test/utils/matches.test.ts
+++ b/test/utils/matches.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { matches } from '../../utils/matches'
+
+describe('matches', () => {
+  it('should return true if the value matches the string option', () => {
+    expect(matches('foo', '^foo$')).toBeTruthy()
+  })
+
+  it('should return true if the value matches one of the string options', () => {
+    expect(matches('foo', ['bar', '^foo$'])).toBeTruthy()
+  })
+
+  it('should allow passing regex flags', () => {
+    expect(
+      matches('FOO', {
+        pattern: '^foo$',
+        flags: 'i',
+      }),
+    ).toBeTruthy()
+  })
+
+  it('should allow passing regex flags in an array', () => {
+    expect(
+      matches('FOO', [
+        'bar',
+        {
+          pattern: '^foo$',
+          flags: 'i',
+        },
+      ]),
+    ).toBeTruthy()
+  })
+})

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -42,8 +42,17 @@ export type TypeOption = 'alphabetical' | 'line-length' | 'natural' | 'custom'
 
 export type DeprecatedCustomGroupsOption = Record<string, string[] | string>
 
+export type RegexOption = SingleRegexOption[] | SingleRegexOption
+
 export type NewlinesBetweenOption = 'ignore' | 'always' | 'never'
 
 export type SpecialCharactersOption = 'remove' | 'trim' | 'keep'
 
 export type OrderOption = 'desc' | 'asc'
+
+type SingleRegexOption =
+  | {
+      pattern: string
+      flags?: string
+    }
+  | string

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -21,12 +21,11 @@ export interface CommonOptions {
 
 export type PartitionByCommentOption =
   | {
-      block?: string[] | boolean | string
-      line?: string[] | boolean | string
+      block?: RegexOption | boolean
+      line?: RegexOption | boolean
     }
-  | string[]
+  | RegexOption
   | boolean
-  | string
 
 export type GroupsOptions<T> = (
   | { newlinesBetween: NewlinesBetweenOption }

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -109,45 +109,6 @@ export let customGroupsJsonSchema: JSONSchema4 = {
   type: 'object',
 }
 
-let allowedPartitionByCommentJsonSchemas: JSONSchema4[] = [
-  {
-    items: {
-      type: 'string',
-    },
-    type: 'array',
-  },
-  {
-    type: 'boolean',
-  },
-  {
-    type: 'string',
-  },
-]
-export let partitionByCommentJsonSchema: JSONSchema4 = {
-  oneOf: [
-    ...allowedPartitionByCommentJsonSchemas,
-    {
-      properties: {
-        block: {
-          oneOf: allowedPartitionByCommentJsonSchemas,
-        },
-        line: {
-          oneOf: allowedPartitionByCommentJsonSchemas,
-        },
-      },
-      type: 'object',
-    },
-  ],
-  description:
-    'Allows to use comments to separate members into logical groups.',
-}
-
-export let partitionByNewLineJsonSchema: JSONSchema4 = {
-  description:
-    'Allows to use newlines to separate the nodes into logical groups.',
-  type: 'boolean',
-}
-
 let singleRegexJsonSchema: JSONSchema4 = {
   oneOf: [
     {
@@ -178,6 +139,37 @@ export let regexJsonSchema: JSONSchema4 = {
     singleRegexJsonSchema,
   ],
   description: 'Regular expression.',
+}
+
+let allowedPartitionByCommentJsonSchemas: JSONSchema4[] = [
+  {
+    type: 'boolean',
+  },
+  regexJsonSchema,
+]
+export let partitionByCommentJsonSchema: JSONSchema4 = {
+  oneOf: [
+    ...allowedPartitionByCommentJsonSchemas,
+    {
+      properties: {
+        block: {
+          oneOf: allowedPartitionByCommentJsonSchemas,
+        },
+        line: {
+          oneOf: allowedPartitionByCommentJsonSchemas,
+        },
+      },
+      type: 'object',
+    },
+  ],
+  description:
+    'Allows to use comments to separate members into logical groups.',
+}
+
+export let partitionByNewLineJsonSchema: JSONSchema4 = {
+  description:
+    'Allows to use newlines to separate the nodes into logical groups.',
+  type: 'boolean',
 }
 
 export let buildUseConfigurationIfJsonSchema = ({

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -148,15 +148,45 @@ export let partitionByNewLineJsonSchema: JSONSchema4 = {
   type: 'boolean',
 }
 
+let singleRegexJsonSchema: JSONSchema4 = {
+  oneOf: [
+    {
+      properties: {
+        pattern: {
+          type: 'string',
+        },
+        flags: {
+          type: 'string',
+        },
+      },
+      additionalProperties: false,
+      type: 'object',
+    },
+    {
+      type: 'string',
+    },
+  ],
+  description: 'Regular expression.',
+}
+
+export let regexJsonSchema: JSONSchema4 = {
+  oneOf: [
+    {
+      items: singleRegexJsonSchema,
+      type: 'array',
+    },
+    singleRegexJsonSchema,
+  ],
+  description: 'Regular expression.',
+}
+
 export let buildUseConfigurationIfJsonSchema = ({
   additionalProperties,
 }: {
   additionalProperties?: Record<string, JSONSchema4>
 } = {}): JSONSchema4 => ({
   properties: {
-    allNamesMatchPattern: {
-      type: 'string',
-    },
+    allNamesMatchPattern: regexJsonSchema,
     ...additionalProperties,
   },
   additionalProperties: false,
@@ -255,13 +285,3 @@ export let buildCustomGroupSelectorJsonSchema = (
   enum: selectors,
   type: 'string',
 })
-
-export let elementNamePatternJsonSchema: JSONSchema4 = {
-  description: 'Element name pattern filter.',
-  type: 'string',
-}
-
-export let elementValuePatternJsonSchema: JSONSchema4 = {
-  description: 'Element value pattern filter.',
-  type: 'string',
-}

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -83,6 +83,7 @@ export let groupsJsonSchema: JSONSchema4 = {
         properties: {
           newlinesBetween: newlinesBetweenJsonSchema,
         },
+        additionalProperties: false,
         type: 'object',
       },
     ],
@@ -159,6 +160,7 @@ export let partitionByCommentJsonSchema: JSONSchema4 = {
           oneOf: allowedPartitionByCommentJsonSchemas,
         },
       },
+      additionalProperties: false,
       type: 'object',
     },
   ],

--- a/utils/get-matching-context-options.ts
+++ b/utils/get-matching-context-options.ts
@@ -1,8 +1,10 @@
+import type { RegexOption } from '../types/common-options'
+
 import { matches } from './matches'
 
 interface Options {
   useConfigurationIf?: {
-    allNamesMatchPattern?: string
+    allNamesMatchPattern?: RegexOption
   }
 }
 

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -3,6 +3,7 @@ import type { TSESLint } from '@typescript-eslint/utils'
 import type {
   SpecialCharactersOption,
   OrderOption,
+  RegexOption,
   TypeOption,
 } from '../types/common-options'
 
@@ -18,7 +19,7 @@ export type Settings = Partial<{
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   partitionByNewLine: boolean
-  ignorePattern: string[]
+  ignorePattern: RegexOption
   ignoreCase: boolean
   order: OrderOption
   type: TypeOption

--- a/utils/has-partition-comment.ts
+++ b/utils/has-partition-comment.ts
@@ -1,16 +1,11 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
+import type { PartitionByCommentOption } from '../types/common-options'
+
 import { isPartitionComment } from './is-partition-comment'
 
 interface HasPartitionCommentParameters {
-  partitionByComment:
-    | {
-        block?: string[] | boolean | string
-        line?: string[] | boolean | string
-      }
-    | string[]
-    | boolean
-    | string
+  partitionByComment: PartitionByCommentOption
   comments: TSESTree.Comment[]
 }
 

--- a/utils/is-partition-comment.ts
+++ b/utils/is-partition-comment.ts
@@ -2,18 +2,16 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_TOKEN_TYPES } from '@typescript-eslint/types'
 
+import type {
+  PartitionByCommentOption,
+  RegexOption,
+} from '../types/common-options'
+
 import { getEslintDisabledRules } from './get-eslint-disabled-rules'
 import { matches } from './matches'
 
 interface IsPartitionCommentParameters {
-  partitionByComment:
-    | {
-        block?: string[] | boolean | string
-        line?: string[] | boolean | string
-      }
-    | string[]
-    | boolean
-    | string
+  partitionByComment: PartitionByCommentOption
   comment: TSESTree.Comment
 }
 
@@ -38,10 +36,13 @@ export let isPartitionComment = ({
     })
   }
 
-  let relevantPartitionByComment =
-    comment.type === AST_TOKEN_TYPES.Block
-      ? partitionByComment.block
-      : partitionByComment.line
+  let relevantPartitionByComment
+  if (comment.type === AST_TOKEN_TYPES.Block && 'block' in partitionByComment) {
+    relevantPartitionByComment = partitionByComment.block
+  }
+  if (comment.type === AST_TOKEN_TYPES.Line && 'line' in partitionByComment) {
+    relevantPartitionByComment = partitionByComment.line
+  }
 
   return (
     // eslint-disable-next-line no-undefined
@@ -57,16 +58,11 @@ let isTrimmedCommentPartitionComment = ({
   partitionByComment,
   trimmedComment,
 }: {
-  partitionByComment: string[] | boolean | string
+  partitionByComment: RegexOption | boolean
   trimmedComment: string
 }): boolean => {
   if (typeof partitionByComment === 'boolean') {
     return partitionByComment
   }
-  if (typeof partitionByComment === 'string') {
-    return matches(trimmedComment.trim(), partitionByComment)
-  }
-  return partitionByComment.some(pattern =>
-    matches(trimmedComment.trim(), pattern),
-  )
+  return matches(trimmedComment, partitionByComment)
 }

--- a/utils/matches.ts
+++ b/utils/matches.ts
@@ -1,2 +1,13 @@
-export let matches = (value: string, pattern: string): boolean =>
-  new RegExp(pattern).test(value)
+import type { RegexOption } from '../types/common-options'
+
+export let matches = (value: string, regexOption: RegexOption): boolean => {
+  if (Array.isArray(regexOption)) {
+    return regexOption.some(opt => matches(value, opt))
+  }
+
+  if (typeof regexOption === 'string') {
+    return new RegExp(regexOption).test(value)
+  }
+
+  return new RegExp(regexOption.pattern, regexOption.flags).test(value)
+}


### PR DESCRIPTION
Resolves #462.

ℹ️ **Hide whitespace changes** when reviewing tests: indentation has changed.

## Description

The objective of this PR is:
- To unify the handling of all `regex`-related options.
- To allow for additional types to be entered for those options.
- To allow users to pass regex `flags`.

## Proposal

- Creates a `RegexOption` type and its associated JSON schema.
```ts
type SingleRegexOption =
  | {
      pattern: string
      flags?: string
    }
  | string

export type RegexOption = SingleRegexOption[] | SingleRegexOption
```

This means that users may enter regex-related options under the following formats:
- `string`: `elementNamePattern: "^foo$"`
- `string[]`: `elementNamePattern: ["^foo$", "^bar$"]`
- `RegexObject`: `elementNamePattern: { pattern: "^foo$", flags: "i" }`,
- `RegexObject[]`: `elementNamePattern: [{ pattern: "^foo$", flags: "i" }, "bar"]`,

In case of arrays, one element is needed to consider this a match.

## Affected options

- `elementNamePattern`.
- `elementValuePattern`.
- `decoratorNamePattern`.
- `partitionByComment`.
- `ignorePattern`.
- `internalPattern`.
- `useConfiguration.allNamesMatchPattern`.
- `useConfiguration.declarationMatchesPattern`.

## Tests

I hesitated to add additional tests for the `partitionByComment` option: each rule that handles that option already have a lot of tests for this, including regex-related tests, so I feel that the added value for such tests would be minimal. 

## What is the purpose of this pull request?

- [x] New Feature
