### PR TITLE
feat: add `customGroups.fallbackSort` option

### DIFF
--- a/docs/content/guide/getting-started.mdx
+++ b/docs/content/guide/getting-started.mdx
@@ -142,6 +142,7 @@ In settings you can set the following options:
 
 - `type` — The type of sorting. Possible values are `'alphabetical'`, `'natural'`, `'line-length'` and `custom`.
 - `order` — The order of sorting. Possible values are `'asc'` and `'desc'`.
+- `fallbackSort` — The fallback sorting type and order to use when two elements are equal.
 - `alphabet` — The custom alphabet to use when `type` is `custom`.
 - `ignoreCase` — Ignore case when sorting.
 - `ignorePattern` — Ignore sorting for elements that match the pattern.

--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -143,7 +143,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -377,6 +377,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   selector?: string
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
@@ -391,6 +392,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   anyOf: Array<{
       selector?: string
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
@@ -407,6 +409,7 @@ An array element will match a `CustomGroupAnyOfDefinition` group if it matches a
 - `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 
 #### Match importance
 

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -178,7 +178,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -653,6 +653,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
@@ -670,6 +671,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       selector?: string
@@ -693,6 +695,7 @@ A class member will match a `CustomGroupAnyOfDefinition` group if it matches all
 - `decoratorNamePattern`: If entered, will check that at least one `decorator` matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 - `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance

--- a/docs/content/rules/sort-decorators.mdx
+++ b/docs/content/rules/sort-decorators.mdx
@@ -142,7 +142,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -108,7 +108,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -291,6 +291,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
@@ -304,6 +305,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   anyOf: Array<{
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
@@ -319,6 +321,7 @@ An enum member will match a `CustomGroupAnyOfDefinition` group if it matches all
 - `elementValuePattern`: If entered, will check that the value of the element matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 
 #### Match importance
 

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -102,7 +102,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-heritage-clauses.mdx
+++ b/docs/content/rules/sort-heritage-clauses.mdx
@@ -85,7 +85,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -141,7 +141,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -560,6 +560,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   selector?: string
@@ -578,6 +579,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   anyOf: Array<{
@@ -600,6 +602,7 @@ An interface member will match a `CustomGroupAnyOfDefinition` group if it matche
 - `elementValuePattern`: Only for properties. If entered, will check that the value of the property matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 - `sortBy`: Overrides the `sortBy` option for that custom group
 - `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -157,7 +157,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -98,7 +98,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -158,7 +158,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -103,7 +103,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -321,6 +321,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
@@ -334,6 +335,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   anyOf: Array<{
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
@@ -348,6 +350,7 @@ A map element will match a `CustomGroupAnyOfDefinition` group if it matches all 
 - `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 
 #### Match importance
 

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -432,6 +432,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
@@ -448,6 +449,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       selector?: string
@@ -469,6 +471,7 @@ A module member will match a `CustomGroupAnyOfDefinition` group if it matches al
 - `decoratorNamePattern`: If entered, will check that at least one `decorator` matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 - `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -201,7 +201,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -121,7 +121,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -122,7 +122,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -507,6 +507,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   selector?: string
@@ -525,6 +526,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   anyOf: Array<{
@@ -547,6 +549,7 @@ An object type will match a `CustomGroupAnyOfDefinition` group if it matches all
 - `elementValuePattern`: Only for properties. If entered, will check that the value of the property matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 - `sortBy`: Overrides the `sortBy` option for that custom group
 - `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -119,7 +119,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -177,7 +177,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -554,6 +554,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   newlinesInside?: 'always' | 'never'
   selector?: string
   modifiers?: string[]
@@ -571,6 +572,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       selector?: string
@@ -592,6 +594,7 @@ An object will match a `CustomGroupAnyOfDefinition` group if it matches all the 
 - `elementValuePattern`: Only for non-function properties. If entered, will check that the value of the property matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 - `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -149,7 +149,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -336,6 +336,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   selector?: string
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
@@ -350,6 +351,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
   anyOf: Array<{
       selector?: string
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
@@ -366,6 +368,7 @@ A set element will match a `CustomGroupAnyOfDefinition` group if it matches all 
 - `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
 
 #### Match importance
 

--- a/docs/content/rules/sort-switch-case.mdx
+++ b/docs/content/rules/sort-switch-case.mdx
@@ -170,7 +170,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -118,7 +118,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -102,7 +102,13 @@ Determines whether the sorted items should be in ascending or descending order.
 ### fallbackSort
 
 <sub>
-  type: `{ type: string; order?: 'asc' | 'desc' }`
+  type:
+  ```
+  {
+    type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
+    order?: 'asc' | 'desc'
+  }
+  ```
 </sub>
 <sub>default: `{ type: 'unsorted' }`</sub>
 

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -22,13 +22,13 @@ import {
   ORDER_ERROR,
 } from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
+import { buildGetCustomGroupOverriddenOptionsFunction } from '../utils/get-custom-groups-compare-options'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import {
   singleCustomGroupJsonSchema,
   allSelectors,
 } from './sort-array-includes/types'
-import { getCustomGroupsCompareOptions } from '../utils/get-custom-groups-compare-options'
 import { doesCustomGroupMatch } from './sort-array-includes/does-custom-group-match'
 import { getMatchingContextOptions } from '../utils/get-matching-context-options'
 import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
@@ -292,10 +292,12 @@ export let sortArray = <MessageIds extends string>({
       ignoreEslintDisabledNodes: boolean,
     ): SortArrayIncludesSortingNode[] =>
       filteredGroupKindNodes.flatMap(groupedNodes =>
-        sortNodesByGroups(groupedNodes, options, {
-          getGroupCompareOptions: groupNumber =>
-            getCustomGroupsCompareOptions(options, groupNumber),
+        sortNodesByGroups({
+          getOptionsByGroupNumber:
+            buildGetCustomGroupOverriddenOptionsFunction(options),
           ignoreEslintDisabledNodes,
+          groups: options.groups,
+          nodes: groupedNodes,
         }),
       )
 

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -240,7 +240,12 @@ let sortDecorators = (
     ignoreEslintDisabledNodes: boolean,
   ): SortDecoratorsSortingNode[] =>
     formattedMembers.flatMap(nodes =>
-      sortNodesByGroups(nodes, options, { ignoreEslintDisabledNodes }),
+      sortNodesByGroups({
+        getOptionsByGroupNumber: () => ({ options }),
+        ignoreEslintDisabledNodes,
+        groups: options.groups,
+        nodes,
+      }),
     )
   let nodes = formattedMembers.flat()
 

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -122,8 +122,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             ignoreEslintDisabledNodes: boolean,
           ): SortExportsSortingNode[] =>
             filteredGroupKindNodes.flatMap(groupedNodes =>
-              sortNodes(groupedNodes, options, {
+              sortNodes({
                 ignoreEslintDisabledNodes,
+                nodes: groupedNodes,
+                options,
               }),
             )
 

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -140,7 +140,12 @@ let sortHeritageClauses = (
   let sortNodesExcludingEslintDisabled = (
     ignoreEslintDisabledNodes: boolean,
   ): SortingNode[] =>
-    sortNodesByGroups(nodes, options, { ignoreEslintDisabledNodes })
+    sortNodesByGroups({
+      getOptionsByGroupNumber: () => ({ options }),
+      ignoreEslintDisabledNodes,
+      groups: options.groups,
+      nodes,
+    })
 
   reportAllErrors<MESSAGE_ID>({
     availableMessageIds: {

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -504,21 +504,26 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let sortNodesExcludingEslintDisabled = (
             ignoreEslintDisabledNodes: boolean,
           ): SortImportsSortingNode[] =>
-            sortNodesByGroups(nodes, options, {
-              getGroupCompareOptions: groupNumber => {
+            sortNodesByGroups({
+              getOptionsByGroupNumber: groupNumber => {
                 if (options.sortSideEffects) {
-                  return options
+                  return {
+                    options,
+                  }
                 }
-                let group = options.groups[groupNumber]
                 return {
-                  ...options,
-                  type: isSideEffectOnlyGroup(group)
-                    ? 'unsorted'
-                    : options.type,
+                  options: {
+                    ...options,
+                    type: isSideEffectOnlyGroup(options.groups[groupNumber])
+                      ? 'unsorted'
+                      : options.type,
+                  },
                 }
               },
               isNodeIgnored: node => node.isIgnored,
               ignoreEslintDisabledNodes,
+              groups: options.groups,
+              nodes,
             })
 
           reportAllErrors<MESSAGE_ID>({

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -188,7 +188,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
         let sortNodesExcludingEslintDisabled = (
           ignoreEslintDisabledNodes: boolean,
         ): SortingNode[] =>
-          sortNodesByGroups(nodes, options, { ignoreEslintDisabledNodes })
+          sortNodesByGroups({
+            getOptionsByGroupNumber: () => ({ options }),
+            ignoreEslintDisabledNodes,
+            groups: options.groups,
+            nodes,
+          })
 
         reportAllErrors<MESSAGE_ID>({
           availableMessageIds: {

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -19,9 +19,9 @@ import {
   GROUP_ORDER_ERROR,
   ORDER_ERROR,
 } from '../utils/report-errors'
+import { buildGetCustomGroupOverriddenOptionsFunction } from '../utils/get-custom-groups-compare-options'
 import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
-import { getCustomGroupsCompareOptions } from '../utils/get-custom-groups-compare-options'
 import { getMatchingContextOptions } from '../utils/get-matching-context-options'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { doesCustomGroupMatch } from './sort-maps/does-custom-group-match'
@@ -173,10 +173,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
           let sortNodesExcludingEslintDisabled = (
             ignoreEslintDisabledNodes: boolean,
           ): SortingNode[] =>
-            sortNodesByGroups(nodes, options, {
-              getGroupCompareOptions: groupNumber =>
-                getCustomGroupsCompareOptions(options, groupNumber),
+            sortNodesByGroups({
+              getOptionsByGroupNumber:
+                buildGetCustomGroupOverriddenOptionsFunction(options),
               ignoreEslintDisabledNodes,
+              groups: options.groups,
+              nodes,
             })
 
           reportAllErrors<MESSAGE_ID>({

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -141,8 +141,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreEslintDisabledNodes: boolean,
         ): SortNamedExportsSortingNode[] =>
           filteredGroupKindNodes.flatMap(groupedNodes =>
-            sortNodes(groupedNodes, options, {
+            sortNodes({
               ignoreEslintDisabledNodes,
+              nodes: groupedNodes,
+              options,
             }),
           )
 

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -139,8 +139,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ignoreEslintDisabledNodes: boolean,
         ): SortNamedImportsSortingNode[] =>
           filteredGroupKindNodes.flatMap(groupedNodes =>
-            sortNodes(groupedNodes, options, {
+            sortNodes({
               ignoreEslintDisabledNodes,
+              nodes: groupedNodes,
+              options,
             }),
           )
 

--- a/rules/sort-object-types/build-node-value-getter.ts
+++ b/rules/sort-object-types/build-node-value-getter.ts
@@ -1,6 +1,7 @@
+import type { NodeValueGetterFunction } from '../../utils/compare'
 import type { SortObjectTypesSortingNode } from './types'
 
 export let buildNodeValueGetter = (
   sortBy: 'value' | 'name',
-): ((node: SortObjectTypesSortingNode) => string) | null =>
+): NodeValueGetterFunction<SortObjectTypesSortingNode> | null =>
   sortBy === 'value' ? node => node.value ?? '' : null

--- a/rules/sort-object-types/get-custom-groups-compare-options.ts
+++ b/rules/sort-object-types/get-custom-groups-compare-options.ts
@@ -1,32 +1,47 @@
+import type { NodeValueGetterFunction } from '../../utils/compare'
 import type { SortObjectTypesSortingNode, Options } from './types'
-import type { CompareOptions } from '../../utils/compare'
 
+import { getCustomGroupsCompareOptions as baseGetCustomGroupsCompareOptions } from '../../utils/get-custom-groups-compare-options'
 import { buildNodeValueGetter } from './build-node-value-getter'
 
-export let getCustomGroupsCompareOptions = (
-  options: Required<Options[0]>,
-  groupNumber: number,
-): CompareOptions<SortObjectTypesSortingNode> & Required<Options[0]> => {
-  if (!Array.isArray(options.customGroups)) {
-    return options
-  }
-  let group = options.groups[groupNumber]
-  let customGroup =
-    typeof group === 'string'
-      ? options.customGroups.find(
-          currentGroup => group === currentGroup.groupName,
-        )
-      : null
+type InputOptions = Pick<
+  Required<Options[0]>,
+  'fallbackSort' | 'customGroups' | 'sortBy' | 'groups' | 'order' | 'type'
+>
 
-  let sortBy =
-    customGroup && 'sortBy' in customGroup ? customGroup.sortBy : options.sortBy
-  sortBy ??= options.sortBy
+export let getCustomGroupsCompareOptions = (
+  options: InputOptions,
+  groupNumber: number,
+): {
+  options: Pick<
+    Required<Options[0]>,
+    'fallbackSort' | 'sortBy' | 'order' | 'type'
+  >
+  nodeValueGetter?: NodeValueGetterFunction<SortObjectTypesSortingNode> | null
+} => {
+  let baseCompareOptions = baseGetCustomGroupsCompareOptions(
+    options,
+    groupNumber,
+  )
+
+  let { customGroups, sortBy, groups } = options
+  if (Array.isArray(customGroups)) {
+    let group = groups[groupNumber]
+    let customGroup =
+      typeof group === 'string'
+        ? customGroups.find(currentGroup => group === currentGroup.groupName)
+        : null
+
+    if (customGroup && 'sortBy' in customGroup && customGroup.sortBy) {
+      ;({ sortBy } = customGroup)
+    }
+  }
 
   return {
-    ...options,
+    options: {
+      ...baseCompareOptions,
+      sortBy,
+    },
     nodeValueGetter: buildNodeValueGetter(sortBy),
-    order: customGroup?.order ?? options.order,
-    type: customGroup?.type ?? options.type,
-    sortBy,
   }
 }

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -86,10 +86,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
       // For each case group, ensure the nodes are in the correct order.
       let hasUnsortedNodes = false
       for (let caseNodesSortingNodeGroup of caseNameSortingNodeGroups) {
-        let sortedCaseNameSortingNodes = sortNodes(
-          caseNodesSortingNodeGroup,
+        let sortedCaseNameSortingNodes = sortNodes({
+          nodes: caseNodesSortingNodeGroup,
+          ignoreEslintDisabledNodes: false,
           options,
-        )
+        })
         hasUnsortedNodes ||= sortedCaseNameSortingNodes.some(
           (node, index) => node !== caseNodesSortingNodeGroup[index],
         )
@@ -220,7 +221,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
           if (b.some(node => node.isDefaultClause)) {
             return -1
           }
-          return compare(a.at(0)!, b.at(0)!, options)
+          return compare({
+            a: a.at(0)!,
+            b: b.at(0)!,
+            options,
+          })
         })
         .flat()
       let sortingNodeGroupsForBlockSortFlat =

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -274,7 +274,12 @@ export let sortUnionOrIntersectionTypes = <MessageIds extends string>({
     let sortNodesExcludingEslintDisabled = (
       ignoreEslintDisabledNodes: boolean,
     ): SortingNode[] =>
-      sortNodesByGroups(nodes, options, { ignoreEslintDisabledNodes })
+      sortNodesByGroups({
+        getOptionsByGroupNumber: () => ({ options }),
+        ignoreEslintDisabledNodes,
+        groups: options.groups,
+        nodes,
+      })
 
     reportAllErrors<MessageIds>({
       sortNodesExcludingEslintDisabled,

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -213,8 +213,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
       ): SortingNodeWithDependencies[] =>
         sortNodesByDependencies(
           formattedMembers.flatMap(nodes =>
-            sortNodes(nodes, options, {
+            sortNodes({
               ignoreEslintDisabledNodes,
+              options,
+              nodes,
             }),
           ),
           {

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1245,6 +1245,58 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedArrayIncludesOrder',
+                },
+              ],
+              output: dedent`
+                [
+                  'fooBar',
+                  'fooZar',
+                ].includes(value)
+              `,
+              code: dedent`
+                [
+                  'fooZar',
+                  'fooBar',
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: does not sort custom groups with 'unsorted' type`,
         rule,
         {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -8021,6 +8021,58 @@ describe(ruleName, () => {
     )
 
     ruleTester.run(
+      `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+      rule,
+      {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    fallbackSort: {
+                      type: 'alphabetical',
+                      order: 'asc',
+                    },
+                    elementNamePattern: '^foo',
+                    type: 'line-length',
+                    groupName: 'foo',
+                    order: 'desc',
+                  },
+                ],
+                type: 'alphabetical',
+                groups: ['foo'],
+                order: 'asc',
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  right: 'fooBar',
+                  left: 'fooZar',
+                },
+                messageId: 'unexpectedClassesOrder',
+              },
+            ],
+            output: dedent`
+              class Class {
+                fooBar: string
+                fooZar: string
+              }
+            `,
+            code: dedent`
+              class Class {
+                fooZar: string
+                fooBar: string
+              }
+            `,
+          },
+        ],
+        valid: [],
+      },
+    )
+
+    ruleTester.run(
       `${ruleName}: does not sort custom groups with 'unsorted' type`,
       rule,
       {

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1097,6 +1097,58 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedEnumsOrder',
+                },
+              ],
+              output: dedent`
+                enum Enum {
+                  fooBar = 'fooBar',
+                  fooZar = 'fooZar',
+                }
+              `,
+              code: dedent`
+                enum Enum {
+                  fooZar = 'fooZar',
+                  fooBar = 'fooBar',
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: does not sort custom groups with 'unsorted' type`,
         rule,
         {

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1257,6 +1257,58 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedInterfacePropertiesOrder',
+                },
+              ],
+              output: dedent`
+                interface Interface {
+                  fooBar: string
+                  fooZar: string
+                }
+              `,
+              code: dedent`
+                interface Interface {
+                  fooZar: string
+                  fooBar: string
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'sortBy'`,
         rule,
         {

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -926,6 +926,58 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedMapElementsOrder',
+                },
+              ],
+              output: dedent`
+                new Map([
+                  [fooBar, fooBar],
+                  [fooZar, fooZar],
+                ])
+              `,
+              code: dedent`
+                new Map([
+                  [fooZar, fooZar],
+                  [fooBar, fooBar],
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: does not sort custom groups with 'unsorted' type`,
         rule,
         {

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -658,6 +658,54 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedModulesOrder',
+                },
+              ],
+              output: dedent`
+                function fooBar() {}
+                function fooZar() {}
+              `,
+              code: dedent`
+                function fooZar() {}
+                function fooBar() {}
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: does not sort custom groups with 'unsorted' type`,
         rule,
         {

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -998,6 +998,58 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedObjectTypesOrder',
+                },
+              ],
+              output: dedent`
+                type Type = {
+                  fooBar: string
+                  fooZar: string
+                }
+              `,
+              code: dedent`
+                type Type = {
+                  fooZar: string
+                  fooBar: string
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'sortBy'`,
         rule,
         {

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2963,6 +2963,58 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedObjectsOrder',
+                },
+              ],
+              output: dedent`
+                let obj = {
+                  fooBar: 'fooBar',
+                  fooZar: 'fooZar',
+                }
+              `,
+              code: dedent`
+                let obj = {
+                  fooZar: 'fooZar',
+                  fooBar: 'fooBar',
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: does not sort custom groups with 'unsorted' type`,
         rule,
         {

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1192,6 +1192,58 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedSetsOrder',
+                },
+              ],
+              output: dedent`
+                new Set([
+                  'fooBar',
+                  'fooZar',
+                ])
+              `,
+              code: dedent`
+                new Set([
+                  'fooZar',
+                  'fooBar',
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}: does not sort custom groups with 'unsorted' type`,
         rule,
         {

--- a/test/utils/compare.test.ts
+++ b/test/utils/compare.test.ts
@@ -7,131 +7,149 @@ import { compare } from '../../utils/compare'
 
 describe('compare', () => {
   describe('alphabetical', () => {
-    let compareOptions = {
+    let options = {
       fallbackSort: { type: 'unsorted' } as const,
       specialCharacters: 'keep' as const,
       type: 'alphabetical' as const,
       locales: 'en-US' as const,
       order: 'asc' as const,
       ignoreCase: false,
+      alphabet: '',
     }
 
     it('sorts by order asc', () => {
       expect(
-        compare(
-          createTestNode({ name: 'b' }),
-          createTestNode({ name: 'a' }),
-          compareOptions,
-        ),
+        compare({
+          b: createTestNode({ name: 'a' }),
+          a: createTestNode({ name: 'b' }),
+          options,
+        }),
       ).toBe(1)
     })
 
     it('sorts by order desc', () => {
       expect(
-        compare(createTestNode({ name: 'a' }), createTestNode({ name: 'b' }), {
-          ...compareOptions,
-          order: 'desc',
+        compare({
+          options: {
+            ...options,
+            order: 'desc',
+          },
+          a: createTestNode({ name: 'a' }),
+          b: createTestNode({ name: 'b' }),
         }),
       ).toBe(1)
     })
 
     it('sorts ignoring case', () => {
       expect(
-        compare(
-          createTestNode({ name: 'aB' }),
-          createTestNode({ name: 'Ab' }),
-          {
-            ...compareOptions,
+        compare({
+          options: {
+            ...options,
             ignoreCase: true,
           },
-        ),
+          a: createTestNode({ name: 'aB' }),
+          b: createTestNode({ name: 'Ab' }),
+        }),
       ).toBe(0)
     })
 
     it('sorts while trimming special characters', () => {
       expect(
-        compare(createTestNode({ name: '_a' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-          specialCharacters: 'trim',
+        compare({
+          options: {
+            ...options,
+            specialCharacters: 'trim',
+          },
+          a: createTestNode({ name: '_a' }),
+          b: createTestNode({ name: 'a' }),
         }),
       ).toBe(0)
     })
 
     it('sorts while removing special characters', () => {
       expect(
-        compare(
-          createTestNode({ name: 'ab' }),
-          createTestNode({ name: 'a_b' }),
-          {
-            ...compareOptions,
+        compare({
+          options: {
+            ...options,
             specialCharacters: 'remove',
           },
-        ),
+          b: createTestNode({ name: 'a_b' }),
+          a: createTestNode({ name: 'ab' }),
+        }),
       ).toBe(0)
     })
   })
 
   describe('natural', () => {
-    let compareOptions = {
+    let options = {
       fallbackSort: { type: 'unsorted' } as const,
       specialCharacters: 'keep' as const,
       locales: 'en-US' as const,
       type: 'natural' as const,
       order: 'asc' as const,
       ignoreCase: false,
+      alphabet: '',
     }
 
     it('sorts by order asc', () => {
       expect(
-        compare(
-          createTestNode({ name: 'b' }),
-          createTestNode({ name: 'a' }),
-          compareOptions,
-        ),
+        compare({
+          b: createTestNode({ name: 'a' }),
+          a: createTestNode({ name: 'b' }),
+          options,
+        }),
       ).toBe(1)
     })
 
     it('sorts by order desc', () => {
       expect(
-        compare(createTestNode({ name: 'a' }), createTestNode({ name: 'b' }), {
-          ...compareOptions,
-          order: 'desc',
+        compare({
+          options: {
+            ...options,
+            order: 'desc',
+          },
+          a: createTestNode({ name: 'a' }),
+          b: createTestNode({ name: 'b' }),
         }),
       ).toBe(1)
     })
 
     it('sorts ignoring case', () => {
       expect(
-        compare(
-          createTestNode({ name: 'aB' }),
-          createTestNode({ name: 'Ab' }),
-          {
-            ...compareOptions,
+        compare({
+          options: {
+            ...options,
             ignoreCase: true,
           },
-        ),
+          a: createTestNode({ name: 'aB' }),
+          b: createTestNode({ name: 'Ab' }),
+        }),
       ).toBe(0)
     })
 
     it('sorts while trimming special characters', () => {
       expect(
-        compare(createTestNode({ name: '_a' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-          specialCharacters: 'trim',
+        compare({
+          options: {
+            ...options,
+            specialCharacters: 'trim',
+          },
+          a: createTestNode({ name: '_a' }),
+          b: createTestNode({ name: 'a' }),
         }),
       ).toBe(0)
     })
 
     it('sorts while removing special characters', () => {
       expect(
-        compare(
-          createTestNode({ name: 'ab' }),
-          createTestNode({ name: 'a_b' }),
-          {
-            ...compareOptions,
+        compare({
+          options: {
+            ...options,
             specialCharacters: 'remove',
           },
-        ),
+          b: createTestNode({ name: 'a_b' }),
+          a: createTestNode({ name: 'ab' }),
+        }),
       ).toBe(0)
     })
   })
@@ -144,30 +162,38 @@ describe('compare', () => {
       locales: 'en-US' as const,
       order: 'desc' as const,
       ignoreCase: false,
+      alphabet: '',
     }
 
     it('sorts by order asc', () => {
       expect(
-        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'aa' }), {
-          ...compareOptions,
-          order: 'asc',
+        compare({
+          options: {
+            ...compareOptions,
+            order: 'desc',
+          },
+          b: createTestNode({ name: 'aa' }),
+          a: createTestNode({ name: 'b' }),
         }),
-      ).toBe(-1)
+      ).toBe(1)
     })
 
     it('sorts by order desc', () => {
       expect(
-        compare(
-          createTestNode({ name: 'aa' }),
-          createTestNode({ name: 'b' }),
-          compareOptions,
-        ),
+        compare({
+          options: {
+            ...compareOptions,
+            order: 'desc',
+          },
+          a: createTestNode({ name: 'aa' }),
+          b: createTestNode({ name: 'b' }),
+        }),
       ).toBe(-1)
     })
   })
 
   describe('custom', () => {
-    let compareOptions = {
+    let options = {
       alphabet: Alphabet.generateRecommendedAlphabet()
         .sortByLocaleCompare('en-US')
         .getCharacters(),
@@ -181,90 +207,109 @@ describe('compare', () => {
 
     it('sorts by order asc', () => {
       expect(
-        compare(
-          createTestNode({ name: 'b' }),
-          createTestNode({ name: 'a' }),
-          compareOptions,
-        ),
+        compare({
+          b: createTestNode({ name: 'a' }),
+          a: createTestNode({ name: 'b' }),
+          options,
+        }),
       ).toBe(1)
     })
 
     it('sorts by order desc', () => {
       expect(
-        compare(createTestNode({ name: 'a' }), createTestNode({ name: 'b' }), {
-          ...compareOptions,
-          order: 'desc',
+        compare({
+          options: {
+            ...options,
+            order: 'desc',
+          },
+          a: createTestNode({ name: 'a' }),
+          b: createTestNode({ name: 'b' }),
         }),
       ).toBe(1)
     })
 
     it('sorts ignoring case', () => {
       expect(
-        compare(
-          createTestNode({ name: 'aB' }),
-          createTestNode({ name: 'Ab' }),
-          {
-            ...compareOptions,
+        compare({
+          options: {
+            ...options,
             ignoreCase: true,
           },
-        ),
+          a: createTestNode({ name: 'aB' }),
+          b: createTestNode({ name: 'Ab' }),
+        }),
       ).toBe(0)
     })
 
     it('sorts while trimming special characters', () => {
       expect(
-        compare(createTestNode({ name: '_a' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-          specialCharacters: 'trim',
+        compare({
+          options: {
+            ...options,
+            specialCharacters: 'trim',
+          },
+          a: createTestNode({ name: '_a' }),
+          b: createTestNode({ name: 'a' }),
         }),
       ).toBe(0)
     })
 
     it('sorts while removing special characters', () => {
       expect(
-        compare(
-          createTestNode({ name: 'ab' }),
-          createTestNode({ name: 'a_b' }),
-          {
-            ...compareOptions,
+        compare({
+          options: {
+            ...options,
             specialCharacters: 'remove',
           },
-        ),
+          b: createTestNode({ name: 'a_b' }),
+          a: createTestNode({ name: 'ab' }),
+        }),
       ).toBe(0)
     })
 
     it('gives minimum priority to characters not in the alphabet', () => {
       expect(
-        compare(createTestNode({ name: 'a' }), createTestNode({ name: 'b' }), {
-          ...compareOptions,
-          alphabet: 'b',
+        compare({
+          options: {
+            ...options,
+            alphabet: 'b',
+          },
+          a: createTestNode({ name: 'a' }),
+          b: createTestNode({ name: 'b' }),
         }),
       ).toBe(1)
+
       expect(
-        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-          alphabet: 'b',
+        compare({
+          options: {
+            ...options,
+            alphabet: 'b',
+          },
+          b: createTestNode({ name: 'a' }),
+          a: createTestNode({ name: 'b' }),
         }),
       ).toBe(-1)
-      expect(
-        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-          alphabet: 'c',
-        }),
-      ).toBe(0)
     })
 
     it('gives maximum priority to void', () => {
       expect(
-        compare(createTestNode({ name: 'a' }), createTestNode({ name: '' }), {
-          ...compareOptions,
-          alphabet: 'a',
+        compare({
+          options: {
+            ...options,
+            alphabet: 'a',
+          },
+          a: createTestNode({ name: 'a' }),
+          b: createTestNode({ name: '' }),
         }),
       ).toBe(1)
       expect(
-        compare(createTestNode({ name: '' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
-          alphabet: 'a',
+        compare({
+          options: {
+            ...options,
+            alphabet: 'a',
+          },
+          b: createTestNode({ name: 'a' }),
+          a: createTestNode({ name: '' }),
         }),
       ).toBe(-1)
     })
@@ -278,55 +323,105 @@ describe('compare', () => {
       locales: 'en-US' as const,
       order: 'desc' as const,
       ignoreCase: false,
+      alphabet: '',
     }
 
     it('does not sort', () => {
       expect(
-        compare(createTestNode({ name: 'b' }), createTestNode({ name: 'a' }), {
-          ...compareOptions,
+        compare({
+          a: createTestNode({ name: 'b' }),
+          b: createTestNode({ name: 'a' }),
+          options: compareOptions,
         }),
       ).toBe(0)
     })
   })
 
+  describe('"nodeValueGetter"', () => {
+    let options = {
+      specialCharacters: 'keep' as const,
+      type: 'alphabetical' as const,
+      locales: 'en-US' as const,
+      order: 'asc' as const,
+      ignoreCase: false,
+      alphabet: '',
+    }
+
+    it('sorts using the "nodeValueGetter"', () => {
+      let a = createTestNode({
+        additionalProperties: { value: 'b' },
+        name: 'a',
+      })
+      let b = createTestNode({
+        additionalProperties: { value: 'a' },
+        name: 'b',
+      })
+      expect(
+        compare({
+          options: {
+            ...options,
+            fallbackSort: { type: 'unsorted' },
+          },
+          nodeValueGetter: node =>
+            'value' in node ? (node.value as string) : '',
+          a,
+          b,
+        }),
+      ).toBe(1)
+    })
+  })
+
   describe('fallback sorting', () => {
-    let compareOptions = {
+    let options = {
       specialCharacters: 'keep' as const,
       type: 'line-length' as const,
       locales: 'en-US' as const,
       order: 'desc' as const,
       ignoreCase: false,
+      alphabet: '',
     }
 
     it('sorts using the fallback configuration', () => {
-      let nodeAaa = createTestNode({ name: 'aaa' })
-      let nodeBbb = createTestNode({ name: 'bbb' })
+      let a = createTestNode({ name: 'aaa' })
+      let b = createTestNode({ name: 'bbb' })
       expect(
-        compare(nodeBbb, nodeAaa, {
-          ...compareOptions,
-          fallbackSort: {
-            type: 'alphabetical',
-            order: 'asc',
-          } as const,
+        compare({
+          options: {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+              order: 'asc',
+            },
+          },
+          a: b,
+          b: a,
         }),
       ).toBe(1)
 
       expect(
-        compare(nodeBbb, nodeAaa, {
-          ...compareOptions,
-          fallbackSort: {
-            type: 'alphabetical',
-            order: 'desc',
-          } as const,
+        compare({
+          options: {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+              order: 'desc',
+            },
+          },
+          a: b,
+          b: a,
         }),
       ).toBe(-1)
 
       expect(
-        compare(nodeBbb, nodeAaa, {
-          ...compareOptions,
-          fallbackSort: {
-            type: 'alphabetical',
-          } as const,
+        compare({
+          options: {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+            },
+          },
+          a: b,
+          b: a,
         }),
       ).toBe(-1)
     })
@@ -335,20 +430,31 @@ describe('compare', () => {
       let node = createTestNode({ name: 'aaa' })
       let duplicateNode = createTestNode({ name: 'aaa' })
       expect(
-        compare(node, duplicateNode, {
-          ...compareOptions,
-          fallbackSort: {
-            type: 'alphabetical',
-            order: 'asc',
-          } as const,
+        compare({
+          options: {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+              order: 'asc',
+            } as const,
+          },
+          b: duplicateNode,
+          a: node,
         }),
       ).toBe(0)
     })
   })
 
-  let createTestNode = ({ name }: { name: string }): SortingNode =>
+  let createTestNode = ({
+    additionalProperties,
+    name,
+  }: {
+    additionalProperties?: object
+    name: string
+  }): SortingNode =>
     ({
       size: name.length,
       name,
+      ...additionalProperties,
     }) as SortingNode
 })

--- a/test/utils/get-custom-groups-compare-options.test.ts
+++ b/test/utils/get-custom-groups-compare-options.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CommonOptions } from '../../types/common-options'
+
+import { getCustomGroupsCompareOptions } from '../../utils/get-custom-groups-compare-options'
+
+describe('get-custom-groups-compare-options', () => {
+  let baseOptions: Pick<CommonOptions, 'fallbackSort' | 'order' | 'type'> = {
+    fallbackSort: {
+      type: 'unsorted',
+    },
+    type: 'alphabetical',
+    order: 'asc',
+  }
+
+  it('return the entered options if "customGroups" is not an array', () => {
+    expect(
+      getCustomGroupsCompareOptions(
+        {
+          ...baseOptions,
+          groups: ['group'],
+          customGroups: {},
+        },
+        0,
+      ),
+    ).toStrictEqual({
+      ...baseOptions,
+    })
+  })
+
+  it('return the entered options if the group is not linked to a custom group', () => {
+    expect(
+      getCustomGroupsCompareOptions(
+        {
+          ...baseOptions,
+          groups: ['group'],
+          customGroups: [],
+        },
+        0,
+      ),
+    ).toStrictEqual({
+      ...baseOptions,
+    })
+  })
+
+  it('overrides "fallbackSort"', () => {
+    expect(
+      getCustomGroupsCompareOptions(
+        {
+          ...baseOptions,
+          customGroups: [
+            {
+              fallbackSort: {
+                type: 'unsorted',
+              },
+              groupName: 'group',
+            },
+          ],
+          groups: ['group'],
+        },
+        0,
+      ),
+    ).toStrictEqual({
+      ...baseOptions,
+      fallbackSort: {
+        type: 'unsorted',
+      },
+    })
+  })
+
+  it('overrides "type"', () => {
+    expect(
+      getCustomGroupsCompareOptions(
+        {
+          ...baseOptions,
+          customGroups: [
+            {
+              groupName: 'group',
+              type: 'unsorted',
+            },
+          ],
+          groups: ['group'],
+        },
+        0,
+      ),
+    ).toStrictEqual({
+      ...baseOptions,
+
+      fallbackSort: {
+        type: 'unsorted',
+      },
+      type: 'unsorted',
+    })
+  })
+
+  it('overrides "order"', () => {
+    expect(
+      getCustomGroupsCompareOptions(
+        {
+          ...baseOptions,
+          customGroups: [
+            {
+              groupName: 'group',
+              order: 'desc',
+            },
+          ],
+          groups: ['group'],
+        },
+        0,
+      ),
+    ).toStrictEqual({
+      ...baseOptions,
+
+      fallbackSort: {
+        type: 'unsorted',
+      },
+      order: 'desc',
+    })
+  })
+})

--- a/test/utils/get-settings.test.ts
+++ b/test/utils/get-settings.test.ts
@@ -20,6 +20,7 @@ describe('get-settings', () => {
 
   it('accepts official settings provided', () => {
     let allowedOptions: { [key in keyof Required<Settings>]: Settings[key] } = {
+      fallbackSort: { type: 'alphabetical' },
       partitionByComment: 'value',
       specialCharacters: 'keep',
       partitionByNewLine: true,

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -1,10 +1,10 @@
 export type CustomGroupsOption<SingleCustomGroup = object> = ({
   newlinesInside?: 'always' | 'never'
+  fallbackSort?: FallbackSortOption
+  order?: OrderOption
   groupName: string
-} & (AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup) & {
-    order?: OrderOption
-    type?: TypeOption
-  })[]
+  type?: TypeOption
+} & (AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup))[]
 
 export interface CommonOptions {
   specialCharacters: SpecialCharactersOption

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -201,6 +201,7 @@ let commonCustomGroupJsonSchemas: Record<string, JSONSchema4> = {
     description: 'Custom group name.',
     type: 'string',
   },
+  fallbackSort: fallbackSortJsonSchema,
   order: orderJsonSchema,
   type: typeJsonSchema,
 }

--- a/utils/get-custom-groups-compare-options.ts
+++ b/utils/get-custom-groups-compare-options.ts
@@ -1,43 +1,87 @@
 import type {
   DeprecatedCustomGroupsOption,
   CustomGroupsOption,
+  FallbackSortOption,
   GroupsOptions,
-  CommonOptions,
+  OrderOption,
+  TypeOption,
 } from '../types/common-options'
+import type { BaseSortNodesByGroupsOptions } from './sort-nodes-by-groups'
 
-type BaseOptions = {
+interface GroupRelatedOptions {
   customGroups: DeprecatedCustomGroupsOption | CustomGroupsOption
   groups: GroupsOptions<string>
-} & CommonOptions
+}
+
+interface OverridableOptions {
+  fallbackSort: FallbackSortOption
+  order: OrderOption
+  type: TypeOption
+}
 
 /**
  * Retrieves the compare options used to sort a given group. If the group is a
  * custom group, its options will be favored over the default options. Returns
  * `null` if the group should not be sorted.
- * @param {BaseOptions} options - The sorting options, including groups and
+ * @param {GroupRelatedOptions & OverridableOptions} options - The sorting options, including groups and
  * custom groups.
  * @param {number} groupNumber - The index of the group to retrieve compare
  * options for.
- * @returns {BaseOptions} The options for the group
+ * @returns {object} The options for the group
  */
-export let getCustomGroupsCompareOptions = <Options extends BaseOptions>(
-  options: Options,
+export let getCustomGroupsCompareOptions = (
+  options: GroupRelatedOptions & OverridableOptions,
   groupNumber: number,
-): Options => {
-  if (!Array.isArray(options.customGroups)) {
-    return options
+): OverridableOptions => {
+  let { customGroups, fallbackSort, groups, order, type } = options
+
+  if (Array.isArray(customGroups)) {
+    let group = groups[groupNumber]
+    let customGroup =
+      typeof group === 'string'
+        ? customGroups.find(currentGroup => group === currentGroup.groupName)
+        : null
+
+    if (customGroup) {
+      fallbackSort = {
+        type: customGroup.fallbackSort?.type ?? fallbackSort.type,
+      }
+      let fallbackOrder = customGroup.fallbackSort?.order ?? fallbackSort.order
+      if (fallbackOrder) {
+        fallbackSort.order = fallbackOrder
+      }
+      order = customGroup.order ?? order
+      type = customGroup.type ?? type
+    }
   }
-  let group = options.groups[groupNumber]
-  let customGroup =
-    typeof group === 'string'
-      ? options.customGroups.find(
-          currentGroup => group === currentGroup.groupName,
-        )
-      : null
 
   return {
-    ...options,
-    order: customGroup?.order ?? options.order,
-    type: customGroup?.type ?? options.type,
+    fallbackSort,
+    order,
+    type,
   }
 }
+
+export let buildGetCustomGroupOverriddenOptionsFunction =
+  (
+    options: BaseSortNodesByGroupsOptions & GroupRelatedOptions,
+  ): ((groupNumber: number) => {
+    options: BaseSortNodesByGroupsOptions
+  }) =>
+  (groupNumber: number) => ({
+    options: getCustomGroupOverriddenOptions({
+      groupNumber,
+      options,
+    }),
+  })
+
+export let getCustomGroupOverriddenOptions = ({
+  groupNumber,
+  options,
+}: {
+  options: BaseSortNodesByGroupsOptions & GroupRelatedOptions
+  groupNumber: number
+}): BaseSortNodesByGroupsOptions => ({
+  ...options,
+  ...getCustomGroupsCompareOptions(options, groupNumber),
+})

--- a/utils/get-settings.ts
+++ b/utils/get-settings.ts
@@ -2,6 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import type {
   SpecialCharactersOption,
+  FallbackSortOption,
   OrderOption,
   RegexOption,
   TypeOption,
@@ -18,6 +19,7 @@ export type Settings = Partial<{
     | string
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
+  fallbackSort: FallbackSortOption
   partitionByNewLine: boolean
   ignorePattern: RegexOption
   ignoreCase: boolean
@@ -39,6 +41,7 @@ export let getSettings = (
       'partitionByNewLine',
       'specialCharacters',
       'ignorePattern',
+      'fallbackSort',
       'ignoreCase',
       'alphabet',
       'locales',


### PR DESCRIPTION
Follow-up of https://github.com/azat-io/eslint-plugin-perfectionist/pull/457 and https://github.com/azat-io/eslint-plugin-perfectionist/pull/469.

### Description

This PR does the following: 

- Adds a `customGroups.fallbackSort` option to rules that support the array-based `customGroups` API.
- Adds the `fallbackSort` option to `settings`.
- Improves documentation readability.
- Refactors `compare`, `sort-nodes` and `sort-nodes-by-groups` in order to prepare for the next PR that will allow us to finally let `sort-object-types` and `sort-interfaces` handle `customGroups.fallbackSort.sortBy`.
- Adds missing tests.

### What is the purpose of this pull request?

- [x] New Feature
