### PR TITLE
fix: fix maximum call stack size with fallback sort

### DIFF
--- a/test/utils/compare.test.ts
+++ b/test/utils/compare.test.ts
@@ -330,6 +330,20 @@ describe('compare', () => {
         }),
       ).toBe(-1)
     })
+
+    it("doesn't sort using the fallback configuration more than once", () => {
+      let node = createTestNode({ name: 'aaa' })
+      let duplicateNode = createTestNode({ name: 'aaa' })
+      expect(
+        compare(node, duplicateNode, {
+          ...compareOptions,
+          fallbackSort: {
+            type: 'alphabetical',
+            order: 'asc',
+          } as const,
+        }),
+      ).toBe(0)
+    })
   })
 
   let createTestNode = ({ name }: { name: string }): SortingNode =>

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -101,9 +101,11 @@ export let compare = <T extends SortingNode>(
   let { fallbackSort, order } = options
   return compare(a, b, {
     ...options,
+    fallbackSort: {
+      type: 'unsorted',
+    },
     order: fallbackSort.order ?? order,
     type: fallbackSort.type,
-    fallbackSort,
   } as CompareOptions<T>)
 }
 


### PR DESCRIPTION
Fixes #472

# Description

Duplicate entries can lead to a maximum call stack size error when using `fallbackSort`.

This PR fixes this bug.

## Critical level of this issue

- Only happens when users write duplicate entries.
  - Should only happen for `exports`.
  - Relatively low chance of happening.
-  Linked to a new feature.

=> Low criticality level.

## What is the purpose of this pull request?

- [x] Bug fix