### PR TITLE
feat(sort-union-types): migrates `groups` to new API

### DIFF
--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -348,6 +348,66 @@ This feature is only applicable when [`partitionByNewLine`](#partitionbynewline)
 }
 ```
 
+### customGroups
+
+<sub>
+  type: `Array<CustomGroupDefinition | CustomGroupAnyOfDefinition>`
+</sub>
+<sub>default: `[]`</sub>
+
+Defines custom groups to match specific object type members.
+
+A custom group definition may follow one of the two following interfaces:
+
+```ts
+interface CustomGroupDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
+  selector?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+}
+
+```
+An type member will match a `CustomGroupDefinition` group if it matches all the filters of the custom group's definition.
+
+or:
+
+```ts
+interface CustomGroupAnyOfDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
+  anyOf: Array<{
+      selector?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  }>
+}
+```
+
+An type member will match a `CustomGroupAnyOfDefinition` group if it matches all the filters of at least one of the `anyOf` items.
+
+#### Attributes
+
+- `groupName` — The group's name, which needs to be put in the [`groups`](#groups) option.
+- `selector` — Filter on the `selector` of the element.
+- `elementNamePattern` — If entered, will check that the name of the element matches the pattern entered.
+- `type` — Overrides the [`type`](#type) option for that custom group. `unsorted` will not sort the group.
+- `order` — Overrides the [`order`](#order) option for that custom group.
+- `fallbackSort` — Overrides the [`fallbackSort`](#fallbacksort) option for that custom group.
+- `newlinesInside` — Enforces a specific newline behavior between elements of the group.
+
+#### Match importance
+
+The `customGroups` list is ordered:
+The first custom group definition that matches an element will be used.
+
+Custom groups have a higher priority than any predefined group.
+
 ## Usage
 
 <CodeTabs
@@ -375,6 +435,7 @@ This feature is only applicable when [`partitionByNewLine`](#partitionbynewline)
                   partitionByNewLine: false,
                   newlinesBetween: 'ignore',
                   groups: [],
+                  customGroups: [],
                 },
               ],
             },
@@ -404,6 +465,7 @@ This feature is only applicable when [`partitionByNewLine`](#partitionbynewline)
                 partitionByNewLine: false,
                 newlinesBetween: 'ignore',
                 groups: [],
+                customGroups: [],
               },
             ],
           },

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -215,9 +215,17 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
 </sub>
 <sub>default: `[]`</sub>
 
-Specifies a list of intersection type groups for sorting. Groups help organize types into categories, making your type definitions more readable and maintainable.
+Each member will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
+The order of items in the `groups` option determines how groups are ordered.
 
-Predefined groups:
+Within a given group, members will be sorted according to the `type`, `order`, `ignoreCase`, etc. options.
+
+Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
+All members of the groups in the array will be sorted together as if they were part of a single group.
+
+Predefined groups are characterized by a single selector.
+
+##### List of selectors
 
 - `'conditional`' — Conditional types.
 - `'function`' — Function types.
@@ -233,19 +241,14 @@ Predefined groups:
 - `'nullish`' — Nullish types (`null` or `undefined`).
 - `'unknown`' — Types that don’t fit into any group specified in the `groups` option.
 
-If the `unknown` group is not specified in the `groups` option, it will automatically be added to the end of the list.
+##### The `unknown` group
 
-Each intersection type will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
-The order of items in the `groups` option determines how groups are ordered.
-
-Within a given group, members will be sorted according to the `type`, `order`, `ignoreCase`, etc. options.
-
-Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
-All members of the groups in the array will be sorted together as if they were part of a single group.
+Members that don’t fit into any group specified in the `groups` option will be placed in the `unknown` group. If the `unknown` group is not specified in the `groups` option,
+it will automatically be added to the end of the list.
 
 #### Example 1
 
-Using all predefined groups:
+Using all selectors:
 
 ```ts
 type Example =

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -370,6 +370,66 @@ This feature is only applicable when [`partitionByNewLine`](#partitionbynewline)
 }
 ```
 
+### customGroups
+
+<sub>
+  type: `Array<CustomGroupDefinition | CustomGroupAnyOfDefinition>`
+</sub>
+<sub>default: `[]`</sub>
+
+Defines custom groups to match specific object type members.
+
+A custom group definition may follow one of the two following interfaces:
+
+```ts
+interface CustomGroupDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
+  selector?: string
+  elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+}
+
+```
+An type member will match a `CustomGroupDefinition` group if it matches all the filters of the custom group's definition.
+
+or:
+
+```ts
+interface CustomGroupAnyOfDefinition {
+  groupName: string
+  type?: 'alphabetical' | 'natural' | 'line-length' | 'unsorted'
+  order?: 'asc' | 'desc'
+  fallbackSort?: { type: string; order?: 'asc' | 'desc' }
+  newlinesInside?: 'always' | 'never'
+  anyOf: Array<{
+      selector?: string
+      elementNamePattern?: string | string[] | { pattern: string; flags?: string } | { pattern: string; flags?: string }[]
+  }>
+}
+```
+
+An type member will match a `CustomGroupAnyOfDefinition` group if it matches all the filters of at least one of the `anyOf` items.
+
+#### Attributes
+
+- `groupName` — The group's name, which needs to be put in the [`groups`](#groups) option.
+- `selector` — Filter on the `selector` of the element.
+- `elementNamePattern` — If entered, will check that the name of the element matches the pattern entered.
+- `type` — Overrides the [`type`](#type) option for that custom group. `unsorted` will not sort the group.
+- `order` — Overrides the [`order`](#order) option for that custom group.
+- `fallbackSort` — Overrides the [`fallbackSort`](#fallbacksort) option for that custom group.
+- `newlinesInside` — Enforces a specific newline behavior between elements of the group.
+
+#### Match importance
+
+The `customGroups` list is ordered:
+The first custom group definition that matches an element will be used.
+
+Custom groups have a higher priority than any predefined group.
+
 ## Usage
 
 <CodeTabs
@@ -397,6 +457,7 @@ This feature is only applicable when [`partitionByNewLine`](#partitionbynewline)
                   partitionByNewLine: false,
                   newlinesBetween: 'ignore',
                   groups: [],
+                  customGroups: [],
                 },
               ],
             },
@@ -426,6 +487,7 @@ This feature is only applicable when [`partitionByNewLine`](#partitionbynewline)
                 partitionByNewLine: false,
                 newlinesBetween: 'ignore',
                 groups: [],
+                customGroups: [],
               },
             ],
           },

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -237,7 +237,17 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
 
 Specifies a list of union type groups for sorting. Groups help organize types into categories, making your type definitions more readable and maintainable.
 
-Predefined groups:
+Each member will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
+The order of items in the `groups` option determines how groups are ordered.
+
+Within a given group, members will be sorted according to the `type`, `order`, `ignoreCase`, etc. options.
+
+Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
+All members of the groups in the array will be sorted together as if they were part of a single group.
+
+Predefined groups are characterized by a single selector.
+
+##### List of selectors
 
 - `'conditional`' — Conditional types.
 - `'function`' — Function types.
@@ -253,19 +263,14 @@ Predefined groups:
 - `'nullish`' — Nullish types (`null` or `undefined`).
 - `'unknown`' — Types that don’t fit into any group entered by the user.
 
-If the `unknown` group is not specified in the `groups` option, it will automatically be added to the end of the list.
+##### The `unknown` group
 
-Each union type will be assigned a single group specified in the `groups` option (or the `unknown` group if no match is found).
-The order of items in the `groups` option determines how groups are ordered.
-
-Within a given group, members will be sorted according to the `type`, `order`, `ignoreCase`, etc. options.
-
-Individual groups can be combined together by placing them in an array. The order of groups in that array does not matter.
-All members of the groups in the array will be sorted together as if they were part of a single group.
+Members that don’t fit into any group specified in the `groups` option will be placed in the `unknown` group. If the `unknown` group is not specified in the `groups` option,
+it will automatically be added to the end of the list.
 
 #### Example 1
 
-Using all predefined groups:
+Using all selectors:
 
 ```ts
 type Example =

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -118,7 +118,7 @@ let sortHeritageClauses = (
     sourceCode,
   })
 
-  let nodes: SortingNode[] = heritageClauses!.map(heritageClause => {
+  let nodes: SortingNode[] = heritageClauses.map(heritageClause => {
     let name = getHeritageClauseExpressionName(heritageClause.expression)
 
     let group = computeGroup({

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -1,4 +1,4 @@
-import type { Options as SortUnionTypesOptions } from './sort-union-types'
+import type { Options as SortUnionTypesOptions } from './sort-union-types/types'
 
 import {
   MISSED_SPACING_ERROR,

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -26,6 +26,7 @@ let defaultOptions: Required<Options[0]> = {
   type: 'alphabetical',
   ignoreCase: true,
   locales: 'en-US',
+  customGroups: [],
   alphabet: '',
   order: 'asc',
   groups: [],

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -2,13 +2,8 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type {
-  PartitionByCommentOption,
-  NewlinesBetweenOption,
-  CommonOptions,
-  GroupsOptions,
-} from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
+import type { Options } from './sort-union-types/types'
 
 import {
   partitionByCommentJsonSchema,
@@ -36,32 +31,6 @@ import { computeGroup } from '../utils/compute-group'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { complete } from '../utils/complete'
-
-export type Options = [
-  Partial<
-    {
-      partitionByComment: PartitionByCommentOption
-      newlinesBetween: NewlinesBetweenOption
-      groups: GroupsOptions<Group>
-      partitionByNewLine: boolean
-    } & CommonOptions
-  >,
-]
-
-type Group =
-  | 'intersection'
-  | 'conditional'
-  | 'function'
-  | 'operator'
-  | 'keyword'
-  | 'literal'
-  | 'nullish'
-  | 'unknown'
-  | 'import'
-  | 'object'
-  | 'named'
-  | 'tuple'
-  | 'union'
 
 type MESSAGE_ID =
   | 'missedSpacingBetweenUnionTypes'

--- a/rules/sort-union-types/types.ts
+++ b/rules/sort-union-types/types.ts
@@ -1,9 +1,30 @@
+import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
+
 import type {
   PartitionByCommentOption,
   NewlinesBetweenOption,
+  CustomGroupsOption,
   CommonOptions,
   GroupsOptions,
+  RegexOption,
 } from '../../types/common-options'
+
+import {
+  buildCustomGroupSelectorJsonSchema,
+  regexJsonSchema,
+} from '../../utils/common-json-schemas'
+
+export type Options = [
+  Partial<
+    {
+      customGroups: CustomGroupsOption<SingleCustomGroup>
+      partitionByComment: PartitionByCommentOption
+      newlinesBetween: NewlinesBetweenOption
+      groups: GroupsOptions<Group>
+      partitionByNewLine: boolean
+    } & CommonOptions
+  >,
+]
 
 export type Selector =
   | IntersectionSelector
@@ -19,16 +40,11 @@ export type Selector =
   | TupleSelector
   | UnionSelector
 
-export type Options = [
-  Partial<
-    {
-      partitionByComment: PartitionByCommentOption
-      newlinesBetween: NewlinesBetweenOption
-      groups: GroupsOptions<Group>
-      partitionByNewLine: boolean
-    } & CommonOptions
-  >,
-]
+export type SingleCustomGroup = {
+  elementNamePattern?: RegexOption
+} & {
+  selector?: Selector
+}
 
 type IntersectionSelector = 'intersection'
 
@@ -55,3 +71,23 @@ type NamedSelector = 'named'
 type TupleSelector = 'tuple'
 
 type UnionSelector = 'union'
+
+export let allSelectors: Selector[] = [
+  'intersection',
+  'conditional',
+  'function',
+  'operator',
+  'keyword',
+  'literal',
+  'nullish',
+  'import',
+  'object',
+  'named',
+  'tuple',
+  'union',
+]
+
+export let singleCustomGroupJsonSchema: Record<string, JSONSchema4> = {
+  selector: buildCustomGroupSelectorJsonSchema(allSelectors),
+  elementNamePattern: regexJsonSchema,
+}

--- a/rules/sort-union-types/types.ts
+++ b/rules/sort-union-types/types.ts
@@ -5,6 +5,20 @@ import type {
   GroupsOptions,
 } from '../../types/common-options'
 
+export type Selector =
+  | IntersectionSelector
+  | ConditionalSelector
+  | FunctionSelector
+  | OperatorSelector
+  | KeywordSelector
+  | LiteralSelector
+  | NullishSelector
+  | ImportSelector
+  | ObjectSelector
+  | NamedSelector
+  | TupleSelector
+  | UnionSelector
+
 export type Options = [
   Partial<
     {
@@ -16,17 +30,28 @@ export type Options = [
   >,
 ]
 
-type Group =
-  | 'intersection'
-  | 'conditional'
-  | 'function'
-  | 'operator'
-  | 'keyword'
-  | 'literal'
-  | 'nullish'
-  | 'unknown'
-  | 'import'
-  | 'object'
-  | 'named'
-  | 'tuple'
-  | 'union'
+type IntersectionSelector = 'intersection'
+
+type Group = 'unknown' | Selector | string
+
+type ConditionalSelector = 'conditional'
+
+type FunctionSelector = 'function'
+
+type OperatorSelector = 'operator'
+
+type KeywordSelector = 'keyword'
+
+type LiteralSelector = 'literal'
+
+type NullishSelector = 'nullish'
+
+type ImportSelector = 'import'
+
+type ObjectSelector = 'object'
+
+type NamedSelector = 'named'
+
+type TupleSelector = 'tuple'
+
+type UnionSelector = 'union'

--- a/rules/sort-union-types/types.ts
+++ b/rules/sort-union-types/types.ts
@@ -1,0 +1,32 @@
+import type {
+  PartitionByCommentOption,
+  NewlinesBetweenOption,
+  CommonOptions,
+  GroupsOptions,
+} from '../../types/common-options'
+
+export type Options = [
+  Partial<
+    {
+      partitionByComment: PartitionByCommentOption
+      newlinesBetween: NewlinesBetweenOption
+      groups: GroupsOptions<Group>
+      partitionByNewLine: boolean
+    } & CommonOptions
+  >,
+]
+
+type Group =
+  | 'intersection'
+  | 'conditional'
+  | 'function'
+  | 'operator'
+  | 'keyword'
+  | 'literal'
+  | 'nullish'
+  | 'unknown'
+  | 'import'
+  | 'object'
+  | 'named'
+  | 'tuple'
+  | 'union'

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1462,6 +1462,457 @@ describe(ruleName, () => {
         valid: [],
       },
     )
+
+    describe(`${ruleName}: custom groups`, () => {
+      ruleTester.run(`${ruleName}: filters on selector`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  rightGroup: 'namedElements',
+                  leftGroup: 'unknown',
+                  left: 'null',
+                  right: 'a',
+                },
+                messageId: 'unexpectedIntersectionTypesGroupOrder',
+              },
+            ],
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'namedElements',
+                    selector: 'named',
+                  },
+                ],
+                groups: ['namedElements', 'unknown'],
+              },
+            ],
+            output: dedent`
+              type T =
+                & a
+                & null
+            `,
+            code: dedent`
+              type T =
+                & null
+                & a
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'namedStartingWithHello',
+                      elementNamePattern,
+                      selector: 'named',
+                    },
+                  ],
+                  groups: ['namedStartingWithHello', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'namedStartingWithHello',
+                    leftGroup: 'unknown',
+                    right: 'helloNamed',
+                    left: 'undefined',
+                  },
+                  messageId: 'unexpectedIntersectionTypesGroupOrder',
+                },
+              ],
+              output: dedent`
+                type Type =
+                  & helloNamed
+                  & null
+                  & undefined
+              `,
+              code: dedent`
+                type Type =
+                  & null
+                  & undefined
+                  & helloNamed
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
+
+      ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'bb',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                },
+                {
+                  data: {
+                    right: 'ccc',
+                    left: 'bb',
+                  },
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                },
+                {
+                  data: {
+                    right: 'dddd',
+                    left: 'ccc',
+                  },
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                },
+                {
+                  data: {
+                    rightGroup: 'reversedNamedByLineLength',
+                    leftGroup: 'unknown',
+                    right: 'eee',
+                    left: "'m'",
+                  },
+                  messageId: 'unexpectedIntersectionTypesGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'reversedNamedByLineLength',
+                      type: 'line-length',
+                      selector: 'named',
+                      order: 'desc',
+                    },
+                  ],
+                  groups: ['reversedNamedByLineLength', 'unknown'],
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+              ],
+              output: dedent`
+                type T =
+                  & dddd
+                  & ccc
+                  & eee
+                  & bb
+                  & ff
+                  & a
+                  & g
+                  & 'm'
+                  & 'o'
+                  & 'p'
+              `,
+              code: dedent`
+                type T =
+                  & a
+                  & bb
+                  & ccc
+                  & dddd
+                  & 'm'
+                  & eee
+                  & ff
+                  & g
+                  & 'o'
+                  & 'p'
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                },
+              ],
+              output: dedent`
+                type T =
+                  & fooBar
+                  & fooZar
+              `,
+              code: dedent`
+                type T =
+                  & fooZar
+                  & fooBar
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: does not sort custom groups with 'unsorted' type`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'unsortedNamed',
+                      selector: 'named',
+                      type: 'unsorted',
+                    },
+                  ],
+                  groups: ['unsortedNamed', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'unsortedNamed',
+                    leftGroup: 'unknown',
+                    left: "'m'",
+                    right: 'c',
+                  },
+                  messageId: 'unexpectedIntersectionTypesGroupOrder',
+                },
+              ],
+              output: dedent`
+                type T =
+                  & b
+                  & a
+                  & d
+                  & e
+                  & c
+                  & 'm'
+              `,
+              code: dedent`
+                type T =
+                  & b
+                  & a
+                  & d
+                  & e
+                  & 'm'
+                  & c
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    anyOf: [
+                      {
+                        elementNamePattern: 'foo|Foo',
+                        selector: 'named',
+                      },
+                      {
+                        elementNamePattern: 'foo|Foo',
+                        selector: 'literal',
+                      },
+                    ],
+                    groupName: 'elementsIncludingFoo',
+                  },
+                ],
+                groups: ['elementsIncludingFoo', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  rightGroup: 'elementsIncludingFoo',
+                  leftGroup: 'unknown',
+                  right: "'foo'",
+                  left: 'null',
+                },
+                messageId: 'unexpectedIntersectionTypesGroupOrder',
+              },
+            ],
+            output: dedent`
+              type T =
+                & 'foo'
+                & cFoo
+
+                & null
+            `,
+            code: dedent`
+              type T =
+                & null
+                & 'foo'
+                & cFoo
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}: allows to use regex for element names in custom groups`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      elementNamePattern: '^(?!.*Foo).*$',
+                      groupName: 'elementsWithoutFoo',
+                    },
+                  ],
+                  groups: ['unknown', 'elementsWithoutFoo'],
+                  type: 'alphabetical',
+                },
+              ],
+              code: dedent`
+                type T =
+                  iHaveFooInMyName
+                  meTooIHaveFoo
+                  a
+                  b
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe('newlinesInside', () => {
+      ruleTester.run(
+        `${ruleName}: allows to use newlinesInside: always`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      newlinesInside: 'always',
+                      groupName: 'group1',
+                      selector: 'named',
+                    },
+                  ],
+                  groups: ['group1'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'missedSpacingBetweenIntersectionTypes',
+                },
+              ],
+              output: dedent`
+                type T =
+                  & a
+
+                  & b
+              `,
+              code: dedent`
+                type T =
+                  & a
+                  & b
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(`${ruleName}: allows to use newlinesInside: never`, rule, {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    newlinesInside: 'never',
+                    groupName: 'group1',
+                    selector: 'named',
+                  },
+                ],
+                type: 'alphabetical',
+                groups: ['group1'],
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  right: 'b',
+                  left: 'a',
+                },
+                messageId: 'extraSpacingBetweenIntersectionTypes',
+              },
+            ],
+            output: dedent`
+              type T =
+                & a
+                & b
+            `,
+            code: dedent`
+              type T =
+                & a
+
+                & b
+            `,
+          },
+        ],
+        valid: [],
+      })
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1465,6 +1465,457 @@ describe(ruleName, () => {
         valid: [],
       },
     )
+
+    describe(`${ruleName}: custom groups`, () => {
+      ruleTester.run(`${ruleName}: filters on selector`, rule, {
+        invalid: [
+          {
+            errors: [
+              {
+                data: {
+                  rightGroup: 'namedElements',
+                  leftGroup: 'unknown',
+                  left: 'null',
+                  right: 'a',
+                },
+                messageId: 'unexpectedUnionTypesGroupOrder',
+              },
+            ],
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'namedElements',
+                    selector: 'named',
+                  },
+                ],
+                groups: ['namedElements', 'unknown'],
+              },
+            ],
+            output: dedent`
+              type T =
+                | a
+                | null
+            `,
+            code: dedent`
+              type T =
+                | null
+                | a
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      for (let elementNamePattern of [
+        'hello',
+        ['noMatch', 'hello'],
+        { pattern: 'HELLO', flags: 'i' },
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ]) {
+        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'namedStartingWithHello',
+                      elementNamePattern,
+                      selector: 'named',
+                    },
+                  ],
+                  groups: ['namedStartingWithHello', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'namedStartingWithHello',
+                    leftGroup: 'unknown',
+                    right: 'helloNamed',
+                    left: 'undefined',
+                  },
+                  messageId: 'unexpectedUnionTypesGroupOrder',
+                },
+              ],
+              output: dedent`
+                type Type =
+                  | helloNamed
+                  | null
+                  | undefined
+              `,
+              code: dedent`
+                type Type =
+                  | null
+                  | undefined
+                  | helloNamed
+              `,
+            },
+          ],
+          valid: [],
+        })
+      }
+
+      ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    right: 'bb',
+                    left: 'a',
+                  },
+                  messageId: 'unexpectedUnionTypesOrder',
+                },
+                {
+                  data: {
+                    right: 'ccc',
+                    left: 'bb',
+                  },
+                  messageId: 'unexpectedUnionTypesOrder',
+                },
+                {
+                  data: {
+                    right: 'dddd',
+                    left: 'ccc',
+                  },
+                  messageId: 'unexpectedUnionTypesOrder',
+                },
+                {
+                  data: {
+                    rightGroup: 'reversedNamedByLineLength',
+                    leftGroup: 'unknown',
+                    right: 'eee',
+                    left: "'m'",
+                  },
+                  messageId: 'unexpectedUnionTypesGroupOrder',
+                },
+              ],
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'reversedNamedByLineLength',
+                      type: 'line-length',
+                      selector: 'named',
+                      order: 'desc',
+                    },
+                  ],
+                  groups: ['reversedNamedByLineLength', 'unknown'],
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+              ],
+              output: dedent`
+                type T =
+                  | dddd
+                  | ccc
+                  | eee
+                  | bb
+                  | ff
+                  | a
+                  | g
+                  | 'm'
+                  | 'o'
+                  | 'p'
+              `,
+              code: dedent`
+                type T =
+                  | a
+                  | bb
+                  | ccc
+                  | dddd
+                  | 'm'
+                  | eee
+                  | ff
+                  | g
+                  | 'o'
+                  | 'p'
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      fallbackSort: {
+                        type: 'alphabetical',
+                        order: 'asc',
+                      },
+                      elementNamePattern: '^foo',
+                      type: 'line-length',
+                      groupName: 'foo',
+                      order: 'desc',
+                    },
+                  ],
+                  type: 'alphabetical',
+                  groups: ['foo'],
+                  order: 'asc',
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'fooBar',
+                    left: 'fooZar',
+                  },
+                  messageId: 'unexpectedUnionTypesOrder',
+                },
+              ],
+              output: dedent`
+                type T =
+                  | fooBar
+                  | fooZar
+              `,
+              code: dedent`
+                type T =
+                  | fooZar
+                  | fooBar
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}: does not sort custom groups with 'unsorted' type`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      groupName: 'unsortedNamed',
+                      selector: 'named',
+                      type: 'unsorted',
+                    },
+                  ],
+                  groups: ['unsortedNamed', 'unknown'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    rightGroup: 'unsortedNamed',
+                    leftGroup: 'unknown',
+                    left: "'m'",
+                    right: 'c',
+                  },
+                  messageId: 'unexpectedUnionTypesGroupOrder',
+                },
+              ],
+              output: dedent`
+                type T =
+                  | b
+                  | a
+                  | d
+                  | e
+                  | c
+                  | 'm'
+              `,
+              code: dedent`
+                type T =
+                  | b
+                  | a
+                  | d
+                  | e
+                  | 'm'
+                  | c
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    anyOf: [
+                      {
+                        elementNamePattern: 'foo|Foo',
+                        selector: 'named',
+                      },
+                      {
+                        elementNamePattern: 'foo|Foo',
+                        selector: 'literal',
+                      },
+                    ],
+                    groupName: 'elementsIncludingFoo',
+                  },
+                ],
+                groups: ['elementsIncludingFoo', 'unknown'],
+                newlinesBetween: 'always',
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  rightGroup: 'elementsIncludingFoo',
+                  leftGroup: 'unknown',
+                  right: "'foo'",
+                  left: 'null',
+                },
+                messageId: 'unexpectedUnionTypesGroupOrder',
+              },
+            ],
+            output: dedent`
+              type T =
+                | 'foo'
+                | cFoo
+
+                | null
+            `,
+            code: dedent`
+              type T =
+                | null
+                | 'foo'
+                | cFoo
+            `,
+          },
+        ],
+        valid: [],
+      })
+
+      ruleTester.run(
+        `${ruleName}: allows to use regex for element names in custom groups`,
+        rule,
+        {
+          valid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      elementNamePattern: '^(?!.*Foo).*$',
+                      groupName: 'elementsWithoutFoo',
+                    },
+                  ],
+                  groups: ['unknown', 'elementsWithoutFoo'],
+                  type: 'alphabetical',
+                },
+              ],
+              code: dedent`
+                type T =
+                  iHaveFooInMyName
+                  meTooIHaveFoo
+                  a
+                  b
+              `,
+            },
+          ],
+          invalid: [],
+        },
+      )
+    })
+
+    describe('newlinesInside', () => {
+      ruleTester.run(
+        `${ruleName}: allows to use newlinesInside: always`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  customGroups: [
+                    {
+                      newlinesInside: 'always',
+                      groupName: 'group1',
+                      selector: 'named',
+                    },
+                  ],
+                  groups: ['group1'],
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'a',
+                  },
+                  messageId: 'missedSpacingBetweenUnionTypes',
+                },
+              ],
+              output: dedent`
+                type T =
+                  | a
+
+                  | b
+              `,
+              code: dedent`
+                type T =
+                  | a
+                  | b
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(`${ruleName}: allows to use newlinesInside: never`, rule, {
+        invalid: [
+          {
+            options: [
+              {
+                customGroups: [
+                  {
+                    newlinesInside: 'never',
+                    groupName: 'group1',
+                    selector: 'named',
+                  },
+                ],
+                type: 'alphabetical',
+                groups: ['group1'],
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  right: 'b',
+                  left: 'a',
+                },
+                messageId: 'extraSpacingBetweenUnionTypes',
+              },
+            ],
+            output: dedent`
+              type T =
+                | a
+                | b
+            `,
+            code: dedent`
+              type T =
+                | a
+
+                | b
+            `,
+          },
+        ],
+        valid: [],
+      })
+    })
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/utils/compute-group.ts
+++ b/utils/compute-group.ts
@@ -1,8 +1,8 @@
 import type {
   DeprecatedCustomGroupsOption,
-  NewlinesBetweenOption,
   CustomGroupsOption,
   AnyOfCustomGroup,
+  GroupsOptions,
 } from '../types/common-options'
 
 import { matches } from './matches'
@@ -12,7 +12,7 @@ interface GetGroupParameters<SingleCustomGroup> {
     customGroups?:
       | CustomGroupsOption<SingleCustomGroup>
       | DeprecatedCustomGroupsOption
-    groups: ({ newlinesBetween: NewlinesBetweenOption } | string[] | string)[]
+    groups: GroupsOptions<string>
   }
   customGroupMatcher?(
     customGroup: AnyOfCustomGroup<SingleCustomGroup> | SingleCustomGroup,

--- a/utils/get-group-number.ts
+++ b/utils/get-group-number.ts
@@ -1,7 +1,7 @@
-import type { NewlinesBetweenOption } from '../types/common-options'
+import type { GroupsOptions } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
 
-type Group = { newlinesBetween: NewlinesBetweenOption } | string[] | string
+type Group = GroupsOptions<string>[number]
 
 export let getGroupNumber = (groups: Group[], node: SortingNode): number => {
   for (let max = groups.length, i = 0; i < max; i++) {

--- a/utils/is-sortable.ts
+++ b/utils/is-sortable.ts
@@ -1,2 +1,2 @@
-export let isSortable = (node: unknown): boolean =>
+export let isSortable = (node: unknown): node is unknown[] =>
   Array.isArray(node) && node.length > 1


### PR DESCRIPTION
### Description

This PR:
- migrates the `sort-union-types` and `sort-intersection-types`'s `groups` to the new API.
- adds the `customGroups` option.

There is no functional change: the list of selectors is the same as the list of predefine groups before.

### What is the purpose of this pull request?

- [x] New Feature
