### PR TITLE
feat: strengthen JSON schemas

### DIFF
--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -10,8 +10,8 @@ import type {
 import type { SortingNode } from '../types/sorting-node'
 
 import {
+  deprecatedCustomGroupsJsonSchema,
   partitionByCommentJsonSchema,
-  customGroupsJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
@@ -161,7 +161,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             type: 'boolean',
           },
           partitionByComment: partitionByCommentJsonSchema,
-          customGroups: customGroupsJsonSchema,
+          customGroups: deprecatedCustomGroupsJsonSchema,
           groups: groupsJsonSchema,
         },
         additionalProperties: false,

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -7,10 +7,10 @@ import type { Options } from './sort-enums/types'
 
 import {
   buildCustomGroupsArrayJsonSchema,
+  deprecatedCustomGroupsJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
   newlinesBetweenJsonSchema,
-  customGroupsJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
@@ -260,16 +260,16 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         properties: {
           ...commonJsonSchemas,
+          customGroups: {
+            oneOf: [
+              deprecatedCustomGroupsJsonSchema,
+              buildCustomGroupsArrayJsonSchema({ singleCustomGroupJsonSchema }),
+            ],
+          },
           forceNumericSort: {
             description:
               'Will always sort numeric enums by their value regardless of the sort type specified.',
             type: 'boolean',
-          },
-          customGroups: {
-            oneOf: [
-              customGroupsJsonSchema,
-              buildCustomGroupsArrayJsonSchema({ singleCustomGroupJsonSchema }),
-            ],
           },
           sortByValue: {
             description: 'Compare enum values instead of names.',

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -9,7 +9,7 @@ import type {
 import type { SortingNode } from '../types/sorting-node'
 
 import {
-  customGroupsJsonSchema,
+  deprecatedCustomGroupsJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
 } from '../utils/common-json-schemas'
@@ -60,7 +60,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       {
         properties: {
           ...commonJsonSchemas,
-          customGroups: customGroupsJsonSchema,
+          customGroups: deprecatedCustomGroupsJsonSchema,
           groups: groupsJsonSchema,
         },
         additionalProperties: false,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -15,6 +15,7 @@ import type {
 
 import {
   buildCustomGroupsArrayJsonSchema,
+  deprecatedCustomGroupsJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
   newlinesBetweenJsonSchema,
@@ -423,12 +424,12 @@ export default createEslintRule<Options, MESSAGE_ID>({
               {
                 properties: {
                   value: {
+                    ...deprecatedCustomGroupsJsonSchema,
                     description: 'Specifies custom groups for value imports.',
-                    type: 'object',
                   },
                   type: {
+                    ...deprecatedCustomGroupsJsonSchema,
                     description: 'Specifies custom groups for type imports.',
-                    type: 'object',
                   },
                 },
                 description: 'Specifies custom groups.',

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -7,9 +7,9 @@ import type { Options } from './sort-jsx-props/types'
 import {
   buildUseConfigurationIfJsonSchema,
   buildCustomGroupsArrayJsonSchema,
+  deprecatedCustomGroupsJsonSchema,
   partitionByNewLineJsonSchema,
   newlinesBetweenJsonSchema,
-  customGroupsJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
   regexJsonSchema,
@@ -229,7 +229,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           ...commonJsonSchemas,
           customGroups: {
             oneOf: [
-              customGroupsJsonSchema,
+              deprecatedCustomGroupsJsonSchema,
               buildCustomGroupsArrayJsonSchema({
                 singleCustomGroupJsonSchema,
               }),

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -13,10 +13,10 @@ import type {
 import {
   buildUseConfigurationIfJsonSchema,
   buildCustomGroupsArrayJsonSchema,
+  deprecatedCustomGroupsJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
   newlinesBetweenJsonSchema,
-  customGroupsJsonSchema,
   buildCommonJsonSchemas,
   groupsJsonSchema,
   regexJsonSchema,
@@ -95,7 +95,7 @@ export let jsonSchema: JSONSchema4 = {
       }),
       customGroups: {
         oneOf: [
-          customGroupsJsonSchema,
+          deprecatedCustomGroupsJsonSchema,
           buildCustomGroupsArrayJsonSchema({
             additionalFallbackSortProperties: { sortBy: sortByJsonSchema },
             singleCustomGroupJsonSchema,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -9,10 +9,10 @@ import type { Modifier, Selector, Options } from './sort-objects/types'
 import {
   buildUseConfigurationIfJsonSchema,
   buildCustomGroupsArrayJsonSchema,
+  deprecatedCustomGroupsJsonSchema,
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
   newlinesBetweenJsonSchema,
-  customGroupsJsonSchema,
   commonJsonSchemas,
   groupsJsonSchema,
   regexJsonSchema,
@@ -447,7 +447,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           },
           customGroups: {
             oneOf: [
-              customGroupsJsonSchema,
+              deprecatedCustomGroupsJsonSchema,
               buildCustomGroupsArrayJsonSchema({ singleCustomGroupJsonSchema }),
             ],
           },

--- a/test/utils/validate-rule-json-schema.ts
+++ b/test/utils/validate-rule-json-schema.ts
@@ -25,6 +25,11 @@ let validateJsonSchema = async (schema: JSONSchema4): Promise<void> => {
 
 let validateTsJsonSchema = async (schema: JSONSchema4): Promise<void> => {
   let generatedTypescript = await compileSchemaForTs(schema, 'id')
+
+  assertGeneratedTsSeemsCorrect(generatedTypescript)
+}
+
+let assertGeneratedTsSeemsCorrect = (generatedTypescript: string): void => {
   for (let [commonJsonSchemaKey, commonJsonSchema] of Object.entries(
     commonJsonSchemas,
   )) {

--- a/test/utils/validate-rule-json-schema.ts
+++ b/test/utils/validate-rule-json-schema.ts
@@ -27,6 +27,7 @@ let validateTsJsonSchema = async (schema: JSONSchema4): Promise<void> => {
   let generatedTypescript = await compileSchemaForTs(schema, 'id')
 
   assertGeneratedTsSeemsCorrect(generatedTypescript)
+  assertNoWeakIndexSignature(generatedTypescript)
 }
 
 let assertGeneratedTsSeemsCorrect = (generatedTypescript: string): void => {
@@ -41,5 +42,13 @@ let assertGeneratedTsSeemsCorrect = (generatedTypescript: string): void => {
         `TypeScript generated from JSON schema seems wrong: no description found for ${commonJsonSchemaKey}:\n${generatedTypescript}`,
       )
     }
+  }
+}
+
+let assertNoWeakIndexSignature = (generatedTypescript: string): void => {
+  if (generatedTypescript.includes('[k: string]: unknown')) {
+    throw new Error(
+      `Weak TypeScript generated from JSON schema: '[k: string]: unknown' index signature found:\n${generatedTypescript}`,
+    )
   }
 }

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -64,7 +64,9 @@ export let buildCommonJsonSchemas = ({
 }: {
   additionalFallbackSortProperties?: Record<string, JSONSchema4>
 } = {}): Record<string, JSONSchema4> => ({
-  fallbackSort: buildFallbackSortJsonSchema(additionalFallbackSortProperties),
+  fallbackSort: buildFallbackSortJsonSchema({
+    additionalProperties: additionalFallbackSortProperties,
+  }),
   specialCharacters: specialCharactersJsonSchema,
   ignoreCase: ignoreCaseJsonSchema,
   alphabet: alphabetJsonSchema,

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -56,6 +56,7 @@ let buildFallbackSortJsonSchema = ({
     ...additionalProperties,
   },
   description: 'Fallback sort order.',
+  additionalProperties: false,
   type: 'object',
 })
 

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -110,7 +110,7 @@ export let groupsJsonSchema: JSONSchema4 = {
   type: 'array',
 }
 
-export let customGroupsJsonSchema: JSONSchema4 = {
+export let deprecatedCustomGroupsJsonSchema: JSONSchema4 = {
   additionalProperties: {
     oneOf: [
       {

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -8,13 +8,14 @@ let typeJsonSchema: JSONSchema4 = {
 
 let orderJsonSchema: JSONSchema4 = {
   description:
-    'Determines whether the sorted items should be in ascending or descending order.',
+    'Specifies whether to sort items in ascending or descending order.',
   enum: ['asc', 'desc'],
   type: 'string',
 }
 
 let alphabetJsonSchema: JSONSchema4 = {
-  description: 'Alphabet to use for the `custom` sort type.',
+  description:
+    "Used only when the `type` option is set to `'custom'`. Specifies the custom alphabet for sorting.",
   type: 'string',
 }
 
@@ -40,7 +41,7 @@ let ignoreCaseJsonSchema: JSONSchema4 = {
 
 let specialCharactersJsonSchema: JSONSchema4 = {
   description:
-    'Controls how special characters should be handled before sorting.',
+    'Specifies whether to trim, remove, or keep special characters before sorting.',
   enum: ['remove', 'trim', 'keep'],
   type: 'string',
 }
@@ -80,7 +81,7 @@ export let commonJsonSchemas: Record<string, JSONSchema4> =
   buildCommonJsonSchemas()
 
 export let newlinesBetweenJsonSchema: JSONSchema4 = {
-  description: 'Specifies how new lines should be handled between groups.',
+  description: 'Specifies how to handle new lines between groups.',
   enum: ['ignore', 'always', 'never'],
   type: 'string',
 }
@@ -106,7 +107,7 @@ export let groupsJsonSchema: JSONSchema4 = {
       },
     ],
   },
-  description: 'Specifies the order of the groups.',
+  description: 'Specifies a list of groups for sorting.',
   type: 'array',
 }
 
@@ -133,9 +134,11 @@ let singleRegexJsonSchema: JSONSchema4 = {
     {
       properties: {
         pattern: {
+          description: 'Regular expression pattern.',
           type: 'string',
         },
         flags: {
+          description: 'Regular expression flags.',
           type: 'string',
         },
       },
@@ -175,9 +178,11 @@ export let partitionByCommentJsonSchema: JSONSchema4 = {
     {
       properties: {
         block: {
+          description: 'Enables specific block comments to separate the nodes.',
           oneOf: allowedPartitionByCommentJsonSchemas,
         },
         line: {
+          description: 'Enables specific line comments to separate the nodes.',
           oneOf: allowedPartitionByCommentJsonSchemas,
         },
       },
@@ -186,12 +191,12 @@ export let partitionByCommentJsonSchema: JSONSchema4 = {
     },
   ],
   description:
-    'Allows to use comments to separate members into logical groups.',
+    'Enables the use of comments to separate the nodes into logical groups.',
 }
 
 export let partitionByNewLineJsonSchema: JSONSchema4 = {
   description:
-    'Allows to use newlines to separate the nodes into logical groups.',
+    'Enables the use of newlines to separate the nodes into logical groups.',
   type: 'boolean',
 }
 
@@ -200,6 +205,8 @@ export let buildUseConfigurationIfJsonSchema = ({
 }: {
   additionalProperties?: Record<string, JSONSchema4>
 } = {}): JSONSchema4 => ({
+  description:
+    'Specifies filters to match a particular options configuration for a given element to sort.',
   properties: {
     allNamesMatchPattern: regexJsonSchema,
     ...additionalProperties,
@@ -215,7 +222,7 @@ let buildCommonCustomGroupJsonSchemas = ({
 } = {}): Record<string, JSONSchema4> => ({
   newlinesInside: {
     description:
-      'Specifies how new lines should be handled between members of the custom group.',
+      'Specifies how to handle new lines between members of the custom group.',
     enum: ['always', 'never'],
     type: 'string',
   },
@@ -273,7 +280,7 @@ export let buildCustomGroupsArrayJsonSchema = ({
       },
     ],
   },
-  description: 'Specifies custom groups.',
+  description: 'Defines custom groups to match specific members.',
   type: 'array',
 })
 


### PR DESCRIPTION
### Description

This PR contains a mix of various JSON schema related fixes and improvements:

- Fix invalid `fallbackSort` JSON schema (it is passing today due to weak validation: missing `additionalProperties: false`)
- Add a test to check for missing `additionalProperties: false` (which generates `[key: string]: uknown` in typings).
- Improve JSON schema descriptions to match the documentation better.

### What is the purpose of this pull request?

- [x] Other

