### PR TITLE
test: add additional JSON schema tests

### DIFF
--- a/test/utils/common-json-schemas.test.ts
+++ b/test/utils/common-json-schemas.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+import Ajv from 'ajv-draft-04'
+
+import {
+  buildCustomGroupsArrayJsonSchema,
+  partitionByCommentJsonSchema,
+  newlinesBetweenJsonSchema,
+  commonJsonSchemas,
+  groupsJsonSchema,
+  regexJsonSchema,
+} from '../../utils/common-json-schemas'
+
+describe('common-json-schemas', () => {
+  describe('commonJsonSchemas', () => {
+    let commonJsonSchemaValidator = new Ajv().compile({
+      properties: commonJsonSchemas,
+      additionalProperties: false,
+      type: 'object',
+    })
+
+    describe('type', () => {
+      it.each(['alphabetical', 'natural', 'line-length', 'custom', 'unsorted'])(
+        "should allow' %s'",
+        type => {
+          expect(
+            commonJsonSchemaValidator({
+              type,
+            }),
+          ).toBeTruthy()
+        },
+      )
+
+      it('should not allow invalid values', () => {
+        expect(
+          commonJsonSchemaValidator({
+            type: 'invalid',
+          }),
+        ).toBeFalsy()
+      })
+    })
+
+    describe('order', () => {
+      it.each(['asc', 'desc'])("should allow' %s'", order => {
+        expect(
+          commonJsonSchemaValidator({
+            order,
+          }),
+        ).toBeTruthy()
+      })
+
+      it('should not allow invalid values', () => {
+        expect(
+          commonJsonSchemaValidator({
+            order: 'invalid',
+          }),
+        ).toBeFalsy()
+      })
+    })
+
+    describe('specialCharacters', () => {
+      it.each(['remove', 'trim', 'keep'])(
+        "should allow' %s'",
+        specialCharacters => {
+          expect(
+            commonJsonSchemaValidator({
+              specialCharacters,
+            }),
+          ).toBeTruthy()
+        },
+      )
+
+      it('should not allow invalid values', () => {
+        expect(
+          commonJsonSchemaValidator({
+            specialCharacters: 'invalid',
+          }),
+        ).toBeFalsy()
+      })
+    })
+
+    describe('fallbackSort', () => {
+      describe('type', () => {
+        it.each([
+          'alphabetical',
+          'natural',
+          'line-length',
+          'custom',
+          'unsorted',
+        ])("should allow' %s'", type => {
+          expect(
+            commonJsonSchemaValidator({
+              fallbackSort: {
+                type,
+              },
+            }),
+          ).toBeTruthy()
+        })
+
+        it('should not allow invalid values', () => {
+          expect(
+            commonJsonSchemaValidator({
+              fallbackSort: {
+                type: 'invalid',
+              },
+            }),
+          ).toBeFalsy()
+        })
+      })
+
+      describe('order', () => {
+        it.each(['asc', 'desc'])("should allow' %s'", order => {
+          expect(
+            commonJsonSchemaValidator({
+              fallbackSort: {
+                order,
+              },
+            }),
+          ).toBeTruthy()
+        })
+
+        it('should not allow invalid values', () => {
+          expect(
+            commonJsonSchemaValidator({
+              fallbackSort: {
+                order: 'invalid',
+              },
+            }),
+          ).toBeFalsy()
+        })
+      })
+
+      it('should not allow additional properties', () => {
+        expect(
+          commonJsonSchemaValidator({
+            fallbackSort: {
+              somethingElse: 'something',
+            },
+          }),
+        ).toBeFalsy()
+      })
+    })
+  })
+
+  describe('newlinesBetween', () => {
+    let newlinesBetweenJsonSchemaValidator = new Ajv().compile(
+      newlinesBetweenJsonSchema,
+    )
+
+    it.each(['ignore', 'always', 'never'])(
+      "should allow' %s'",
+      newlinesBetween => {
+        expect(newlinesBetweenJsonSchemaValidator(newlinesBetween)).toBeTruthy()
+      },
+    )
+
+    it('should not allow invalid values', () => {
+      expect(newlinesBetweenJsonSchemaValidator('invalid')).toBeFalsy()
+    })
+  })
+
+  describe('groups', () => {
+    let groupsJsonSchemaValidator = new Ajv().compile(groupsJsonSchema)
+
+    it('should allow an array of strings', () => {
+      expect(groupsJsonSchemaValidator(['group1', 'group2'])).toBeTruthy()
+    })
+
+    it('should allow an array of arrays of strings', () => {
+      expect(
+        groupsJsonSchemaValidator([['group1', 'group2'], ['group3']]),
+      ).toBeTruthy()
+    })
+
+    describe('newlinesBetween', () => {
+      it.each(['ignore', 'always', 'never'])(
+        "should allow' %s'",
+        newlinesBetween => {
+          expect(
+            groupsJsonSchemaValidator([
+              'group1',
+              { newlinesBetween },
+              'group2',
+            ]),
+          ).toBeTruthy()
+        },
+      )
+
+      it('should not allow invalid values', () => {
+        expect(
+          groupsJsonSchemaValidator([
+            'group1',
+            { newlinesBetween: 'invalid' },
+            'group2',
+          ]),
+        ).toBeFalsy()
+      })
+
+      it('should not allow additional properties', () => {
+        expect(
+          groupsJsonSchemaValidator([
+            'group1',
+            { newlinesBetween: 'always', something: 'something' },
+            'group2',
+          ]),
+        ).toBeFalsy()
+      })
+    })
+  })
+
+  describe('customGroups', () => {
+    let customGroupsJsonSchema = new Ajv().compile(
+      buildCustomGroupsArrayJsonSchema({
+        singleCustomGroupJsonSchema: {
+          customGroupProperty: { type: 'string' },
+        },
+      }),
+    )
+
+    it('should allow arrays of custom groups', () => {
+      expect(
+        customGroupsJsonSchema([
+          {
+            customGroupProperty: 'value',
+            groupName: 'group',
+          },
+        ]),
+      ).toBeTruthy()
+    })
+
+    it("should allow arrays of 'anyOf' custom groups", () => {
+      expect(
+        customGroupsJsonSchema([
+          {
+            anyOf: [
+              {
+                customGroupProperty: 'ss',
+              },
+            ],
+            groupName: 'group',
+          },
+        ]),
+      ).toBeTruthy()
+    })
+  })
+
+  describe('partitionByComment', () => {
+    let partitionByCommentJsonSchemaValidator = new Ajv().compile(
+      partitionByCommentJsonSchema,
+    )
+
+    it('should allow boolean values', () => {
+      expect(partitionByCommentJsonSchemaValidator(true)).toBeTruthy()
+    })
+
+    it.each([{ block: true }, { line: true }, { block: true, line: true }])(
+      "should allow '%s'",
+      partitionByComment => {
+        expect(
+          partitionByCommentJsonSchemaValidator(partitionByComment),
+        ).toBeTruthy()
+      },
+    )
+  })
+
+  describe('regex', () => {
+    let regexJsonSchemaValidator = new Ajv().compile(regexJsonSchema)
+
+    it('should allow string values', () => {
+      expect(regexJsonSchemaValidator('some string')).toBeTruthy()
+    })
+
+    it.each([{ pattern: 'pattern' }, { pattern: 'pattern', flags: 'flags' }])(
+      "should allow '%s'",
+      regex => {
+        expect(regexJsonSchemaValidator(regex)).toBeTruthy()
+      },
+    )
+
+    it("should enforce 'pattern'", () => {
+      expect(
+        regexJsonSchemaValidator({
+          something: 'something',
+          pattern: 'pattern',
+        }),
+      ).toBeFalsy()
+    })
+
+    it('should not allow additional properties', () => {
+      expect(
+        regexJsonSchemaValidator({
+          something: 'something',
+          pattern: 'pattern',
+        }),
+      ).toBeFalsy()
+    })
+  })
+})

--- a/test/utils/common-json-schemas.test.ts
+++ b/test/utils/common-json-schemas.test.ts
@@ -105,6 +105,14 @@ describe('common-json-schemas', () => {
             }),
           ).toBeFalsy()
         })
+
+        it('should not allow the empty object', () => {
+          expect(
+            commonJsonSchemaValidator({
+              fallbackSort: {},
+            }),
+          ).toBeFalsy()
+        })
       })
 
       describe('order', () => {
@@ -205,6 +213,10 @@ describe('common-json-schemas', () => {
         ).toBeFalsy()
       })
     })
+
+    it('should not allow the empty object', () => {
+      expect(groupsJsonSchemaValidator(['group1', {}, 'group2'])).toBeFalsy()
+    })
   })
 
   describe('customGroups', () => {
@@ -241,6 +253,16 @@ describe('common-json-schemas', () => {
         ]),
       ).toBeTruthy()
     })
+
+    it("should enforce 'groupName'", () => {
+      expect(
+        customGroupsJsonSchema([
+          {
+            customGroupProperty: 'value',
+          },
+        ]),
+      ).toBeFalsy()
+    })
   })
 
   describe('partitionByComment', () => {
@@ -260,6 +282,10 @@ describe('common-json-schemas', () => {
         ).toBeTruthy()
       },
     )
+
+    it('should not allow the empty object', () => {
+      expect(partitionByCommentJsonSchemaValidator({})).toBeFalsy()
+    })
   })
 
   describe('regex', () => {
@@ -292,6 +318,10 @@ describe('common-json-schemas', () => {
           pattern: 'pattern',
         }),
       ).toBeFalsy()
+    })
+
+    it('should not allow the empty object', () => {
+      expect(regexJsonSchemaValidator({})).toBeFalsy()
     })
   })
 })

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -58,6 +58,7 @@ let buildFallbackSortJsonSchema = ({
   },
   description: 'Fallback sort order.',
   additionalProperties: false,
+  minProperties: 1,
   type: 'object',
 })
 
@@ -102,6 +103,7 @@ export let groupsJsonSchema: JSONSchema4 = {
         properties: {
           newlinesBetween: newlinesBetweenJsonSchema,
         },
+        required: ['newlinesBetween'],
         additionalProperties: false,
         type: 'object',
       },
@@ -143,6 +145,7 @@ let singleRegexJsonSchema: JSONSchema4 = {
         },
       },
       additionalProperties: false,
+      required: ['pattern'],
       // https://github.com/azat-io/eslint-plugin-perfectionist/pull/490#issuecomment-2720969705
       // Uncomment the code below in the next major version (v5)
       // To uncomment: required: ['pattern'],
@@ -187,6 +190,7 @@ export let partitionByCommentJsonSchema: JSONSchema4 = {
         },
       },
       additionalProperties: false,
+      minProperties: 1,
       type: 'object',
     },
   ],
@@ -265,6 +269,7 @@ export let buildCustomGroupsArrayJsonSchema = ({
         },
         description: 'Custom group block.',
         additionalProperties: false,
+        required: ['groupName'],
         type: 'object',
       },
       {
@@ -276,6 +281,7 @@ export let buildCustomGroupsArrayJsonSchema = ({
         },
         description: 'Custom group.',
         additionalProperties: false,
+        required: ['groupName'],
         type: 'object',
       },
     ],


### PR DESCRIPTION
### Description

This PR does the following:
- Adds tests for `common-json-schemas`.
- Strengthen a few JSON schemas by enforcing the following properties:
  - Forbid `fallbackSort: {}`.
  - Forbid `{}` objects inside `groups`.
  - Forbid `{}` in `{ pattern: string; flags?: string }` RegExp objects.
  - Forbid `partitionByComment: {}`.
  - Enforce `groupName` in `customGroups` array objects.

### What is the purpose of this pull request?

- [x] Other