### PR TITLE
test: add tests to detect invalid JSON schema definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "eslint": "^9.25.1",
     "eslint-plugin-eslint-plugin": "^6.4.0",
     "execa": "^9.5.2",
+    "json-schema-to-typescript-lite": "^14.1.0",
     "keyux": "^0.11.1",
     "lightningcss": "^1.29.3",
     "nanostores": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.5.2
+      json-schema-to-typescript-lite:
+        specifier: ^14.1.0
+        version: 14.1.0
       keyux:
         specifier: ^0.11.1
         version: 0.11.1
@@ -195,6 +198,10 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@apidevtools/json-schema-ref-parser@11.9.3':
+    resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
+    engines: {node: '>= 16'}
 
   '@astrojs/check@0.9.4':
     resolution: {integrity: sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==}
@@ -1079,6 +1086,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jsdevtools/ono@7.1.3':
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
   '@keyv/serialize@1.0.3':
     resolution: {integrity: sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==}
@@ -3524,6 +3534,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-typescript-lite@14.1.0:
+    resolution: {integrity: sha512-b8K6P3aiLgiYKYcHacgZKrwPXPyjekqRPV5vkNfBt0EoohcOSXEbcuGzgi6KQmsAhuy5Mh2KMxofXodRhMxURA==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -5669,6 +5682,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@apidevtools/json-schema-ref-parser@11.9.3':
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
+
   '@astrojs/check@0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.8.3)':
     dependencies:
       '@astrojs/language-server': 2.15.4(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.8.3)
@@ -6650,6 +6669,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jsdevtools/ono@7.1.3': {}
 
   '@keyv/serialize@1.0.3':
     dependencies:
@@ -9721,6 +9742,11 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-to-typescript-lite@14.1.0:
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 11.9.3
+      '@types/json-schema': 7.0.15
 
   json-schema-traverse@0.4.1: {}
 

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-array-includes'
@@ -2822,6 +2823,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { Alphabet } from '../../utils/alphabet'
@@ -8700,6 +8701,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-decorators.test.ts
+++ b/test/rules/sort-decorators.test.ts
@@ -1,9 +1,10 @@
 import type { TestCaseError } from '@typescript-eslint/rule-tester'
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { Alphabet } from '../../utils/alphabet'
@@ -4124,6 +4125,9 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1,5 +1,6 @@
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import type { Options } from '../../rules/sort-enums/types'
@@ -3013,6 +3014,9 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
     ruleTester.run(`${ruleName}: detects numeric enums`, rule, {
       valid: [
         {

--- a/test/rules/sort-heritage-clauses.test.ts
+++ b/test/rules/sort-heritage-clauses.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-heritage-clauses'
@@ -1260,6 +1261,9 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -5,6 +5,7 @@ import type {
 import type { CompilerOptions } from 'typescript'
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { afterAll, describe, expect, it, vi } from 'vitest'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { createModuleResolutionCache } from 'typescript'
@@ -6837,6 +6838,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1,5 +1,6 @@
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import type { Options } from '../../rules/sort-interfaces'
@@ -5343,6 +5344,9 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1,5 +1,6 @@
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-intersection-types'
@@ -2469,6 +2470,9 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1,6 +1,7 @@
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import typescriptParser from '@typescript-eslint/parser'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import path from 'node:path'
 import dedent from 'dedent'
 
@@ -2951,6 +2952,9 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { Alphabet } from '../../utils/alphabet'
@@ -2448,6 +2449,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { Alphabet } from '../../utils/alphabet'
@@ -3554,6 +3555,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-named-exports'
@@ -2179,6 +2180,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-named-imports'
@@ -2723,6 +2724,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { Alphabet } from '../../utils/alphabet'
@@ -5389,6 +5390,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { Alphabet } from '../../utils/alphabet'
@@ -2769,6 +2770,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-switch-case.test.ts
+++ b/test/rules/sort-switch-case.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-switch-case'
@@ -2720,6 +2721,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(`${ruleName}: not works if discriminant is true`, rule, {
       valid: [
         dedent`

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1,5 +1,6 @@
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-union-types'
@@ -2501,6 +2502,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,
       rule,

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -1,8 +1,9 @@
 import type { Rule } from 'eslint'
 
+import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-variable-declarations'
@@ -1674,6 +1675,10 @@ describe(ruleName, () => {
   })
 
   describe(`${ruleName}: misc`, () => {
+    it('validates JSON schema', async () => {
+      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+    })
+
     let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
     ruleTester.run(eslintDisableRuleTesterName, rule, {
       invalid: [


### PR DESCRIPTION
- Follow-up of https://github.com/azat-io/eslint-plugin-perfectionist/pull/521. It will compile once that PR is merged.
- Related issues: https://github.com/azat-io/eslint-plugin-perfectionist/issues/520

### Description

The current tests don't seem to detect invalid JSON schema definitions. This PR uses `json-schema-to-typescript-lite` (used in `eslint-typegen`) as a dev dependency to test all rules schemas. 

### What is the purpose of this pull request? 
- [x] Other

