### PR TITLE
fix(sort-objects): fix nested objects not impacted by `styledComponents`

### DIFF
--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -155,23 +155,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
         return
       }
 
-      let isStyledCallExpression = (identifier: TSESTree.Expression): boolean =>
-        identifier.type === 'Identifier' && identifier.name === 'styled'
-      let isCssCallExpression = (identifier: TSESTree.Expression): boolean =>
-        identifier.type === 'Identifier' && identifier.name === 'css'
-      let isStyledComponents = (
-        styledNode: TSESTree.Node | undefined,
-      ): boolean =>
-        !!styledNode &&
-        ((styledNode.type === 'CallExpression' &&
-          (isCssCallExpression(styledNode.callee) ||
-            (styledNode.callee.type === 'MemberExpression' &&
-              isStyledCallExpression(styledNode.callee.object)) ||
-            (styledNode.callee.type === 'CallExpression' &&
-              isStyledCallExpression(styledNode.callee.callee)))) ||
-          (styledNode.type === 'JSXExpressionContainer' &&
-            styledNode.parent.type === 'JSXAttribute' &&
-            styledNode.parent.name.name === 'style'))
       if (
         !options.styledComponents &&
         (isStyledComponents(nodeObject.parent) ||
@@ -623,4 +606,32 @@ let getCallExpressionParentName = ({
   }
 
   return callParent.callee.type === 'Identifier' ? callParent.callee.name : null
+}
+
+let isStyledCallExpression = (identifier: TSESTree.Expression): boolean =>
+  identifier.type === 'Identifier' && identifier.name === 'styled'
+
+let isCssCallExpression = (identifier: TSESTree.Expression): boolean =>
+  identifier.type === 'Identifier' && identifier.name === 'css'
+
+let isStyledComponents = (styledNode: TSESTree.Node): boolean => {
+  if (
+    styledNode.type === 'JSXExpressionContainer' &&
+    styledNode.parent.type === 'JSXAttribute' &&
+    styledNode.parent.name.name === 'style'
+  ) {
+    return true
+  }
+
+  if (styledNode.type !== 'CallExpression') {
+    return false
+  }
+
+  return (
+    isCssCallExpression(styledNode.callee) ||
+    (styledNode.callee.type === 'MemberExpression' &&
+      isStyledCallExpression(styledNode.callee.object)) ||
+    (styledNode.callee.type === 'CallExpression' &&
+      isStyledCallExpression(styledNode.callee.callee))
+  )
 }

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -155,11 +155,14 @@ export default createEslintRule<Options, MESSAGE_ID>({
         return
       }
 
+      let objectRoot =
+        nodeObject.type === 'ObjectPattern' ? null : getRootObject(nodeObject)
       if (
+        objectRoot &&
         !options.styledComponents &&
-        (isStyledComponents(nodeObject.parent) ||
-          (nodeObject.parent.type === 'ArrowFunctionExpression' &&
-            isStyledComponents(nodeObject.parent.parent)))
+        (isStyledComponents(objectRoot.parent) ||
+          (objectRoot.parent.type === 'ArrowFunctionExpression' &&
+            isStyledComponents(objectRoot.parent.parent)))
       ) {
         return
       }
@@ -556,6 +559,19 @@ let getObjectParent = ({
     }
   }
   return null
+}
+
+let getRootObject = (
+  node: TSESTree.ObjectExpression,
+): TSESTree.ObjectExpression => {
+  let objectRoot = node
+  while (
+    objectRoot.parent.type === 'Property' &&
+    objectRoot.parent.parent.type === 'ObjectExpression'
+  ) {
+    objectRoot = objectRoot.parent.parent
+  }
+  return objectRoot
 }
 
 let getVariableParentName = ({

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -5507,6 +5507,27 @@ describe(ruleName, () => {
               },
             ],
           },
+          {
+            code: dedent`
+              const PropsBox = styled.div((props) => ({
+                nested1: {
+                  nested2: {
+                    [theme.breakpoints.down('mid2')]: {
+                      right: '24px',
+                    },
+                    [theme.breakpoints.down('mid1')]: {
+                      bottom: '-273px',
+                    }
+                  }
+                }
+              }))
+            `,
+            options: [
+              {
+                styledComponents: false,
+              },
+            ],
+          },
         ],
         invalid: [],
       },


### PR DESCRIPTION
- Fixes #516

### Description

This PR simply applies the `styledComponents` detection to nested objects.

### What is the purpose of this pull request?
- [x] Bug fix
