### PR TITLE
fix: fix false positive eslint-disable errors raised

### DIFF
--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -3221,7 +3221,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            [
+              'b',
+              'c',
+              // eslint-disable-next-line
+              'a',
+            ].includes(value)
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -9850,7 +9850,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            class Class {
+              b
+              c
+              // eslint-disable-next-line
+              a
+            }
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-decorators.test.ts
+++ b/test/rules/sort-decorators.test.ts
@@ -5066,7 +5066,41 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            @B
+            @C
+            // eslint-disable-next-line
+            @A
+            class Class {
+
+              @B
+              @C
+              // eslint-disable-next-line
+              @A
+              property
+
+              @B
+              @C
+              // eslint-disable-next-line
+              @A
+              accessor field
+
+              @B
+              @C
+              // eslint-disable-next-line
+              @A
+              method(
+                @B
+                @C
+                // eslint-disable-next-line
+                @A
+                parameter) {}
+            }
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -4074,7 +4074,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            enum Enum {
+              B = 'B',
+              C = 'C',
+              // eslint-disable-next-line
+              A = 'A',
+            }
+          `,
+        },
+      ],
     })
   })
 })

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -1762,7 +1762,16 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            export { b } from "./b"
+            export { c } from "./c"
+            // eslint-disable-next-line
+            export { a } from "./a"
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-heritage-clauses.test.ts
+++ b/test/rules/sort-heritage-clauses.test.ts
@@ -1917,7 +1917,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            class Class implements
+              B,
+              C,
+              // eslint-disable-next-line
+              A
+            {}
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -7184,7 +7184,16 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            import { b } from "./b"
+            import { c } from "./c"
+            // eslint-disable-next-line
+            import { a } from "./a"
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -5687,7 +5687,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            interface Interface {
+              b: string;
+              c: string;
+              // eslint-disable-next-line
+              a: string;
+            }
+          `,
+        },
+      ],
     })
   })
 })

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -2780,7 +2780,17 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            type Type =
+              & B
+              & C
+              // eslint-disable-next-line
+              & A
+          `,
+        },
+      ],
     })
   })
 })

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -2810,7 +2810,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            <Element
+              b="b"
+              c="c"
+              // eslint-disable-next-line
+              a="a"
+            />
+          `,
+        },
+      ],
     })
   })
 })

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -2851,7 +2851,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            new Map([
+              [b, 'b'],
+              [c, 'c'],
+              // eslint-disable-next-line
+              [a, 'a'],
+            ])
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -4350,7 +4350,16 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            function b() {}
+            function c() {}
+            // eslint-disable-next-line
+            function a() {}
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1647,7 +1647,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            export {
+              b,
+              c,
+              // eslint-disable-next-line
+              a
+            }
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -2191,7 +2191,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            import {
+              b,
+              c,
+              // eslint-disable-next-line
+              a
+            } from 'module'
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -4993,7 +4993,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            type Type = {
+              b: string;
+              c: string;
+              // eslint-disable-next-line
+              a: string;
+            }
+          `,
+        },
+      ],
     })
   })
 })

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -6446,7 +6446,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            let obj = {
+              b = 'b',
+              c = 'c',
+              // eslint-disable-next-line
+              a = 'a',
+            }
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -3168,7 +3168,18 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            new Set([
+              'b',
+              'c',
+              // eslint-disable-next-line
+              'a',
+            ])
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -2812,7 +2812,17 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            type Type =
+              | B
+              | C
+              // eslint-disable-next-line
+              | A
+          `,
+        },
+      ],
     })
   })
 })

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -2106,7 +2106,17 @@ describe(ruleName, () => {
           options: [{}],
         },
       ],
-      valid: [],
+      valid: [
+        {
+          code: dedent`
+            let
+              b,
+              c,
+              // eslint-disable-next-line
+              a
+          `,
+        },
+      ],
     })
 
     eslintRuleTester.run(

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -50,9 +50,6 @@ export let compare = <T extends SortingNode>({
   return computeCompareValue({
     options: {
       ...options,
-      fallbackSort: {
-        type: 'unsorted',
-      },
       order: fallbackSort.order ?? order,
       type: fallbackSort.type,
     },

--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -76,7 +76,8 @@ export let reportAllErrors = <
     if (
       firstUnorderedNodeDependentOnRight ||
       leftIndex > rightIndex ||
-      leftIndex >= indexOfRightExcludingEslintDisabled
+      (left.isEslintDisabled &&
+        leftIndex >= indexOfRightExcludingEslintDisabled)
     ) {
       if (firstUnorderedNodeDependentOnRight) {
         messageIds.push(availableMessageIds.unexpectedDependencyOrder!)


### PR DESCRIPTION
- Issue: https://github.com/azat-io/eslint-plugin-perfectionist/issues/483 (one of the two bugs of that issue)

### Description

Some `eslint-disable` errors are raised when they should not in specific situations due to a missing condition.

### Bug severity

Low:
- Not related to a new feature.
- Only happens in specific situations.
- Can be bypassed by moving elements around in the worst case.

### Code example

```ts
interface Test {
  b: string;
  c: string;
  // eslint-disable-next-line
  a: string;
}
```

This currently raises an unfixable error.

### What is the purpose of this pull request?

- [x] Bug fix
