### PR TITLE
feat(sort-imports): update default groups to new API

### DIFF
--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -323,6 +323,7 @@ The list of selectors is sorted from most to least important:
 #### Modifiers
 
 - `'type'` — Typescript time imports.
+- `'value'` — Value imports.
 
 #### Important notes
 
@@ -353,23 +354,23 @@ import type { FC } from 'react'
 Example 2 (The most important group is written in the comments):
 
 ```ts
-// 'builtin' - Node.js Built-in Modules
+// 'value-builtin' - Node.js Built-in Modules
 import path from 'path'
-// 'external' - External modules installed in the project
+// 'value-external' - External modules installed in the project
 import axios from 'axios'
-// 'internal' - Your internal modules
+// 'value-internal' - Your internal modules
 import Button from '~/components/Button'
-// 'parent' - Modules from parent directory
+// 'value-parent' - Modules from parent directory
 import formatNumber from '../utils/format-number'
-// 'sibling' - Modules from the same directory
+// 'value-sibling' - Modules from the same directory
 import config from './config'
-// 'side-effect' - Side effect imports
+// 'value-side-effect' - Side effect imports
 import './set-production-env.js'
-// side-effect-style - Side effect style imports
+// value-side-effect-style - Side effect style imports
 import './styles.scss'
-// 'index' - Main file from the current directory
+// 'value-index' - Main file from the current directory
 import main from '.'
-// 'style' - Styles
+// 'value-style' - Styles
 import styles from './index.module.css'
 // 'type-external' - TypeScript type imports
 import type { FC } from 'react'

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -319,6 +319,7 @@ The list of selectors is sorted from most to least important:
 - `'internal'` — Your internal modules.
 - `'builtin'` — Node.js Built-in Modules.
 - `'external'` — External modules installed in the project.
+- `'import'` — Any import.
 
 #### Modifiers
 
@@ -350,6 +351,8 @@ import type { FC } from 'react'
 - `type` (`type` selector).
 - `type-external` (`type` modifier).
 - `external`.
+- `type-import`.
+- `import`.
 
 Example 2 (The most important group is written in the comments):
 

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -282,12 +282,12 @@ Specifies the  directory of the root `tsconfig.json` file (ex: `.`). This is use
   default:
   ```
   [
-    'type',
-    ['builtin', 'external'],
-    'internal-type',
-    'internal',
-    ['parent-type', 'sibling-type', 'index-type'],
-    ['parent', 'sibling', 'index'],
+    'type-import',
+    ['value-builtin', 'value-external'],
+    'type-internal',
+    'value-internal',
+    ['type-parent', 'type-sibling', 'type-index'],
+    ['value-parent', 'value-sibling', 'value-index'],
     'unknown',
   ]
   ```
@@ -520,13 +520,13 @@ you must write a custom group definition that does the same as what the predefin
 ```js
    groups: [
 +    'react',                           // [!code ++]
-     'type',
-     ['builtin', 'external'],
+     'type-import',
+     ['value-builtin', 'value-external'],
 +    'lodash',                          // [!code ++]
-     'internal-type',
-     'internal',
-     ['parent-type', 'sibling-type', 'index-type'],
-     ['parent', 'sibling', 'index'],
+     'type-internal',
+     'value-internal',
+     ['type-parent', 'type-sibling', 'type-index'],
+     ['value-parent', 'value-sibling', 'value-index'],
      'unknown',
    ],
 +  customGroups: [                      // [!code ++]
@@ -577,12 +577,12 @@ Specifies which environment’s built-in modules should be recognized. If you ar
                   newlinesBetween: 'always',
                   maxLineLength: undefined,
                   groups: [
-                    'type',
-                    ['builtin', 'external'],
-                    'internal-type',
-                    'internal',
-                    ['parent-type', 'sibling-type', 'index-type'],
-                    ['parent', 'sibling', 'index'],
+                    'type-import',
+                    ['value-builtin', 'value-external'],
+                    'type-internal',
+                    'value-internal',
+                    ['type-parent', 'type-sibling', 'type-index'],
+                    ['value-parent', 'value-sibling', 'value-index'],
                     'unknown',
                   ],
                   customGroups: [],
@@ -618,12 +618,12 @@ Specifies which environment’s built-in modules should be recognized. If you ar
                 newlinesBetween: 'always',
                 maxLineLength: undefined,
                 groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
+                  'type-import',
+                  ['value-builtin', 'value-external'],
+                  'type-internal',
+                  'value-internal',
+                  ['type-parent', 'type-sibling', 'type-index'],
+                  ['value-parent', 'value-sibling', 'value-index'],
                   'unknown',
                 ],
                 customGroups: [],

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -61,12 +61,12 @@ import { complete } from '../utils/complete'
 let cachedGroupsByModifiersAndSelectors = new Map<string, string[]>()
 
 let defaultGroups = [
-  'type',
-  ['builtin', 'external'],
-  'internal-type',
-  'internal',
-  ['parent-type', 'sibling-type', 'index-type'],
-  ['parent', 'sibling', 'index'],
+  'type-import',
+  ['value-builtin', 'value-external'],
+  'type-internal',
+  'value-internal',
+  ['type-parent', 'type-sibling', 'type-index'],
+  ['value-parent', 'value-sibling', 'value-index'],
   'unknown',
 ]
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -233,6 +233,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
         selectors.push(selector)
       }
 
+      if (!modifiers.includes('type')) {
+        modifiers.push('value')
+      }
+
       group ??=
         computeGroupExceptUnknown({
           customGroups: Array.isArray(options.customGroups)

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -232,6 +232,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       for (let selector of commonSelectors) {
         selectors.push(selector)
       }
+      selectors.push('import')
 
       if (!modifiers.includes('type')) {
         modifiers.push('value')

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -60,6 +60,16 @@ import { complete } from '../utils/complete'
  */
 let cachedGroupsByModifiersAndSelectors = new Map<string, string[]>()
 
+let defaultGroups = [
+  'type',
+  ['builtin', 'external'],
+  'internal-type',
+  'internal',
+  ['parent-type', 'sibling-type', 'index-type'],
+  ['parent', 'sibling', 'index'],
+  'unknown',
+]
+
 export type MESSAGE_ID =
   | 'missedSpacingBetweenImports'
   | 'unexpectedImportsGroupOrder'
@@ -73,15 +83,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
     let userOptions = context.options.at(0)
     let options = getOptionsWithCleanGroups(
       complete(userOptions, settings, {
-        groups: [
-          'type',
-          ['builtin', 'external'],
-          'internal-type',
-          'internal',
-          ['parent-type', 'sibling-type', 'index-type'],
-          ['parent', 'sibling', 'index'],
-          'unknown',
-        ],
         fallbackSort: { type: 'unsorted' },
         internalPattern: ['^~/.+'],
         partitionByComment: false,
@@ -89,6 +90,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         newlinesBetween: 'always',
         specialCharacters: 'keep',
         sortSideEffects: false,
+        groups: defaultGroups,
         type: 'alphabetical',
         environment: 'node',
         customGroups: [],
@@ -475,15 +477,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
   },
   defaultOptions: [
     {
-      groups: [
-        'type',
-        ['builtin', 'external'],
-        'internal-type',
-        'internal',
-        ['parent-type', 'sibling-type', 'index-type'],
-        ['parent', 'sibling', 'index'],
-        'unknown',
-      ],
       customGroups: { value: {}, type: {} },
       internalPattern: ['^~/.+'],
       partitionByComment: false,
@@ -491,6 +484,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       specialCharacters: 'keep',
       newlinesBetween: 'always',
       sortSideEffects: false,
+      groups: defaultGroups,
       type: 'alphabetical',
       environment: 'node',
       ignoreCase: true,

--- a/rules/sort-imports/types.ts
+++ b/rules/sort-imports/types.ts
@@ -59,6 +59,7 @@ export type Selector =
   | InternalSelector
   | BuiltinSelector
   | SiblingSelector
+  | ImportSelector
   | ObjectSelector
   | ParentSelector
   | IndexSelector
@@ -133,6 +134,8 @@ type ParentSelector = 'parent'
  */
 type ObjectSelector = 'object'
 
+type ImportSelector = 'import'
+
 type IndexSelector = 'index'
 
 type StyleSelector = 'style'
@@ -150,6 +153,7 @@ export let allSelectors: Selector[] = [
   'internal',
   'builtin',
   'sibling',
+  'import',
   'parent',
   'index',
   'style',

--- a/rules/sort-imports/types.ts
+++ b/rules/sort-imports/types.ts
@@ -78,7 +78,7 @@ export interface SortImportsSortingNode extends SortingNode {
 
 export type Group = ValueGroup | TypeGroup | 'unknown' | string
 
-export type Modifier = TypeModifier
+export type Modifier = ValueModifier | TypeModifier
 
 type TypeGroup = JoinWithDash<[TypeModifier, Selector]>
 
@@ -137,6 +137,8 @@ type IndexSelector = 'index'
 
 type StyleSelector = 'style'
 
+type ValueModifier = 'value'
+
 type TypeModifier = 'type'
 
 type TypeSelector = 'type'
@@ -164,7 +166,7 @@ export let allDeprecatedSelectors: Selector[] = [
   'object',
 ]
 
-export let allModifiers: Modifier[] = ['type']
+export let allModifiers: Modifier[] = ['type', 'value']
 
 /**
  * Ideally, we should generate as many schemas as there are selectors, and ensure

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2933,6 +2933,45 @@ describe(ruleName, () => {
             valid: [],
           },
         )
+
+        ruleTester.run(
+          `${ruleName}(${type}): prioritizes "external" over "import"`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'external',
+                      leftGroup: 'import',
+                      left: './a',
+                      right: 'b',
+                    },
+                    messageId: 'unexpectedImportsGroupOrder',
+                  },
+                ],
+                options: [
+                  {
+                    ...options,
+                    groups: ['external', 'import'],
+                  },
+                ],
+                output: dedent`
+                  import b from 'b'
+
+                  import a from './a'
+                `,
+                code: dedent`
+                  import a from './a'
+
+                  import b from 'b'
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
       })
 
       describe(`custom groups`, () => {

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -88,8 +88,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'internal-type',
-                leftGroup: 'internal',
+                rightGroup: 'type-internal',
+                leftGroup: 'value-internal',
                 right: '~/i',
                 left: '~/b',
               },
@@ -104,8 +104,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                leftGroup: 'sibling-type',
-                rightGroup: 'builtin',
+                rightGroup: 'value-builtin',
+                leftGroup: 'type-sibling',
                 left: './d',
                 right: 'fs',
               },
@@ -127,17 +127,17 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'index-type',
+                leftGroup: 'value-parent',
+                rightGroup: 'type-index',
                 right: './index.d.ts',
-                leftGroup: 'parent',
                 left: '../../h',
               },
               messageId: 'unexpectedImportsGroupOrder',
             },
             {
               data: {
-                leftGroup: 'index',
-                rightGroup: 'type',
+                rightGroup: 'type-import',
+                leftGroup: 'value-index',
                 right: 't',
                 left: '.',
               },
@@ -243,8 +243,8 @@ describe(ruleName, () => {
           errors: [
             {
               data: {
-                rightGroup: 'external',
-                leftGroup: 'index',
+                rightGroup: 'value-external',
+                leftGroup: 'value-index',
                 right: 'a',
                 left: '.',
               },
@@ -252,8 +252,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                leftGroup: 'internal',
-                rightGroup: 'type',
+                leftGroup: 'value-internal',
+                rightGroup: 'type-import',
                 left: '~/c',
                 right: 't',
               },
@@ -261,8 +261,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'internal',
-                leftGroup: 'parent',
+                rightGroup: 'value-internal',
+                leftGroup: 'value-parent',
                 left: '../../e',
                 right: '~/b',
               },
@@ -383,9 +383,9 @@ describe(ruleName, () => {
               },
               {
                 data: {
-                  rightGroup: 'external',
+                  rightGroup: 'value-external',
+                  leftGroup: 'value-parent',
                   right: 'console.log',
-                  leftGroup: 'parent',
                   left: '../b',
                 },
                 messageId: 'unexpectedImportsGroupOrder',
@@ -706,8 +706,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'external',
-                leftGroup: 'sibling',
+                rightGroup: 'value-external',
+                leftGroup: 'value-sibling',
                 left: './b',
                 right: 'c',
               },
@@ -1043,8 +1043,8 @@ describe(ruleName, () => {
               },
               {
                 data: {
-                  leftGroup: 'internal',
-                  rightGroup: 'builtin',
+                  leftGroup: 'value-internal',
+                  rightGroup: 'value-builtin',
                   left: '~/b',
                   right: 'fs',
                 },
@@ -3417,8 +3417,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'internal-type',
-                leftGroup: 'internal',
+                rightGroup: 'type-internal',
+                leftGroup: 'value-internal',
                 right: '~/i',
                 left: '~/b',
               },
@@ -3433,8 +3433,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                leftGroup: 'sibling-type',
-                rightGroup: 'builtin',
+                rightGroup: 'value-builtin',
+                leftGroup: 'type-sibling',
                 left: './d',
                 right: 'fs',
               },
@@ -3456,17 +3456,17 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'index-type',
+                leftGroup: 'value-parent',
+                rightGroup: 'type-index',
                 right: './index.d.ts',
-                leftGroup: 'parent',
                 left: '../../h',
               },
               messageId: 'unexpectedImportsGroupOrder',
             },
             {
               data: {
-                leftGroup: 'index',
-                rightGroup: 'type',
+                rightGroup: 'type-import',
+                leftGroup: 'value-index',
                 right: 't',
                 left: '.',
               },
@@ -3572,8 +3572,8 @@ describe(ruleName, () => {
           errors: [
             {
               data: {
-                rightGroup: 'external',
-                leftGroup: 'index',
+                rightGroup: 'value-external',
+                leftGroup: 'value-index',
                 right: 'a',
                 left: '.',
               },
@@ -3581,8 +3581,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                leftGroup: 'internal',
-                rightGroup: 'type',
+                leftGroup: 'value-internal',
+                rightGroup: 'type-import',
                 left: '~/c',
                 right: 't',
               },
@@ -3590,8 +3590,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'internal',
-                leftGroup: 'parent',
+                rightGroup: 'value-internal',
+                leftGroup: 'value-parent',
                 left: '../../e',
                 right: '~/b',
               },
@@ -3712,9 +3712,9 @@ describe(ruleName, () => {
               },
               {
                 data: {
-                  rightGroup: 'external',
+                  rightGroup: 'value-external',
+                  leftGroup: 'value-parent',
                   right: 'console.log',
-                  leftGroup: 'parent',
                   left: '../b',
                 },
                 messageId: 'unexpectedImportsGroupOrder',
@@ -4036,8 +4036,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'external',
-                leftGroup: 'sibling',
+                rightGroup: 'value-external',
+                leftGroup: 'value-sibling',
                 left: './b',
                 right: 'c',
               },
@@ -4373,8 +4373,8 @@ describe(ruleName, () => {
               },
               {
                 data: {
-                  leftGroup: 'internal',
-                  rightGroup: 'builtin',
+                  leftGroup: 'value-internal',
+                  rightGroup: 'value-builtin',
                   left: '~/b',
                   right: 'fs',
                 },
@@ -4738,8 +4738,8 @@ describe(ruleName, () => {
           errors: [
             {
               data: {
-                rightGroup: 'internal-type',
-                leftGroup: 'internal',
+                rightGroup: 'type-internal',
+                leftGroup: 'value-internal',
                 right: '~/i',
                 left: '~/b',
               },
@@ -4754,8 +4754,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                leftGroup: 'sibling-type',
-                rightGroup: 'builtin',
+                rightGroup: 'value-builtin',
+                leftGroup: 'type-sibling',
                 left: './d',
                 right: 'fs',
               },
@@ -4791,17 +4791,17 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'index-type',
+                leftGroup: 'value-parent',
+                rightGroup: 'type-index',
                 right: './index.d.ts',
-                leftGroup: 'parent',
                 left: '../../h',
               },
               messageId: 'unexpectedImportsGroupOrder',
             },
             {
               data: {
-                leftGroup: 'index',
-                rightGroup: 'type',
+                rightGroup: 'type-import',
+                leftGroup: 'value-index',
                 right: 't',
                 left: '.',
               },
@@ -4921,8 +4921,8 @@ describe(ruleName, () => {
           errors: [
             {
               data: {
-                rightGroup: 'external',
-                leftGroup: 'index',
+                rightGroup: 'value-external',
+                leftGroup: 'value-index',
                 right: 'a',
                 left: '.',
               },
@@ -4930,8 +4930,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                leftGroup: 'internal',
-                rightGroup: 'type',
+                leftGroup: 'value-internal',
+                rightGroup: 'type-import',
                 left: '~/c',
                 right: 't',
               },
@@ -4939,8 +4939,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'internal',
-                leftGroup: 'parent',
+                rightGroup: 'value-internal',
+                leftGroup: 'value-parent',
                 left: '../../e',
                 right: '~/b',
               },
@@ -5061,9 +5061,9 @@ describe(ruleName, () => {
               },
               {
                 data: {
-                  rightGroup: 'external',
+                  rightGroup: 'value-external',
+                  leftGroup: 'value-parent',
                   right: 'console.log',
-                  leftGroup: 'parent',
                   left: '../b',
                 },
                 messageId: 'unexpectedImportsGroupOrder',
@@ -5370,8 +5370,8 @@ describe(ruleName, () => {
             },
             {
               data: {
-                rightGroup: 'external',
-                leftGroup: 'sibling',
+                rightGroup: 'value-external',
+                leftGroup: 'value-sibling',
                 left: './b',
                 right: 'c',
               },
@@ -5765,8 +5765,8 @@ describe(ruleName, () => {
             errors: [
               {
                 data: {
-                  leftGroup: 'internal',
-                  rightGroup: 'builtin',
+                  leftGroup: 'value-internal',
+                  rightGroup: 'value-builtin',
                   left: '~/b',
                   right: 'fs',
                 },


### PR DESCRIPTION
- Follow-up of https://github.com/azat-io/eslint-plugin-perfectionist/pull/505.
- Related to the following issues:
  - https://github.com/azat-io/eslint-plugin-perfectionist/issues/494.
  - https://github.com/azat-io/eslint-plugin-perfectionist/issues/510.

# Description

This PR adds a `value` modifier alongside an `import` selector in order for the `groups` option not to rely on deprecated selectors.

## `import` selector

This selector has the lowest priority of all selectors and will match every import.

## `value` modifier

Similar to the `type` modifier. Any non-`type` import will have the `value` modifier, even `side-effect` imports.

## Tests impacted

No input/output impact. Only error messages had to be updated.

### What is the purpose of this pull request?

- [x] New Feature
