### PR TITLE
feat(sort-imports): add back `ts-equals` (`object` group) modifier

### DIFF
--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -325,6 +325,7 @@ The list of selectors is sorted from most to least important:
 
 - `'type'` — Typescript time imports.
 - `'value'` — Value imports.
+- `'ts-equals'` — TypeScript import-equals imports.
 
 #### Important notes
 
@@ -387,6 +388,8 @@ import type { InputProps } from '../Input'
 import type { Details } from './data'
 // 'type-index' - TypeScript type imports from main directory file
 import type { BaseOptions } from './index.d.ts'
+// 'value-ts-equals-import' - TypeScript import-equals imports
+import NotFoundError = ErrorsNamespace.NotFoundError
 ```
 
 #### Newlines between groups

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -288,6 +288,7 @@ Specifies the  directory of the root `tsconfig.json` file (ex: `.`). This is use
     'value-internal',
     ['type-parent', 'type-sibling', 'type-index'],
     ['value-parent', 'value-sibling', 'value-index'],
+    'ts-equals-import',
     'unknown',
   ]
   ```
@@ -530,6 +531,7 @@ you must write a custom group definition that does the same as what the predefin
      'value-internal',
      ['type-parent', 'type-sibling', 'type-index'],
      ['value-parent', 'value-sibling', 'value-index'],
+     'ts-equals-import',
      'unknown',
    ],
 +  customGroups: [                      // [!code ++]
@@ -586,6 +588,7 @@ Specifies which environment’s built-in modules should be recognized. If you ar
                     'value-internal',
                     ['type-parent', 'type-sibling', 'type-index'],
                     ['value-parent', 'value-sibling', 'value-index'],
+                    'ts-equals-import',
                     'unknown',
                   ],
                   customGroups: [],
@@ -627,6 +630,7 @@ Specifies which environment’s built-in modules should be recognized. If you ar
                   'value-internal',
                   ['type-parent', 'type-sibling', 'type-index'],
                   ['value-parent', 'value-sibling', 'value-index'],
+                  'ts-equals-import',
                   'unknown',
                 ],
                 customGroups: [],

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -220,20 +220,22 @@ export default createEslintRule<Options, MESSAGE_ID>({
         })
       }
 
-      if (isStyleSideEffect) {
-        selectors.push('side-effect-style')
-      }
+      if (!isNonExternalReferenceTsImportEquals(node)) {
+        if (isStyleSideEffect) {
+          selectors.push('side-effect-style')
+        }
 
-      if (isSideEffect) {
-        selectors.push('side-effect')
-      }
+        if (isSideEffect) {
+          selectors.push('side-effect')
+        }
 
-      if (isStyleValue) {
-        selectors.push('style')
-      }
+        if (isStyleValue) {
+          selectors.push('style')
+        }
 
-      for (let selector of commonSelectors) {
-        selectors.push(selector)
+        for (let selector of commonSelectors) {
+          selectors.push(selector)
+        }
       }
       selectors.push('import')
 
@@ -705,4 +707,17 @@ let computeDependencyNames = ({
     }
   }
   return returnValue
+}
+
+let isNonExternalReferenceTsImportEquals = (
+  node:
+    | TSESTree.TSImportEqualsDeclaration
+    | TSESTree.VariableDeclaration
+    | TSESTree.ImportDeclaration,
+): node is TSESTree.TSImportEqualsDeclaration => {
+  if (node.type !== 'TSImportEqualsDeclaration') {
+    return false
+  }
+
+  return node.moduleReference.type !== 'TSExternalModuleReference'
 }

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -241,6 +241,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
         modifiers.push('value')
       }
 
+      if (node.type === 'TSImportEqualsDeclaration') {
+        modifiers.push('ts-equals')
+      }
+
       group ??=
         computeGroupExceptUnknown({
           customGroups: Array.isArray(options.customGroups)

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -69,6 +69,7 @@ let defaultGroups = [
   'value-internal',
   ['type-parent', 'type-sibling', 'type-index'],
   ['value-parent', 'value-sibling', 'value-index'],
+  'ts-equals-import',
   'unknown',
 ]
 

--- a/rules/sort-imports/types.ts
+++ b/rules/sort-imports/types.ts
@@ -77,9 +77,9 @@ export interface SortImportsSortingNode extends SortingNodeWithDependencies {
   isIgnored: boolean
 }
 
-export type Group = ValueGroup | TypeGroup | 'unknown' | string
+export type Modifier = TsEqualsModifier | ValueModifier | TypeModifier
 
-export type Modifier = ValueModifier | TypeModifier
+export type Group = ValueGroup | TypeGroup | 'unknown' | string
 
 type TypeGroup = JoinWithDash<[TypeModifier, Selector]>
 
@@ -118,6 +118,8 @@ type ParentTypeSelector = 'parent-type'
  * @deprecated for the modifier and selector
  */
 type IndexTypeSelector = 'index-type'
+
+type TsEqualsModifier = 'ts-equals'
 
 type ExternalSelector = 'external'
 
@@ -170,7 +172,7 @@ export let allDeprecatedSelectors: Selector[] = [
   'object',
 ]
 
-export let allModifiers: Modifier[] = ['type', 'value']
+export let allModifiers: Modifier[] = ['type', 'ts-equals', 'value']
 
 /**
  * Ideally, we should generate as many schemas as there are selectors, and ensure

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -3650,6 +3650,7 @@ describe(ruleName, () => {
               ],
               output: dedent`
                 import aImport from "b";
+
                 // Part: 1
                 import a = aImport.a1.a2;
               `,

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2974,6 +2974,92 @@ describe(ruleName, () => {
         )
       })
 
+      describe('modifiers priority', () => {
+        ruleTester.run(
+          `${ruleName}(${type}): prioritizes "type" over "ts-equals"`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'type-import',
+                      leftGroup: 'external',
+                      right: 'z',
+                      left: 'f',
+                    },
+                    messageId: 'unexpectedImportsGroupOrder',
+                  },
+                ],
+                options: [
+                  {
+                    ...options,
+                    groups: ['type-import', 'external', 'ts-equals-import'],
+                  },
+                ],
+                output: dedent`
+                  import type a from './a'
+                  import type z = z
+
+                  import f from 'f'
+                `,
+                code: dedent`
+                  import type a from './a'
+
+                  import f from 'f'
+
+                  import type z = z
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}(${type}): prioritizes "value" over "ts-equals"`,
+          rule,
+          {
+            invalid: [
+              {
+                errors: [
+                  {
+                    data: {
+                      rightGroup: 'value-import',
+                      leftGroup: 'external',
+                      right: 'z',
+                      left: 'f',
+                    },
+                    messageId: 'unexpectedImportsGroupOrder',
+                  },
+                ],
+                options: [
+                  {
+                    ...options,
+                    groups: ['value-import', 'external', 'ts-equals-import'],
+                  },
+                ],
+                output: dedent`
+                  import a from './a'
+                  import z = z
+
+                  import f from 'f'
+                `,
+                code: dedent`
+                  import a from './a'
+
+                  import f from 'f'
+
+                  import z = z
+                `,
+              },
+            ],
+            valid: [],
+          },
+        )
+      })
+
       describe(`custom groups`, () => {
         for (let elementNamePattern of [
           'hello',

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -368,7 +368,7 @@ describe(ruleName, () => {
     })
 
     ruleTester.run(
-      `${ruleName}(${type}): supports typescript object-imports`,
+      `${ruleName}(${type}): supports typescript ts import-equals`,
       rule,
       {
         invalid: [
@@ -383,19 +383,12 @@ describe(ruleName, () => {
               },
               {
                 data: {
+                  leftGroup: 'ts-equals-import',
                   rightGroup: 'value-external',
-                  leftGroup: 'value-parent',
-                  right: 'console.log',
-                  left: '../b',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
                   left: 'console.log',
                   right: 'c/c',
                 },
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
               },
             ],
             output: dedent`
@@ -403,9 +396,10 @@ describe(ruleName, () => {
 
               import { A } from 'a'
               import c = require('c/c')
-              import log = console.log
 
               import { B } from '../b'
+
+              import log = console.log
             `,
             code: dedent`
               import type T = require("T")
@@ -426,9 +420,10 @@ describe(ruleName, () => {
 
               import { A } from 'a'
               import c = require('c/c')
-              import log = console.log
 
               import { B } from '../b'
+
+              import log = console.log
             `,
             options: [options],
           },
@@ -4112,7 +4107,7 @@ describe(ruleName, () => {
     })
 
     ruleTester.run(
-      `${ruleName}(${type}): supports typescript object-imports`,
+      `${ruleName}(${type}): supports typescript ts import-equals`,
       rule,
       {
         invalid: [
@@ -4127,19 +4122,12 @@ describe(ruleName, () => {
               },
               {
                 data: {
+                  leftGroup: 'ts-equals-import',
                   rightGroup: 'value-external',
-                  leftGroup: 'value-parent',
-                  right: 'console.log',
-                  left: '../b',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
                   left: 'console.log',
                   right: 'c/c',
                 },
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
               },
             ],
             output: dedent`
@@ -4147,9 +4135,10 @@ describe(ruleName, () => {
 
               import { A } from 'a'
               import c = require('c/c')
-              import log = console.log
 
               import { B } from '../b'
+
+              import log = console.log
             `,
             code: dedent`
               import type T = require("T")
@@ -4170,10 +4159,10 @@ describe(ruleName, () => {
 
               import { A } from 'a'
               import c = require('c/c')
-              import log = console.log
 
               import { B } from '../b'
 
+              import log = console.log
             `,
             options: [options],
           },
@@ -5461,7 +5450,7 @@ describe(ruleName, () => {
     })
 
     ruleTester.run(
-      `${ruleName}(${type}): supports typescript object-imports`,
+      `${ruleName}(${type}): supports typescript ts import-equals`,
       rule,
       {
         invalid: [
@@ -5476,29 +5465,23 @@ describe(ruleName, () => {
               },
               {
                 data: {
+                  leftGroup: 'ts-equals-import',
                   rightGroup: 'value-external',
-                  leftGroup: 'value-parent',
-                  right: 'console.log',
-                  left: '../b',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
                   left: 'console.log',
                   right: 'c/c',
                 },
-                messageId: 'unexpectedImportsOrder',
+                messageId: 'unexpectedImportsGroupOrder',
               },
             ],
             output: dedent`
               import type T = require("T")
 
               import c = require('c/c')
-              import log = console.log
               import { A } from 'a'
 
               import { B } from '../b'
+
+              import log = console.log
             `,
             code: dedent`
               import type T = require("T")
@@ -5518,10 +5501,11 @@ describe(ruleName, () => {
               import type T = require("T")
 
               import c = require('c/c')
-              import log = console.log
               import { A } from 'a'
 
               import { B } from '../b'
+
+              import log = console.log
             `,
             options: [options],
           },

--- a/test/utils/validate-generated-groups-configuration.test.ts
+++ b/test/utils/validate-generated-groups-configuration.test.ts
@@ -11,7 +11,7 @@ describe('validate-generated-groups-configuration', () => {
     'double-selector',
     'three-word-selector',
   ]
-  let modifiers = ['modifier1', 'modifier2', 'modifier3']
+  let modifiers = ['modifier1', 'modifier2', 'modifier3', 'double-modifier']
 
   it('allows predefined groups', () => {
     let allModifierCombinationPermutations =
@@ -54,18 +54,21 @@ describe('validate-generated-groups-configuration', () => {
     ).not.toThrow()
   })
 
-  it('throws an error with predefined groups with duplicate modifiers', () => {
-    expect(() =>
-      validateGeneratedGroupsConfiguration({
-        options: {
-          groups: ['modifier1-modifier1-selector1'],
-          customGroups: [],
-        },
-        selectors,
-        modifiers,
-      }),
-    ).toThrow('Invalid group(s): modifier1-modifier1-selector1')
-  })
+  it.each(['modifier1-modifier1', 'double-modifier-modifier1-double-modifier'])(
+    "throws an error with duplicate modifiers '(%s)'",
+    groupModifiers => {
+      expect(() =>
+        validateGeneratedGroupsConfiguration({
+          options: {
+            groups: [`${groupModifiers}-selector1`],
+            customGroups: [],
+          },
+          selectors,
+          modifiers,
+        }),
+      ).toThrow(`Invalid group(s): ${groupModifiers}-selector1`)
+    },
+  )
 
   it('throws an error if a duplicate group is provided', () => {
     expect(() =>
@@ -84,17 +87,22 @@ describe('validate-generated-groups-configuration', () => {
     expect(() =>
       validateGeneratedGroupsConfiguration({
         options: {
+          groups: [
+            'modifier1-selector1',
+            'nonAllowedModifier-selector1',
+            'myCustomGroup',
+            '',
+          ],
           customGroups: [
             {
               groupName: 'myCustomGroupNotReferenced',
             },
           ],
-          groups: ['modifier1-selector1', 'myCustomGroup', ''],
         },
         selectors,
         modifiers,
       }),
-    ).toThrow('Invalid group(s): myCustomGroup')
+    ).toThrow('Invalid group(s): nonAllowedModifier-selector1, myCustomGroup')
   })
 
   it('throws an error with consecutive newlines objects', () => {


### PR DESCRIPTION
# Description

In [`62c5c62` (#505)](https://github.com/azat-io/eslint-plugin-perfectionist/pull/505/commits/62c5c621162bc2102c9890d5f450594259eed33d), the `object` group/selector was deprecated as it was never matched.

The previous documentation had this description:

https://github.com/azat-io/eslint-plugin-perfectionist/blob/f7907794ea899e1deae3f75de77b965bb3d09d5a/docs/content/rules/sort-imports.mdx?plain=1#L309

This PR does two things:
- It adds a `ts-equals` modifier that matches those objects.
- It prevents non-external reference ts import-equals imports from matching `external`:
  - `import log = console.log` currently matches `external` (it was matching `unknown` before https://github.com/azat-io/eslint-plugin-perfectionist/pull/508), but this syntax can also match internal imports (see the second example below).

## Example

```ts
// `value-ts-equals-import`
import log = console.log
```

```ts
// `type-ts-equals-import`
import type ForbiddenError = ErrorsNamespace.ForbiddenError
```

```ts
// `value-ts-equals-external`
import someImport = require('some-external-module')
```

### What is the purpose of this pull request?

- [x] Bug fix
- [x] New Feature
