### PR TITLE
feat: handle `regex` objects until full deprecation

### DIFF
--- a/utils/matches.ts
+++ b/utils/matches.ts
@@ -9,5 +9,10 @@ export let matches = (value: string, regexOption: RegexOption): boolean => {
     return new RegExp(regexOption).test(value)
   }
 
+  // Handler for non-string regexes until an error is thrown
+  if ('source' in regexOption) {
+    return new RegExp(regexOption.source as string).test(value)
+  }
+
   return new RegExp(regexOption.pattern, regexOption.flags).test(value)
 }


### PR DESCRIPTION
- Related issue: https://github.com/azat-io/eslint-plugin-perfectionist/issues/488
- Alternative PR: https://github.com/azat-io/eslint-plugin-perfectionist/pull/490

### Description

This PR adds a handler for actual RegExp objects. They should not be tolerated but there currently is an issue with the JSON schema.

On the next major version, an error can be thrown to prevent breaking some user configurations.

- [x] New Feature
