### PR TITLE
fix: prevent circular dependency loops

### DIFF
--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -67,10 +67,10 @@ export let reportAllErrors = <
 
     let firstUnorderedNodeDependentOnRight: undefined | T
     if (availableMessageIds.unexpectedDependencyOrder) {
-      firstUnorderedNodeDependentOnRight = getFirstUnorderedNodeDependentOn(
-        right as unknown as SortingNodeWithDependencies,
-        nodes as unknown as SortingNodeWithDependencies[],
-      ) as unknown as T
+      firstUnorderedNodeDependentOnRight = getFirstUnorderedNodeDependentOn({
+        nodes: nodes as unknown as SortingNodeWithDependencies[],
+        node: right as unknown as SortingNodeWithDependencies,
+      }) as unknown as T
     }
 
     if (

--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -6,6 +6,7 @@ import type { GroupsOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 import type { MakeFixesParameters } from './make-fixes'
 
+import { getNonCircularDependenciesByNode } from './sort-nodes-by-dependencies'
 import { getFirstUnorderedNodeDependentOn } from './sort-nodes-by-dependencies'
 import { createNodeIndexMap } from './create-node-index-map'
 import { getNewlinesErrors } from './get-newlines-errors'
@@ -53,6 +54,12 @@ export let reportAllErrors = <
     sortNodesExcludingEslintDisabled(true)
   let nodeIndexMap = createNodeIndexMap(sortedNodes)
 
+  let nonCircularDependenciesByNode =
+    availableMessageIds.unexpectedDependencyOrder
+      ? getNonCircularDependenciesByNode(
+          nodes as unknown as SortingNodeWithDependencies[],
+        )
+      : new Map()
   pairwise(nodes, (left, right) => {
     let leftNumber = options.groups ? getGroupNumber(options.groups, left) : 0
     let rightNumber = options.groups ? getGroupNumber(options.groups, right) : 0
@@ -70,6 +77,7 @@ export let reportAllErrors = <
       firstUnorderedNodeDependentOnRight = getFirstUnorderedNodeDependentOn({
         nodes: nodes as unknown as SortingNodeWithDependencies[],
         node: right as unknown as SortingNodeWithDependencies,
+        nonCircularDependenciesByNode,
       }) as unknown as T
     }
 

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -67,29 +67,30 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
 /**
  * Returns the first node that is dependent on the given node but is not ordered
  * before it.
- * @param {SortingNodeWithDependencies} node - The node to check dependencies
+ * @param {object} params - The parameters for the operation
+ * @param {SortingNodeWithDependencies} params.node - The node to check dependencies
  * for.
- * @param {SortingNodeWithDependencies[]} currentlyOrderedNodes - The list of
+ * @param {SortingNodeWithDependencies[]} params.nodes - The list of
  * nodes currently ordered.
  * @returns {SortingNodeWithDependencies | undefined} The first unordered
  * dependent node, or `undefined` if none found.
  */
 export let getFirstUnorderedNodeDependentOn = <
   T extends SortingNodeWithDependencies,
->(
-  node: T,
-  currentlyOrderedNodes: T[],
-): undefined | T => {
-  let nonCircularDependenciesByNode = getNonCircularDependenciesByNode(
-    currentlyOrderedNodes,
-  )
-  let nodesDependentOnNode = currentlyOrderedNodes.filter(
-    currentlyOrderedNode =>
-      nonCircularDependenciesByNode.get(currentlyOrderedNode)?.has(node),
+>({
+  nodes,
+  node,
+}: {
+  nodes: T[]
+  node: T
+}): undefined | T => {
+  let nodesNonCircularDependencies = getNonCircularDependenciesByNode(nodes)
+  let nodesDependentOnNode = nodes.filter(currentlyOrderedNode =>
+    nodesNonCircularDependencies.get(currentlyOrderedNode)?.has(node),
   )
   return nodesDependentOnNode.find(firstNodeDependentOnNode => {
-    let currentIndexOfNode = currentlyOrderedNodes.indexOf(node)
-    let currentIndexOfFirstNodeDependentOnNode = currentlyOrderedNodes.indexOf(
+    let currentIndexOfNode = nodes.indexOf(node)
+    let currentIndexOfFirstNodeDependentOnNode = nodes.indexOf(
       firstNodeDependentOnNode,
     )
     return currentIndexOfFirstNodeDependentOnNode < currentIndexOfNode

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -32,6 +32,7 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
   let result: T[] = []
   let visitedNodes = new Set<T>()
   let inProcessNodes = new Set<T>()
+  let nonCircularDependenciesByNode = getNonCircularDependenciesByNode(nodes)
 
   let visitNode = (sortingNode: T): void => {
     if (visitedNodes.has(sortingNode)) {
@@ -43,10 +44,7 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
     }
     inProcessNodes.add(sortingNode)
 
-    let dependentNodes = nodes.filter(({ dependencyName, name }) =>
-      sortingNode.dependencies.includes(dependencyName ?? name),
-    )
-    for (let dependentNode of dependentNodes) {
+    for (let dependentNode of nonCircularDependenciesByNode.get(sortingNode)!) {
       if (
         !extraOptions.ignoreEslintDisabledNodes ||
         !dependentNode.isEslintDisabled
@@ -82,11 +80,12 @@ export let getFirstUnorderedNodeDependentOn = <
   node: T,
   currentlyOrderedNodes: T[],
 ): undefined | T => {
+  let nonCircularDependenciesByNode = getNonCircularDependenciesByNode(
+    currentlyOrderedNodes,
+  )
   let nodesDependentOnNode = currentlyOrderedNodes.filter(
     currentlyOrderedNode =>
-      currentlyOrderedNode.dependencies.includes(
-        node.dependencyName ?? node.name,
-      ),
+      nonCircularDependenciesByNode.get(currentlyOrderedNode)?.has(node),
   )
   return nodesDependentOnNode.find(firstNodeDependentOnNode => {
     let currentIndexOfNode = currentlyOrderedNodes.indexOf(node)
@@ -95,4 +94,23 @@ export let getFirstUnorderedNodeDependentOn = <
     )
     return currentIndexOfFirstNodeDependentOnNode < currentIndexOfNode
   })
+}
+
+let getNonCircularDependenciesByNode = <T extends SortingNodeWithDependencies>(
+  nodes: T[],
+): Map<T, Set<T>> => {
+  let nonCircularDependenciesMap = new Map<T, Set<T>>()
+
+  for (let node of nodes) {
+    let dependentNodes = nodes.filter(({ dependencyName, name }) =>
+      node.dependencies.includes(dependencyName ?? name),
+    )
+    let nodeNonCircularDependencies: T[] = dependentNodes.filter(
+      dependentNode =>
+        !dependentNode.dependencies.includes(node.dependencyName ?? node.name),
+    )
+    nonCircularDependenciesMap.set(node, new Set(nodeNonCircularDependencies))
+  }
+
+  return nonCircularDependenciesMap
 }

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -72,21 +72,24 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
  * for.
  * @param {SortingNodeWithDependencies[]} params.nodes - The list of
  * nodes currently ordered.
+ * @param {Map<SortingNodeWithDependencies, Set<SortingNodeWithDependencies>>} params.nonCircularDependenciesByNode
+ * - The map of nodes to their non-circular dependencies.
  * @returns {SortingNodeWithDependencies | undefined} The first unordered
  * dependent node, or `undefined` if none found.
  */
 export let getFirstUnorderedNodeDependentOn = <
   T extends SortingNodeWithDependencies,
 >({
+  nonCircularDependenciesByNode,
   nodes,
   node,
 }: {
+  nonCircularDependenciesByNode: Map<T, Set<T>>
   nodes: T[]
   node: T
 }): undefined | T => {
-  let nodesNonCircularDependencies = getNonCircularDependenciesByNode(nodes)
   let nodesDependentOnNode = nodes.filter(currentlyOrderedNode =>
-    nodesNonCircularDependencies.get(currentlyOrderedNode)?.has(node),
+    nonCircularDependenciesByNode.get(currentlyOrderedNode)?.has(node),
   )
   return nodesDependentOnNode.find(firstNodeDependentOnNode => {
     let currentIndexOfNode = nodes.indexOf(node)
@@ -97,7 +100,9 @@ export let getFirstUnorderedNodeDependentOn = <
   })
 }
 
-let getNonCircularDependenciesByNode = <T extends SortingNodeWithDependencies>(
+export let getNonCircularDependenciesByNode = <
+  T extends SortingNodeWithDependencies,
+>(
   nodes: T[],
 ): Map<T, Set<T>> => {
   let nonCircularDependenciesMap = new Map<T, Set<T>>()


### PR DESCRIPTION
Fixes partially #477.

### Description

This PR prevents circular dependencies from raising unfixable errors:

```ts
class MyClass2 {
  static property = MyClass1.property;
}

class MyClass1 {
  static property = MyClass2.property;
}
```

Dependency order will not be enforced for elements being dependent in a circular way, meaning that the standard order will take over (it will expect `MyClass1` to come before `MyClass2` due to the alphabetical sort).

### What is the purpose of this pull request?

- [x] Bug fix
