### PR TITLE
fix: throw an error if RegExp expressions are entered

### DIFF
--- a/test/utils/matches.test.ts
+++ b/test/utils/matches.test.ts
@@ -31,4 +31,11 @@ describe('matches', () => {
       ]),
     ).toBeTruthy()
   })
+
+  it('should throw an error if the regex option is not a string', () => {
+    expect(() => matches('foo', /foo/u as unknown as string)).toThrow(
+      'Invalid configuration: please enter your RegExp expressions as strings.\n' +
+        'For example, write ".*foo" instead of /.*foo/',
+    )
+  })
 })

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -137,6 +137,9 @@ let singleRegexJsonSchema: JSONSchema4 = {
         },
       },
       additionalProperties: false,
+      // https://github.com/azat-io/eslint-plugin-perfectionist/pull/490#issuecomment-2720969705
+      // Uncomment the code below in the next major version (v5)
+      // To uncomment: required: ['pattern'],
       type: 'object',
     },
     {

--- a/utils/matches.ts
+++ b/utils/matches.ts
@@ -9,7 +9,8 @@ export let matches = (value: string, regexOption: RegexOption): boolean => {
     return new RegExp(regexOption).test(value)
   }
 
-  // Handler for non-string regexes until an error is thrown
+  // Handler for non-string regexes until an error is thrown on the JSON schema
+  // Level
   if ('source' in regexOption) {
     throw new Error(
       'Invalid configuration: please enter your RegExp expressions as strings.\n' +

--- a/utils/matches.ts
+++ b/utils/matches.ts
@@ -9,5 +9,13 @@ export let matches = (value: string, regexOption: RegexOption): boolean => {
     return new RegExp(regexOption).test(value)
   }
 
+  // Handler for non-string regexes until an error is thrown
+  if ('source' in regexOption) {
+    throw new Error(
+      'Invalid configuration: please enter your RegExp expressions as strings.\n' +
+        'For example, write ".*foo" instead of /.*foo/',
+    )
+  }
+
   return new RegExp(regexOption.pattern, regexOption.flags).test(value)
 }


### PR DESCRIPTION
- Issue: https://github.com/azat-io/eslint-plugin-perfectionist/issues/488
- Alternative PR: https://github.com/azat-io/eslint-plugin-perfectionist/pull/489

## Description

This PR throws a custom error when a RegExp option is entered instead of a string.

![Screenshot 2025-03-13 at 12 55 17](https://github.com/user-attachments/assets/283fc3bb-0cbe-44a1-97c2-01d1d2aa5753)

In the next major version, the error can be added on the JSON schema level.

### What is the purpose of this pull request?

- [x] Bug fix
