### PR TITLE
feat(sort-exports): add `groups`-related options

### DIFF
--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -88,7 +88,7 @@ Specifies the sorting method.
 - `'natural'` — Sort items in a [natural](https://github.com/yobacca/natural-orderby) order (e.g., “item2” < “item10”).
 - `'line-length'` — Sort items by the length of the code line (shorter lines first).
 - `'custom'` — Sort items using the alphabet entered in the [`alphabet`](#alphabet) option.
-- `'unsorted'` — Do not sort items.
+- `'unsorted'` — Do not sort items. [`grouping`](#groups) and [`newlines behavior`](#newlinesbetween) are still enforced.
 
 ### order
 
@@ -193,6 +193,22 @@ export { AnotherNamed } from './second-folder';
 
 Each group of exports (separated by empty lines) is treated independently, and the order within each group is preserved.
 
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between groups.
+
+- `ignore` — Do not report errors related to new lines.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed.
+
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
+This option is only applicable when `partitionByNewLine` is `false`.
+
 ### [DEPRECATED] groupKind
 
 <sub>default: `'mixed'`</sub>
@@ -241,6 +257,25 @@ Example: `type-export`.
 
 Members that don’t fit into any group specified in the `groups` option will be placed in the `unknown` group. If the `unknown` group is not specified in the `groups` option,
 it will automatically be added to the end of the list.
+
+##### Newlines between groups
+
+You may place `newlinesBetween` objects between your groups to enforce the newline behavior between two specific groups.
+
+See the [`newlinesBetween`](#newlinesbetween) option.
+
+This feature is only applicable when `partitionByNewLine` is false.
+
+```ts
+{
+  newlinesBetween: 'always',
+  groups: [
+    'a',
+    { newlinesBetween: 'never' }, // Overrides the global newlinesBetween option
+    'b',
+  ]
+}
+```
 
 ### customGroups
 
@@ -324,6 +359,7 @@ Custom groups have a higher priority than any predefined group.
                   specialCharacters: 'keep',
                   partitionByComment: false,
                   partitionByNewLine: false,
+                  newlinesBetween: 'ignore',
                   groupKind: 'mixed',
                   groups: [],
                   customGroups: [],
@@ -354,6 +390,7 @@ Custom groups have a higher priority than any predefined group.
                 specialCharacters: 'keep',
                 partitionByComment: false,
                 partitionByNewLine: false,
+                newlinesBetween: 'ignore',
                 groupKind: 'mixed',
                 groups: [],
                 customGroups: [],

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -193,9 +193,11 @@ export { AnotherNamed } from './second-folder';
 
 Each group of exports (separated by empty lines) is treated independently, and the order within each group is preserved.
 
-### groupKind
+### [DEPRECATED] groupKind
 
 <sub>default: `'mixed'`</sub>
+
+Use the [groups](#groups) option with the `value` and `type` modifiers instead.
 
 Allows you to group exports by their kind, determining whether value exports should come before or after type exports.
 

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -203,6 +203,43 @@ Allows you to group exports by their kind, determining whether value exports sho
 - `values-first` — Group all value exports before type exports.
 - `types-first` — Group all type exports before value exports.
 
+### groups
+
+<sub>
+  type: `Array<string | string[]>`
+</sub>
+<sub>default: `[]`</sub>
+
+Allows you to specify a list of export groups for sorting. Groups help organize exports into categories, making them more readable and maintainable.
+
+Each export will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
+The order of items in the `groups` option determines how groups are ordered.
+
+Within a given group, members will be sorted according to the `type`, `order`, `ignoreCase`, etc. options.
+
+Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
+All members of the groups in the array will be sorted together as if they were part of a single group.
+
+Predefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.
+
+#### Selectors
+
+The only selector possible for this rule is `export`.
+
+#### Modifiers
+
+- `value`: Matches value exports.
+- `type`: Matches type exports.
+
+Example: `type-export`.
+
+#### Important notes
+
+##### The `unknown` group
+
+Members that don’t fit into any group specified in the `groups` option will be placed in the `unknown` group. If the `unknown` group is not specified in the `groups` option,
+it will automatically be added to the end of the list.
+
 ## Usage
 
 <CodeTabs
@@ -229,6 +266,7 @@ Allows you to group exports by their kind, determining whether value exports sho
                   partitionByComment: false,
                   partitionByNewLine: false,
                   groupKind: 'mixed',
+                  groups: []
                 },
               ],
             },
@@ -257,6 +295,7 @@ Allows you to group exports by their kind, determining whether value exports sho
                 partitionByComment: false,
                 partitionByNewLine: false,
                 groupKind: 'mixed',
+                groups: []
               },
             ],
           },

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -242,6 +242,63 @@ Example: `type-export`.
 Members that don’t fit into any group specified in the `groups` option will be placed in the `unknown` group. If the `unknown` group is not specified in the `groups` option,
 it will automatically be added to the end of the list.
 
+### customGroups
+
+<sub>
+  type: `Array<CustomGroupDefinition | CustomGroupAnyOfDefinition>`
+</sub>
+<sub>default: `{}`</sub>
+
+You can define your own groups and use regexp patterns to match specific exports.
+
+A custom group definition may follow one of the two following interfaces:
+
+```ts
+interface CustomGroupDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  selector?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+}
+
+```
+An export will match a `CustomGroupDefinition` group if it matches all the filters of the custom group's definition.
+
+or:
+
+```ts
+interface CustomGroupAnyOfDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  anyOf: Array<{
+      selector?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  }>
+}
+```
+
+An export will match a `CustomGroupAnyOfDefinition` group if it matches all the filters of at least one of the `anyOf` items.
+
+#### Attributes
+
+- `groupName`: The group's name, which needs to be put in the `groups` option.
+- `selector`: Filter on the `selector` of the element.
+- `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
+- `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
+- `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
+
+#### Match importance
+
+The `customGroups` list is ordered:
+The first custom group definition that matches an element will be used.
+
+Custom groups have a higher priority than any predefined group.
+
 ## Usage
 
 <CodeTabs
@@ -268,7 +325,8 @@ it will automatically be added to the end of the list.
                   partitionByComment: false,
                   partitionByNewLine: false,
                   groupKind: 'mixed',
-                  groups: []
+                  groups: [],
+                  customGroups: [],
                 },
               ],
             },
@@ -297,7 +355,8 @@ it will automatically be added to the end of the list.
                 partitionByComment: false,
                 partitionByNewLine: false,
                 groupKind: 'mixed',
-                groups: []
+                groups: [],
+                customGroups: [],
               },
             ],
           },

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -327,7 +327,7 @@ This feature is only applicable when `partitionByNewLine` is false.
 </sub>
 <sub>default: `{}`</sub>
 
-You can define your own groups and use regexp patterns to match specific object type members.
+You can define your own groups and use regexp patterns to match specific elements.
 
 A custom group definition may follow one of the two following interfaces:
 

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -82,8 +82,8 @@ export let jsonSchema: JSONSchema4 = {
     properties: {
       ...commonJsonSchemas,
       groupKind: {
+        description: '[DEPRECATED] Specifies top-level groups.',
         enum: ['mixed', 'literals-first', 'spreads-first'],
-        description: 'Specifies top-level groups.',
         type: 'string',
       },
       customGroups: buildCustomGroupsArrayJsonSchema({

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -220,8 +220,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           ...commonJsonSchemas,
           groupKind: {
+            description: '[DEPRECATED] Specifies top-level groups.',
             enum: ['mixed', 'values-first', 'types-first'],
-            description: 'Specifies top-level groups.',
             type: 'string',
           },
           customGroups: buildCustomGroupsArrayJsonSchema({

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -1,10 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type {
-  PartitionByCommentOption,
-  CommonOptions,
-} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
+import type { Options } from './sort-exports/types'
 
 import {
   partitionByCommentJsonSchema,
@@ -22,16 +19,6 @@ import { ORDER_ERROR } from '../utils/report-errors'
 import { getSettings } from '../utils/get-settings'
 import { sortNodes } from '../utils/sort-nodes'
 import { complete } from '../utils/complete'
-
-type Options = [
-  Partial<
-    {
-      groupKind: 'values-first' | 'types-first' | 'mixed'
-      partitionByComment: PartitionByCommentOption
-      partitionByNewLine: boolean
-    } & CommonOptions
-  >,
-]
 
 interface SortExportsSortingNode
   extends SortingNode<

--- a/rules/sort-exports/does-custom-group-match.ts
+++ b/rules/sort-exports/does-custom-group-match.ts
@@ -1,0 +1,43 @@
+import type { AnyOfCustomGroup } from '../../types/common-options'
+import type { SingleCustomGroup, Modifier } from './types'
+
+import { matches } from '../../utils/matches'
+
+interface DoesCustomGroupMatchParameters {
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
+  modifiers: Modifier[]
+  elementName: string
+}
+
+export let doesCustomGroupMatch = (
+  props: DoesCustomGroupMatchParameters,
+): boolean => {
+  if ('anyOf' in props.customGroup) {
+    return props.customGroup.anyOf.some(subgroup =>
+      doesCustomGroupMatch({ ...props, customGroup: subgroup }),
+    )
+  }
+
+  if (props.customGroup.modifiers) {
+    for (let modifier of props.customGroup.modifiers) {
+      if (!props.modifiers.includes(modifier)) {
+        return false
+      }
+    }
+  }
+
+  if (
+    'elementNamePattern' in props.customGroup &&
+    props.customGroup.elementNamePattern
+  ) {
+    let matchesElementNamePattern: boolean = matches(
+      props.elementName,
+      props.customGroup.elementNamePattern,
+    )
+    if (!matchesElementNamePattern) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/rules/sort-exports/types.ts
+++ b/rules/sort-exports/types.ts
@@ -7,6 +7,9 @@ import type { JoinWithDash } from '../../types/join-with-dash'
 
 export type Options = Partial<
   {
+    /**
+     * @deprecated for {@link `groups`}
+     */
     groupKind: 'values-first' | 'types-first' | 'mixed'
     partitionByComment: PartitionByCommentOption
     groups: GroupsOptions<Group>

--- a/rules/sort-exports/types.ts
+++ b/rules/sort-exports/types.ts
@@ -1,0 +1,12 @@
+import type {
+  PartitionByCommentOption,
+  CommonOptions,
+} from '../../types/common-options'
+
+export type Options = Partial<
+  {
+    groupKind: 'values-first' | 'types-first' | 'mixed'
+    partitionByComment: PartitionByCommentOption
+    partitionByNewLine: boolean
+  } & CommonOptions
+>[]

--- a/rules/sort-exports/types.ts
+++ b/rules/sort-exports/types.ts
@@ -1,12 +1,23 @@
+import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
+
 import type {
   PartitionByCommentOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
 
+import {
+  buildCustomGroupModifiersJsonSchema,
+  buildCustomGroupSelectorJsonSchema,
+  regexJsonSchema,
+} from '../../utils/common-json-schemas'
+
 export type Options = Partial<
   {
+    customGroups: CustomGroupsOption<SingleCustomGroup>
     /**
      * @deprecated for {@link `groups`}
      */
@@ -16,6 +27,13 @@ export type Options = Partial<
     partitionByNewLine: boolean
   } & CommonOptions
 >[]
+
+export type SingleCustomGroup = {
+  modifiers?: Modifier[]
+  selector?: Selector
+} & {
+  elementNamePattern?: RegexOption
+}
 
 export type Modifier = ValueModifier | TypeModifier
 
@@ -30,3 +48,12 @@ type ExportSelector = 'export'
 type ValueModifier = 'value'
 
 type TypeModifier = 'type'
+
+export let allSelectors: Selector[] = ['export']
+export let allModifiers: Modifier[] = ['value', 'type']
+
+export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
+  modifiers: buildCustomGroupModifiersJsonSchema(allModifiers),
+  selector: buildCustomGroupSelectorJsonSchema(allSelectors),
+  elementNamePattern: regexJsonSchema,
+}

--- a/rules/sort-exports/types.ts
+++ b/rules/sort-exports/types.ts
@@ -1,12 +1,29 @@
 import type {
   PartitionByCommentOption,
   CommonOptions,
+  GroupsOptions,
 } from '../../types/common-options'
+import type { JoinWithDash } from '../../types/join-with-dash'
 
 export type Options = Partial<
   {
     groupKind: 'values-first' | 'types-first' | 'mixed'
     partitionByComment: PartitionByCommentOption
+    groups: GroupsOptions<Group>
     partitionByNewLine: boolean
   } & CommonOptions
 >[]
+
+export type Modifier = ValueModifier | TypeModifier
+
+export type Selector = ExportSelector
+
+type ExportGroup = JoinWithDash<[ValueModifier, TypeModifier, ExportSelector]>
+
+type Group = ExportGroup | 'unknown' | string
+
+type ExportSelector = 'export'
+
+type ValueModifier = 'value'
+
+type TypeModifier = 'type'

--- a/rules/sort-exports/types.ts
+++ b/rules/sort-exports/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 
 import type {
   PartitionByCommentOption,
+  NewlinesBetweenOption,
   CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
@@ -23,6 +24,7 @@ export type Options = Partial<
      */
     groupKind: 'values-first' | 'types-first' | 'mixed'
     partitionByComment: PartitionByCommentOption
+    newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
   } & CommonOptions

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -102,16 +102,16 @@ export let jsonSchema: JSONSchema4 = {
           }),
         ],
       },
+      groupKind: {
+        description: '[DEPRECATED] Specifies top-level groups.',
+        enum: ['mixed', 'required-first', 'optional-first'],
+        type: 'string',
+      },
       useConfigurationIf: buildUseConfigurationIfJsonSchema({
         additionalProperties: {
           declarationMatchesPattern: regexJsonSchema,
         },
       }),
-      groupKind: {
-        enum: ['mixed', 'required-first', 'optional-first'],
-        description: 'Specifies top-level groups.',
-        type: 'string',
-      },
       partitionByComment: partitionByCommentJsonSchema,
       partitionByNewLine: partitionByNewLineJsonSchema,
       newlinesBetween: newlinesBetweenJsonSchema,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -493,7 +493,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
             },
           }),
           destructureOnly: {
-            description: 'Controls whether to sort only destructured objects.',
+            description:
+              '[DEPRECATED] Controls whether to sort only destructured objects.',
             type: 'boolean',
           },
           objectDeclarations: {

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -811,6 +811,43 @@ describe(ruleName, () => {
         valid: [],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use predefined groups`,
+      rule,
+      {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  rightGroup: 'value-export',
+                  leftGroup: 'type-export',
+                  right: 'b',
+                  left: 'a',
+                },
+                messageId: 'unexpectedExportsGroupOrder',
+              },
+            ],
+            options: [
+              {
+                ...options,
+                groups: ['value-export', 'type-export'],
+              },
+            ],
+            output: dedent`
+              export { b } from 'b';
+              export type { a } from 'a';
+            `,
+            code: dedent`
+              export type { a } from 'a';
+              export { b } from 'b';
+            `,
+          },
+        ],
+        valid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {


### PR DESCRIPTION
- Request from https://github.com/azat-io/eslint-plugin-perfectionist/issues/479#issue-2898499262

> PS: We would love to see groups extended to sort-exports as well, especially once this feature is supported 👍

## Description

This PR adds the following options to `sort-exports`:
- `groups`
- `customGroups` (new API)
- `newlinesBetween`

It also deprecates `groupKind` for `groups`.

### `groups`

- Allowed selectors: `export`.
- Allowed modifiers: `value`, `type`.

Example:

- `value-export`.
- `type-export`.

### `customGroups`

The `customGroups` option supports `elementNamePattern`.

## What is the purpose of this pull request?

- [x] New Feature
