### PR TITLE
fix(sort-imports): fix undetected typescript import-equals dependencies

### DIFF
--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -543,13 +543,15 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             overloadSignatureGroups[overloadSignatureGroupMemberIndex]?.at(-1)
 
           let sortingNode: SortClassSortingNodes = {
-            dependencyName: getDependencyName({
-              nodeNameWithoutStartingHash: name.startsWith('#')
-                ? name.slice(1)
-                : name,
-              isStatic: modifiers.includes('static'),
-              isPrivateHash,
-            }),
+            dependencyNames: [
+              getDependencyName({
+                nodeNameWithoutStartingHash: name.startsWith('#')
+                  ? name.slice(1)
+                  : name,
+                isStatic: modifiers.includes('static'),
+                isPrivateHash,
+              }),
+            ],
             overloadSignaturesGroupId:
               overloadSignatureGroupMemberIndex === -1
                 ? null

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -173,6 +173,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 : null,
             isEslintDisabled: isNodeEslintDisabled(member, eslintDisabledLines),
             size: rangeToDiff(member, sourceCode),
+            dependencyNames: [name],
             node: member,
             dependencies,
             group,

--- a/rules/sort-imports/types.ts
+++ b/rules/sort-imports/types.ts
@@ -12,8 +12,8 @@ import type {
   RegexOption,
   TypeOption,
 } from '../../types/common-options'
+import type { SortingNodeWithDependencies } from '../../utils/sort-nodes-by-dependencies'
 import type { JoinWithDash } from '../../types/join-with-dash'
-import type { SortingNode } from '../../types/sorting-node'
 
 import {
   buildCustomGroupModifiersJsonSchema,
@@ -72,7 +72,7 @@ export type SingleCustomGroup = {
   elementNamePattern?: RegexOption
 }
 
-export interface SortImportsSortingNode extends SortingNode {
+export interface SortImportsSortingNode extends SortingNodeWithDependencies {
   isIgnored: boolean
 }
 

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -311,7 +311,7 @@ let analyzeModule = ({
       isEslintDisabled: isNodeEslintDisabled(node, eslintDisabledLines),
       size: rangeToDiff(node, sourceCode),
       addSafetySemicolonWhenInline,
-      dependencyName: name,
+      dependencyNames: [name],
       dependencies,
       group,
       name,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -342,7 +342,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 eslintDisabledLines,
               ),
               size: rangeToDiff(property, sourceCode),
-              dependencyName,
+              dependencyNames: [dependencyName],
               node: property,
               dependencies,
               group,

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -184,6 +184,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               eslintDisabledLines,
             ),
             size: rangeToDiff(declaration, sourceCode),
+            dependencyNames: [name],
             node: declaration,
             dependencies,
             name,

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -3320,6 +3320,269 @@ describe(ruleName, () => {
         })
       })
     })
+
+    describe('detects dependencies', () => {
+      ruleTester.run(
+        `${ruleName}(${type}): detects typescript import-equals dependencies`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  groups: ['unknown'],
+                },
+              ],
+              output: dedent`
+                import { aImport } from "b";
+                import a = aImport.a1.a2;
+              `,
+              code: dedent`
+                import a = aImport.a1.a2;
+                import { aImport } from "b";
+              `,
+            },
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  groups: ['unknown'],
+                },
+              ],
+              output: dedent`
+                import * as aImport from "b";
+                import a = aImport.a1.a2;
+              `,
+              code: dedent`
+                import a = aImport.a1.a2;
+                import * as aImport from "b";
+              `,
+            },
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  groups: ['unknown'],
+                },
+              ],
+              output: dedent`
+                import aImport from "b";
+                import a = aImport.a1.a2;
+              `,
+              code: dedent`
+                import a = aImport.a1.a2;
+                import aImport from "b";
+              `,
+            },
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  groups: ['unknown'],
+                },
+              ],
+              output: dedent`
+                import aImport = require("b")
+                import a = aImport.a1.a2;
+              `,
+              code: dedent`
+                import a = aImport.a1.a2;
+                import aImport = require("b")
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over group configuration`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      groupName: 'importsStartingWithA',
+                      elementNamePattern: '^a',
+                    },
+                    {
+                      groupName: 'importsStartingWithB',
+                      elementNamePattern: '^b',
+                    },
+                  ],
+                  groups: ['importsStartingWithA', 'importsStartingWithB'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+                {
+                  data: {
+                    left: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'missedSpacingBetweenImports',
+                },
+              ],
+              output: dedent`
+                import aImport from "b";
+
+                import a = aImport.a1.a2;
+              `,
+              code: dedent`
+                import a = aImport.a1.a2;
+                import aImport from "b";
+              `,
+            },
+          ],
+          valid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      groupName: 'importsStartingWithA',
+                      elementNamePattern: '^a',
+                    },
+                    {
+                      groupName: 'importsStartingWithB',
+                      elementNamePattern: '^b',
+                    },
+                  ],
+                  groups: ['importsStartingWithA', 'importsStartingWithB'],
+                },
+              ],
+              code: dedent`
+                import aImport from "b";
+                import a = aImport.a1.a2;
+              `,
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+              ],
+              output: dedent`
+                import aImport from "b";
+                // Part: 1
+                import a = aImport.a1.a2;
+              `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: '^Part',
+                },
+              ],
+              code: dedent`
+                import a = aImport.a1.a2;
+                // Part: 1
+                import aImport from "b";
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'ignore',
+                  partitionByNewLine: true,
+                },
+              ],
+              output: dedent`
+                import aImport from "b";
+
+                import a = aImport.a1.a2;
+              `,
+              code: dedent`
+                import a = aImport.a1.a2;
+
+                import aImport from "b";
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -3582,6 +3582,71 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): prioritizes content-separation over dependencies`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    nodeDependentOnRight: 'yImport.y1.y2',
+                    right: 'z',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+                {
+                  data: {
+                    nodeDependentOnRight: 'aImport.a1.a2',
+                    right: 'b',
+                  },
+                  messageId: 'unexpectedImportsDependencyOrder',
+                },
+              ],
+              output: dedent`
+                import f = fImport.f1.f2;
+
+                import yImport from "z";
+
+                import y = yImport.y1.y2;
+
+                export { something } from "something";
+
+                import aImport from "b";
+
+                import a = aImport.a1.a2;
+
+                import fImport from "g";
+              `,
+              code: dedent`
+                import f = fImport.f1.f2;
+
+                import y = yImport.y1.y2;
+
+                import yImport from "z";
+
+                export { something } from "something";
+
+                import a = aImport.a1.a2;
+
+                import aImport from "b";
+
+                import fImport from "g";
+              `,
+              options: [
+                {
+                  ...options,
+                  newlinesBetween: 'ignore',
+                  partitionByNewLine: true,
+                },
+              ],
+            },
+          ],
+          valid: [],
+        },
+      )
     })
   })
 

--- a/test/utils/compute-nodes-in-circular-dependencies.test.ts
+++ b/test/utils/compute-nodes-in-circular-dependencies.test.ts
@@ -37,6 +37,7 @@ describe('computeNodesInCircularDependencies', () => {
   let createTestNode = (name: string): SortingNodeWithDependencies =>
     ({
       dependencies: [] as string[],
+      dependencyNames: [name],
       name,
     }) as SortingNodeWithDependencies
 })

--- a/test/utils/is-node-dependent-on-other-node.test.ts
+++ b/test/utils/is-node-dependent-on-other-node.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SortingNodeWithDependencies } from '../../utils/sort-nodes-by-dependencies'
+
+import { isNodeDependentOnOtherNode } from '../../utils/is-node-dependent-on-other-node'
+
+describe('isNodeDependentOnOtherNode', () => {
+  it('should return false if the two nodes are strictly equal', () => {
+    let node = createNodeWithDependencies({
+      dependencyNames: [],
+      dependencies: [],
+    })
+
+    expect(isNodeDependentOnOtherNode(node, node)).toBeFalsy()
+  })
+
+  it('should return true if a dependency is among the dependency names', () => {
+    let node1 = createNodeWithDependencies({
+      dependencyNames: ['a', 'b'],
+      dependencies: [],
+    })
+    let node2 = createNodeWithDependencies({
+      dependencyNames: [],
+      dependencies: ['b'],
+    })
+
+    expect(isNodeDependentOnOtherNode(node1, node2)).toBeTruthy()
+  })
+
+  let createNodeWithDependencies = ({
+    dependencyNames,
+    dependencies,
+  }: {
+    dependencyNames: string[]
+    dependencies: string[]
+  }): SortingNodeWithDependencies =>
+    ({
+      dependencyNames,
+      dependencies,
+    }) as SortingNodeWithDependencies
+})

--- a/utils/compute-nodes-in-circular-dependencies.ts
+++ b/utils/compute-nodes-in-circular-dependencies.ts
@@ -28,11 +28,11 @@ export let computeNodesInCircularDependencies = <
     path.push(element)
 
     for (let dependency of element.dependencies) {
-      let dependencyElement = elements.find(
-        currentElement =>
-          currentElement.dependencyName === dependency ||
-          currentElement.name === dependency,
-      )
+      let dependencyElement = elements
+        .filter(currentElement => currentElement !== element)
+        .find(currentElement =>
+          currentElement.dependencyNames.includes(dependency),
+        )
       if (dependencyElement) {
         depthFirstSearch(dependencyElement, [...path])
       }

--- a/utils/is-node-dependent-on-other-node.ts
+++ b/utils/is-node-dependent-on-other-node.ts
@@ -1,0 +1,10 @@
+import type { SortingNodeWithDependencies } from './sort-nodes-by-dependencies'
+
+export let isNodeDependentOnOtherNode = (
+  sortingNode1: SortingNodeWithDependencies,
+  sortingNode2: SortingNodeWithDependencies,
+): boolean =>
+  sortingNode1 !== sortingNode2 &&
+  sortingNode2.dependencies.includes(
+    sortingNode1.dependencyName ?? sortingNode1.name,
+  )

--- a/utils/is-node-dependent-on-other-node.ts
+++ b/utils/is-node-dependent-on-other-node.ts
@@ -3,8 +3,11 @@ import type { SortingNodeWithDependencies } from './sort-nodes-by-dependencies'
 export let isNodeDependentOnOtherNode = (
   sortingNode1: SortingNodeWithDependencies,
   sortingNode2: SortingNodeWithDependencies,
-): boolean =>
-  sortingNode1 !== sortingNode2 &&
-  sortingNode2.dependencies.includes(
-    sortingNode1.dependencyName ?? sortingNode1.name,
+): boolean => {
+  if (sortingNode1 === sortingNode2) {
+    return false
+  }
+  return sortingNode1.dependencyNames.some(dependency =>
+    sortingNode2.dependencies.includes(dependency),
   )
+}

--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -7,6 +7,7 @@ import type { SortingNode } from '../types/sorting-node'
 import type { MakeFixesParameters } from './make-fixes'
 
 import { computeNodesInCircularDependencies } from './compute-nodes-in-circular-dependencies'
+import { isNodeDependentOnOtherNode } from './is-node-dependent-on-other-node'
 import { createNodeIndexMap } from './create-node-index-map'
 import { getNewlinesErrors } from './get-newlines-errors'
 import { getGroupNumber } from './get-group-number'
@@ -152,9 +153,7 @@ let getFirstUnorderedNodeDependentOn = <T extends SortingNodeWithDependencies>({
   let nodesDependentOnNode = nodes.filter(
     currentlyOrderedNode =>
       !nodesInCircularDependencies.has(currentlyOrderedNode) &&
-      currentlyOrderedNode.dependencies.includes(
-        node.dependencyName ?? node.name,
-      ),
+      isNodeDependentOnOtherNode(node, currentlyOrderedNode),
   )
   return nodesDependentOnNode.find(firstNodeDependentOnNode => {
     let currentIndexOfNode = nodes.indexOf(node)

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -8,14 +8,7 @@ import { isNodeDependentOnOtherNode } from './is-node-dependent-on-other-node'
 export interface SortingNodeWithDependencies<
   Node extends TSESTree.Node = TSESTree.Node,
 > extends SortingNode<Node> {
-  /**
-   * Custom name used to check if a node is a dependency of another node. If
-   * unspecified, defaults to the SortingNode's name.
-   */
-  dependencyName?: string
-  /**
-   * List of dependencies for the node
-   */
+  dependencyNames: string[]
   dependencies: string[]
 }
 

--- a/utils/sort-nodes-by-dependencies.ts
+++ b/utils/sort-nodes-by-dependencies.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../types/sorting-node'
 
 import { computeNodesInCircularDependencies } from './compute-nodes-in-circular-dependencies'
+import { isNodeDependentOnOtherNode } from './is-node-dependent-on-other-node'
 
 export interface SortingNodeWithDependencies<
   Node extends TSESTree.Node = TSESTree.Node,
@@ -12,7 +13,9 @@ export interface SortingNodeWithDependencies<
    * unspecified, defaults to the SortingNode's name.
    */
   dependencyName?: string
-  /** List of dependencies for the node */
+  /**
+   * List of dependencies for the node
+   */
   dependencies: string[]
 }
 
@@ -42,10 +45,8 @@ export let sortNodesByDependencies = <T extends SortingNodeWithDependencies>(
     }
 
     let dependentNodes = nodes
-      .filter(dependentNode => !nodesInCircularDependencies.has(dependentNode))
-      .filter(({ dependencyName, name }) =>
-        sortingNode.dependencies.includes(dependencyName ?? name),
-      )
+      .filter(node => !nodesInCircularDependencies.has(node))
+      .filter(node => isNodeDependentOnOtherNode(node, sortingNode))
 
     for (let dependentNode of dependentNodes) {
       if (


### PR DESCRIPTION
- Fixes https://github.com/azat-io/eslint-plugin-perfectionist/issues/513.
- Waiting for https://github.com/azat-io/eslint-plugin-perfectionist/pull/505 to be merged before opening.

### Description

In typescript projects targetting Node.js, typescript import-equals re-order may result in runtime errors due to usage before initialization.

## List of all instances of dependencies **not** detected

### `default` import

```ts
import a = aImport.a1.a2;
import aImport from "b";
```

### `wildcard` import

```ts
import a = aImport.a1.a2;
import * as aImport from "b";
```

### `named` import

```ts
import a = aImport.a1.a2;
import { aImport } from "b";
```

### What is the purpose of this pull request?

- [x] Bug fix