### PR TITLE
fix: remove deprecated eslint get source code api

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -38,7 +38,6 @@ import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -169,7 +168,7 @@ export let sortArray = <MessageIds extends string>({
     return
   }
 
-  let sourceCode = getSourceCode(context)
+  let { sourceCode, id } = context
   let settings = getSettings(context.settings)
 
   let matchedContextOptions = getMatchingContextOptions({
@@ -189,7 +188,7 @@ export let sortArray = <MessageIds extends string>({
   validateNewlinesAndPartitionConfiguration(options)
 
   let eslintDisabledLines = getEslintDisabledLines({
-    ruleName: context.id,
+    ruleName: id,
     sourceCode,
   })
 

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -46,7 +46,6 @@ import { getDecoratorName } from '../utils/get-decorator-name'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
 import { getGroupNumber } from '../utils/get-group-number'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -127,9 +126,9 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
       })
       validateNewlinesAndPartitionConfiguration(options)
 
-      let sourceCode = getSourceCode(context)
+      let { sourceCode, id } = context
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
       let className = node.parent.id?.name

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -26,7 +26,6 @@ import { getDecoratorName } from '../utils/get-decorator-name'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -193,9 +192,9 @@ let sortDecorators = (
   if (!isSortable(decorators)) {
     return
   }
-  let sourceCode = getSourceCode(context)
+  let { sourceCode, id } = context
   let eslintDisabledLines = getEslintDisabledLines({
-    ruleName: context.id,
+    ruleName: id,
     sourceCode,
   })
 

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -35,7 +35,6 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
 import { getEnumMembers } from '../utils/get-enum-members'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -93,9 +92,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       })
       validateNewlinesAndPartitionConfiguration(options)
 
-      let sourceCode = getSourceCode(context)
+      let { sourceCode, id } = context
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
 

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -17,7 +17,6 @@ import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { ORDER_ERROR } from '../utils/report-errors'
 import { getSettings } from '../utils/get-settings'
@@ -63,9 +62,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
     let options = complete(context.options.at(0), settings, defaultOptions)
     validateCustomSortConfiguration(options)
 
-    let sourceCode = getSourceCode(context)
+    let { sourceCode, id } = context
     let eslintDisabledLines = getEslintDisabledLines({
-      ruleName: context.id,
+      ruleName: id,
       sourceCode,
     })
 

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -21,7 +21,6 @@ import { GROUP_ORDER_ERROR, ORDER_ERROR } from '../utils/report-errors'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -113,9 +112,9 @@ let sortHeritageClauses = (
   if (!isSortable(heritageClauses)) {
     return
   }
-  let sourceCode = getSourceCode(context)
+  let { sourceCode, id } = context
   let eslintDisabledLines = getEslintDisabledLines({
-    ruleName: context.id,
+    ruleName: id,
     sourceCode,
   })
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -42,7 +42,6 @@ import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -217,9 +216,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       }
     }
 
-    let sourceCode = getSourceCode(context)
+    let { sourceCode, filename, id } = context
     let eslintDisabledLines = getEslintDisabledLines({
-      ruleName: context.id,
+      ruleName: id,
       sourceCode,
     })
     let sortingNodes: SortImportsSortingNode[] = []
@@ -335,7 +334,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
         let resolution = typescriptImport.resolveModuleName(
           value,
-          context.filename,
+          filename,
           tsConfigOutput.compilerOptions,
           typescriptImport.sys,
           tsConfigOutput.cache,

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -34,7 +34,6 @@ import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -91,7 +90,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       }
 
       let settings = getSettings(context.settings)
-      let sourceCode = getSourceCode(context)
+      let { sourceCode, id } = context
       let matchedContextOptions = getMatchingContextOptions({
         nodeNames: node.openingElement.attributes
           .filter(
@@ -127,7 +126,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       }
 
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
 

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -31,7 +31,6 @@ import { singleCustomGroupJsonSchema } from './sort-maps/types'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -76,7 +75,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         return
       }
 
-      let sourceCode = getSourceCode(context)
+      let { sourceCode, id } = context
       let settings = getSettings(context.settings)
 
       let matchedContextOptions = getMatchingContextOptions({
@@ -97,7 +96,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       })
 
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
 

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -47,7 +47,6 @@ import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
 import { getGroupNumber } from '../utils/get-group-number'
 import { getEnumMembers } from '../utils/get-enum-members'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -138,9 +137,9 @@ export default createEslintRule<SortModulesOptions, MESSAGE_ID>({
     })
     validateNewlinesAndPartitionConfiguration(options)
 
-    let sourceCode = getSourceCode(context)
+    let { sourceCode, id } = context
     let eslintDisabledLines = getEslintDisabledLines({
-      ruleName: context.id,
+      ruleName: id,
       sourceCode,
     })
 

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -17,7 +17,6 @@ import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { ORDER_ERROR } from '../utils/report-errors'
 import { getSettings } from '../utils/get-settings'
@@ -68,9 +67,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let options = complete(context.options.at(0), settings, defaultOptions)
       validateCustomSortConfiguration(options)
 
-      let sourceCode = getSourceCode(context)
+      let { sourceCode, id } = context
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
 

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -17,7 +17,6 @@ import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { ORDER_ERROR } from '../utils/report-errors'
 import { getSettings } from '../utils/get-settings'
@@ -71,9 +70,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let options = complete(context.options.at(0), settings, defaultOptions)
       validateCustomSortConfiguration(options)
 
-      let sourceCode = getSourceCode(context)
+      let { sourceCode, id } = context
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
 

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -48,7 +48,6 @@ import { createEslintRule } from '../utils/create-eslint-rule'
 import { sortByJsonSchema } from './sort-object-types/types'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -186,7 +185,7 @@ export let sortObjectTypeElements = <MessageIds extends string>({
   }
 
   let settings = getSettings(context.settings)
-  let sourceCode = getSourceCode(context)
+  let { sourceCode, id } = context
   let matchedContextOptions = getMatchingContextOptions({
     nodeNames: elements.map(node =>
       getNodeName({ typeElement: node, sourceCode }),
@@ -218,7 +217,7 @@ export let sortObjectTypeElements = <MessageIds extends string>({
   }
 
   let eslintDisabledLines = getEslintDisabledLines({
-    ruleName: context.id,
+    ruleName: id,
     sourceCode,
   })
 

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -1,3 +1,5 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
 import { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNodeWithDependencies } from '../utils/sort-nodes-by-dependencies'
@@ -42,7 +44,6 @@ import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -87,7 +88,7 @@ let defaultOptions: Required<Options[0]> = {
 export default createEslintRule<Options, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
-    let sourceCode = getSourceCode(context)
+    let { sourceCode, id } = context
 
     let sortObject = (
       nodeObject: TSESTree.ObjectExpression | TSESTree.ObjectPattern,
@@ -181,7 +182,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       }
 
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
 
@@ -532,7 +533,7 @@ let getNodeName = ({
   sourceCode,
   property,
 }: {
-  sourceCode: ReturnType<typeof getSourceCode>
+  sourceCode: TSESLint.SourceCode
   property: TSESTree.Property
 }): string => {
   if (property.key.type === 'Identifier') {
@@ -547,7 +548,7 @@ let getNodeValue = ({
   sourceCode,
   property,
 }: {
-  sourceCode: ReturnType<typeof getSourceCode>
+  sourceCode: TSESLint.SourceCode
   property: TSESTree.Property
 }): string | null => {
   if (

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -10,7 +10,6 @@ import { reportErrors, ORDER_ERROR, RIGHT, LEFT } from '../utils/report-errors'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { commonJsonSchemas } from '../utils/common-json-schemas'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -50,7 +49,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let options = complete(context.options.at(0), settings, defaultOptions)
       validateCustomSortConfiguration(options)
 
-      let sourceCode = getSourceCode(context)
+      let { sourceCode } = context
       let isDiscriminantTrue =
         switchNode.discriminant.type === 'Literal' &&
         switchNode.discriminant.value === true

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -32,7 +32,6 @@ import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { useGroups } from '../utils/use-groups'
@@ -173,9 +172,9 @@ export let sortUnionOrIntersectionTypes = <MessageIds extends string>({
   })
   validateNewlinesAndPartitionConfiguration(options)
 
-  let sourceCode = getSourceCode(context)
+  let { sourceCode, id } = context
   let eslintDisabledLines = getEslintDisabledLines({
-    ruleName: context.id,
+    ruleName: id,
     sourceCode,
   })
 

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -19,7 +19,6 @@ import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
-import { getSourceCode } from '../utils/get-source-code'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
@@ -62,9 +61,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       let options = complete(context.options.at(0), settings, defaultOptions)
       validateCustomSortConfiguration(options)
 
-      let sourceCode = getSourceCode(context)
+      let { sourceCode, id } = context
       let eslintDisabledLines = getEslintDisabledLines({
-        ruleName: context.id,
+        ruleName: id,
         sourceCode,
       })
 

--- a/utils/get-source-code.ts
+++ b/utils/get-source-code.ts
@@ -1,8 +1,0 @@
-import type { TSESLint } from '@typescript-eslint/utils'
-
-export let getSourceCode = (
-  context: TSESLint.RuleContext<string, unknown[]>,
-): TSESLint.SourceCode =>
-  /* v8 ignore next 2 */
-  // eslint-disable-next-line typescript/no-unnecessary-condition
-  context.sourceCode ?? context.getSourceCode()


### PR DESCRIPTION
### Description

We added support old `getSourceCode` API here:
https://github.com/azat-io/eslint-plugin-perfectionist/issues/101

`context.sourceCode` ESLint API was added here:
https://github.com/eslint/eslint/pull/17107

The old `context.getSourceCode()` API was deprecated in favor of `context.sourceCode` in v8.48.0:
https://github.com/eslint/eslint/releases/tag/v8.40.0 

We currently support ESLint 8.45.0+:
https://github.com/azat-io/eslint-plugin-perfectionist/pull/480

I guess we can remove support for the old API?

### Additional context

N/A.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
