### PR TITLE
fix(sort-imports): fix weak JSON schema typings generated

### DIFF
--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -464,39 +464,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
           internalPattern: regexJsonSchema,
           groups: groupsJsonSchema,
         },
-        allOf: [
-          {
-            $ref: '#/definitions/max-line-length-requires-line-length-type',
-          },
-        ],
-        dependencies: {
-          maxLineLength: ['type'],
-        },
+
         additionalProperties: false,
         type: 'object',
-      },
-      definitions: {
-        'max-line-length-requires-line-length-type': {
-          anyOf: [
-            {
-              not: {
-                required: ['maxLineLength'],
-                type: 'object',
-              },
-              type: 'object',
-            },
-            {
-              $ref: '#/definitions/is-line-length',
-            },
-          ],
-        },
-        'is-line-length': {
-          properties: {
-            type: { enum: ['line-length'], type: 'string' },
-          },
-          required: ['type'],
-          type: 'object',
-        },
       },
       id: 'sort-imports',
       uniqueItems: true,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -464,11 +464,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
           internalPattern: regexJsonSchema,
           groups: groupsJsonSchema,
         },
-
         additionalProperties: false,
         type: 'object',
       },
-      id: 'sort-imports',
       uniqueItems: true,
       type: 'array',
     },


### PR DESCRIPTION
- Fixes #529

### Description

`sort-imports` JSON schema was recently updated to allow an array of configurations to be passed (useful when we want to match elements and not sort them with `type: 'unsorted'`).

Its JSON schema is also more complex than other rules as it has the following definitions: 
- `is-line-length` to check that if the configuration is `line-length`.
- `max-line-length-requires-line-length-type` to ensure that the `maxLineLength` option is only passed when `type` is `line-length`.

For some reason, this makes `eslint-typegen` fail to generate accurate Typescript types.

This PR removes those two JSON Schema definitions and adds a simple test to check whether the generated Typescript is correct. 

<details>
<summary>Generated TS</summary>

```ts
export type Id = {
  /**
   * Fallback sort order.
   */
  fallbackSort?: {
    /**
     * Determines whether the sorted items should be in ascending or descending order.
     */
    order?: ("asc" | "desc")
    /**
     * Specifies the sorting method.
     */
    type?: ("alphabetical" | "natural" | "line-length" | "custom" | "unsorted")
    [k: string]: unknown
  }
  /**
   * Controls how special characters should be handled before sorting.
   */
  specialCharacters?: ("remove" | "trim" | "keep")
  /**
   * Controls whether sorting should be case-sensitive or not.
   */
  ignoreCase?: boolean
  /**
   * Alphabet to use for the `custom` sort type.
   */
  alphabet?: string
  /**
   * Specifies the sorting locales.
   */
  locales?: (string | string[])
  /**
   * Determines whether the sorted items should be in ascending or descending order.
   */
  order?: ("asc" | "desc")
  /**
   * Specifies the sorting method.
   */
  type?: ("alphabetical" | "natural" | "line-length" | "custom" | "unsorted")
  customGroups?: ({
    /**
     * Specifies custom groups for value imports.
     */
    value?: {
      [k: string]: unknown
    }
    /**
     * Specifies custom groups for type imports.
     */
    type?: {
      [k: string]: unknown
    }
  } | ({
    /**
     * Specifies how new lines should be handled between members of the custom group.
     */
    newlinesInside?: ("always" | "never")
    /**
     * Fallback sort order.
     */
    fallbackSort?: {
      /**
       * Determines whether the sorted items should be in ascending or descending order.
       */
      order?: ("asc" | "desc")
      /**
       * Specifies the sorting method.
       */
      type?: ("alphabetical" | "natural" | "line-length" | "custom" | "unsorted")
      [k: string]: unknown
    }
    /**
     * Custom group name.
     */
    groupName?: string
    /**
     * Determines whether the sorted items should be in ascending or descending order.
     */
    order?: ("asc" | "desc")
    /**
     * Specifies the sorting method.
     */
    type?: ("alphabetical" | "natural" | "line-length" | "custom" | "unsorted")
    anyOf?: {
      /**
       * Modifier filters.
       */
      modifiers?: ("default" | "named" | "require" | "side-effect" | "ts-equals" | "type" | "value" | "wildcard")[]
      /**
       * Selector filter.
       */
      selector?: ("side-effect-style" | "tsconfig-path" | "side-effect" | "external" | "internal" | "builtin" | "sibling" | "subpath" | "import" | "parent" | "index" | "style" | "type")
      /**
       * Regular expression.
       */
      elementValuePattern?: (({
        pattern?: string
        flags?: string
      } | string)[] | ({
        pattern?: string
        flags?: string
      } | string))
      /**
       * Regular expression.
       */
      elementNamePattern?: (({
        pattern?: string
        flags?: string
      } | string)[] | ({
        pattern?: string
        flags?: string
      } | string))
    }[]
  } | {
    /**
     * Specifies how new lines should be handled between members of the custom group.
     */
    newlinesInside?: ("always" | "never")
    /**
     * Fallback sort order.
     */
    fallbackSort?: {
      /**
       * Determines whether the sorted items should be in ascending or descending order.
       */
      order?: ("asc" | "desc")
      /**
       * Specifies the sorting method.
       */
      type?: ("alphabetical" | "natural" | "line-length" | "custom" | "unsorted")
      [k: string]: unknown
    }
    /**
     * Custom group name.
     */
    groupName?: string
    /**
     * Determines whether the sorted items should be in ascending or descending order.
     */
    order?: ("asc" | "desc")
    /**
     * Specifies the sorting method.
     */
    type?: ("alphabetical" | "natural" | "line-length" | "custom" | "unsorted")
    /**
     * Modifier filters.
     */
    modifiers?: ("default" | "named" | "require" | "side-effect" | "ts-equals" | "type" | "value" | "wildcard")[]
    /**
     * Selector filter.
     */
    selector?: ("side-effect-style" | "tsconfig-path" | "side-effect" | "external" | "internal" | "builtin" | "sibling" | "subpath" | "import" | "parent" | "index" | "style" | "type")
    /**
     * Regular expression.
     */
    elementValuePattern?: (({
      pattern?: string
      flags?: string
    } | string)[] | ({
      pattern?: string
      flags?: string
    } | string))
    /**
     * Regular expression.
     */
    elementNamePattern?: (({
      pattern?: string
      flags?: string
    } | string)[] | ({
      pattern?: string
      flags?: string
    } | string))
  })[])
  /**
   * Specifies the maximum line length.
   */
  maxLineLength?: number
  /**
   * Controls whether side-effect imports should be sorted.
   */
  sortSideEffects?: boolean
  /**
   * Specifies the environment.
   */
  environment?: ("node" | "bun")
  /**
   * Specifies the tsConfig root directory.
   */
  tsconfigRootDir?: string
  /**
   * Allows to use comments to separate members into logical groups.
   */
  partitionByComment?: (boolean | (({
    pattern?: string
    flags?: string
  } | string)[] | ({
    pattern?: string
    flags?: string
  } | string)) | {
    block?: (boolean | (({
      pattern?: string
      flags?: string
    } | string)[] | ({
      pattern?: string
      flags?: string
    } | string)))
    line?: (boolean | (({
      pattern?: string
      flags?: string
    } | string)[] | ({
      pattern?: string
      flags?: string
    } | string)))
  })
  /**
   * Allows to use newlines to separate the nodes into logical groups.
   */
  partitionByNewLine?: boolean
  /**
   * Specifies how new lines should be handled between groups.
   */
  newlinesBetween?: ("ignore" | "always" | "never")
  /**
   * Regular expression.
   */
  internalPattern?: (({
    pattern?: string
    flags?: string
  } | string)[] | ({
    pattern?: string
    flags?: string
  } | string))
  /**
   * Specifies the order of the groups.
   */
  groups?: (string | string[] | {
    /**
     * Specifies how new lines should be handled between groups.
     */
    newlinesBetween?: ("ignore" | "always" | "never")
  })[]
}[]
```
</details>

- [x] Bug fix
