### PR TITLE
feat(sort-objects): add `fallbackSort.sortByValue`-related options

### DIFF
--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -162,6 +162,7 @@ Determines whether the sorted items should be in ascending or descending order.
   {
     type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
     order?: 'asc' | 'desc'
+    sortBy?: 'name' | 'value'
   }
   ```
 </sub>
@@ -560,7 +561,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
-  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  fallbackSort?: { type: string; order?: 'asc' | 'desc'; sortBy?: 'name' | 'value' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   selector?: string
@@ -579,7 +580,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
-  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  fallbackSort?: { type: string; order?: 'asc' | 'desc'; sortBy?: 'name' | 'value' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   anyOf: Array<{

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -124,6 +124,7 @@ Determines whether the sorted items should be in ascending or descending order.
   {
     type: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted'
     order?: 'asc' | 'desc'
+    sortBy?: 'name' | 'value'
   }
   ```
 </sub>
@@ -507,7 +508,7 @@ interface CustomGroupDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
-  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  fallbackSort?: { type: string; order?: 'asc' | 'desc'; sortBy?: 'name' | 'value' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   selector?: string
@@ -526,7 +527,7 @@ interface CustomGroupAnyOfDefinition {
   groupName: string
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
-  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  fallbackSort?: { type: string; order?: 'asc' | 'desc'; sortBy?: 'name' | 'value' }
   sortBy?: 'name' | 'value'
   newlinesInside?: 'always' | 'never'
   anyOf: Array<{

--- a/rules/sort-object-types/get-custom-groups-compare-options.ts
+++ b/rules/sort-object-types/get-custom-groups-compare-options.ts
@@ -17,6 +17,7 @@ export let getCustomGroupsCompareOptions = (
     Required<Options[0]>,
     'fallbackSort' | 'sortBy' | 'order' | 'type'
   >
+  fallbackSortNodeValueGetter?: NodeValueGetterFunction<SortObjectTypesSortingNode> | null
   nodeValueGetter?: NodeValueGetterFunction<SortObjectTypesSortingNode> | null
 } => {
   let baseCompareOptions = baseGetCustomGroupsCompareOptions(
@@ -24,7 +25,8 @@ export let getCustomGroupsCompareOptions = (
     groupNumber,
   )
 
-  let { customGroups, sortBy, groups } = options
+  let { fallbackSort, customGroups, sortBy, groups } = options
+  let fallbackSortBy = fallbackSort.sortBy
   if (Array.isArray(customGroups)) {
     let group = groups[groupNumber]
     let customGroup =
@@ -32,16 +34,26 @@ export let getCustomGroupsCompareOptions = (
         ? customGroups.find(currentGroup => group === currentGroup.groupName)
         : null
 
-    if (customGroup && 'sortBy' in customGroup && customGroup.sortBy) {
-      ;({ sortBy } = customGroup)
+    if (customGroup) {
+      fallbackSortBy = customGroup.fallbackSort?.sortBy ?? fallbackSortBy
+      if ('sortBy' in customGroup && customGroup.sortBy) {
+        ;({ sortBy } = customGroup)
+      }
     }
   }
 
   return {
     options: {
       ...baseCompareOptions,
+      fallbackSort: {
+        ...baseCompareOptions.fallbackSort,
+        sortBy: fallbackSortBy,
+      },
       sortBy,
     },
+    fallbackSortNodeValueGetter: fallbackSortBy
+      ? buildNodeValueGetter(fallbackSortBy)
+      : null,
     nodeValueGetter: buildNodeValueGetter(sortBy),
   }
 }

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -6,6 +6,7 @@ import type {
   PartitionByCommentOption,
   NewlinesBetweenOption,
   CustomGroupsOption,
+  FallbackSortOption,
   CommonOptions,
   GroupsOptions,
   RegexOption,
@@ -21,13 +22,19 @@ import {
 
 export type Options = Partial<
   {
+    customGroups:
+      | CustomGroupsOption<
+          SingleCustomGroup,
+          {
+            fallbackSort?: { sortBy?: 'value' | 'name' } & FallbackSortOption
+          }
+        >
+      | DeprecatedCustomGroupsOption
     useConfigurationIf: {
       declarationMatchesPattern?: RegexOption
       allNamesMatchPattern?: RegexOption
     }
-    customGroups:
-      | CustomGroupsOption<SingleCustomGroup>
-      | DeprecatedCustomGroupsOption
+    fallbackSort: { sortBy?: 'value' | 'name' } & FallbackSortOption
     /**
      * @deprecated for {@link `groups`}
      */
@@ -41,7 +48,7 @@ export type Options = Partial<
      */
     ignorePattern: RegexOption
     sortBy: 'value' | 'name'
-  } & CommonOptions
+  } & Omit<CommonOptions, 'fallbackSort'>
 >[]
 
 export type SingleCustomGroup = (

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1303,6 +1303,47 @@ describe(ruleName, () => {
                 }
               `,
             },
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        sortBy: 'value',
+                      },
+                      elementValuePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedInterfacePropertiesOrder',
+                },
+              ],
+              output: dedent`
+                interface Interface {
+                  b: fooBar
+                  a: fooZar
+                }
+              `,
+              code: dedent`
+                interface Interface {
+                  a: fooZar
+                  b: fooBar
+                }
+              `,
+            },
           ],
           valid: [],
         },
@@ -5045,6 +5086,40 @@ describe(ruleName, () => {
                 c: string;
                 bb: string;
                 a: string;
+              }
+            `,
+          },
+          {
+            errors: [
+              {
+                data: {
+                  right: 'bb',
+                  left: 'c',
+                },
+                messageId: 'unexpectedInterfacePropertiesOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+              },
+            ],
+            output: dedent`
+              interface Interface {
+                bb: string;
+                c: boolean;
+                a: number;
+              }
+            `,
+            code: dedent`
+              interface Interface {
+                c: boolean;
+                bb: string;
+                a: number;
               }
             `,
           },

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -1044,6 +1044,47 @@ describe(ruleName, () => {
                 }
               `,
             },
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        sortBy: 'value',
+                      },
+                      elementValuePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedObjectTypesOrder',
+                },
+              ],
+              output: dedent`
+                type Type = {
+                  b: fooBar
+                  a: fooZar
+                }
+              `,
+              code: dedent`
+                type Type = {
+                  a: fooZar
+                  b: fooBar
+                }
+              `,
+            },
           ],
           valid: [],
         },
@@ -4325,6 +4366,40 @@ describe(ruleName, () => {
                 c: string;
                 bb: string;
                 a: string;
+              }
+            `,
+          },
+          {
+            errors: [
+              {
+                data: {
+                  right: 'bb',
+                  left: 'c',
+                },
+                messageId: 'unexpectedObjectTypesOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+              },
+            ],
+            output: dedent`
+              type Type = {
+                bb: string;
+                c: boolean;
+                a: number;
+              }
+            `,
+            code: dedent`
+              type Type = {
+                c: boolean;
+                bb: string;
+                a: number;
               }
             `,
           },

--- a/test/rules/sort-object-types/get-custom-groups-compare-options.test.ts
+++ b/test/rules/sort-object-types/get-custom-groups-compare-options.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
-import type { CommonOptions } from '../../types/common-options'
+import type { Options } from '../../../rules/sort-object-types/types'
 
-import { getCustomGroupsCompareOptions } from '../../utils/get-custom-groups-compare-options'
+import { getCustomGroupsCompareOptions } from '../../../rules/sort-object-types/get-custom-groups-compare-options'
 
 describe('get-custom-groups-compare-options', () => {
-  let baseOptions: Pick<CommonOptions, 'fallbackSort' | 'order' | 'type'> = {
+  let commonOptions: Pick<
+    Required<Options[0]>,
+    'fallbackSort' | 'sortBy' | 'order' | 'type'
+  > = {
     fallbackSort: {
       type: 'unsorted',
+      sortBy: 'name',
     },
     type: 'alphabetical',
+    sortBy: 'name',
     order: 'asc',
   }
 
@@ -17,14 +22,16 @@ describe('get-custom-groups-compare-options', () => {
     expect(
       getCustomGroupsCompareOptions(
         {
-          ...baseOptions,
+          ...commonOptions,
           groups: ['group'],
           customGroups: {},
         },
         0,
       ),
     ).toStrictEqual({
-      ...baseOptions,
+      fallbackSortNodeValueGetter: null,
+      options: commonOptions,
+      nodeValueGetter: null,
     })
   })
 
@@ -32,14 +39,16 @@ describe('get-custom-groups-compare-options', () => {
     expect(
       getCustomGroupsCompareOptions(
         {
-          ...baseOptions,
+          ...commonOptions,
           groups: ['group'],
           customGroups: [],
         },
         0,
       ),
     ).toStrictEqual({
-      ...baseOptions,
+      fallbackSortNodeValueGetter: null,
+      options: commonOptions,
+      nodeValueGetter: null,
     })
   })
 
@@ -48,7 +57,7 @@ describe('get-custom-groups-compare-options', () => {
       expect(
         getCustomGroupsCompareOptions(
           {
-            ...baseOptions,
+            ...commonOptions,
             customGroups: [
               {
                 fallbackSort: {
@@ -62,10 +71,15 @@ describe('get-custom-groups-compare-options', () => {
           0,
         ),
       ).toStrictEqual({
-        ...baseOptions,
-        fallbackSort: {
-          type: 'unsorted',
+        options: {
+          ...commonOptions,
+          fallbackSort: {
+            ...commonOptions.fallbackSort,
+            type: 'unsorted',
+          },
         },
+        fallbackSortNodeValueGetter: null,
+        nodeValueGetter: null,
       })
     })
 
@@ -73,7 +87,7 @@ describe('get-custom-groups-compare-options', () => {
       expect(
         getCustomGroupsCompareOptions(
           {
-            ...baseOptions,
+            ...commonOptions,
             customGroups: [
               {
                 fallbackSort: {
@@ -88,11 +102,47 @@ describe('get-custom-groups-compare-options', () => {
           0,
         ),
       ).toStrictEqual({
-        ...baseOptions,
-        fallbackSort: {
-          type: 'alphabetical',
-          order: 'desc',
+        options: {
+          ...commonOptions,
+          fallbackSort: {
+            ...commonOptions.fallbackSort,
+            type: 'alphabetical',
+            order: 'desc',
+          },
         },
+        fallbackSortNodeValueGetter: null,
+        nodeValueGetter: null,
+      })
+    })
+
+    it('overrides "fallbackSort.sortBy"', () => {
+      expect(
+        getCustomGroupsCompareOptions(
+          {
+            ...commonOptions,
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                groupName: 'group',
+              },
+            ],
+            groups: ['group'],
+          },
+          0,
+        ),
+      ).toStrictEqual({
+        options: {
+          ...commonOptions,
+          fallbackSort: {
+            type: 'alphabetical',
+            sortBy: 'value',
+          },
+        },
+        fallbackSortNodeValueGetter: expect.any(Function),
+        nodeValueGetter: null,
       })
     })
   })
@@ -101,7 +151,7 @@ describe('get-custom-groups-compare-options', () => {
     expect(
       getCustomGroupsCompareOptions(
         {
-          ...baseOptions,
+          ...commonOptions,
           customGroups: [
             {
               groupName: 'group',
@@ -113,11 +163,12 @@ describe('get-custom-groups-compare-options', () => {
         0,
       ),
     ).toStrictEqual({
-      ...baseOptions,
-      fallbackSort: {
+      options: {
+        ...commonOptions,
         type: 'unsorted',
       },
-      type: 'unsorted',
+      fallbackSortNodeValueGetter: null,
+      nodeValueGetter: null,
     })
   })
 
@@ -125,7 +176,7 @@ describe('get-custom-groups-compare-options', () => {
     expect(
       getCustomGroupsCompareOptions(
         {
-          ...baseOptions,
+          ...commonOptions,
           customGroups: [
             {
               groupName: 'group',
@@ -137,11 +188,12 @@ describe('get-custom-groups-compare-options', () => {
         0,
       ),
     ).toStrictEqual({
-      ...baseOptions,
-      fallbackSort: {
-        type: 'unsorted',
+      options: {
+        ...commonOptions,
+        order: 'desc',
       },
-      order: 'desc',
+      fallbackSortNodeValueGetter: null,
+      nodeValueGetter: null,
     })
   })
 })

--- a/test/utils/compare.test.ts
+++ b/test/utils/compare.test.ts
@@ -426,6 +426,32 @@ describe('compare', () => {
       ).toBe(-1)
     })
 
+    it('handles `fallbackSort.nodeValueGetter`', () => {
+      let a = createTestNode({
+        additionalProperties: { value: 'b' },
+        name: 'aaa',
+      })
+      let b = createTestNode({
+        additionalProperties: { value: 'a' },
+        name: 'bbb',
+      })
+      expect(
+        compare({
+          options: {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+              order: 'asc',
+            },
+          },
+          fallbackSortNodeValueGetter: node =>
+            'value' in node ? (node.value as string) : '',
+          a,
+          b,
+        }),
+      ).toBe(1)
+    })
+
     it("doesn't sort using the fallback configuration more than once", () => {
       let node = createTestNode({ name: 'aaa' })
       let duplicateNode = createTestNode({ name: 'aaa' })

--- a/test/utils/sort-nodes-by-groups.test.ts
+++ b/test/utils/sort-nodes-by-groups.test.ts
@@ -127,6 +127,33 @@ describe('sort-nodes-by-groups', () => {
     ).toStrictEqual([nodeB, nodeA])
   })
 
+  it('should handle "fallbackSortNodeValueGetter"', () => {
+    let nodeA = createTestNode(
+      { group: 'group1', name: 'a' },
+      { actualValue: 'b' },
+    )
+    let nodeB = createTestNode(
+      { group: 'group1', name: 'a' },
+      { actualValue: 'a' },
+    )
+    expect(
+      sortNodesByGroups({
+        getOptionsByGroupNumber: () => ({
+          options: {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+            },
+          },
+          fallbackSortNodeValueGetter: node => node.actualValue,
+        }),
+        ignoreEslintDisabledNodes: false,
+        nodes: [nodeA, nodeB],
+        groups: ['group1'],
+      }),
+    ).toStrictEqual([nodeB, nodeA])
+  })
+
   let createTestNode = <T extends object>(
     node: {
       isEslintDisabled?: boolean

--- a/test/utils/sort-nodes.test.ts
+++ b/test/utils/sort-nodes.test.ts
@@ -82,6 +82,24 @@ describe('sort-nodes', () => {
     ).toStrictEqual([nodeB, nodeA])
   })
 
+  it('should handle "fallbackSortNodeValueGetter"', () => {
+    let nodeA = createTestNode({ name: 'a' }, { actualValue: 'b' })
+    let nodeB = createTestNode({ name: 'a' }, { actualValue: 'a' })
+    expect(
+      sortNodes({
+        options: {
+          ...options,
+          fallbackSort: {
+            type: 'alphabetical',
+          },
+        },
+        fallbackSortNodeValueGetter: node => node.actualValue,
+        ignoreEslintDisabledNodes: false,
+        nodes: [nodeA, nodeB],
+      }),
+    ).toStrictEqual([nodeB, nodeA])
+  })
+
   let createTestNode = <T extends object>(
     node: {
       isEslintDisabled?: boolean

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -1,10 +1,14 @@
-export type CustomGroupsOption<SingleCustomGroup = object> = ({
+export type CustomGroupsOption<
+  SingleCustomGroup = object,
+  AdditionalOptions = Record<never, never>,
+> = ({
   newlinesInside?: 'always' | 'never'
   fallbackSort?: FallbackSortOption
   order?: OrderOption
   groupName: string
   type?: TypeOption
-} & (AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup))[]
+} & (AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup) &
+  AdditionalOptions)[]
 
 export interface CommonOptions {
   specialCharacters: SpecialCharactersOption

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -45,24 +45,36 @@ let specialCharactersJsonSchema: JSONSchema4 = {
   type: 'string',
 }
 
-let fallbackSortJsonSchema: JSONSchema4 = {
+let buildFallbackSortJsonSchema = ({
+  additionalProperties,
+}: {
+  additionalProperties?: Record<string, JSONSchema4>
+} = {}): JSONSchema4 => ({
   properties: {
     order: orderJsonSchema,
     type: typeJsonSchema,
+    ...additionalProperties,
   },
   description: 'Fallback sort order.',
   type: 'object',
-}
+})
 
-export let commonJsonSchemas: Record<string, JSONSchema4> = {
+export let buildCommonJsonSchemas = ({
+  additionalFallbackSortProperties,
+}: {
+  additionalFallbackSortProperties?: Record<string, JSONSchema4>
+} = {}): Record<string, JSONSchema4> => ({
+  fallbackSort: buildFallbackSortJsonSchema(additionalFallbackSortProperties),
   specialCharacters: specialCharactersJsonSchema,
-  fallbackSort: fallbackSortJsonSchema,
   ignoreCase: ignoreCaseJsonSchema,
   alphabet: alphabetJsonSchema,
   locales: localesJsonSchema,
   order: orderJsonSchema,
   type: typeJsonSchema,
-}
+})
+
+export let commonJsonSchemas: Record<string, JSONSchema4> =
+  buildCommonJsonSchemas()
 
 export let newlinesBetweenJsonSchema: JSONSchema4 = {
   description: 'Specifies how new lines should be handled between groups.',
@@ -190,32 +202,42 @@ export let buildUseConfigurationIfJsonSchema = ({
   type: 'object',
 })
 
-let commonCustomGroupJsonSchemas: Record<string, JSONSchema4> = {
+let buildCommonCustomGroupJsonSchemas = ({
+  additionalFallbackSortProperties,
+}: {
+  additionalFallbackSortProperties?: Record<string, JSONSchema4>
+} = {}): Record<string, JSONSchema4> => ({
   newlinesInside: {
     description:
       'Specifies how new lines should be handled between members of the custom group.',
     enum: ['always', 'never'],
     type: 'string',
   },
+  fallbackSort: buildFallbackSortJsonSchema({
+    additionalProperties: additionalFallbackSortProperties,
+  }),
   groupName: {
     description: 'Custom group name.',
     type: 'string',
   },
-  fallbackSort: fallbackSortJsonSchema,
   order: orderJsonSchema,
   type: typeJsonSchema,
-}
+})
 
 export let buildCustomGroupsArrayJsonSchema = ({
+  additionalFallbackSortProperties,
   singleCustomGroupJsonSchema,
 }: {
+  additionalFallbackSortProperties?: Record<string, JSONSchema4>
   singleCustomGroupJsonSchema?: Record<string, JSONSchema4>
 }): JSONSchema4 => ({
   items: {
     oneOf: [
       {
         properties: {
-          ...commonCustomGroupJsonSchemas,
+          ...buildCommonCustomGroupJsonSchemas({
+            additionalFallbackSortProperties,
+          }),
           anyOf: {
             items: {
               properties: {
@@ -234,7 +256,9 @@ export let buildCustomGroupsArrayJsonSchema = ({
       },
       {
         properties: {
-          ...commonCustomGroupJsonSchemas,
+          ...buildCommonCustomGroupJsonSchemas({
+            additionalFallbackSortProperties,
+          }),
           ...singleCustomGroupJsonSchema,
         },
         description: 'Custom group.',

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -11,6 +11,7 @@ import { convertBooleanToSign } from './convert-boolean-to-sign'
 export type NodeValueGetterFunction<T extends SortingNode> = (node: T) => string
 
 interface CompareParameters<T extends SortingNode> {
+  fallbackSortNodeValueGetter?: NodeValueGetterFunction<T> | null
   options: { maxLineLength?: number } & CommonOptions
   nodeValueGetter?: NodeValueGetterFunction<T> | null
   a: T
@@ -23,6 +24,7 @@ type IndexByCharacters = Map<string, number>
 let alphabetCache = new Map<string, IndexByCharacters>()
 
 export let compare = <T extends SortingNode>({
+  fallbackSortNodeValueGetter,
   nodeValueGetter,
   options,
   a,
@@ -50,7 +52,7 @@ export let compare = <T extends SortingNode>({
       order: fallbackSort.order ?? order,
       type: fallbackSort.type,
     },
-    nodeValueGetter: finalNodeValueGetter,
+    nodeValueGetter: fallbackSortNodeValueGetter ?? finalNodeValueGetter,
     a,
     b,
   })

--- a/utils/sort-nodes-by-groups.ts
+++ b/utils/sort-nodes-by-groups.ts
@@ -14,6 +14,7 @@ interface SortNodesByGroupsParameters<
   T extends SortingNode,
 > {
   getOptionsByGroupNumber(groupNumber: number): {
+    fallbackSortNodeValueGetter?: NodeValueGetterFunction<T> | null
     nodeValueGetter?: NodeValueGetterFunction<T> | null
     options: Options
   }
@@ -54,9 +55,8 @@ export let sortNodesByGroups = <
   for (let groupNumber of Object.keys(nodesByNonIgnoredGroupNumber).sort(
     (a, b) => Number(a) - Number(b),
   )) {
-    let { nodeValueGetter, options } = getOptionsByGroupNumber(
-      Number(groupNumber),
-    )
+    let { fallbackSortNodeValueGetter, nodeValueGetter, options } =
+      getOptionsByGroupNumber(Number(groupNumber))
     let nodesToPush = nodesByNonIgnoredGroupNumber[Number(groupNumber)]!
 
     let groupIgnoredNodes = new Set(
@@ -67,6 +67,7 @@ export let sortNodesByGroups = <
       ...sortNodes({
         isNodeIgnored: node => groupIgnoredNodes.has(node),
         ignoreEslintDisabledNodes: false,
+        fallbackSortNodeValueGetter,
         nodes: nodesToPush,
         nodeValueGetter,
         options,

--- a/utils/sort-nodes.ts
+++ b/utils/sort-nodes.ts
@@ -5,6 +5,7 @@ import type { SortingNode } from '../types/sorting-node'
 import { compare } from './compare'
 
 interface SortNodesParameters<T extends SortingNode> {
+  fallbackSortNodeValueGetter?: NodeValueGetterFunction<T> | null
   options: { maxLineLength?: number } & CommonOptions
   nodeValueGetter?: NodeValueGetterFunction<T> | null
   ignoreEslintDisabledNodes: boolean
@@ -13,6 +14,7 @@ interface SortNodesParameters<T extends SortingNode> {
 }
 
 export let sortNodes = <T extends SortingNode>({
+  fallbackSortNodeValueGetter,
   ignoreEslintDisabledNodes,
   nodeValueGetter,
   isNodeIgnored,
@@ -34,6 +36,7 @@ export let sortNodes = <T extends SortingNode>({
 
   let sortedNodes = [...nonIgnoredNodes].sort((a, b) =>
     compare({
+      fallbackSortNodeValueGetter,
       nodeValueGetter,
       options,
       a,


### PR DESCRIPTION
Follow-up of https://github.com/azat-io/eslint-plugin-perfectionist/pull/457, https://github.com/azat-io/eslint-plugin-perfectionist/pull/469 and https://github.com/azat-io/eslint-plugin-perfectionist/pull/474.

Should fully resolve https://github.com/azat-io/eslint-plugin-perfectionist/issues/68 now.

# Description

This final PR adds the following options to `sort-objects` and `sort-interfaces`.
- `fallbackSort.sortByValue`.
- `customGroups.fallbackSort.sortByValue`.

## Example

```json
{
  "groups": [
    "unknown",
    "metaProperties"
  ],
  "customGroups": [
    {
      "type": "line-length",
      "groupName": "metaProperties",
      "elementNamePattern": "^_",
      "fallbackSort": {
        "type": "alphabetical",
        "order": "asc",
        "sortBy": "value"
      }
    }
  ]
}
```

Enforced result:
```ts
interface Interface {
  someNonMetaProperty: any;
  // All meta properties below have the same line-length => Sort them by alphabetical order ASC based on their value
  _arg1: number;
  _arg3: number;
  _arg5: number;
  _arg2: string;
  _arg4: string;
  _arg6: string;
}
```

## What is the purpose of this pull request?

- [x] New Feature