### PR TITLE
fix: prevent newlines fixes between different partitions

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -229,7 +229,7 @@ export let sortArray = <MessageIds extends string>({
         options,
       })
 
-      let sortingNode: SortArrayIncludesSortingNode = {
+      let sortingNode: Omit<SortArrayIncludesSortingNode, 'partitionId'> = {
         isEslintDisabled: isNodeEslintDisabled(element, eslintDisabledLines),
         size: rangeToDiff(element, sourceCode),
         node: element,
@@ -250,7 +250,10 @@ export let sortArray = <MessageIds extends string>({
         accumulator.push([])
       }
 
-      accumulator.at(-1)!.push(sortingNode)
+      accumulator.at(-1)!.push({
+        ...sortingNode,
+        partitionId: accumulator.length,
+      })
 
       return accumulator
     },

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -542,7 +542,7 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
           let overloadSignatureGroupMember =
             overloadSignatureGroups[overloadSignatureGroupMemberIndex]?.at(-1)
 
-          let sortingNode: SortClassSortingNodes = {
+          let sortingNode: Omit<SortClassSortingNodes, 'partitionId'> = {
             dependencyNames: [
               getDependencyName({
                 nodeNameWithoutStartingHash: name.startsWith('#')
@@ -580,7 +580,10 @@ export default createEslintRule<SortClassesOptions, MESSAGE_ID>({
             accumulator.push([])
           }
 
-          accumulator.at(-1)!.push(sortingNode)
+          accumulator.at(-1)!.push({
+            ...sortingNode,
+            partitionId: accumulator.length,
+          })
 
           return accumulator
         },

--- a/rules/sort-decorators.ts
+++ b/rules/sort-decorators.ts
@@ -211,7 +211,7 @@ let sortDecorators = (
         name,
       })
 
-      let sortingNode: SortDecoratorsSortingNode = {
+      let sortingNode: Omit<SortDecoratorsSortingNode, 'partitionId'> = {
         isEslintDisabled: isNodeEslintDisabled(decorator, eslintDisabledLines),
         size: rangeToDiff(decorator, sourceCode),
         node: decorator,
@@ -231,7 +231,10 @@ let sortDecorators = (
         accumulator.push([])
       }
 
-      accumulator.at(-1)!.push(sortingNode)
+      accumulator.at(-1)!.push({
+        ...sortingNode,
+        partitionId: accumulator.length,
+      })
 
       return accumulator
     },

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -161,7 +161,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           })
 
           let lastSortingNode = accumulator.at(-1)?.at(-1)
-          let sortingNode: SortEnumsSortingNode = {
+          let sortingNode: Omit<SortEnumsSortingNode, 'partitionId'> = {
             numericValue: member.initializer
               ? getExpressionNumberValue(
                   member.initializer,
@@ -191,7 +191,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             accumulator.push([])
           }
 
-          accumulator.at(-1)!.push(sortingNode)
+          accumulator.at(-1)!.push({
+            ...sortingNode,
+            partitionId: accumulator.length,
+          })
           return accumulator
         },
         [[]],

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -134,11 +134,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
         name,
         node,
       }
-      let lastNode = formattedMembers.at(-1)?.at(-1)
+      let lastSortingNode = formattedMembers.at(-1)?.at(-1)
 
       if (
         shouldPartition({
-          lastSortingNode: lastNode,
+          lastSortingNode,
           sortingNode,
           sourceCode,
           options,

--- a/rules/sort-exports.ts
+++ b/rules/sort-exports.ts
@@ -125,7 +125,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         options,
       })
 
-      let sortingNode: SortExportsSortingNode = {
+      let sortingNode: Omit<SortExportsSortingNode, 'partitionId'> = {
         isEslintDisabled: isNodeEslintDisabled(node, eslintDisabledLines),
         groupKind: node.exportKind === 'value' ? 'value' : 'type',
         size: rangeToDiff(node, sourceCode),
@@ -147,7 +147,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
         formattedMembers.push([])
       }
 
-      formattedMembers.at(-1)!.push(sortingNode)
+      formattedMembers.at(-1)!.push({
+        ...sortingNode,
+        partitionId: formattedMembers.length,
+      })
     }
 
     return {

--- a/rules/sort-heritage-clauses.ts
+++ b/rules/sort-heritage-clauses.ts
@@ -133,6 +133,7 @@ let sortHeritageClauses = (
       ),
       size: rangeToDiff(heritageClause, sourceCode),
       node: heritageClause,
+      partitionId: 0,
       group,
       name,
     }

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -522,8 +522,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
 let hasContentBetweenNodes = (
   sourceCode: TSESLint.SourceCode,
-  left: SortImportsSortingNode,
-  right: SortImportsSortingNode,
+  left: Pick<SortImportsSortingNode, 'node'>,
+  right: Pick<SortImportsSortingNode, 'node'>,
 ): boolean =>
   sourceCode.getTokensBetween(left.node, right.node, {
     includeComments: false,

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -271,6 +271,17 @@ export default createEslintRule<Options, MESSAGE_ID>({
           name,
         }) ?? 'unknown'
 
+      let hasMultipleImportDeclarations = isSortable(
+        (node as TSESTree.ImportDeclaration).specifiers,
+      )
+      let size = rangeToDiff(node, sourceCode)
+      if (
+        hasMultipleImportDeclarations &&
+        options.maxLineLength &&
+        size > options.maxLineLength
+      ) {
+        size = name.length + 10
+      }
       sortingNodes.push({
         isIgnored:
           !options.sortSideEffects &&
@@ -280,17 +291,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
         isEslintDisabled: isNodeEslintDisabled(node, eslintDisabledLines),
         dependencyNames: computeDependencyNames({ sourceCode, node }),
         dependencies: computeDependencies(node),
-        size: rangeToDiff(node, sourceCode),
         addSafetySemicolonWhenInline: true,
         group,
+        size,
         name,
         node,
-        ...(options.type === 'line-length' &&
-          options.maxLineLength && {
-            hasMultipleImportDeclarations: isSortable(
-              (node as TSESTree.ImportDeclaration).specifiers,
-            ),
-          }),
       })
     }
 

--- a/rules/sort-jsx-props.ts
+++ b/rules/sort-jsx-props.ts
@@ -164,7 +164,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               name,
             })
 
-            let sortingNode: SortingNode = {
+            let sortingNode: Omit<SortingNode, 'partitionId'> = {
               isEslintDisabled: isNodeEslintDisabled(
                 attribute,
                 eslintDisabledLines,
@@ -187,7 +187,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
               accumulator.push([])
             }
 
-            accumulator.at(-1)!.push(sortingNode)
+            accumulator.at(-1)!.push({
+              ...sortingNode,
+              partitionId: accumulator.length,
+            })
 
             return accumulator
           },

--- a/rules/sort-maps.ts
+++ b/rules/sort-maps.ts
@@ -136,7 +136,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             options,
           })
 
-          let sortingNode: SortingNode = {
+          let sortingNode: Omit<SortingNode, 'partitionId'> = {
             isEslintDisabled: isNodeEslintDisabled(
               element,
               eslintDisabledLines,
@@ -158,7 +158,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             formattedMembers.push([])
           }
 
-          formattedMembers.at(-1)!.push(sortingNode)
+          formattedMembers.at(-1)!.push({
+            ...sortingNode,
+            partitionId: formattedMembers.length,
+          })
         }
 
         for (let nodes of formattedMembers) {

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -307,7 +307,7 @@ let analyzeModule = ({
       options,
     })
 
-    let sortingNode: SortingNodeWithDependencies = {
+    let sortingNode: Omit<SortingNodeWithDependencies, 'partitionId'> = {
       isEslintDisabled: isNodeEslintDisabled(node, eslintDisabledLines),
       size: rangeToDiff(node, sourceCode),
       addSafetySemicolonWhenInline,
@@ -330,7 +330,10 @@ let analyzeModule = ({
       formattedNodes.push([])
     }
 
-    formattedNodes.at(-1)?.push(sortingNode)
+    formattedNodes.at(-1)?.push({
+      ...sortingNode,
+      partitionId: formattedNodes.length,
+    })
   }
 
   let sortNodesExcludingEslintDisabled = (

--- a/rules/sort-named-exports.ts
+++ b/rules/sort-named-exports.ts
@@ -139,7 +139,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           options,
         })
 
-        let sortingNode: SortNamedExportsSortingNode = {
+        let sortingNode: Omit<SortNamedExportsSortingNode, 'partitionId'> = {
           isEslintDisabled: isNodeEslintDisabled(
             specifier,
             eslintDisabledLines,
@@ -163,7 +163,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
           formattedMembers.push([])
         }
 
-        formattedMembers.at(-1)!.push(sortingNode)
+        formattedMembers.at(-1)!.push({
+          ...sortingNode,
+          partitionId: formattedMembers.length,
+        })
       }
 
       let groupKindOrder

--- a/rules/sort-named-imports.ts
+++ b/rules/sort-named-imports.ts
@@ -136,7 +136,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           options,
         })
 
-        let sortingNode: SortNamedImportsSortingNode = {
+        let sortingNode: Omit<SortNamedImportsSortingNode, 'partitionId'> = {
           groupKind:
             specifier.type === 'ImportSpecifier' &&
             specifier.importKind === 'type'
@@ -164,7 +164,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
           formattedMembers.push([])
         }
 
-        formattedMembers.at(-1)!.push(sortingNode)
+        formattedMembers.at(-1)!.push({
+          ...sortingNode,
+          partitionId: formattedMembers.length,
+        })
       }
 
       let groupKindOrder

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -302,6 +302,7 @@ export let sortObjectTypeElements = <MessageIds extends string>({
         groupKind: isMemberOptional(typeElement) ? 'optional' : 'required',
         size: rangeToDiff(typeElement, sourceCode),
         addSafetySemicolonWhenInline: true,
+        partitionId: accumulator.length,
         node: typeElement,
         group,
         value,

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -336,18 +336,19 @@ export default createEslintRule<Options, MESSAGE_ID>({
               dependencyName = property.value.name
             }
 
-            let sortingNode: SortingNodeWithDependencies = {
-              isEslintDisabled: isNodeEslintDisabled(
-                property,
-                eslintDisabledLines,
-              ),
-              size: rangeToDiff(property, sourceCode),
-              dependencyNames: [dependencyName],
-              node: property,
-              dependencies,
-              group,
-              name,
-            }
+            let sortingNode: Omit<SortingNodeWithDependencies, 'partitionId'> =
+              {
+                isEslintDisabled: isNodeEslintDisabled(
+                  property,
+                  eslintDisabledLines,
+                ),
+                size: rangeToDiff(property, sourceCode),
+                dependencyNames: [dependencyName],
+                node: property,
+                dependencies,
+                group,
+                name,
+              }
 
             if (
               shouldPartition({
@@ -360,7 +361,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
               accumulator.push([])
             }
 
-            accumulator.at(-1)!.push(sortingNode)
+            accumulator.at(-1)!.push({
+              ...sortingNode,
+              partitionId: accumulator.length,
+            })
 
             return accumulator
           },

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -69,6 +69,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
               name: getCaseName(sourceCode, caseNode),
               isEslintDisabled: false,
               node: caseNode.test,
+              group: 'unknown',
             })
           }
           if (
@@ -120,7 +121,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         })
       }
 
-      let sortingNodes = switchNode.cases.map(
+      let sortingNodes: SortSwitchCaseSortingNode[] = switchNode.cases.map(
         (caseNode: TSESTree.SwitchCase) => ({
           size: caseNode.test
             ? rangeToDiff(caseNode.test, sourceCode)
@@ -129,6 +130,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           addSafetySemicolonWhenInline: true,
           isDefaultClause: !caseNode.test,
           isEslintDisabled: false,
+          group: 'unknown',
           node: caseNode,
         }),
       )

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -67,6 +67,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
             accumulator.at(-1)!.push({
               size: rangeToDiff(caseNode.test, sourceCode),
               name: getCaseName(sourceCode, caseNode),
+              partitionId: accumulator.length,
               isEslintDisabled: false,
               node: caseNode.test,
               group: 'unknown',
@@ -131,6 +132,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           isDefaultClause: !caseNode.test,
           isEslintDisabled: false,
           group: 'unknown',
+          partitionId: 0,
           node: caseNode,
         }),
       )

--- a/rules/sort-union-types.ts
+++ b/rules/sort-union-types.ts
@@ -235,7 +235,7 @@ export let sortUnionOrIntersectionTypes = <MessageIds extends string>({
 
       let lastGroup = accumulator.at(-1)
       let lastSortingNode = lastGroup?.at(-1)
-      let sortingNode: SortingNode = {
+      let sortingNode: Omit<SortingNode, 'partitionId'> = {
         isEslintDisabled: isNodeEslintDisabled(type, eslintDisabledLines),
         size: rangeToDiff(type, sourceCode),
         node: type,
@@ -256,7 +256,10 @@ export let sortUnionOrIntersectionTypes = <MessageIds extends string>({
         accumulator.push(lastGroup)
       }
 
-      lastGroup?.push(sortingNode)
+      lastGroup?.push({
+        ...sortingNode,
+        partitionId: accumulator.length,
+      })
       return accumulator
     },
     [[]],

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -112,7 +112,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
           })
 
           let lastSortingNode = accumulator.at(-1)?.at(-1)
-          let sortingNode: SortingNodeWithDependencies = {
+          let sortingNode: Omit<SortingNodeWithDependencies, 'partitionId'> = {
             group: computeGroup({
               customGroupMatcher: customGroup =>
                 doesCustomGroupMatch({
@@ -146,7 +146,10 @@ export default createEslintRule<Options, MESSAGE_ID>({
             accumulator.push([])
           }
 
-          accumulator.at(-1)?.push(sortingNode)
+          accumulator.at(-1)?.push({
+            ...sortingNode,
+            partitionId: accumulator.length,
+          })
 
           return accumulator
         },

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -2038,6 +2038,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedArrayIncludesOrder',
+                },
+              ],
+              output: dedent`
+                [
+                  'a',
+
+                  // Partition comment
+
+                  'b',
+                  'c',
+                ].includes(value)
+              `,
+              code: dedent`
+                [
+                  'a',
+
+                  // Partition comment
+
+                  'c',
+                  'b',
+                ].includes(value)
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
   })
 

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4841,6 +4841,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedClassesOrder',
+                },
+              ],
+              output: dedent`
+                class Class {
+                  a
+
+                  // Partition comment
+
+                  b
+                  c
+                }
+              `,
+              code: dedent`
+                class Class {
+                  a
+
+                  // Partition comment
+
+                  c
+                  b
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     describe(`${ruleName}(${type}): sorts inline elements correctly`, () => {

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1803,6 +1803,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'A',
+                      groupName: 'A',
+                    },
+                  ],
+                  groups: ['A', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'B',
+                    left: 'C',
+                  },
+                  messageId: 'unexpectedEnumsOrder',
+                },
+              ],
+              output: dedent`
+                enum Enum {
+                  A = 'A',
+
+                  // Partition comment
+
+                  B = 'B',
+                  C = 'C',
+                }
+              `,
+              code: dedent`
+                enum Enum {
+                  A = 'A',
+
+                  // Partition comment
+
+                  C = 'C',
+                  B = 'B',
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
   })
 

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -1682,6 +1682,57 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedExportsOrder',
+                },
+              ],
+              output: dedent`
+                export { a } from 'a'
+
+                // Partition comment
+
+                export { b } from 'b'
+                export { c } from 'c'
+              `,
+              code: dedent`
+                export { a } from 'a'
+
+                // Partition comment
+
+                export { c } from 'c'
+                export { b } from 'b'
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     describe(`${ruleName}(${type}): "commentAbove" inside groups`, () => {

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2148,20 +2148,18 @@ describe(ruleName, () => {
               output: dedent`
                 import a from 'a';
 
-                // Siblings
+                // Partition comment
 
                 import { b } from './b';
                 import { c } from './c';
-
               `,
               code: dedent`
                 import a from 'a';
 
-                // Siblings
+                // Partition comment
 
                 import { c } from './c';
                 import { b } from './b';
-
               `,
             },
           ],

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2115,6 +2115,59 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: './b',
+                    left: './c',
+                  },
+                  messageId: 'unexpectedImportsOrder',
+                },
+              ],
+              output: dedent`
+                import a from 'a';
+
+                // Siblings
+
+                import { b } from './b';
+                import { c } from './c';
+
+              `,
+              code: dedent`
+                import a from 'a';
+
+                // Siblings
+
+                import { c } from './c';
+                import { b } from './b';
+
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     ruleTester.run(
@@ -3812,17 +3865,18 @@ describe(ruleName, () => {
                 // Part: 1
                 import a = aImport.a1.a2;
               `,
+              code: dedent`
+                import a = aImport.a1.a2;
+
+                // Part: 1
+                import aImport from "b";
+              `,
               options: [
                 {
                   ...options,
                   partitionByComment: '^Part',
                 },
               ],
-              code: dedent`
-                import a = aImport.a1.a2;
-                // Part: 1
-                import aImport from "b";
-              `,
             },
           ],
           valid: [],

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -2907,6 +2907,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedInterfacePropertiesOrder',
+                },
+              ],
+              output: dedent`
+                interface Interface {
+                  a
+
+                  // Partition comment
+
+                  b
+                  c
+                }
+              `,
+              code: dedent`
+                interface Interface {
+                  a
+
+                  // Partition comment
+
+                  c
+                  b
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     ruleTester.run(

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1449,6 +1449,59 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedIntersectionTypesOrder',
+                },
+              ],
+              output: dedent`
+                type Type =
+                  & a
+
+                  // Partition comment
+
+                  & b
+                  & c
+              `,
+              code: dedent`
+                type Type =
+                  & a
+
+                  // Partition comment
+
+                  & c
+                  & b
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     ruleTester.run(

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1632,6 +1632,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedMapElementsOrder',
+                },
+              ],
+              output: dedent`
+                new Map([
+                  [a, 'a'],
+
+                  // Partition comment
+
+                  [b, 'b'],
+                  [c, 'c'],
+                ])
+              `,
+              code: dedent`
+                new Map([
+                  [a, 'a'],
+
+                  // Partition comment
+
+                  [c, 'c'],
+                  [b, 'b'],
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -2551,6 +2551,57 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedModulesOrder',
+                },
+              ],
+              output: dedent`
+                function a() {}
+
+                // Partition comment
+
+                function b() {}
+                function c() {}
+              `,
+              code: dedent`
+                function a() {}
+
+                // Partition comment
+
+                function c() {}
+                function b() {}
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     describe(`${ruleName}(${type}): sorts inline elements correctly`, () => {

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1733,6 +1733,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedNamedExportsOrder',
+                },
+              ],
+              output: dedent`
+                export {
+                  a,
+
+                  // Partition comment
+
+                  b,
+                  c,
+                } from 'module'
+              `,
+              code: dedent`
+                export {
+                  a,
+
+                  // Partition comment
+
+                  c,
+                  b,
+                } from 'module'
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
   })
 

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1898,6 +1898,61 @@ describe(ruleName, () => {
         },
       )
     })
+
+    ruleTester.run(
+      `${ruleName}(${type}): ignores newline fixes between different partitions`,
+      rule,
+      {
+        invalid: [
+          {
+            options: [
+              {
+                ...options,
+                customGroups: [
+                  {
+                    elementNamePattern: 'a',
+                    groupName: 'a',
+                  },
+                ],
+                groups: ['a', 'unknown'],
+                newlinesBetween: 'never',
+                partitionByComment: true,
+              },
+            ],
+            errors: [
+              {
+                data: {
+                  right: 'b',
+                  left: 'c',
+                },
+                messageId: 'unexpectedNamedImportsOrder',
+              },
+            ],
+            output: dedent`
+              import {
+                a,
+
+                // Partition comment
+
+                b,
+                c,
+              } from 'module'
+            `,
+            code: dedent`
+              import {
+                a,
+
+                // Partition comment
+
+                c,
+                b,
+              } from 'module'
+            `,
+          },
+        ],
+        valid: [],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2702,6 +2702,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedObjectTypesOrder',
+                },
+              ],
+              output: dedent`
+                type Type = {
+                  a: string
+
+                  // Partition comment
+
+                  b: string
+                  c: string
+                }
+              `,
+              code: dedent`
+                type Type = {
+                  a: string
+
+                  // Partition comment
+
+                  c: string
+                  b: string
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     ruleTester.run(

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2556,6 +2556,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedObjectsOrder',
+                },
+              ],
+              output: dedent`
+                let obj = {
+                  a,
+
+                  // Partition comment
+
+                  b,
+                  c,
+                }
+              `,
+              code: dedent`
+                let obj = {
+                  a,
+
+                  // Partition comment
+
+                  c,
+                  b,
+                }
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     ruleTester.run(

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1985,6 +1985,61 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedSetsOrder',
+                },
+              ],
+              output: dedent`
+                new Set([
+                  'a',
+
+                  // Partition comment
+
+                  'b',
+                  'c',
+                ])
+              `,
+              code: dedent`
+                new Set([
+                  'a',
+
+                  // Partition comment
+
+                  'c',
+                  'b',
+                ])
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
   })
 

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1452,6 +1452,59 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedUnionTypesOrder',
+                },
+              ],
+              output: dedent`
+                type Type =
+                  | a
+
+                  // Partition comment
+
+                  | b
+                  | c
+              `,
+              code: dedent`
+                type Type =
+                  | a
+
+                  // Partition comment
+
+                  | c
+                  | b
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
 
     ruleTester.run(

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -2123,6 +2123,59 @@ describe(ruleName, () => {
           valid: [],
         },
       )
+
+      ruleTester.run(
+        `${ruleName}(${type}): ignores newline fixes between different partitions`,
+        rule,
+        {
+          invalid: [
+            {
+              options: [
+                {
+                  ...options,
+                  customGroups: [
+                    {
+                      elementNamePattern: 'a',
+                      groupName: 'a',
+                    },
+                  ],
+                  groups: ['a', 'unknown'],
+                  newlinesBetween: 'never',
+                  partitionByComment: true,
+                },
+              ],
+              errors: [
+                {
+                  data: {
+                    right: 'b',
+                    left: 'c',
+                  },
+                  messageId: 'unexpectedVariableDeclarationsOrder',
+                },
+              ],
+              output: dedent`
+                let
+                  a,
+
+                  // Partition comment
+
+                  b,
+                  c
+              `,
+              code: dedent`
+                let
+                  a,
+
+                  // Partition comment
+
+                  c,
+                  b
+              `,
+            },
+          ],
+          valid: [],
+        },
+      )
     })
   })
 

--- a/types/sorting-node.ts
+++ b/types/sorting-node.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types'
 
 export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
-  hasMultipleImportDeclarations?: boolean
   addSafetySemicolonWhenInline?: boolean
   isEslintDisabled: boolean
   group: string

--- a/types/sorting-node.ts
+++ b/types/sorting-node.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
   addSafetySemicolonWhenInline?: boolean
   isEslintDisabled: boolean
+  partitionId: number
   group: string
   name: string
   size: number

--- a/types/sorting-node.ts
+++ b/types/sorting-node.ts
@@ -4,7 +4,7 @@ export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
   hasMultipleImportDeclarations?: boolean
   addSafetySemicolonWhenInline?: boolean
   isEslintDisabled: boolean
-  group?: string
+  group: string
   name: string
   size: number
   node: Node

--- a/utils/compare.ts
+++ b/utils/compare.ts
@@ -78,7 +78,7 @@ let computeCompareValue = <T extends SortingNode>({
       sortingFunction = getAlphabeticalSortingFunction(options, nodeValueGetter)
       break
     case 'line-length':
-      sortingFunction = getLineLengthSortingFunction(options, nodeValueGetter)
+      sortingFunction = getLineLengthSortingFunction()
       break
     case 'unsorted':
       return 0
@@ -172,27 +172,10 @@ let getCustomSortingFunction = <T extends SortingNode>(
 }
 
 let getLineLengthSortingFunction =
-  <T extends SortingNode>(
-    { maxLineLength }: { maxLineLength?: number },
-    nodeValueGetter: NodeValueGetterFunction<T>,
-  ): SortingFunction<T> =>
+  <T extends SortingNode>(): SortingFunction<T> =>
   (aNode: T, bNode: T) => {
     let aSize = aNode.size
     let bSize = bNode.size
-
-    if (maxLineLength) {
-      let isTooLong = (size: number, node: T): undefined | boolean =>
-        size > maxLineLength && node.hasMultipleImportDeclarations
-
-      if (isTooLong(aSize, aNode)) {
-        aSize = nodeValueGetter(aNode).length + 10
-      }
-
-      if (isTooLong(bSize, bNode)) {
-        bSize = nodeValueGetter(bNode).length + 10
-      }
-    }
-
     return aSize - bSize
   }
 

--- a/utils/get-lines-between.ts
+++ b/utils/get-lines-between.ts
@@ -4,8 +4,8 @@ import type { SortingNode } from '../types/sorting-node'
 
 export let getLinesBetween = (
   source: TSESLint.SourceCode,
-  left: SortingNode,
-  right: SortingNode,
+  left: Pick<SortingNode, 'node'>,
+  right: Pick<SortingNode, 'node'>,
 ): number => {
   let linesBetween = source.lines.slice(
     left.node.loc.end.line,

--- a/utils/get-newlines-between-errors.ts
+++ b/utils/get-newlines-between-errors.ts
@@ -51,7 +51,10 @@ export let getNewlinesBetweenErrors = <
   right,
   left,
 }: GetNewlinesBetweenErrorsParameters<MessageIds, T>): MessageIds[] => {
-  if (leftGroupIndex > rightGroupIndex) {
+  if (
+    leftGroupIndex > rightGroupIndex ||
+    left.partitionId !== right.partitionId
+  ) {
     return []
   }
 

--- a/utils/make-newlines-between-fixes.ts
+++ b/utils/make-newlines-between-fixes.ts
@@ -43,6 +43,10 @@ export let makeNewlinesBetweenFixes = <T extends SortingNode>({
     let sortedSortingNode = sortedNodes.at(i)!
     let nextSortedSortingNode = sortedNodes.at(i + 1)!
 
+    if (sortedSortingNode.partitionId !== nextSortedSortingNode.partitionId) {
+      continue
+    }
+
     let nodeGroupIndex = getGroupIndex(options.groups, sortedSortingNode)
     let nextNodeGroupIndex = getGroupIndex(
       options.groups,

--- a/utils/should-partition.ts
+++ b/utils/should-partition.ts
@@ -13,10 +13,10 @@ interface ShouldPartitionParameters {
     partitionByComment?: PartitionByCommentOption
     partitionByNewLine?: boolean
   }
-  lastSortingNode: SortingNode | undefined
+  lastSortingNode: Pick<SortingNode, 'node'> | undefined
+  sortingNode: Pick<SortingNode, 'node'>
   tokenValueToIgnoreBefore?: string
   sourceCode: TSESLint.SourceCode
-  sortingNode: SortingNode
 }
 
 export let shouldPartition = ({


### PR DESCRIPTION
- Related comment: https://github.com/azat-io/eslint-plugin-perfectionist/issues/479#issuecomment-2953160238
- Follow-up of https://github.com/azat-io/eslint-plugin-perfectionist/pull/554

## Description

Users can separate partitions with comments using `partitionByComment`. However, newlines errors and fixes will be raised/applied between two consecutive elements of different partitions.
https://github.com/azat-io/eslint-plugin-perfectionist/pull/554 reduced the occurrences of this happening, but it may still happen in some configurations, such as when partition A depends on the first groups of the `groups` option, and partition B depends on last groups of the `groups` options.

## Code example

```ts
"perfectionist/sort-imports": ["error", {
    groups: [
      "external",
      'sibling'
    ],
    newlinesBetween: "never",
    partitionByComment: true,
    type: "alphabetical"
}]
```

```ts
import a from 'a';

// Siblings

import { c } from './c';
import { b } from './b';
```

Gets linted into ➡️

```ts
import a from 'a';
// Siblings
import { b } from './b';
import { c } from './c';
```
❌ *Newline enforced between partitions above and before // Siblings*

### What is the purpose of this pull request?

- [x] Bug fix
