### PR TITLE
fix(sort-objects): fix object destructuring dependencies not detected

### DIFF
--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -367,6 +367,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
               })
             }
 
+            let dependencyName: string = name
+            if (isDestructuredObject && property.value.type === 'Identifier') {
+              dependencyName = property.value.name
+            }
+
             let sortingNode: SortingNodeWithDependencies = {
               isEslintDisabled: isNodeEslintDisabled(
                 property,
@@ -374,6 +379,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               ),
               size: rangeToDiff(property, sourceCode),
               group: getGroup(),
+              dependencyName,
               node: property,
               dependencies,
               name,

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1166,6 +1166,91 @@ describe(ruleName, () => {
       )
 
       ruleTester.run(
+        `${ruleName}(${type}): detects dependencies in object destructuring`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'a',
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedObjectsDependencyOrder',
+                },
+              ],
+              output: dedent`
+                let {
+                  b: bRenamed,
+                  a = bRenamed,
+                } = obj;
+              `,
+              code: dedent`
+                let {
+                  a = bRenamed,
+                  b: bRenamed,
+                } = obj;
+              `,
+              options: [options],
+            },
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'a',
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedObjectsDependencyOrder',
+                },
+              ],
+              output: dedent`
+                let [{
+                  b: bRenamed,
+                  a = bRenamed,
+                }] = [obj];
+              `,
+              code: dedent`
+                let [{
+                  a = bRenamed,
+                  b: bRenamed,
+                }] = [obj];
+              `,
+              options: [options],
+            },
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'a',
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedObjectsDependencyOrder',
+                },
+              ],
+              output: dedent`
+                let {
+                  [b]: bRenamed,
+                  a = bRenamed,
+                } = obj;
+              `,
+              code: dedent`
+                let {
+                  a = bRenamed,
+                  [b]: bRenamed,
+                } = obj;
+              `,
+              options: [options],
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}): detects circular dependencies`,
         rule,
         {


### PR DESCRIPTION
Fixes #491.

### Description

This PR fixes dependencies in object destructuring not being detected.

### What is the purpose of this pull request?

- [x] Bug fix
