### PR TITLE
fix(sort-imports): fix json-schema throwing uncaught warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@typescript-eslint/types": "^6.13.0",
     "@vercel/og": "^0.6.8",
     "@vitest/coverage-v8": "^3.1.2",
+    "ajv-draft-04": "^1.0.0",
     "astro": "^5.7.4",
     "browserslist": "^4.24.4",
     "changelogen": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.1.2
         version: 3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.3)(terser@5.37.0)(yaml@2.7.1))
+      ajv-draft-04:
+        specifier: ^1.0.0
+        version: 1.0.0(ajv@8.13.0)
       astro:
         specifier: ^5.7.4
         version: 5.7.4(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.3)(rollup@4.40.0)(terser@5.37.0)(typescript@5.8.3)(yaml@2.7.1)

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -489,7 +489,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
           maxLineLength: ['type'],
         },
         additionalProperties: false,
-        id: 'sort-imports',
         type: 'object',
       },
       definitions: {
@@ -515,6 +514,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           type: 'object',
         },
       },
+      id: 'sort-imports',
       uniqueItems: true,
       type: 'array',
     },

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-array-includes'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -2824,7 +2824,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-classes'
 
@@ -8702,7 +8702,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-decorators.test.ts
+++ b/test/rules/sort-decorators.test.ts
@@ -1,12 +1,12 @@
 import type { TestCaseError } from '@typescript-eslint/rule-tester'
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-decorators'
 
@@ -4126,7 +4126,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1,10 +1,10 @@
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import type { Options } from '../../rules/sort-enums/types'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-enums'
 
@@ -3015,7 +3015,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
     ruleTester.run(`${ruleName}: detects numeric enums`, rule, {
       valid: [

--- a/test/rules/sort-heritage-clauses.test.ts
+++ b/test/rules/sort-heritage-clauses.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-heritage-clauses'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -1262,7 +1262,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -5,7 +5,6 @@ import type {
 import type { CompilerOptions } from 'typescript'
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { afterAll, describe, expect, it, vi } from 'vitest'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { createModuleResolutionCache } from 'typescript'
@@ -17,6 +16,7 @@ import type { MESSAGE_ID } from '../../rules/sort-imports'
 
 import * as readClosestTsConfigUtilities from '../../rules/sort-imports/read-closest-ts-config-by-path'
 import * as getTypescriptImportUtilities from '../../rules/sort-imports/get-typescript-import'
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-imports'
 
@@ -6839,7 +6839,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1,10 +1,10 @@
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import type { Options } from '../../rules/sort-interfaces'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-interfaces'
 
@@ -5345,7 +5345,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1,8 +1,8 @@
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-intersection-types'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -2471,7 +2471,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1,10 +1,10 @@
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import typescriptParser from '@typescript-eslint/parser'
 import { afterAll, describe, expect, it } from 'vitest'
 import path from 'node:path'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-jsx-props'
 
@@ -2953,7 +2953,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
     ruleTester.run(
       `${ruleName}: sets alphabetical asc sorting as default`,

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-maps'
 
@@ -2450,7 +2450,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-modules'
 
@@ -3556,7 +3556,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-named-exports'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -2181,7 +2181,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-named-imports'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -2725,7 +2725,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-objects'
 
@@ -5391,7 +5391,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-sets'
 
@@ -2771,7 +2771,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-switch-case.test.ts
+++ b/test/rules/sort-switch-case.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-switch-case'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -2722,7 +2722,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(`${ruleName}: not works if discriminant is true`, rule, {

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1,8 +1,8 @@
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-union-types'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -2503,7 +2503,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     ruleTester.run(

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint'
 
-import { compile as compileSchema } from 'json-schema-to-typescript-lite'
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { RuleTester as EslintRuleTester } from 'eslint'
 import { afterAll, describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
+import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-variable-declarations'
 import { Alphabet } from '../../utils/alphabet'
 
@@ -1676,7 +1676,9 @@ describe(ruleName, () => {
 
   describe(`${ruleName}: misc`, () => {
     it('validates the JSON schema', async () => {
-      await expect(compileSchema(rule.meta.schema, 'id')).resolves.not.toThrow()
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
     })
 
     let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`

--- a/test/utils/validate-rule-json-schema.ts
+++ b/test/utils/validate-rule-json-schema.ts
@@ -1,0 +1,22 @@
+import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
+
+import { compile as compileSchemaForTs } from 'json-schema-to-typescript-lite'
+import Ajv from 'ajv-draft-04'
+
+export let validateRuleJsonSchema = async (
+  schemaOrSchemas: readonly JSONSchema4[] | JSONSchema4,
+): Promise<void> => {
+  if (Array.isArray(schemaOrSchemas)) {
+    for (let schema of schemaOrSchemas) {
+      // eslint-disable-next-line no-await-in-loop
+      await validateJsonSchema(schema as JSONSchema4)
+    }
+    return
+  }
+  await validateJsonSchema(schemaOrSchemas as JSONSchema4)
+}
+
+let validateJsonSchema = async (schema: JSONSchema4): Promise<void> => {
+  new Ajv().compile(schema)
+  await compileSchemaForTs(schema, 'id')
+}

--- a/utils/alphabet.ts
+++ b/utils/alphabet.ts
@@ -122,7 +122,7 @@ export class Alphabet {
           character.uppercaseCharacterCodePoint ??
             character.lowercaseCharacterCodePoint!
         ]
-      // eslint-disable-next-line no-undefined
+
       if (otherCharacterIndex === undefined) {
         continue
       }

--- a/utils/is-partition-comment.ts
+++ b/utils/is-partition-comment.ts
@@ -45,7 +45,6 @@ export let isPartitionComment = ({
   }
 
   return (
-    // eslint-disable-next-line no-undefined
     relevantPartitionByComment !== undefined &&
     isTrimmedCommentPartitionComment({
       partitionByComment: relevantPartitionByComment,


### PR DESCRIPTION
- Fixes #524
- Fixes #525

### Description

The test added in https://github.com/azat-io/eslint-plugin-perfectionist/pull/521 does not catch another error that was existing in the JSON schema of `sort-imports`:

The `id` of the JSON schema needs to be placed at the root too.

This PR installs the dev-dependency `ajv-draft-04` and uses it in tests to further strengthen JSON schema validation.

<img width="1305" alt="Screenshot 2025-04-23 at 10 08 00" src="https://github.com/user-attachments/assets/37882ff3-3fd6-4c43-8d3d-0b731e1e93ec" />

Technically, I think that the `json-schema-to-typescript-lite` dev-dependency and test should not be needed anymore, but I've kept it for safety.

### Bug severity

Low: does not prevent linting.

### What is the purpose of this pull request?

- [x] Bug fix