### PR TITLE
perf(sort-imports): use `validateGeneratedGroupsConfiguration`

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -35,7 +35,6 @@ import { validateSideEffectsConfiguration } from './sort-imports/validate-side-e
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { getCustomGroupOverriddenOptions } from '../utils/get-custom-groups-compare-options'
 import { readClosestTsConfigByPath } from './sort-imports/read-closest-ts-config-by-path'
-import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { getOptionsWithCleanGroups } from '../utils/get-options-with-clean-groups'
 import { computeCommonSelectors } from './sort-imports/compute-common-selectors'
 import { isSideEffectOnlyGroup } from './sort-imports/is-side-effect-only-group'
@@ -105,34 +104,19 @@ export default createEslintRule<Options, MESSAGE_ID>({
       } as const),
     )
 
-    if (Array.isArray(options.customGroups)) {
-      validateGeneratedGroupsConfiguration({
-        options: {
-          ...options,
-          customGroups: options.customGroups,
-        },
-        selectors: [...allSelectors, ...allDeprecatedSelectors],
-        modifiers: allModifiers,
-      })
-    } else {
-      let generatedGroups = generatePredefinedGroups({
-        cache: cachedGroupsByModifiersAndSelectors,
-        selectors: allSelectors,
-        modifiers: allModifiers,
-      })
-      validateGroupsConfiguration({
-        allowedCustomGroups: [
-          ...Object.keys(options.customGroups.type ?? {}),
-          ...Object.keys(options.customGroups.value ?? {}),
-        ],
-        allowedPredefinedGroups: [
-          ...generatedGroups,
-          ...allDeprecatedSelectors,
-          'unknown',
-        ],
-        options,
-      })
-    }
+    validateGeneratedGroupsConfiguration({
+      options: {
+        ...options,
+        customGroups: Array.isArray(options.customGroups)
+          ? options.customGroups
+          : {
+              ...options.customGroups.type,
+              ...options.customGroups.value,
+            },
+      },
+      selectors: [...allSelectors, ...allDeprecatedSelectors],
+      modifiers: allModifiers,
+    })
     validateCustomSortConfiguration(options)
     validateNewlinesAndPartitionConfiguration(options)
     validateSideEffectsConfiguration(options)


### PR DESCRIPTION
- Fixes https://github.com/azat-io/eslint-plugin-perfectionist/issues/527.

### Description

Only affects configurations using the deprecated `customGroups` API.

There are 2 ways to validate groups currently:
- [`validateGeneratedGroupsConfiguration`](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/utils/validate-generated-groups-configuration.ts) for the new API.
- [`validateGroupsConfiguration`](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/utils/validate-groups-configuration.ts) for the old API.

`validateGroupsConfiguration` relies on an array of all allowed predefined groups to work and is not optimized for large allowed groups arrays (which is the case with many selectors and modifiers, as you can permute modifiers as you wish).

This PR makes `sort-imports` use `validateGeneratedGroupsConfiguration` in both cases to ensure optimal performance all the time.

### Tests

Tests made in local, linting is fast as before with this version.

#### Before

![Screenshot 2025-04-24 at 14 45 16](https://github.com/user-attachments/assets/1a41651d-8d26-42d4-9242-3c643cdcba79)

#### After

![Screenshot 2025-04-24 at 14 33 12](https://github.com/user-attachments/assets/759a84e4-008c-4663-86bc-c72763c94e5d)

### What is the purpose of this pull request?

- [x] Bug fix
