### PR TITLE
feat(sort-imports): allow to find alternate `tsconfig` file

### DIFF
--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -267,13 +267,31 @@ Specifies a maximum line length for sorting imports. When the line length exceed
 
 This option is only available when the type is set to `'line-length'`.
 
-### tsconfigRootDir
+### tsconfig
+
+<sub>
+  type: `{ rootDir: string; filename?: string }`
+</sub>
+<sub>default: undefined</sub>
+
+- `rootDir` — Specifies the directory of the root `tsconfig.json` file (ex: `.`). This is used in [`groups`](#groups) for:
+  - Marking aliased imports as `internal`.
+  - Marking imports matching [tsconfig paths](https://www.typescriptlang.org/tsconfig/#paths) as `tsconfig-path`.
+- `filename` — Specifies the `tsconfig` filename to search for (by default: `tsconfig.json`).
+
+If this option is not set, the rule will not search for a `tsconfig.json` file.
+
+### [DEPRECATED] tsconfigRootDir
 
 <sub>default: `undefined`</sub>
+
+Use the [tsconfig](#tsconfig) option with the `rootDir` attribute.
 
 Specifies the  directory of the root `tsconfig.json` file (ex: `.`). This is used in [`groups`](#groups) for:
 - Marking aliased imports as `internal`.
 - Marking imports matching [tsconfig paths](https://www.typescriptlang.org/tsconfig/#paths) as `tsconfig-path`.
+
+If this option is not set, the rule will not search for a `tsconfig.json` file.
 
 ### groups
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -62,17 +62,6 @@ import { complete } from '../utils/complete'
  */
 let cachedGroupsByModifiersAndSelectors = new Map<string, string[]>()
 
-let defaultGroups = [
-  'type-import',
-  ['value-builtin', 'value-external'],
-  'type-internal',
-  'value-internal',
-  ['type-parent', 'type-sibling', 'type-index'],
-  ['value-parent', 'value-sibling', 'value-index'],
-  'ts-equals-import',
-  'unknown',
-]
-
 export type MESSAGE_ID =
   | 'unexpectedImportsDependencyOrder'
   | 'missedSpacingBetweenImports'
@@ -80,29 +69,43 @@ export type MESSAGE_ID =
   | 'extraSpacingBetweenImports'
   | 'unexpectedImportsOrder'
 
+let defaultOptions: Required<
+  Omit<Options[0], 'tsconfigRootDir' | 'maxLineLength'>
+> &
+  Pick<Options[0], 'tsconfigRootDir' | 'maxLineLength'> = {
+  groups: [
+    'type-import',
+    ['value-builtin', 'value-external'],
+    'type-internal',
+    'value-internal',
+    ['type-parent', 'type-sibling', 'type-index'],
+    ['value-parent', 'value-sibling', 'value-index'],
+    'ts-equals-import',
+    'unknown',
+  ],
+  internalPattern: ['^~/.+', '^@/.+'],
+  fallbackSort: { type: 'unsorted' },
+  partitionByComment: false,
+  partitionByNewLine: false,
+  newlinesBetween: 'always',
+  specialCharacters: 'keep',
+  sortSideEffects: false,
+  type: 'alphabetical',
+  environment: 'node',
+  customGroups: [],
+  ignoreCase: true,
+  locales: 'en-US',
+  alphabet: '',
+  order: 'asc',
+}
+
 export default createEslintRule<Options, MESSAGE_ID>({
   create: context => {
     let settings = getSettings(context.settings)
 
     let userOptions = context.options.at(0)
     let options = getOptionsWithCleanGroups(
-      complete(userOptions, settings, {
-        internalPattern: ['^~/.+', '^@/.+'],
-        fallbackSort: { type: 'unsorted' },
-        partitionByComment: false,
-        partitionByNewLine: false,
-        newlinesBetween: 'always',
-        specialCharacters: 'keep',
-        sortSideEffects: false,
-        groups: defaultGroups,
-        type: 'alphabetical',
-        environment: 'node',
-        customGroups: [],
-        ignoreCase: true,
-        locales: 'en-US',
-        alphabet: '',
-        order: 'asc',
-      } as const),
+      complete(userOptions, settings, defaultOptions),
     )
 
     validateGeneratedGroupsConfiguration({
@@ -486,24 +489,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     type: 'suggestion',
     fixable: 'code',
   },
-  defaultOptions: [
-    {
-      customGroups: { value: {}, type: {} },
-      internalPattern: ['^~/.+', '^@/.+'],
-      partitionByComment: false,
-      partitionByNewLine: false,
-      specialCharacters: 'keep',
-      newlinesBetween: 'always',
-      sortSideEffects: false,
-      groups: defaultGroups,
-      type: 'alphabetical',
-      environment: 'node',
-      ignoreCase: true,
-      locales: 'en-US',
-      alphabet: '',
-      order: 'asc',
-    },
-  ],
+  defaultOptions: [defaultOptions],
   name: 'sort-imports',
 })
 

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -129,6 +129,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       ? readClosestTsConfigByPath({
           tsconfigRootDir: options.tsconfigRootDir,
           filePath: context.physicalFilename,
+          tsconfigFilename: 'tsconfig.json',
           contextCwd: context.cwd,
         })
       : null

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -70,9 +70,9 @@ export type MESSAGE_ID =
   | 'unexpectedImportsOrder'
 
 let defaultOptions: Required<
-  Omit<Options[0], 'tsconfigRootDir' | 'maxLineLength'>
+  Omit<Options[0], 'tsconfigRootDir' | 'maxLineLength' | 'tsconfig'>
 > &
-  Pick<Options[0], 'tsconfigRootDir' | 'maxLineLength'> = {
+  Pick<Options[0], 'tsconfigRootDir' | 'maxLineLength' | 'tsconfig'> = {
   groups: [
     'type-import',
     ['value-builtin', 'value-external'],
@@ -125,11 +125,13 @@ export default createEslintRule<Options, MESSAGE_ID>({
     validateNewlinesAndPartitionConfiguration(options)
     validateSideEffectsConfiguration(options)
 
-    let tsConfigOutput = options.tsconfigRootDir
+    let tsconfigRootDirectory =
+      options.tsconfig?.rootDir ?? options.tsconfigRootDir
+    let tsConfigOutput = tsconfigRootDirectory
       ? readClosestTsConfigByPath({
-          tsconfigRootDir: options.tsconfigRootDir,
+          tsconfigFilename: options.tsconfig?.filename ?? 'tsconfig.json',
+          tsconfigRootDir: tsconfigRootDirectory,
           filePath: context.physicalFilename,
-          tsconfigFilename: 'tsconfig.json',
           contextCwd: context.cwd,
         })
       : null
@@ -443,6 +445,21 @@ export default createEslintRule<Options, MESSAGE_ID>({
               buildCustomGroupsArrayJsonSchema({ singleCustomGroupJsonSchema }),
             ],
           },
+          tsconfig: {
+            properties: {
+              rootDir: {
+                description: 'Specifies the tsConfig root directory.',
+                type: 'string',
+              },
+              filename: {
+                description: 'Specifies the tsConfig filename.',
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+            required: ['rootDir'],
+            type: 'object',
+          },
           maxLineLength: {
             description: 'Specifies the maximum line length.',
             exclusiveMinimum: true,
@@ -581,7 +598,7 @@ let computeGroupExceptUnknown = ({
 }: {
   options: Omit<
     Required<Options[0]>,
-    'tsconfigRootDir' | 'maxLineLength' | 'customGroups'
+    'tsconfigRootDir' | 'maxLineLength' | 'customGroups' | 'tsconfig'
   >
   customGroups: DeprecatedCustomGroupsOption | CustomGroupsOption | undefined
   selectors?: Selector[]

--- a/rules/sort-imports/read-closest-ts-config-by-path.ts
+++ b/rules/sort-imports/read-closest-ts-config-by-path.ts
@@ -59,7 +59,7 @@ export let readClosestTsConfigByPath = ({
   } while (directory.length > 1 && directory.length >= tsconfigRootDir.length)
 
   throw new Error(
-    `Couldn't find any tsconfig.json relative to '${filePath}' within '${tsconfigRootDir}'.`,
+    `Couldn't find any ${tsconfigFilename} relative to '${filePath}' within '${tsconfigRootDir}'.`,
   )
 }
 

--- a/rules/sort-imports/read-closest-ts-config-by-path.ts
+++ b/rules/sort-imports/read-closest-ts-config-by-path.ts
@@ -22,10 +22,12 @@ export let contentCacheByPath = new Map<
 >()
 
 export let readClosestTsConfigByPath = ({
+  tsconfigFilename,
   tsconfigRootDir,
   contextCwd,
   filePath,
 }: {
+  tsconfigFilename: string
   tsconfigRootDir: string
   contextCwd: string
   filePath: string
@@ -39,7 +41,7 @@ export let readClosestTsConfigByPath = ({
   let checkedDirectories = [directory]
 
   do {
-    let tsconfigPath = path.join(directory, 'tsconfig.json')
+    let tsconfigPath = path.join(directory, tsconfigFilename)
     let cachedDirectory = directoryCacheByPath.get(directory)
     if (!cachedDirectory && fs.existsSync(tsconfigPath)) {
       cachedDirectory = tsconfigPath

--- a/rules/sort-imports/read-closest-ts-config-by-path.ts
+++ b/rules/sort-imports/read-closest-ts-config-by-path.ts
@@ -15,27 +15,27 @@ export interface ReadClosestTsConfigByPathValue {
   cache: ts.ModuleResolutionCache
 }
 
-interface ReadClosestTsConfigByPathParameters {
-  tsconfigRootDir: string
-  contextCwd: string
-  filePath: string
-}
-
 export let directoryCacheByPath = new Map<string, string>()
 export let contentCacheByPath = new Map<
   string,
   ReadClosestTsConfigByPathValue
 >()
 
-export let readClosestTsConfigByPath = (
-  input: ReadClosestTsConfigByPathParameters,
-): ReadClosestTsConfigByPathValue | null => {
+export let readClosestTsConfigByPath = ({
+  tsconfigRootDir,
+  contextCwd,
+  filePath,
+}: {
+  tsconfigRootDir: string
+  contextCwd: string
+  filePath: string
+}): ReadClosestTsConfigByPathValue | null => {
   let typescriptImport = getTypescriptImport()
   if (!typescriptImport) {
     return null
   }
 
-  let directory = path.dirname(input.filePath)
+  let directory = path.dirname(filePath)
   let checkedDirectories = [directory]
 
   do {
@@ -49,22 +49,15 @@ export let readClosestTsConfigByPath = (
       for (let checkedDirectory of checkedDirectories) {
         directoryCacheByPath.set(checkedDirectory, cachedDirectory)
       }
-      return getCompilerOptions(
-        typescriptImport,
-        input.contextCwd,
-        cachedDirectory,
-      )
+      return getCompilerOptions(typescriptImport, contextCwd, cachedDirectory)
     }
 
     directory = path.dirname(directory)
     checkedDirectories.push(directory)
-  } while (
-    directory.length > 1 &&
-    directory.length >= input.tsconfigRootDir.length
-  )
+  } while (directory.length > 1 && directory.length >= tsconfigRootDir.length)
 
   throw new Error(
-    `Couldn't find any tsconfig.json relative to '${input.filePath}' within '${input.tsconfigRootDir}'.`,
+    `Couldn't find any tsconfig.json relative to '${filePath}' within '${tsconfigRootDir}'.`,
   )
 }
 

--- a/rules/sort-imports/types.ts
+++ b/rules/sort-imports/types.ts
@@ -28,10 +28,19 @@ export type Options = Partial<{
         type?: DeprecatedCustomGroupsOption
       }
     | CustomGroupsOption<SingleCustomGroup>
+  tsconfig:
+    | {
+        filename?: string
+        rootDir: string
+      }
+    | undefined
   partitionByComment: PartitionByCommentOption
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   newlinesBetween: NewlinesBetweenOption
+  /**
+   * @deprecated for `tsconfig`
+   */
   tsconfigRootDir: undefined | string
   maxLineLength: undefined | number
   fallbackSort: FallbackSortOption

--- a/rules/sort-imports/types.ts
+++ b/rules/sort-imports/types.ts
@@ -32,14 +32,14 @@ export type Options = Partial<{
   specialCharacters: SpecialCharactersOption
   locales: NonNullable<Intl.LocalesArgument>
   newlinesBetween: NewlinesBetweenOption
+  tsconfigRootDir: undefined | string
+  maxLineLength: undefined | number
   fallbackSort: FallbackSortOption
   internalPattern: RegexOption[]
   groups: GroupsOptions<Group>
   environment: 'node' | 'bun'
   partitionByNewLine: boolean
   sortSideEffects: boolean
-  tsconfigRootDir?: string
-  maxLineLength?: number
   ignoreCase: boolean
   order: OrderOption
   type: TypeOption

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -7592,7 +7592,142 @@ describe(ruleName, () => {
       })
 
       describe('tsconfig option', () => {
-        // TODO
+        ruleTester.run(
+          `${ruleName}: marks internal imports as 'internal'`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    tsconfig: {
+                      filename: 'tsconfig.json',
+                      rootDir: '.',
+                    },
+                    groups: ['internal', 'unknown'],
+                  },
+                ],
+                before: () => {
+                  mockReadClosestTsConfigByPathWith({
+                    baseUrl: './rules/',
+                  })
+                },
+                code: dedent`
+                  import { x } from 'sort-imports'
+
+                  import { a } from './a';
+                `,
+                after: () => {
+                  vi.resetAllMocks()
+                },
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}: marks external imports as 'external'`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    tsconfig: {
+                      filename: 'tsconfig.json',
+                      rootDir: '.',
+                    },
+                    groups: ['external', 'unknown'],
+                  },
+                ],
+                code: dedent`
+                  import type { ParsedCommandLine } from 'typescript'
+
+                  import { a } from './a';
+                `,
+                before: () => {
+                  mockReadClosestTsConfigByPathWith({
+                    baseUrl: '.',
+                  })
+                },
+                after: () => {
+                  vi.resetAllMocks()
+                },
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}: marks non-resolved imports as 'external'`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    tsconfig: {
+                      filename: 'tsconfig.json',
+                      rootDir: '.',
+                    },
+                    groups: ['external', 'unknown'],
+                  },
+                ],
+                before: () => {
+                  mockReadClosestTsConfigByPathWith({
+                    baseUrl: '.',
+                  })
+                },
+                code: dedent`
+                  import { b } from 'b'
+
+                  import { a } from './a';
+                `,
+                after: () => {
+                  vi.resetAllMocks()
+                },
+              },
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}: uses the fallback algorithm if typescript is not present`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    tsconfig: {
+                      filename: 'tsconfig.json',
+                      rootDir: '.',
+                    },
+                    groups: ['external', 'unknown'],
+                  },
+                ],
+                before: () => {
+                  vi.spyOn(
+                    getTypescriptImportUtilities,
+                    'getTypescriptImport',
+                  ).mockReturnValue(null)
+                },
+                code: dedent`
+                  import { b } from 'b'
+
+                  import { a } from './a';
+                `,
+                after: () => {
+                  vi.resetAllMocks()
+                },
+              },
+            ],
+            invalid: [],
+          },
+        )
       })
     })
 

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -7464,119 +7464,125 @@ describe(ruleName, () => {
     })
 
     describe(`${ruleName}: handles tsconfig.json`, () => {
-      ruleTester.run(
-        `${ruleName}: marks internal imports as 'internal'`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  groups: ['internal', 'unknown'],
-                  tsconfigRootDir: '.',
+      describe('tsconfigRootDir option', () => {
+        ruleTester.run(
+          `${ruleName}: marks internal imports as 'internal'`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    groups: ['internal', 'unknown'],
+                    tsconfigRootDir: '.',
+                  },
+                ],
+                before: () => {
+                  mockReadClosestTsConfigByPathWith({
+                    baseUrl: './rules/',
+                  })
                 },
-              ],
-              before: () => {
-                mockReadClosestTsConfigByPathWith({
-                  baseUrl: './rules/',
-                })
+                code: dedent`
+                  import { x } from 'sort-imports'
+
+                  import { a } from './a';
+                `,
               },
-              code: dedent`
-                import { x } from 'sort-imports'
+            ],
+            invalid: [],
+          },
+        )
 
-                import { a } from './a';
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
+        ruleTester.run(
+          `${ruleName}: marks external imports as 'external'`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    groups: ['external', 'unknown'],
+                    tsconfigRootDir: '.',
+                  },
+                ],
+                code: dedent`
+                  import type { ParsedCommandLine } from 'typescript'
 
-      ruleTester.run(
-        `${ruleName}: marks external imports as 'external'`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  groups: ['external', 'unknown'],
-                  tsconfigRootDir: '.',
+                  import { a } from './a';
+                `,
+                before: () => {
+                  mockReadClosestTsConfigByPathWith({
+                    baseUrl: '.',
+                  })
                 },
-              ],
-              code: dedent`
-                import type { ParsedCommandLine } from 'typescript'
-
-                import { a } from './a';
-              `,
-              before: () => {
-                mockReadClosestTsConfigByPathWith({
-                  baseUrl: '.',
-                })
               },
-            },
-          ],
-          invalid: [],
-        },
-      )
+            ],
+            invalid: [],
+          },
+        )
 
-      ruleTester.run(
-        `${ruleName}: marks non-resolved imports as 'external'`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  groups: ['external', 'unknown'],
-                  tsconfigRootDir: '.',
+        ruleTester.run(
+          `${ruleName}: marks non-resolved imports as 'external'`,
+          rule,
+          {
+            valid: [
+              {
+                options: [
+                  {
+                    groups: ['external', 'unknown'],
+                    tsconfigRootDir: '.',
+                  },
+                ],
+                before: () => {
+                  mockReadClosestTsConfigByPathWith({
+                    baseUrl: '.',
+                  })
                 },
-              ],
-              before: () => {
-                mockReadClosestTsConfigByPathWith({
-                  baseUrl: '.',
-                })
-              },
-              code: dedent`
-                import { b } from 'b'
+                code: dedent`
+                  import { b } from 'b'
 
-                import { a } from './a';
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: uses the fallback algorithm if typescript is not present`,
-        rule,
-        {
-          valid: [
-            {
-              before: () => {
-                mockReadClosestTsConfigByPathWith(null)
-                vi.spyOn(
-                  getTypescriptImportUtilities,
-                  'getTypescriptImport',
-                ).mockReturnValue(null)
+                  import { a } from './a';
+                `,
               },
-              options: [
-                {
-                  groups: ['external', 'unknown'],
-                  tsconfigRootDir: '.',
+            ],
+            invalid: [],
+          },
+        )
+
+        ruleTester.run(
+          `${ruleName}: uses the fallback algorithm if typescript is not present`,
+          rule,
+          {
+            valid: [
+              {
+                before: () => {
+                  mockReadClosestTsConfigByPathWith(null)
+                  vi.spyOn(
+                    getTypescriptImportUtilities,
+                    'getTypescriptImport',
+                  ).mockReturnValue(null)
                 },
-              ],
-              code: dedent`
-                import { b } from 'b'
+                options: [
+                  {
+                    groups: ['external', 'unknown'],
+                    tsconfigRootDir: '.',
+                  },
+                ],
+                code: dedent`
+                  import { b } from 'b'
 
-                import { a } from './a';
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
+                  import { a } from './a';
+                `,
+              },
+            ],
+            invalid: [],
+          },
+        )
+      })
+
+      describe('tsconfig option', () => {
+        // TODO
+      })
     })
 
     let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -7487,6 +7487,9 @@ describe(ruleName, () => {
 
                   import { a } from './a';
                 `,
+                after: () => {
+                  vi.resetAllMocks()
+                },
               },
             ],
             invalid: [],
@@ -7514,6 +7517,9 @@ describe(ruleName, () => {
                   mockReadClosestTsConfigByPathWith({
                     baseUrl: '.',
                   })
+                },
+                after: () => {
+                  vi.resetAllMocks()
                 },
               },
             ],
@@ -7543,6 +7549,9 @@ describe(ruleName, () => {
 
                   import { a } from './a';
                 `,
+                after: () => {
+                  vi.resetAllMocks()
+                },
               },
             ],
             invalid: [],
@@ -7556,7 +7565,6 @@ describe(ruleName, () => {
             valid: [
               {
                 before: () => {
-                  mockReadClosestTsConfigByPathWith(null)
                   vi.spyOn(
                     getTypescriptImportUtilities,
                     'getTypescriptImport',
@@ -7573,6 +7581,9 @@ describe(ruleName, () => {
 
                   import { a } from './a';
                 `,
+                after: () => {
+                  vi.resetAllMocks()
+                },
               },
             ],
             invalid: [],
@@ -7907,22 +7918,18 @@ describe(ruleName, () => {
   })
 
   let mockReadClosestTsConfigByPathWith = (
-    compilerOptions: CompilerOptions | null,
+    compilerOptions: CompilerOptions,
   ): void => {
     vi.spyOn(
       readClosestTsConfigUtilities,
       'readClosestTsConfigByPath',
-    ).mockReturnValue(
-      compilerOptions
-        ? {
-            cache: createModuleResolutionCache(
-              '.',
-              filename => filename,
-              compilerOptions,
-            ),
-            compilerOptions,
-          }
-        : null,
-    )
+    ).mockReturnValue({
+      cache: createModuleResolutionCache(
+        '.',
+        filename => filename,
+        compilerOptions,
+      ),
+      compilerOptions,
+    })
   }
 })

--- a/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
+++ b/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
@@ -47,6 +47,7 @@ vi.mock('../../../rules/sort-imports/get-typescript-import', () => ({
 let testInput = {
   filePath: '../../repos/repo/packages/package/file.ts',
   tsconfigRootDir: '../../repos/repo',
+  tsconfigFilename: 'tsconfig.json',
   contextCwd: '../../../',
 }
 
@@ -146,6 +147,7 @@ describe('readClosestTsConfigByPath', () => {
 
         // This should call to fs.existsSync three times: c, b, a.
         readClosestTsConfigByPath({
+          tsconfigFilename: 'tsconfig.json',
           filePath: './a/b/c/d.ts',
           tsconfigRootDir: './a',
           contextCwd: '../../',
@@ -156,6 +158,7 @@ describe('readClosestTsConfigByPath', () => {
          * from cache, pointing to a.
          */
         let actual = readClosestTsConfigByPath({
+          tsconfigFilename: 'tsconfig.json',
           filePath: './a/b/c/e/f.ts',
           tsconfigRootDir: './a',
           contextCwd: './',
@@ -179,6 +182,7 @@ describe('readClosestTsConfigByPath', () => {
          * This should call to fs.existsSync 4 times: d, c, b, a
          */
         readClosestTsConfigByPath({
+          tsconfigFilename: 'tsconfig.json',
           filePath: './a/b/c/d/e.ts',
           tsconfigRootDir: './a',
           contextCwd: '../../',
@@ -189,6 +193,7 @@ describe('readClosestTsConfigByPath', () => {
          * Then it should retrieve b from cache, pointing to a
          */
         let actual = readClosestTsConfigByPath({
+          tsconfigFilename: 'tsconfig.json',
           filePath: './a/b/f/g/h.ts',
           tsconfigRootDir: './a',
           contextCwd: '../../',

--- a/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
+++ b/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
@@ -236,7 +236,7 @@ describe('readClosestTsConfigByPath', () => {
         )
       })
 
-      it('throws when searching hits.', () => {
+      it('throws when searching fails.', () => {
         mockExistsSync.mockReturnValue(false)
         mockReadConfigFileReturnValue()
         mockParseJsonConfigFileContentReturnValue()


### PR DESCRIPTION
- Resolves #536

### Description

This PR:
- Adds an option `tsconfig: { rootDir: string; filename?: string}`.
  - If `filename` is not entered, will search for the closest `tsconfig.json` file.
- Deprecates `tsconfigRootDir`.

### What is the purpose of this pull request?

- [x] New Feature
