### PR TITLE
fix: fix invalid `newlinesBetween` result enforced

### DIFF
--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1808,6 +1808,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenArrayIncludesMembers',
+                      },
+                    ],
+                    output: dedent`
+                      [
+                        a,
+                        b,
+                      ].includes(value)
+                    `,
+                    code: dedent`
+                      [
+                        a,
+
+                        b,
+                      ].includes(value)
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4651,6 +4651,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenClassMembers',
+                      },
+                    ],
+                    output: dedent`
+                      class Class {
+                        a
+                        b
+                      }
+                    `,
+                    code: dedent`
+                      class Class {
+                        a
+
+                        b
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1573,6 +1573,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'A', groupName: 'a' },
+                          { elementNamePattern: 'B', groupName: 'b' },
+                          { elementNamePattern: 'C', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'B',
+                          left: 'A',
+                        },
+                        messageId: 'extraSpacingBetweenEnumsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      enum Enum {
+                        A = 'A',
+                        B = 'B',
+                      }
+                    `,
+                    code: dedent`
+                      enum Enum {
+                        A = 'A',
+
+                        B = 'B',
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -1471,6 +1471,63 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenExports',
+                      },
+                    ],
+                    output: dedent`
+                      export { a } from 'a'
+                      export { b } from 'b'
+                    `,
+                    code: dedent`
+                      export { a } from 'a'
+
+                      export { b } from 'b'
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2199,6 +2199,65 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: {
+                          value: {
+                            unusedGroup: 'X',
+                            a: 'a',
+                            b: 'b',
+                            c: 'c',
+                          },
+                        },
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenImports',
+                      },
+                    ],
+                    output: dedent`
+                      import { a } from 'a';
+                      import { b } from 'b';
+                    `,
+                    code: dedent`
+                      import { a } from 'a';
+
+                      import { b } from 'b';
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -2683,6 +2683,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenInterfaceMembers',
+                      },
+                    ],
+                    output: dedent`
+                      interface Interface {
+                        a: string
+                        b: string
+                      }
+                    `,
+                    code: dedent`
+                      interface Interface {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1252,6 +1252,57 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          { newlinesBetween: 'never' },
+                          'tuple',
+                          { newlinesBetween: 'never' },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'null',
+                          left: 'A',
+                        },
+                        messageId: 'extraSpacingBetweenIntersectionTypes',
+                      },
+                    ],
+                    output: dedent`
+                      type T =
+                        A &
+                        null
+                    `,
+                    code: dedent`
+                      type T =
+                        A &
+
+                        null
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1390,6 +1390,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenJSXPropsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      <Component
+                        a
+                        b
+                      />
+                    `,
+                    code: dedent`
+                      <Component
+                        a
+
+                        b
+                      />
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1402,6 +1402,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenMapElementsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      new Map([
+                        [a, 'a'],
+                        [b, 'b'],
+                      ])
+                    `,
+                    code: dedent`
+                      new Map([
+                        [a, 'a'],
+
+                        [b, 'b'],
+                      ])
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -2360,6 +2360,63 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenModulesMembers',
+                      },
+                    ],
+                    output: dedent`
+                      function a() {}
+                      function b() {}
+                    `,
+                    code: dedent`
+                      function a() {}
+
+                      function b() {}
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2479,6 +2479,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenObjectTypeMembers',
+                      },
+                    ],
+                    output: dedent`
+                      type T = {
+                        a: string
+                        b: string
+                      }
+                    `,
+                    code: dedent`
+                      type T = {
+                        a: string
+
+                        b: string
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2423,6 +2423,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenObjectMembers',
+                      },
+                    ],
+                    output: dedent`
+                      let obj = {
+                        a: null,
+                        b: null,
+                      }
+                    `,
+                    code: dedent`
+                      let obj = {
+                        a: null,
+
+                        b: null,
+                      }
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1755,6 +1755,67 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'a',
+                          { newlinesBetween: 'never' },
+                          'unusedGroup',
+                          { newlinesBetween: 'never' },
+                          'b',
+                          { newlinesBetween: 'always' },
+                          'c',
+                        ],
+                        customGroups: [
+                          { elementNamePattern: 'a', groupName: 'a' },
+                          { elementNamePattern: 'b', groupName: 'b' },
+                          { elementNamePattern: 'c', groupName: 'c' },
+                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'b',
+                          left: 'a',
+                        },
+                        messageId: 'extraSpacingBetweenSetsMembers',
+                      },
+                    ],
+                    output: dedent`
+                      new Set([
+                        a,
+                        b,
+                      ])
+                    `,
+                    code: dedent`
+                      new Set([
+                        a,
+
+                        b,
+                      ])
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1255,6 +1255,57 @@ describe(ruleName, () => {
             )
           }
 
+          for (let globalNewlinesBetween of [
+            'always',
+            'ignore',
+            'never',
+          ] as const) {
+            ruleTester.run(
+              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
+              rule,
+              {
+                invalid: [
+                  {
+                    options: [
+                      {
+                        ...options,
+                        groups: [
+                          'named',
+                          { newlinesBetween: 'never' },
+                          'tuple',
+                          { newlinesBetween: 'never' },
+                          'nullish',
+                        ],
+                        newlinesBetween: globalNewlinesBetween,
+                      },
+                    ],
+                    errors: [
+                      {
+                        data: {
+                          right: 'null',
+                          left: 'A',
+                        },
+                        messageId: 'extraSpacingBetweenUnionTypes',
+                      },
+                    ],
+                    output: dedent`
+                      type T =
+                        A |
+                        null
+                    `,
+                    code: dedent`
+                      type T =
+                        A |
+
+                        null
+                    `,
+                  },
+                ],
+                valid: [],
+              },
+            )
+          }
+
           for (let [globalNewlinesBetween, groupNewlinesBetween] of [
             ['ignore', 'never'] as const,
             ['never', 'ignore'] as const,

--- a/test/utils/get-newlines-between-option.test.ts
+++ b/test/utils/get-newlines-between-option.test.ts
@@ -186,8 +186,9 @@ describe('get-newlines-between-option', () => {
       })
 
       describe('non-adjacent groups', () => {
-        it('should return `always` if the global option is `always`', () => {
-          for (let newlinesBetween of ['always', 'ignore', 'never'] as const) {
+        it.each(['always', 'ignore', 'never'] as const)(
+          'should return `always` if the global option is `always`',
+          newlinesBetween => {
             expect(
               getNewlinesBetweenOption(
                 buildParameters({
@@ -201,8 +202,8 @@ describe('get-newlines-between-option', () => {
                 }),
               ),
             ).toBe('always')
-          }
-        })
+          },
+        )
 
         it('should return `always` if `always` exists between the groups', () => {
           expect(
@@ -238,8 +239,9 @@ describe('get-newlines-between-option', () => {
           ).toBe('ignore')
         })
 
-        it('should return the global option if no `ignore` or `always` exist', () => {
-          for (let newlinesBetween of ['always', 'ignore', 'never'] as const) {
+        it.each(['always', 'ignore', 'never'] as const)(
+          'should return the global option (`%s`) if no `ignore` or `always` exist',
+          newlinesBetween => {
             expect(
               getNewlinesBetweenOption(
                 buildParameters({
@@ -255,8 +257,8 @@ describe('get-newlines-between-option', () => {
                 }),
               ),
             ).toBe(newlinesBetween)
-          }
-        })
+          },
+        )
       })
     })
   })

--- a/test/utils/get-newlines-between-option.test.ts
+++ b/test/utils/get-newlines-between-option.test.ts
@@ -274,6 +274,27 @@ describe('get-newlines-between-option', () => {
         )
 
         it.each(['always', 'ignore', 'never'] as const)(
+          'should return `never` if there are only `never` between all groups and global option is `%s`',
+          newlinesBetween => {
+            expect(
+              getNewlinesBetweenOption(
+                buildParameters({
+                  groups: [
+                    'group1',
+                    { newlinesBetween: 'never' },
+                    'someOtherGroup',
+                    { newlinesBetween: 'never' },
+                    'group2',
+                    'someOtherGroup2',
+                  ],
+                  newlinesBetween,
+                }),
+              ),
+            ).toBe('never')
+          },
+        )
+
+        it.each(['always', 'ignore', 'never'] as const)(
           'should return the global option (`%s`) if no `ignore` or `always` exist',
           newlinesBetween => {
             expect(

--- a/test/utils/get-newlines-between-option.test.ts
+++ b/test/utils/get-newlines-between-option.test.ts
@@ -7,46 +7,45 @@ import { getNewlinesBetweenOption } from '../../utils/get-newlines-between-optio
 
 describe('get-newlines-between-option', () => {
   describe('global "newlinesBetween" option', () => {
-    it('should return the global option if "customGroups" is not defined', () => {
-      expect(
-        getNewlinesBetweenOption(
-          buildParameters({
-            newlinesBetween: 'ignore',
-          }),
-        ),
-      ).toBe('ignore')
-    })
+    it.each(['always', 'ignore', 'never'] as const)(
+      'should return the global option (`%s`) if "customGroups" is not defined',
+      newlinesBetween => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              newlinesBetween,
+            }),
+          ),
+        ).toBe(newlinesBetween)
+      },
+    )
 
-    it('should return the global option if "customGroups" is not an array', () => {
-      expect(
-        getNewlinesBetweenOption(
-          buildParameters({
-            newlinesBetween: 'ignore',
-            customGroups: {},
-          }),
-        ),
-      ).toBe('ignore')
-    })
+    it.each(['always', 'ignore', 'never'] as const)(
+      'should return the global option (`%s`) if "customGroups" is not an array',
+      newlinesBetween => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: {},
+              newlinesBetween,
+            }),
+          ),
+        ).toBe(newlinesBetween)
+      },
+    )
 
-    it('should return "ignore" if "newlinesBetween" is "ignore"', () => {
-      expect(
-        getNewlinesBetweenOption(
-          buildParameters({
-            newlinesBetween: 'ignore',
-          }),
-        ),
-      ).toBe('ignore')
-    })
-
-    it('should return "never" if "newlinesBetween" is "never"', () => {
-      expect(
-        getNewlinesBetweenOption(
-          buildParameters({
-            newlinesBetween: 'never',
-          }),
-        ),
-      ).toBe('never')
-    })
+    it.each(['ignore', 'never'] as const)(
+      'should return "%s" if "newlinesBetween" is "%s"',
+      newlinesBetween => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              newlinesBetween,
+            }),
+          ),
+        ).toBe(newlinesBetween)
+      },
+    )
 
     it('should return "always" if "newlinesBetween" is "always" and nodeGroupNumber !== nextNodeGroupNumber', () => {
       expect(
@@ -74,37 +73,43 @@ describe('get-newlines-between-option', () => {
       ).toBe('never')
     })
 
-    it("should return the global option if the node's group is within an array", () => {
-      expect(
-        getNewlinesBetweenOption(
-          buildParameters({
-            customGroups: [
-              {
-                groupName: 'group1',
-              },
-            ],
-            groups: [['group1', 'group3'], 'group2'],
-            newlinesBetween: 'never',
-          }),
-        ),
-      ).toBe('never')
-    })
+    it.each(['always', 'ignore', 'never'] as const)(
+      "should return the global option (`%s`) if the node's group is within an array",
+      newlinesBetween => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+              ],
+              groups: [['group1', 'group3'], 'group2'],
+              newlinesBetween,
+            }),
+          ),
+        ).toBe(newlinesBetween)
+      },
+    )
 
-    it("should return the global option if the next node's group is within an array", () => {
-      expect(
-        getNewlinesBetweenOption(
-          buildParameters({
-            customGroups: [
-              {
-                groupName: 'group1',
-              },
-            ],
-            groups: ['group1', ['group2', 'group3']],
-            newlinesBetween: 'never',
-          }),
-        ),
-      ).toBe('never')
-    })
+    it.each(['always', 'ignore', 'never'] as const)(
+      "should return the global option (`%s`) if the next node's group is within an array",
+      newlinesBetween => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+              ],
+              groups: ['group1', ['group2', 'group3']],
+              newlinesBetween,
+            }),
+          ),
+        ).toBe(newlinesBetween)
+      },
+    )
   })
 
   describe('custom groups "newlinesBetween" option', () => {
@@ -118,72 +123,95 @@ describe('get-newlines-between-option', () => {
         ],
         nextSortingNodeGroup: 'group1',
         sortingNodeGroup: 'group1',
-        newlinesBetween: 'never',
       } as const
 
-      it('should return the "newlinesInside" option if defined', () => {
-        expect(
-          getNewlinesBetweenOption(
-            buildParameters({
-              ...parameters,
-              customGroups: [
-                {
-                  newlinesInside: 'always',
-                  groupName: 'group1',
-                },
-              ],
-            }),
-          ),
-        ).toBe('always')
-      })
+      it.each(['always', 'never'] as const)(
+        'should return the "newlinesInside" option (`%s`) if defined',
+        newlinesInside => {
+          expect(
+            getNewlinesBetweenOption(
+              buildParameters({
+                ...parameters,
+                customGroups: [
+                  {
+                    groupName: 'group1',
+                    newlinesInside,
+                  },
+                ],
+                newlinesBetween: 'never',
+              }),
+            ),
+          ).toBe(newlinesInside)
+        },
+      )
 
-      it('should return the global option if the "newlinesInside" option is not defined', () => {
-        expect(
-          getNewlinesBetweenOption(
-            buildParameters({
-              ...parameters,
-              customGroups: [
-                {
-                  groupName: 'group1',
-                },
-              ],
-            }),
-          ),
-        ).toBe('never')
-      })
+      it.each(['ignore', 'never'] as const)(
+        'should return the global option (`%s`) if the "newlinesInside" option is not defined',
+        newlinesBetween => {
+          expect(
+            getNewlinesBetweenOption(
+              buildParameters({
+                ...parameters,
+                customGroups: [
+                  {
+                    groupName: 'group1',
+                  },
+                ],
+                newlinesBetween,
+              }),
+            ),
+          ).toBe(newlinesBetween)
+        },
+      )
     })
 
     describe('when the node and next node do not belong to the same custom group', () => {
-      it('should return the global option', () => {
-        expect(
-          getNewlinesBetweenOption(
-            buildParameters({
-              customGroups: [
-                {
-                  groupName: 'group1',
-                },
-                {
-                  groupName: 'group2',
-                },
-              ],
-              newlinesBetween: 'never',
-            }),
-          ),
-        ).toBe('never')
-      })
+      it.each(['always', 'ignore', 'never'] as const)(
+        'should return the global option (`%s`)',
+        newlinesBetween => {
+          expect(
+            getNewlinesBetweenOption(
+              buildParameters({
+                customGroups: [
+                  {
+                    groupName: 'group1',
+                  },
+                  {
+                    groupName: 'group2',
+                  },
+                ],
+                newlinesBetween,
+              }),
+            ),
+          ).toBe(newlinesBetween)
+        },
+      )
     })
 
     describe('newlinesBetween option between two groups', () => {
-      it('should return the newlinesBetween option between two adjacent groups', () => {
-        expect(
-          getNewlinesBetweenOption(
-            buildParameters({
-              groups: ['group1', { newlinesBetween: 'always' }, 'group2'],
-              newlinesBetween: 'never',
-            }),
-          ),
-        ).toBe('always')
-      })
+      it.each([
+        { globalNewlinesBetween: 'always', newlinesBetween: 'always' },
+        { globalNewlinesBetween: 'always', newlinesBetween: 'ignore' },
+        { globalNewlinesBetween: 'always', newlinesBetween: 'never' },
+        { globalNewlinesBetween: 'ignore', newlinesBetween: 'always' },
+        { globalNewlinesBetween: 'ignore', newlinesBetween: 'ignore' },
+        { globalNewlinesBetween: 'ignore', newlinesBetween: 'never' },
+        { globalNewlinesBetween: 'never', newlinesBetween: 'always' },
+        { globalNewlinesBetween: 'never', newlinesBetween: 'ignore' },
+        { globalNewlinesBetween: 'never', newlinesBetween: 'never' },
+      ] as const)(
+        'should return the newlinesBetween option between two adjacent groups (%s)',
+        ({ globalNewlinesBetween, newlinesBetween }) => {
+          expect(
+            getNewlinesBetweenOption(
+              buildParameters({
+                groups: ['group1', { newlinesBetween }, 'group2'],
+                newlinesBetween: globalNewlinesBetween,
+              }),
+            ),
+          ).toBe(newlinesBetween)
+        },
+      )
 
       describe('non-adjacent groups', () => {
         it.each(['always', 'ignore', 'never'] as const)(
@@ -205,39 +233,45 @@ describe('get-newlines-between-option', () => {
           },
         )
 
-        it('should return `always` if `always` exists between the groups', () => {
-          expect(
-            getNewlinesBetweenOption(
-              buildParameters({
-                groups: [
-                  'group1',
-                  'someOtherGroup',
-                  { newlinesBetween: 'always' },
-                  'group2',
-                ],
-                newlinesBetween: 'never',
-              }),
-            ),
-          ).toBe('always')
-        })
+        it.each(['always', 'ignore', 'never'] as const)(
+          'should return `always` if `always` exists between the groups and global option is `%s`',
+          newlinesBetween => {
+            expect(
+              getNewlinesBetweenOption(
+                buildParameters({
+                  groups: [
+                    'group1',
+                    'someOtherGroup',
+                    { newlinesBetween: 'always' },
+                    'group2',
+                  ],
+                  newlinesBetween,
+                }),
+              ),
+            ).toBe('always')
+          },
+        )
 
-        it('should return `ignore` if `ignore` exists between the groups', () => {
-          expect(
-            getNewlinesBetweenOption(
-              buildParameters({
-                groups: [
-                  'group1',
-                  'someOtherGroup',
-                  { newlinesBetween: 'ignore' },
-                  'group2',
-                  { newlinesBetween: 'always' },
-                  'someOtherGroup2',
-                ],
-                newlinesBetween: 'never',
-              }),
-            ),
-          ).toBe('ignore')
-        })
+        it.each(['ignore', 'never'] as const)(
+          'should return `ignore` if `ignore` exists between the groups and not `always` with global option `%s`',
+          newlinesBetween => {
+            expect(
+              getNewlinesBetweenOption(
+                buildParameters({
+                  groups: [
+                    'group1',
+                    'someOtherGroup',
+                    { newlinesBetween: 'ignore' },
+                    'group2',
+                    { newlinesBetween: 'always' },
+                    'someOtherGroup2',
+                  ],
+                  newlinesBetween,
+                }),
+              ),
+            ).toBe('ignore')
+          },
+        )
 
         it.each(['always', 'ignore', 'never'] as const)(
           'should return the global option (`%s`) if no `ignore` or `always` exist',

--- a/test/utils/validate-custom-sort-configuration.test.ts
+++ b/test/utils/validate-custom-sort-configuration.test.ts
@@ -3,16 +3,17 @@ import { describe, expect, it } from 'vitest'
 import { validateCustomSortConfiguration } from '../../utils/validate-custom-sort-configuration'
 
 describe('validate-custom-sort-configuration', () => {
-  it('accepts empty alphabet when type is not `custom`', () => {
-    for (let type of ['alphabetical', 'line-length', 'natural'] as const) {
+  it.each(['alphabetical', 'line-length', 'natural'] as const)(
+    'accepts empty alphabet when type is `%s`',
+    type => {
       expect(() =>
         validateCustomSortConfiguration({
           alphabet: '',
           type,
         }),
       ).not.toThrow()
-    }
-  })
+    },
+  )
 
   it('throws when an empty alphabet is entered while type is `custom`', () => {
     expect(() =>

--- a/test/utils/validate-newlines-and-partition-configuration.test.ts
+++ b/test/utils/validate-newlines-and-partition-configuration.test.ts
@@ -3,10 +3,9 @@ import { describe, expect, it } from 'vitest'
 import { validateNewlinesAndPartitionConfiguration } from '../../utils/validate-newlines-and-partition-configuration'
 
 describe('validate-newlines-and-partition-configuration', () => {
-  it("throws an error when 'partitionByNewline' is enabled and 'newlinesBetween' is not 'ignore'", () => {
-    let newlinesBetweenValues = ['always', 'never'] as const
-
-    for (let newlinesBetween of newlinesBetweenValues) {
+  it.each(['always', 'never'] as const)(
+    "throws an error when 'partitionByNewline' is enabled and 'newlinesBetween' is '%s'",
+    newlinesBetween => {
       expect(() => {
         validateNewlinesAndPartitionConfiguration({
           partitionByNewLine: true,
@@ -16,13 +15,12 @@ describe('validate-newlines-and-partition-configuration', () => {
       }).toThrow(
         "The 'partitionByNewLine' and 'newlinesBetween' options cannot be used together",
       )
-    }
-  })
+    },
+  )
 
-  it("throws an error when 'partitionByNewline' is enabled and 'newlinesBetween' objects exist in 'groups'", () => {
-    let newlinesBetweenValues = ['always', 'never', 'ignore'] as const
-
-    for (let newlinesBetween of newlinesBetweenValues) {
+  it.each(['always', 'never', 'ignore'] as const)(
+    "throws an error when 'partitionByNewline' is enabled and `newlinesBetween: '%s'` objects exist in 'groups'",
+    newlinesBetween => {
       expect(() => {
         validateNewlinesAndPartitionConfiguration({
           groups: [{ newlinesBetween }],
@@ -32,8 +30,8 @@ describe('validate-newlines-and-partition-configuration', () => {
       }).toThrow(
         "'newlinesBetween' objects can not be used in 'groups' alongside 'partitionByNewLine'",
       )
-    }
-  })
+    },
+  )
 
   it("allows 'partitionByNewline' when 'newlinesBetween' is 'ignore'", () => {
     expect(() => {
@@ -45,10 +43,9 @@ describe('validate-newlines-and-partition-configuration', () => {
     }).not.toThrow()
   })
 
-  it("allows 'newlinesBetween' when 'partitionByNewline' is 'false'", () => {
-    let newlinesBetweenValues = ['always', 'never', 'ignore'] as const
-
-    for (let newlinesBetween of newlinesBetweenValues) {
+  it.each(['always', 'never', 'ignore'] as const)(
+    "allows `newlinesBetween: '%s'` when 'partitionByNewline' is 'false'",
+    newlinesBetween => {
       expect(() => {
         validateNewlinesAndPartitionConfiguration({
           partitionByNewLine: false,
@@ -56,6 +53,6 @@ describe('validate-newlines-and-partition-configuration', () => {
           groups: [],
         })
       }).not.toThrow()
-    }
-  })
+    },
+  )
 })

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -99,6 +99,9 @@ export let getNewlinesBetweenOption = ({
       if (newlinesBetweenOptions.has('ignore')) {
         return 'ignore'
       }
+      if (newlinesBetweenOptions.has('never')) {
+        return 'never'
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #501

## Description

When two elements belong to different groups, we check all the `newlinesBetween` options in-between those groups to deduce if we should enforce a newline behavior or not.

A case was missing: when all in-between elements have `newlinesBetween: never`, we should enforce no newline.

## Bug severity

Low:
- Does not affect build/runtime.
- Appears in quite specific cases.

## What is the purpose of this pull request?

- [x] Bug fix
