### PR TITLE
fix(sort-imports): fix explicit `fallbackSort` overriding side-effects

### DIFF
--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -1829,6 +1829,31 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): does not sort side-effects and side-effect-style even with fallback sort`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  groups: ['side-effect', 'side-effect-style'],
+                  fallbackSort: { type: 'alphabetical' },
+                },
+              ],
+              code: dedent`
+                import 'b';
+                import 'a';
+
+                import 'b.css';
+                import 'a.css';
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
     })
 
     ruleTester.run(

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -30,6 +30,10 @@ export let compare = <T extends SortingNode>({
   a,
   b,
 }: CompareParameters<T>): number => {
+  if (options.type === 'unsorted') {
+    return 0
+  }
+
   let finalNodeValueGetter = nodeValueGetter ?? ((node: T) => node.name)
   let compareValue = computeCompareValue({
     nodeValueGetter: finalNodeValueGetter,


### PR DESCRIPTION
Fixes https://github.com/azat-io/eslint-plugin-perfectionist/issues/483

### Description

Explicitely writing `fallbackSort` in `sort-imports` will override `sideEffects` which should stay unsorted.

### Bug severity

Medium-high:
- Related to a relatively new feature (fallback sorting)
- Requires writing an explicit `fallbackSort` option, meaning that `type` should be `line-length` logically.
- Side-effects import order can break runtime.

=> I think that a hotfix is justified.

### What is the purpose of this pull request?

- [x] Bug fix
