### PR TITLE
feat(sort-jsx-props): migrate `groups`-related option to new API

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -378,6 +378,7 @@ interface CustomGroupDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   selector?: string
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
@@ -393,6 +394,7 @@ interface CustomGroupAnyOfDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       selector?: string
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
@@ -410,6 +412,7 @@ An array element will match a `CustomGroupAnyOfDefinition` group if it matches a
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
 - `fallbackSort`: Overrides the fallbackSort option for that custom group
+- `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -292,6 +292,7 @@ interface CustomGroupDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
@@ -306,6 +307,7 @@ interface CustomGroupAnyOfDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
@@ -322,6 +324,7 @@ An enum member will match a `CustomGroupAnyOfDefinition` group if it matches all
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
 - `fallbackSort`: Overrides the fallbackSort option for that custom group
+- `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance
 

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -294,6 +294,7 @@ interface CustomGroupDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   selector?: string
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
@@ -309,6 +310,7 @@ interface CustomGroupAnyOfDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       selector?: string
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
@@ -326,6 +328,7 @@ An export will match a `CustomGroupAnyOfDefinition` group if it matches all the 
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
 - `fallbackSort`: Overrides the fallbackSort option for that custom group
+- `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance
 

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -234,13 +234,29 @@ Use the [useConfigurationIf.tagMatchesPattern](#useconfigurationif) option along
 
 Allows you to specify names or patterns for JSX elements that should be ignored by this rule. This can be useful if you have specific components that you do not want to sort.
 
-You can specify their names or a regexp pattern to ignore, for example: `'^Table.+'` to ignore all object types whose names begin with the word Table.
+You can specify their names or a regexp pattern to ignore, for example: `'^Table.+'` to ignore all JSX elements whose names begin with the word Table.
 
 ### partitionByNewLine
 
 <sub>default: `false`</sub>
 
 When `true`, the rule will not sort members if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+### newlinesBetween
+
+<sub>default: `'ignore'`</sub>
+
+Specifies how new lines should be handled between groups.
+
+- `ignore` — Do not report errors related to new lines.
+- `always` — Enforce one new line between each group, and forbid new lines inside a group.
+- `never` — No new lines are allowed.
+
+You can also enforce the newline behavior between two specific groups through the `groups` options.
+
+See the [`groups`](#newlines-between-groups) option.
+
+This option is only applicable when `partitionByNewLine` is `false`.
 
 ### useConfigurationIf
 
@@ -255,7 +271,7 @@ When `true`, the rule will not sort members if there is an empty line between th
 </sub>
 <sub>default: `{}`</sub>
 
-Allows you to specify filters to match a particular options configuration for a given object type.
+Allows you to specify filters to match a particular options configuration for a given JSX element.
 
 The first matching options configuration will be used. If no configuration matches, the default options configuration will be used.
 

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -329,21 +329,26 @@ Example configuration:
 
 Allows you to specify a list of JSX props groups for sorting. Groups help organize props into categories, making your components more readable and maintainable.
 
-Predefined groups:
-
-- `'multiline'` — Props with multiline values.
-- `'shorthand'` — Shorthand props, which are used without a value, typically for boolean props.
-- `'unknown'` — Props that don’t fit into any group specified in the `groups` option.
-
-If the `unknown` group is not specified in the `groups` option, it will automatically be added to the end of the list.
-
-Each JSX prop will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
+Each element will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
 The order of items in the `groups` option determines how groups are ordered.
 
 Within a given group, members will be sorted according to the `type`, `order`, `ignoreCase`, etc. options.
 
 Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
 All members of the groups in the array will be sorted together as if they were part of a single group.
+
+Predefined groups are characterized by a single selector and potentially multiple modifiers. You may enter modifiers in any order, but the selector must always come at the end.
+
+##### List of selectors
+
+The only selector possible for this rule is `prop`.
+
+#### Modifiers
+
+- `multiline`: Matches multiline props.
+- `shorthand`: Matches shorthand props, which are used without a value, typically for boolean props.
+
+Example: `shorthand-prop`.
 
 #### Newlines between groups
 
@@ -385,9 +390,9 @@ Custom group matching takes precedence over predefined group matching.
 ```js
  {
    groups: [
-     'multiline',
+     'multiline-prop',
      'unknown',
-     'shorthand',
+     'shorthand-prop',
 +    'callback',       // [!code ++]
    ],
 +  customGroups: {     // [!code ++]

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -371,19 +371,94 @@ This feature is only applicable when `partitionByNewLine` is false.
 
 ### customGroups
 
+<Important title="Migrating from the old API">
+Support for the object-based `customGroups` option is deprecated.
+
+Migrating from the old to the current API is easy:
+
+Old API:
+```ts
+{
+  "key1": "value1",
+  "key2": "value2"
+}
+```
+
+Current API:
+```ts
+[
+  {
+    "groupName": "key1",
+    "elementNamePattern": "value1"
+  },
+  {
+    "groupName": "key2",
+    "elementNamePattern": "value2"
+  }
+]
+```
+</Important>
+
 <sub>
-  type: `{ [groupName: string]: string | string[] }`
+  type: `Array<CustomGroupDefinition | CustomGroupAnyOfDefinition>`
 </sub>
-<sub>default: `{}`</sub>
+<sub>default: `[]`</sub>
 
-You can define your own groups and use regexp patterns to match specific JSX attributes.
+You can define your own groups and use regexp patterns to match specific JSX prop.
 
-Each key of `customGroups` represents a group name which you can then use in the `groups` option. The value for each key can either be of type:
-- `string` — A JSX prop's name matching the value will be marked as part of the group referenced by the key.
-- `string[]` — A JSX prop's name matching any of the values of the array will be marked as part of the group referenced by the key.
-The order of values in the array does not matter.
+A custom group definition may follow one of the two following interfaces:
 
-Custom group matching takes precedence over predefined group matching.
+```ts
+interface CustomGroupDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc'; sortBy?: 'name' | 'value' }
+  newlinesInside?: 'always' | 'never'
+  selector?: string
+  modifiers?: string[]
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+}
+
+```
+A JSX prop will match a `CustomGroupDefinition` group if it matches all the filters of the custom group's definition.
+
+or:
+
+```ts
+interface CustomGroupAnyOfDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc'; sortBy?: 'name' | 'value' }
+  newlinesInside?: 'always' | 'never'
+  anyOf: Array<{
+      selector?: string
+      modifiers?: string[]
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  }>
+}
+```
+
+A JSX prop will match a `CustomGroupAnyOfDefinition` group if it matches all the filters of at least one of the `anyOf` items.
+
+#### Attributes
+
+- `groupName`: The group's name, which needs to be put in the `groups` option.
+- `selector`: Filter on the `selector` of the element.
+- `modifiers`: Filter on the `modifiers` of the element. (All the modifiers of the element must be present in that list)
+- `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
+- `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
+- `order`: Overrides the sort order for that custom group
+- `fallbackSort`: Overrides the fallbackSort option for that custom group
+- `newlinesInside`: Enforces a specific newline behavior between elements of the group.
+
+#### Match importance
+
+The `customGroups` list is ordered:
+The first custom group definition that matches an element will be used.
+
+Custom groups have a higher priority than any predefined group.
 
 #### Example
 
@@ -395,9 +470,12 @@ Custom group matching takes precedence over predefined group matching.
      'shorthand-prop',
 +    'callback',       // [!code ++]
    ],
-+  customGroups: {     // [!code ++]
-+    callback: '^on.+' // [!code ++]
-+  }                   // [!code ++]
++  customGroups: [     // [!code ++]
++    {                 // [!code ++]
++      groupName: 'callback',      // [!code ++]
++      elementNamePattern: '^on.+' // [!code ++]
++    }                 // [!code ++]
++  ]                   // [!code ++]
  }
 ```
 

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -418,6 +418,7 @@ interface CustomGroupDefinition {
   selector?: string
   modifiers?: string[]
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  elementValuePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
 ```
@@ -436,6 +437,7 @@ interface CustomGroupAnyOfDefinition {
       selector?: string
       modifiers?: string[]
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+      elementValuePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
 }
 ```
@@ -448,6 +450,7 @@ A JSX prop will match a `CustomGroupAnyOfDefinition` group if it matches all the
 - `selector`: Filter on the `selector` of the element.
 - `modifiers`: Filter on the `modifiers` of the element. (All the modifiers of the element must be present in that list)
 - `elementNamePattern`: If entered, will check that the name of the element matches the pattern entered.
+- `elementValuePattern`: If entered, will check that the value of the element matches the pattern entered.
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
 - `fallbackSort`: Overrides the fallbackSort option for that custom group

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -322,6 +322,7 @@ interface CustomGroupDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
 
@@ -336,6 +337,7 @@ interface CustomGroupAnyOfDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
   }>
@@ -351,6 +353,7 @@ A map element will match a `CustomGroupAnyOfDefinition` group if it matches all 
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
 - `fallbackSort`: Overrides the fallbackSort option for that custom group
+- `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance
 

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -337,6 +337,7 @@ interface CustomGroupDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   selector?: string
   elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
 }
@@ -352,6 +353,7 @@ interface CustomGroupAnyOfDefinition {
   type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
   order?: 'asc' | 'desc'
   fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
   anyOf: Array<{
       selector?: string
       elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
@@ -369,6 +371,7 @@ A set element will match a `CustomGroupAnyOfDefinition` group if it matches all 
 - `type`: Overrides the sort type for that custom group. `unsorted` will not sort the group.
 - `order`: Overrides the sort order for that custom group
 - `fallbackSort`: Overrides the fallbackSort option for that custom group
+- `newlinesInside`: Enforces a specific newline behavior between elements of the group.
 
 #### Match importance
 

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -1,13 +1,7 @@
 import { TSESTree } from '@typescript-eslint/types'
 
-import type {
-  DeprecatedCustomGroupsOption,
-  NewlinesBetweenOption,
-  CommonOptions,
-  GroupsOptions,
-  RegexOption,
-} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
+import type { Options } from './sort-jsx-props/types'
 
 import {
   buildUseConfigurationIfJsonSchema,
@@ -41,30 +35,11 @@ import { useGroups } from '../utils/use-groups'
 import { complete } from '../utils/complete'
 import { matches } from '../utils/matches'
 
-type Options = Partial<
-  {
-    useConfigurationIf: {
-      allNamesMatchPattern?: RegexOption
-      tagMatchesPattern?: RegexOption
-    }
-    customGroups: DeprecatedCustomGroupsOption
-    newlinesBetween: NewlinesBetweenOption
-    groups: GroupsOptions<Group>
-    partitionByNewLine: boolean
-    /**
-     * @deprecated for {@link `useConfigurationIf.tagMatchesPattern`}
-     */
-    ignorePattern: RegexOption
-  } & CommonOptions
->[]
-
 type MESSAGE_ID =
   | 'missedSpacingBetweenJSXPropsMembers'
   | 'extraSpacingBetweenJSXPropsMembers'
   | 'unexpectedJSXPropsGroupOrder'
   | 'unexpectedJSXPropsOrder'
-
-type Group = 'multiline' | 'shorthand' | 'unknown' | string
 
 let defaultOptions: Required<Options[0]> = {
   fallbackSort: { type: 'unsorted' },

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -19,11 +19,12 @@ import {
   ORDER_ERROR,
 } from '../utils/report-errors'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
+import { validateGeneratedGroupsConfiguration } from '../utils/validate-generated-groups-configuration'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
-import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getMatchingContextOptions } from '../utils/get-matching-context-options'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
+import { allModifiers, allSelectors } from './sort-jsx-props/types'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
@@ -85,9 +86,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
       })
       let options = complete(matchedContextOptions, settings, defaultOptions)
       validateCustomSortConfiguration(options)
-      validateGroupsConfiguration({
-        allowedPredefinedGroups: ['multiline', 'shorthand', 'unknown'],
-        allowedCustomGroups: Object.keys(options.customGroups),
+      validateGeneratedGroupsConfiguration({
+        selectors: allSelectors,
+        modifiers: allModifiers,
         options,
       })
       validateNewlinesAndPartitionConfiguration(options)

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -158,6 +158,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
               for (let customGroup of options.customGroups) {
                 if (
                   doesCustomGroupMatch({
+                    elementValue: attribute.value
+                      ? sourceCode.getText(attribute.value)
+                      : null,
                     elementName: name,
                     customGroup,
                     selectors,

--- a/rules/sort-jsx-props/does-custom-group-match.ts
+++ b/rules/sort-jsx-props/does-custom-group-match.ts
@@ -1,0 +1,58 @@
+import type { SingleCustomGroup, Selector, Modifier } from './types'
+import type { AnyOfCustomGroup } from '../../types/common-options'
+
+import { matches } from '../../utils/matches'
+
+interface DoesCustomGroupMatchParameters {
+  customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
+  selectors: Selector[]
+  modifiers: Modifier[]
+  elementName: string
+}
+
+/**
+ * Determines whether a custom group matches the given properties.
+ * @param {DoesCustomGroupMatchParameters} props - The properties to compare
+ * with the custom group, including selectors, modifiers, and element name.
+ * @returns {boolean} `true` if the custom group matches the properties;
+ * otherwise, `false`.
+ */
+export let doesCustomGroupMatch = (
+  props: DoesCustomGroupMatchParameters,
+): boolean => {
+  if ('anyOf' in props.customGroup) {
+    // At least one subgroup must match
+    return props.customGroup.anyOf.some(subgroup =>
+      doesCustomGroupMatch({ ...props, customGroup: subgroup }),
+    )
+  }
+  if (
+    props.customGroup.selector &&
+    !props.selectors.includes(props.customGroup.selector)
+  ) {
+    return false
+  }
+
+  if (props.customGroup.modifiers) {
+    for (let modifier of props.customGroup.modifiers) {
+      if (!props.modifiers.includes(modifier)) {
+        return false
+      }
+    }
+  }
+
+  if (
+    'elementNamePattern' in props.customGroup &&
+    props.customGroup.elementNamePattern
+  ) {
+    let matchesElementNamePattern: boolean = matches(
+      props.elementName,
+      props.customGroup.elementNamePattern,
+    )
+    if (!matchesElementNamePattern) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/rules/sort-jsx-props/does-custom-group-match.ts
+++ b/rules/sort-jsx-props/does-custom-group-match.ts
@@ -5,6 +5,7 @@ import { matches } from '../../utils/matches'
 
 interface DoesCustomGroupMatchParameters {
   customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup
+  elementValue: string | null
   selectors: Selector[]
   modifiers: Modifier[]
   elementName: string
@@ -48,6 +49,19 @@ export let doesCustomGroupMatch = (
     let matchesElementNamePattern: boolean = matches(
       props.elementName,
       props.customGroup.elementNamePattern,
+    )
+    if (!matchesElementNamePattern) {
+      return false
+    }
+  }
+
+  if (
+    'elementValuePattern' in props.customGroup &&
+    props.customGroup.elementValuePattern
+  ) {
+    let matchesElementNamePattern: boolean = matches(
+      props.elementValue ?? '',
+      props.customGroup.elementValuePattern,
     )
     if (!matchesElementNamePattern) {
       return false

--- a/rules/sort-jsx-props/types.ts
+++ b/rules/sort-jsx-props/types.ts
@@ -36,6 +36,7 @@ export type Options = Partial<
 >[]
 
 export interface SingleCustomGroup {
+  elementValuePattern?: RegexOption
   elementNamePattern?: RegexOption
   modifiers?: Modifier[]
   selector?: Selector
@@ -92,5 +93,6 @@ export let allModifiers: Modifier[] = ['shorthand', 'multiline']
 export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
   modifiers: buildCustomGroupModifiersJsonSchema(allModifiers),
   selector: buildCustomGroupSelectorJsonSchema(allSelectors),
+  elementValuePattern: regexJsonSchema,
   elementNamePattern: regexJsonSchema,
 }

--- a/rules/sort-jsx-props/types.ts
+++ b/rules/sort-jsx-props/types.ts
@@ -1,0 +1,26 @@
+import type {
+  DeprecatedCustomGroupsOption,
+  NewlinesBetweenOption,
+  CommonOptions,
+  GroupsOptions,
+  RegexOption,
+} from '../../types/common-options'
+
+export type Options = Partial<
+  {
+    useConfigurationIf: {
+      allNamesMatchPattern?: RegexOption
+      tagMatchesPattern?: RegexOption
+    }
+    customGroups: DeprecatedCustomGroupsOption
+    newlinesBetween: NewlinesBetweenOption
+    groups: GroupsOptions<Group>
+    partitionByNewLine: boolean
+    /**
+     * @deprecated for {@link `useConfigurationIf.tagMatchesPattern`}
+     */
+    ignorePattern: RegexOption
+  } & CommonOptions
+>[]
+
+type Group = 'multiline' | 'shorthand' | 'unknown' | string

--- a/rules/sort-jsx-props/types.ts
+++ b/rules/sort-jsx-props/types.ts
@@ -5,6 +5,7 @@ import type {
   GroupsOptions,
   RegexOption,
 } from '../../types/common-options'
+import type { JoinWithDash } from '../../types/join-with-dash'
 
 export type Options = Partial<
   {
@@ -23,4 +24,57 @@ export type Options = Partial<
   } & CommonOptions
 >[]
 
-type Group = 'multiline' | 'shorthand' | 'unknown' | string
+export interface SingleCustomGroup {
+  elementValuePattern?: RegexOption
+  elementNamePattern?: RegexOption
+  modifiers?: Modifier[]
+  selector?: Selector
+}
+
+export type Selector = MultilineSelector | ShorthandSelector | PropertySelector
+
+export type Modifier = MultilineModifier | ShorthandModifier
+
+type PropertyGroup = JoinWithDash<
+  [ShorthandModifier, MultilineModifier, PropertySelector]
+>
+
+/**
+ * Only used in code, so I don't know if it's worth maintaining this.
+ */
+type Group =
+  | ShorthandGroup
+  | MultilineGroup
+  | PropertyGroup
+  | 'unknown'
+  | string
+
+/**
+ * @deprecated For {@link `MultilineModifier`}
+ */
+type MultilineGroup = JoinWithDash<[MultilineSelector]>
+
+/**
+ * @deprecated For {@link `ShorthandModifier`}
+ */
+type ShorthandGroup = JoinWithDash<[ShorthandSelector]>
+
+/**
+ * @deprecated For {@link `ShorthandModifier`}
+ */
+type ShorthandSelector = 'shorthand'
+
+/**
+ * @deprecated For {@link `MultilineModifier`}
+ */
+type MultilineSelector = 'multiline'
+
+type MultilineModifier = 'multiline'
+
+type ShorthandModifier = 'shorthand'
+
+type PropertySelector = 'prop'
+
+export let allSelectors: Selector[] = ['multiline', 'prop', 'shorthand']
+
+export let allModifiers: Modifier[] = ['shorthand', 'multiline']

--- a/rules/sort-jsx-props/types.ts
+++ b/rules/sort-jsx-props/types.ts
@@ -1,11 +1,20 @@
+import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
+
 import type {
   DeprecatedCustomGroupsOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
   RegexOption,
 } from '../../types/common-options'
 import type { JoinWithDash } from '../../types/join-with-dash'
+
+import {
+  buildCustomGroupModifiersJsonSchema,
+  buildCustomGroupSelectorJsonSchema,
+  regexJsonSchema,
+} from '../../utils/common-json-schemas'
 
 export type Options = Partial<
   {
@@ -13,7 +22,9 @@ export type Options = Partial<
       allNamesMatchPattern?: RegexOption
       tagMatchesPattern?: RegexOption
     }
-    customGroups: DeprecatedCustomGroupsOption
+    customGroups:
+      | CustomGroupsOption<SingleCustomGroup>
+      | DeprecatedCustomGroupsOption
     newlinesBetween: NewlinesBetweenOption
     groups: GroupsOptions<Group>
     partitionByNewLine: boolean
@@ -25,7 +36,6 @@ export type Options = Partial<
 >[]
 
 export interface SingleCustomGroup {
-  elementValuePattern?: RegexOption
   elementNamePattern?: RegexOption
   modifiers?: Modifier[]
   selector?: Selector
@@ -78,3 +88,9 @@ type PropertySelector = 'prop'
 export let allSelectors: Selector[] = ['multiline', 'prop', 'shorthand']
 
 export let allModifiers: Modifier[] = ['shorthand', 'multiline']
+
+export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
+  modifiers: buildCustomGroupModifiersJsonSchema(allModifiers),
+  selector: buildCustomGroupSelectorJsonSchema(allSelectors),
+  elementNamePattern: regexJsonSchema,
+}

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -686,6 +686,57 @@ describe(ruleName, () => {
         })
       }
 
+      for (let elementValuePattern of [
+        'HELLO',
+        ['noMatch', 'HELLO'],
+        { pattern: 'hello', flags: 'i' },
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'valuesStartingWithHello',
+                    leftGroup: 'unknown',
+                    right: 'z',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedJSXPropsGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'valuesStartingWithHello',
+                      elementValuePattern,
+                    },
+                  ],
+                  groups: ['valuesStartingWithHello', 'unknown'],
+                },
+              ],
+              output: dedent`
+                <Element
+                  z="HELLO_VALUE"
+                  a="a"
+                  b
+                />
+              `,
+              code: dedent`
+                <Element
+                  a="a"
+                  b
+                  z="HELLO_VALUE"
+                />
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
+
       ruleTester.run(
         `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
         rule,

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -549,6 +549,422 @@ describe(ruleName, () => {
       },
     )
 
+    describe(`${ruleName}: custom groups`, () => {
+      ruleTester.run(`${ruleName}: filters on selector`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  rightGroup: 'shorthandElements',
+                  leftGroup: 'unknown',
+                  right: 'a',
+                  left: 'b',
+                },
+                messageId: 'unexpectedJSXPropsGroupOrder',
+              },
+            ],
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'shorthandElements',
+                    selector: 'shorthand',
+                  },
+                ],
+                groups: ['shorthandElements', 'unknown'],
+              },
+            ],
+            output: dedent`
+              <Element
+                a
+                b="b"
+              />
+            `,
+            code: dedent`
+              <Element
+                b="b"
+                a
+              />
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(`${ruleName}: filters on modifier`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  rightGroup: 'shorthandElements',
+                  leftGroup: 'unknown',
+                  right: 'a',
+                  left: 'b',
+                },
+                messageId: 'unexpectedJSXPropsGroupOrder',
+              },
+            ],
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'shorthandElements',
+                    modifiers: ['shorthand'],
+                  },
+                ],
+                groups: ['shorthandElements', 'unknown'],
+              },
+            ],
+            output: dedent`
+              <Element
+                a
+                b="b"
+              />
+            `,
+            code: dedent`
+              <Element
+                b="b"
+                a
+              />
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'shorthandsStartingWithHello',
+                      modifiers: ['shorthand'],
+                      elementNamePattern,
+                    },
+                  ],
+                  groups: ['shorthandsStartingWithHello', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'shorthandsStartingWithHello',
+                    right: 'helloShorthand',
+                    leftGroup: 'unknown',
+                    left: 'b',
+                  },
+                  messageId: 'unexpectedJSXPropsGroupOrder',
+                },
+              ],
+              output: dedent`
+                <Element
+                  helloShorthand
+                  a="a"
+                  b="b"
+                />
+              `,
+              code: dedent`
+                <Element
+                  a="a"
+                  b="b"
+                  helloShorthand
+                />
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
+
+      ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'bb',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedJSXPropsOrder',
+                },
+                {
+                  data: {
+                    right: 'ccc',
+                    left: 'bb',
+                  },
+                  messageId: 'unexpectedJSXPropsOrder',
+                },
+                {
+                  data: {
+                    right: 'dddd',
+                    left: 'ccc',
+                  },
+                  messageId: 'unexpectedJSXPropsOrder',
+                },
+                {
+                  data: {
+                    rightGroup: 'reversedShorthandsByLineLength',
+                    leftGroup: 'unknown',
+                    right: 'eee',
+                    left: 'm',
+                  },
+                  messageId: 'unexpectedJSXPropsGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'reversedShorthandsByLineLength',
+                      modifiers: ['shorthand'],
+                      type: 'line-length',
+                      order: 'desc',
+                    },
+                  ],
+                  groups: ['reversedShorthandsByLineLength', 'unknown'],
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+              ],
+              output: dedent`
+                <Element
+                  dddd
+                  ccc
+                  eee
+                  bb
+                  ff
+                  a
+                  g
+                  m="m"
+                  o="o"
+                  p="p"
+                />
+              `,
+              code: dedent`
+                <Element
+                  a
+                  bb
+                  ccc
+                  dddd
+                  m="m"
+                  eee
+                  ff
+                  g
+                  o="o"
+                  p="p"
+                />
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedJSXPropsOrder',
+                },
+              ],
+              output: dedent`
+                <Element
+                  fooBar
+                  fooZar
+                />
+              `,
+              code: dedent`
+                <Element
+                  fooZar
+                  fooBar
+                />
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: does not sort custom groups with 'unsorted' type`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'unsortedShorthands',
+                      modifiers: ['shorthand'],
+                      type: 'unsorted',
+                    },
+                  ],
+                  groups: ['unsortedShorthands', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'unsortedShorthands',
+                    leftGroup: 'unknown',
+                    right: 'c',
+                    left: 'm',
+                  },
+                  messageId: 'unexpectedJSXPropsGroupOrder',
+                },
+              ],
+              output: dedent`
+                <Element
+                  b
+                  a
+                  d
+                  e
+                  c
+                  m="m"
+                />
+              `,
+              code: dedent`
+                <Element
+                  b
+                  a
+                  d
+                  e
+                  m="m"
+                  c
+                />
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    anyOf: [
+                      {
+                        elementNamePattern: 'foo|Foo',
+                        modifiers: ['shorthand'],
+                      },
+                      {
+                        elementNamePattern: 'foo|Foo',
+                      },
+                    ],
+                    groupName: 'elementsIncludingFoo',
+                  },
+                ],
+                groups: ['elementsIncludingFoo', 'unknown'],
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  rightGroup: 'elementsIncludingFoo',
+                  leftGroup: 'unknown',
+                  right: 'cFoo',
+                  left: 'a',
+                },
+                messageId: 'unexpectedJSXPropsGroupOrder',
+              },
+            ],
+            output: dedent`
+              <Element
+                cFoo
+                foo="foo"
+                a
+              />
+            `,
+            code: dedent`
+              <Element
+                a
+                cFoo
+                foo="foo"
+              />
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}: allows to use regex for element names in custom groups`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      elementNamePattern: '^(?!.*Foo).*$',
+                      groupName: 'elementsWithoutFoo',
+                    },
+                  ],
+                  groups: ['unknown', 'elementsWithoutFoo'],
+                  type: 'alphabetical',
+                },
+              ],
+              code: dedent`
+                <Element
+                  iHaveFooInMyName
+                  meTooIHaveFoo
+                  a
+                  b
+                />
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): allows to remove special characters`,
       rule,


### PR DESCRIPTION
- Resolves partially https://github.com/azat-io/eslint-plugin-perfectionist/issues/493

## Description

This PR allows `sort-jsx-props` to handle the new `customGroups` API.

### Selector

- `prop`
- [DEPRECATED] `multiline`: allows keeping the existing `multiline` group.
- [DEPRECATED] `shorthand`: allows keeping the existing `shorthand` group.

### Modifiers

- `multiline`
- `shorthand`

### New `customGroups` API

The old `customGroups` object-based API is still handled.

Handles:
- `elementNamePattern`.
- `elementValuePattern`: can match arrow functions with `"\(\s*.*\s*\)\s*=>"`
  - Detecting function expressions in JSX props is not straightfoward: it requires us to use the RegExp above. I haven't put a `method` selector in this PR yet.

## What is the purpose of this pull request?

- [x] New Feature
