### PR TITLE
fix(sort-imports): allow single imports to be linted for `commentAbove`

### DIFF
--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -1697,6 +1697,40 @@ describe(ruleName, () => {
       })
 
       ruleTester.run(
+        `${ruleName}(${type}): reports missing comments for single nodes`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    missedCommentAbove: 'Comment above',
+                    right: 'a',
+                  },
+                  messageId: 'missedCommentAboveExport',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+                },
+              ],
+              output: dedent`
+                // Comment above
+                export { a } from "a";
+              `,
+              code: dedent`
+                export { a } from "a";
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}): ignores shebangs and comments at the top of the file`,
         rule,
         {

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -4049,6 +4049,40 @@ describe(ruleName, () => {
       })
 
       ruleTester.run(
+        `${ruleName}(${type}): reports missing comments for single nodes`,
+        rule,
+        {
+          invalid: [
+            {
+              errors: [
+                {
+                  data: {
+                    missedCommentAbove: 'Comment above',
+                    right: 'a',
+                  },
+                  messageId: 'missedCommentAboveImport',
+                },
+              ],
+              options: [
+                {
+                  ...options,
+                  groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+                },
+              ],
+              output: dedent`
+                // Comment above
+                import { a } from "a";
+              `,
+              code: dedent`
+                import { a } from "a";
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
+
+      ruleTester.run(
         `${ruleName}(${type}): ignores shebangs and comments at the top of the file`,
         rule,
         {

--- a/utils/pairwise.ts
+++ b/utils/pairwise.ts
@@ -1,10 +1,8 @@
-import { isSortable } from './is-sortable'
-
 export let pairwise = <T>(
   nodes: T[],
   callback: (left: null | T, right: T) => void,
 ): void => {
-  if (!isSortable(nodes)) {
+  if (nodes.length === 0) {
     return
   }
 


### PR DESCRIPTION
- Original issue: https://github.com/azat-io/eslint-plugin-perfectionist/issues/479
- Original comment: https://github.com/azat-io/eslint-plugin-perfectionist/issues/479#issuecomment-2941422278

## Description

For small optimization purposes, node arrays that don't have a size of 2 are not considered, which makes sense sorting-wise.

The `commentAbove` option should work for files containing a single import, however.

### Changes

- Allows `pairwise` to iterate on single-element arrays.

## Bug severity

Very low.

## What is the purpose of this pull request?

- [x] Bug fix