### PR TITLE
refactor: migrate to eslint vitest tester

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@types/node": "^24.1.0",
     "@types/unist": "^3.0.3",
     "@typescript-eslint/parser": "^8.38.0",
-    "@typescript-eslint/rule-tester": "^8.38.0",
     "@typescript-eslint/types": "^6.13.0",
     "@vercel/og": "^0.8.5",
     "@vitest/coverage-v8": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "dedent": "^1.6.0",
     "eslint": "^9.32.0",
     "eslint-plugin-eslint-plugin": "^6.5.0",
+    "eslint-vitest-rule-tester": "^2.2.1",
     "json-schema-to-typescript-lite": "^15.0.0",
     "keyux": "^0.11.3",
     "lightningcss": "^1.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       eslint-plugin-eslint-plugin:
         specifier: ^6.5.0
         version: 6.5.0(eslint@9.32.0(jiti@2.5.1))
+      eslint-vitest-rule-tester:
+        specifier: ^2.2.1
+        version: 2.2.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.0))
       json-schema-to-typescript-lite:
         specifier: ^15.0.0
         version: 15.0.0
@@ -1438,6 +1441,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -3006,6 +3012,12 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-vitest-rule-tester@2.2.1:
+    resolution: {integrity: sha512-eE9gCVlerY5eU4UXk0BvWBMk+qBw8BgdrcWnW8u2Qh+BFqOsBRkx/iOjnJ0+oDfwIBnpYpouaISh0QST9h+jRA==}
+    peerDependencies:
+      eslint: ^9.0.0
+      vitest: ^1.0.0 || ^2.0.0 || ^3.0.0
 
   eslint@9.32.0:
     resolution: {integrity: sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==}
@@ -7530,6 +7542,11 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/eslint@9.6.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -9605,6 +9622,16 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-vitest-rule-tester@2.2.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.0)):
+    dependencies:
+      '@types/eslint': 9.6.1
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      eslint: 9.32.0(jiti@2.5.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint@9.32.0(jiti@2.5.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.38.0
         version: 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/rule-tester':
-        specifier: ^8.38.0
-        version: 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       '@vercel/og':
         specifier: ^0.8.5
         version: 0.8.5
@@ -1510,12 +1507,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/rule-tester@8.38.0':
-    resolution: {integrity: sha512-uoGpIY8WdJw1KOnUTZTmp99k+DtpBJEKuGk/asSY6GfWz7vlF84p/EpTL6jraD0hW/3mkU/ipd5Nq0UxfIidsw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
 
   '@typescript-eslint/scope-manager@8.38.0':
     resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
@@ -7629,20 +7620,6 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/rule-tester@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
-    dependencies:
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
-      ajv: 6.12.6
-      eslint: 9.32.0(jiti@2.5.1)
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      semver: 7.7.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   '@typescript-eslint/scope-manager@8.38.0':
     dependencies:

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1,3032 +1,5910 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-array-includes'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-array-includes'
+describe('sort-array-includes', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-array-includes',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            output: dedent`
-              [
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'a',
-                'c',
-                'b',
-                'd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              [
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts spread elements`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...bbbb',
-                left: '...ccc',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              ...aaa,
-              ...ccc,
-              ...bbbb,
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            [
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores nullable array elements`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            output: dedent`
-              ['a', 'b', 'c',, 'd'].includes(value)
-            `,
-            code: dedent`
-              ['b', 'a', 'c',, 'd'].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              ['a', 'b', 'c',, 'd'].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allow to put spread elements to the end`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '...other',
-                  right: 'c',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            output: dedent`
-              ['a', 'b', 'c', ...other].includes(value)
-            `,
-            code: dedent`
-              ['a', 'b', ...other, 'c'].includes(value)
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            code: dedent`
-              ['a', 'b', 'c', ...other].includes(value)
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts array constructor`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ).includes(value)
-          `,
-          code: dedent`
-            new Array(
-              'a',
-              'c',
-              'b',
-              'd',
-            ).includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ).includes(value)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows mixed sorting`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...d',
-                left: 'bbb',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ).includes(value)
-          `,
-          code: dedent`
-            new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ).includes(value)
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ).includes(value)
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-    })
-
-    describe(`${ruleName}(${type}): partition by new line`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use new line as partition`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-                {
-                  data: {
-                    right: 'b',
-                    left: 'e',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              output: dedent`
-                [
-                  'a',
-                  'd',
-
-                  'c',
-
-                  'b',
-                  'e',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'd',
-                  'a',
-
-                  'c',
-
-                  'e',
-                  'b',
-                ].includes(value)
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByNewLine: true,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize partitions over group kind`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '...d',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-                {
-                  data: {
-                    right: '...b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groupKind: 'spreads-first',
-                  partitionByNewLine: true,
-                },
-              ],
-              output: dedent`
-                [
-                  ...d,
-                  'c',
-
-                  ...b,
-                  'a',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'c',
-                  ...d,
-
-                  'a',
-                  ...b,
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): partition comments`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bbb',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-                {
-                  data: {
-                    right: 'fff',
-                    left: 'gg',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              output: dedent`
-                [
-                  // Part: A
-                  // Not partition comment
-                  'bbb',
-                  'cc',
-                  'd',
-                  // Part: B
-                  'aaaa',
-                  'e',
-                  // Part: C
-                  // Not partition comment
-                  'fff',
-                  'gg',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  // Part: A
-                  'cc',
-                  'd',
-                  // Not partition comment
-                  'bbb',
-                  // Part: B
-                  'aaaa',
-                  'e',
-                  // Part: C
-                  'gg',
-                  // Not partition comment
-                  'fff',
-                ].includes(value)
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                [
-                  // Comment
-                  'bb',
-                  // Other comment
-                  'a',
-                ].includes(value)
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                [
-                  /* Partition Comment */
-                  // Part: A
-                  'd',
-                  // Part: B
-                  'aaa',
-                  'bb',
-                  'c',
-                  /* Other */
-                  'e',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  /* Partition Comment */
-                  // Part: A
-                  'd',
-                  // Part: B
-                  'aaa',
-                  'c',
-                  'bb',
-                  /* Other */
-                  'e',
-                ].includes(value)
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize partitions over group kind`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '...d',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-                {
-                  data: {
-                    right: '...b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              output: dedent`
-                [
-                  ...d,
-                  'c',
-                  // Part: 1
-                  ...b,
-                  'a',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'c',
-                  ...d,
-                  // Part: 1
-                  'a',
-                  ...b,
-                ].includes(value)
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part:',
-                  groupKind: 'spreads-first',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                [
-                  /* Comment */
-                  'a',
-                  'b'
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'b',
-                  /* Comment */
-                  'a'
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  [
-                    'b',
-                    // Comment
-                    'a'
-                  ].includes(value)
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  [
-                    'c',
-                    // b
-                    'b',
-                    // a
-                    'a'
-                  ].includes(value)
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['a', 'b'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  [
-                    'b',
-                    // I am a partition comment because I don't have f o o
-                    'a'
-                  ].includes(value)
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                [
-                  // Comment
-                  'a',
-                  'b'
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'b',
-                  // Comment
-                  'a'
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  [
-                    'b',
-                    /* Comment */
-                    'a'
-                  ].includes(value)
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  [
-                    'c',
-                    /* b */
-                    'b',
-                    /* a */
-                    'a'
-                  ].includes(value)
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['a', 'b'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  [
-                    'b',
-                    /* I am a partition comment because I don't have f o o */
-                    'a'
-                  ].includes(value)
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
+    it('accepts sorted arrays in includes() calls', async () => {
+      await valid({
+        code: dedent`
+          ['aaa', 'bb', 'c'].includes('aaa')
+        `,
+        options: [options],
       })
     })
 
-    ruleTester.run(`${ruleName}(${type}): allows to use regex`, rule, {
-      valid: [
-        {
-          code: dedent`
-            [
-              'e',
-              'f',
-              // I am a partition comment because I don't have f o o
-              'a',
-              'b',
-            ].includes(value)
-          `,
-          options: [
-            {
-              ...options,
-              partitionByComment: ['^(?!.*foo).*$'],
+    it('reports error when array in includes() is not sorted', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'c',
             },
-          ],
-        },
-      ],
-      invalid: [],
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['aaa', 'bb', 'c'].includes('aaa')
+        `,
+        code: dedent`
+          ['bb', 'c', 'aaa'].includes('aaa')
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              [
-                '$a',
-                'b',
-                '$c',
-              ].includes(value)
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              [
-                'ab',
-                'a$c',
-              ].includes(value)
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            [
-              '你好',
-              '世界',
-              'a',
-              'A',
-              'b',
-              'B'
-            ].includes(value)
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            output: dedent`
-              [
-                a, b
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                b, a
-              ].includes(value)
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            output: dedent`
-              [
-                a, b,
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                b, a,
-              ].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use predefined groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'spread',
-                  leftGroup: 'literal',
-                  right: '...b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedArrayIncludesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['spread', 'literal'],
-                groupKind: 'mixed',
-              },
-            ],
-            output: dedent`
-              [
-                ...b,
-                'a',
-                'c'
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'c',
-                ...b,
-                'a'
-              ].includes(value)
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'literalElements',
-                    selector: 'literal',
-                  },
-                ],
-                groups: ['literalElements', 'unknown'],
-                groupKind: 'mixed',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'literalElements',
-                  leftGroup: 'unknown',
-                  left: '...b',
-                  right: 'a',
-                },
-                messageId: 'unexpectedArrayIncludesGroupOrder',
-              },
-            ],
-            output: dedent`
-              [
-                'a',
-                ...b,
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                ...b,
-                'a',
-              ].includes(value)
-            `,
-          },
-        ],
-        valid: [],
+    it('preserves array structure when fixing sort order', async () => {
+      await valid({
+        code: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        options: [options],
       })
 
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'literalsStartingWithHello',
-                      selector: 'literal',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['literalsStartingWithHello', 'unknown'],
-                  groupKind: 'mixed',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'literalsStartingWithHello',
-                    right: 'helloLiteral',
-                    leftGroup: 'unknown',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedArrayIncludesGroupOrder',
-                },
-              ],
-              output: dedent`
-                [
-                  'helloLiteral',
-                  'a',
-                  'b',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'a',
-                  'b',
-                  'helloLiteral',
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedLiteralsByLineLength',
-                    leftGroup: 'unknown',
-                    left: '...m',
-                    right: 'eee',
-                  },
-                  messageId: 'unexpectedArrayIncludesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedLiteralsByLineLength',
-                      selector: 'literal',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedLiteralsByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  groupKind: 'mixed',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                [
-                  'dddd',
-                  'ccc',
-                  'eee',
-                  'bb',
-                  'ff',
-                  'a',
-                  'g',
-                  ...m,
-                  ...o,
-                  ...p,
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'a',
-                  'bb',
-                  'ccc',
-                  'dddd',
-                  ...m,
-                  'eee',
-                  'ff',
-                  'g',
-                  ...o,
-                  ...p,
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedArrayIncludesOrder',
-                },
-              ],
-              output: dedent`
-                [
-                  'fooBar',
-                  'fooZar',
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'fooZar',
-                  'fooBar',
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedLiterals',
-                      selector: 'literal',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedLiterals', 'unknown'],
-                  groupKind: 'mixed',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedLiterals',
-                    leftGroup: 'unknown',
-                    left: '...m',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedArrayIncludesGroupOrder',
-                },
-              ],
-              output: dedent`
-                [
-                  'b',
-                  'a',
-                  'd',
-                  'e',
-                  'c',
-                  ...m,
-                ].includes(value)
-              `,
-              code: dedent`
-                [
-                  'b',
-                  'a',
-                  'd',
-                  'e',
-                  ...m,
-                  'c',
-                ].includes(value)
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'literal',
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'spread',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: '...foo',
-                  left: 'a',
-                },
-                messageId: 'unexpectedArrayIncludesGroupOrder',
-              },
-            ],
-            output: dedent`
-              [
-                '...foo',
-                'cFoo',
-                'a',
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'a',
-                '...foo',
-                'cFoo',
-              ].includes(value)
-            `,
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
           },
         ],
-        valid: [],
+        output: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'c',
+            'b',
+            'd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts spread elements in includes() calls', async () => {
+      await valid({
+        code: dedent`
+          [
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ].includes(value)
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                [
-                  'iHaveFooInMyName',
-                  'meTooIHaveFoo',
-                  'a',
-                  'b',
-                ].includes(value)
-              `,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...bbbb',
+              left: '...ccc',
             },
-          ],
-          invalid: [],
-        },
-      )
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            ...aaa,
+            ...ccc,
+            ...bbbb,
+          ].includes(value)
+        `,
+        options: [options],
+      })
     })
 
-    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      for (let allNamesMatchPattern of [
-        'foo',
-        ['noMatch', 'foo'],
-        { pattern: 'FOO', flags: 'i' },
-        ['noMatch', { pattern: 'foo', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    useConfigurationIf: {
-                      allNamesMatchPattern,
-                    },
-                  },
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: '^r$',
-                        groupName: 'r',
-                      },
-                      {
-                        elementNamePattern: '^g$',
-                        groupName: 'g',
-                      },
-                      {
-                        elementNamePattern: '^b$',
-                        groupName: 'b',
-                      },
-                    ],
-                    useConfigurationIf: {
-                      allNamesMatchPattern: '^r|g|b$',
-                    },
-                    groups: ['r', 'g', 'b'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'g',
-                      leftGroup: 'b',
-                      right: 'g',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedArrayIncludesGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'r',
-                      leftGroup: 'g',
-                      right: 'r',
-                      left: 'g',
-                    },
-                    messageId: 'unexpectedArrayIncludesGroupOrder',
-                  },
-                ],
-                output: dedent`
-                  [
-                    'r',
-                    'g',
-                    'b',
-                  ].includes(value)
-                `,
-                code: dedent`
-                  [
-                    'b',
-                    'g',
-                    'r',
-                  ].includes(value)
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedArrayIncludesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  [
-                    'a',
-
-
-                   'y',
-                  'z',
-
-                      'b'
-                  ].includes(value)
-                `,
-                output: dedent`
-                  [
-                    'a',
-                   'b',
-                  'y',
-                      'z'
-                  ].includes(value)
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenArrayIncludesMembers',
-                  },
-                ],
-                output: dedent`
-                  [
-                    'a', 
-
-                  'b',
-                  ].includes(value)
-                `,
-                code: dedent`
-                  [
-                    'a', 'b',
-                  ].includes(value)
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedArrayIncludesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenArrayIncludesMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  [
-                    'a',
-
-                   'y',
-                  'z',
-
-                      'b',
-                  ].includes(value)
-                `,
-                code: dedent`
-                  [
-                    'a',
-
-
-                   'z',
-                  'y',
-                      'b',
-                  ].includes(value)
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenArrayIncludesMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                  },
-                ],
-                output: dedent`
-                  [
-                    'a',
-
-                    'b',
-
-                    'c',
-                    'd',
-
-
-                    'e'
-                  ].includes(value)
-                `,
-                code: dedent`
-                  [
-                    'a',
-                    'b',
-
-
-                    'c',
-
-                    'd',
-
-
-                    'e'
-                  ].includes(value)
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenArrayIncludesMembers',
-                      },
-                    ],
-                    output: dedent`
-                      [
-                        a,
-
-
-                        b,
-                      ].includes(value)
-                    `,
-                    code: dedent`
-                      [
-                        a,
-                        b,
-                      ].includes(value)
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenArrayIncludesMembers',
-                      },
-                    ],
-                    output: dedent`
-                      [
-                        a,
-                        b,
-                      ].includes(value)
-                    `,
-                    code: dedent`
-                      [
-                        a,
-
-                        b,
-                      ].includes(value)
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      [
-                        a,
-
-                        b,
-                      ].includes(value)
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      [
-                        a,
-                        b,
-                      ].includes(value)
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
+    it('handles arrays with empty slots correctly', async () => {
+      await valid({
+        code: dedent`
+          ['a', 'b', 'c',, 'd'].includes(value)
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['a', 'b', 'c',, 'd'].includes(value)
+        `,
+        code: dedent`
+          ['b', 'a', 'c',, 'd'].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('places spread elements after literals with literals-first option', async () => {
+      let literalsFirstOptions = [
         {
-          invalid: [
+          ...options,
+          groupKind: 'literals-first',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          ['a', 'b', 'c', ...other].includes(value)
+        `,
+        options: literalsFirstOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '...other',
+              right: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['a', 'b', 'c', ...other].includes(value)
+        `,
+        code: dedent`
+          ['a', 'b', ...other, 'c'].includes(value)
+        `,
+        options: literalsFirstOptions,
+      })
+    })
+
+    it('sorts elements in Array constructor calls', async () => {
+      await valid({
+        code: dedent`
+          new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ).includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ).includes(value)
+        `,
+        code: dedent`
+          new Array(
+            'a',
+            'c',
+            'b',
+            'd',
+          ).includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts mixed literals and spread elements together with mixed grouping', async () => {
+      let mixedOptions = [
+        {
+          ...options,
+          groupKind: 'mixed',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ).includes(value)
+        `,
+        options: mixedOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'bbb',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ).includes(value)
+        `,
+        code: dedent`
+          new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ).includes(value)
+        `,
+        options: mixedOptions,
+      })
+    })
+
+    it('sorts elements within newline-separated groups independently', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+            'd',
+
+            'c',
+
+            'b',
+            'e',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'd',
+            'a',
+
+            'c',
+
+            'e',
+            'b',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats each newline-separated section as independent partition', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...d,
+            'c',
+
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...d,
+
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('applies grouping rules within each partition separately', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          [
+            ...a,
+            ...b,
+            'c',
+            'd',
+
+            ...e,
+            'f',
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            // Part: A
+            // Not partition comment
+            'bbb',
+            'cc',
+            'd',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            // Not partition comment
+            'fff',
+            'gg',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            // Part: A
+            'cc',
+            'd',
+            // Not partition comment
+            'bbb',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            'gg',
+            // Not partition comment
+            'fff',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          [
+            // Comment
+            'bb',
+            // Other comment
+            'a',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      let multiplePatternOptions = [
+        {
+          ...options,
+          partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+        },
+      ]
+
+      await invalid({
+        output: dedent`
+          [
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'bb',
+            'c',
+            /* Other */
+            'e',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'c',
+            'bb',
+            /* Other */
+            'e',
+          ].includes(value)
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        options: multiplePatternOptions,
+      })
+    })
+
+    it('applies grouping within comment-defined partitions', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part:',
+          groupKind: 'spreads-first',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...d,
+            'c',
+            // Part: 1
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...d,
+            // Part: 1
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      let lineCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            line: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            /* Comment */
+            'a',
+            'b'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            /* Comment */
+            'a'
+          ].includes(value)
+        `,
+        options: lineCommentsOnlyOptions,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'b',
+            // Comment
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'c',
+            // b
+            'b',
+            // a
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'b',
+            // I am a partition comment because I don't have f o o
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      let blockCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            block: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            // Comment
+            'a',
+            'b'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            // Comment
+            'a'
+          ].includes(value)
+        `,
+        options: blockCommentsOnlyOptions,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'b',
+            /* Comment */
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          [
+            'c',
+            /* b */
+            'b',
+            /* a */
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'b',
+            /* I am a partition comment because I don't have f o o */
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'e',
+            'f',
+            // I am a partition comment because I don't have f o o
+            'a',
+            'b',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          [
+            '$a',
+            'b',
+            '$c',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          [
+            'ab',
+            'a$c',
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          [
+            '你好',
+            '世界',
+            'a',
+            'A',
+            'b',
+            'B'
+          ].includes(value)
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts single-line arrays correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            a, b
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            b, a
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles trailing commas in single-line arrays', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            a, b,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            b, a,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'spread',
+              leftGroup: 'literal',
+              right: '...b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['spread', 'literal'],
+            groupKind: 'mixed',
+          },
+        ],
+        output: dedent`
+          [
+            ...b,
+            'a',
+            'c'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...b,
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      let customGroupOptions = [
+        {
+          customGroups: [
             {
-              output: [
-                dedent`
-                  [
-                    'a', // Comment after
-                    'b',
-
-                    'c'
-                  ].includes(value)
-                `,
-                dedent`
-                  [
-                    'a', // Comment after
-
-                    'b',
-                    'c'
-                  ].includes(value)
-                `,
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'b|c',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedArrayIncludesGroupOrder',
-                },
-              ],
-              code: dedent`
-                [
-                  'b',
-                  'a', // Comment after
-
-                  'c'
-                ].includes(value)
-              `,
+              groupName: 'literalElements',
+              selector: 'literal',
             },
           ],
-          valid: [],
+          groups: ['literalElements', 'unknown'],
+          groupKind: 'mixed',
         },
-      )
+      ]
 
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
+      await invalid({
+        errors: [
           {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedArrayIncludesOrder',
-                  },
-                ],
-                output: dedent`
-                  [
-                    'a',
-
-                    // Partition comment
-
-                    'b',
-                    'c',
-                  ].includes(value)
-                `,
-                code: dedent`
-                  [
-                    'a',
-
-                    // Partition comment
-
-                    'c',
-                    'b',
-                  ].includes(value)
-                `,
-              },
-            ],
-            valid: [],
+            data: {
+              rightGroup: 'literalElements',
+              leftGroup: 'unknown',
+              left: '...b',
+              right: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
           },
-        )
-      }
+        ],
+        output: dedent`
+          [
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        options: customGroupOptions,
+      })
     })
-  })
 
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        let customGroupOptions = [
           {
-            errors: [
+            customGroups: [
               {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
+                groupName: 'literalsStartingWithHello',
+                selector: 'literal',
+                elementNamePattern,
               },
             ],
-            output: dedent`
-              [
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'a',
-                'c',
-                'b',
-                'd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            options: [options],
+            groups: ['literalsStartingWithHello', 'unknown'],
+            groupKind: 'mixed',
           },
-        ],
-        valid: [
-          {
-            code: dedent`
-              [
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
+        ]
 
-    ruleTester.run(`${ruleName}(${type}): sorts spread elements`, rule, {
-      invalid: [
-        {
+        await invalid({
           errors: [
             {
               data: {
-                right: '...bbbb',
-                left: '...ccc',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              ...aaa,
-              ...ccc,
-              ...bbbb,
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            [
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores nullable array elements`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            output: dedent`
-              ['a', 'b', 'c',, 'd'].includes(value)
-            `,
-            code: dedent`
-              ['b', 'a', 'c',, 'd'].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              ['a', 'b', 'c',, 'd'].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allow to put spread elements to the end`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '...other',
-                  right: 'c',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            output: dedent`
-              ['a', 'b', 'c', ...other].includes(value)
-            `,
-            code: dedent`
-              ['a', 'b', ...other, 'c'].includes(value)
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            code: dedent`
-              ['a', 'b', 'c', ...other].includes(value)
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts array constructor`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ).includes(value)
-          `,
-          code: dedent`
-            new Array(
-              'a',
-              'c',
-              'b',
-              'd',
-            ).includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ).includes(value)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows mixed sorting`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...d',
-                left: 'bbb',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ).includes(value)
-          `,
-          code: dedent`
-            new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ).includes(value)
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ).includes(value)
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bbbb',
-                  left: 'ccc',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            output: dedent`
-              [
-                'aaaaa',
-                'bbbb',
-                'ccc',
-                'dd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'aaaaa',
-                'ccc',
-                'bbbb',
-                'dd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              [
-                'aaaaa',
-                'bbbb',
-                'ccc',
-                'dd',
-                'e',
-                ...other,
-              ].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts spread elements`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...bbbb',
-                left: '...aaa',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              ...bbbb,
-              ...aaa,
-              ...ccc,
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            [
-              ...bbbb,
-              ...aaa,
-              ...ccc,
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores nullable array elements`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              ['a', 'b', 'c',, 'd'].includes(value)
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allow to put spread elements to the end`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '...other',
-                  right: 'c',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            output: dedent`
-              ['a', 'b', 'c', ...other].includes(value)
-            `,
-            code: dedent`
-              ['a', 'b', ...other, 'c'].includes(value)
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            code: dedent`
-              ['a', 'b', 'c', ...other].includes(value)
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts array constructor`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            new Array(
-              'aaaa',
-              'bbb',
-              'cc',
-              'd',
-            ).includes(value)
-          `,
-          code: dedent`
-            new Array(
-              'aaaa',
-              'cc',
-              'bbb',
-              'd',
-            ).includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Array(
-              'aaaa',
-              'bbb',
-              'cc',
-              'd',
-            ).includes(value)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows mixed sorting`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: '...d',
-                right: 'bbb',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ).includes(value)
-          `,
-          code: dedent`
-            new Array(
-              'aaaa',
-              ...d,
-              'bbb',
-              'cc',
-            ).includes(value)
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ).includes(value)
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              [
-                'bb',
-                'c',
-                'a',
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'a',
-                'bb',
-                'c',
-              ].includes(value)
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              [
-                'bb',
-                'a',
-                'c',
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'c',
-                'bb',
-                'a',
-              ].includes(value)
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts arrays`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              'a',
-              'b',
-              'c',
-              'd',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'a',
-              'c',
-              'b',
-              'd',
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            [
-              'a',
-              'b',
-              'c',
-              'd',
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            [
-              'b',
-              'c',
-              'a'
-            ].includes(value)
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['b', 'a'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                rightGroup: 'literalsStartingWithHello',
+                right: 'helloLiteral',
+                leftGroup: 'unknown',
+                left: 'b',
               },
               messageId: 'unexpectedArrayIncludesGroupOrder',
             },
           ],
           output: dedent`
             [
-              'ba',
-              'bb',
-              'ab',
-              'aa',
+              'helloLiteral',
+              'a',
+              'b',
             ].includes(value)
           `,
           code: dedent`
             [
-              'ab',
-              'aa',
-              'ba',
-              'bb',
+              'a',
+              'b',
+              'helloLiteral',
             ].includes(value)
           `,
-        },
-      ],
-      valid: [],
-    })
+          options: customGroupOptions,
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
+    it('overrides sort type and order for specific groups', async () => {
+      let customSortOptions = [
         {
-          options: [
+          customGroups: [
             {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groupName: 'reversedLiteralsByLineLength',
+              selector: 'literal',
+              type: 'line-length',
+              order: 'desc',
             },
           ],
+          groups: ['reversedLiteralsByLineLength', 'unknown'],
+          type: 'alphabetical',
+          groupKind: 'mixed',
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedLiteralsByLineLength',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'eee',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'dddd',
+            'ccc',
+            'eee',
+            'bb',
+            'ff',
+            'a',
+            'g',
+            ...m,
+            ...o,
+            ...p,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'bb',
+            'ccc',
+            'dddd',
+            ...m,
+            'eee',
+            'ff',
+            'g',
+            ...o,
+            ...p,
+          ].includes(value)
+        `,
+        options: customSortOptions,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      let fallbackSortOptions = [
+        {
+          customGroups: [
+            {
+              fallbackSort: {
+                type: 'alphabetical',
+                order: 'asc',
+              },
+              elementNamePattern: '^foo',
+              type: 'line-length',
+              groupName: 'foo',
+              order: 'desc',
+            },
+          ],
+          type: 'alphabetical',
+          groups: ['foo'],
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'fooBar',
+            'fooZar',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'fooZar',
+            'fooBar',
+          ].includes(value)
+        `,
+        options: fallbackSortOptions,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      let unsortedGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'unsortedLiterals',
+              selector: 'literal',
+              type: 'unsorted',
+            },
+          ],
+          groups: ['unsortedLiterals', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedLiterals',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'b',
+            'a',
+            'd',
+            'e',
+            'c',
+            ...m,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a',
+            'd',
+            'e',
+            ...m,
+            'c',
+          ].includes(value)
+        `,
+        options: unsortedGroupOptions,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      let anyOfOptions = [
+        {
+          customGroups: [
+            {
+              anyOf: [
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'literal',
+                },
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'spread',
+                },
+              ],
+              groupName: 'elementsIncludingFoo',
+            },
+          ],
+          groups: ['elementsIncludingFoo', 'unknown'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: '...foo',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            '...foo',
+            'cFoo',
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            '...foo',
+            'cFoo',
+          ].includes(value)
+        `,
+        options: anyOfOptions,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          [
+            'iHaveFooInMyName',
+            'meTooIHaveFoo',
+            'a',
+            'b',
+          ].includes(value)
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array of patterns', ['noMatch', 'foo']],
+      ['case-insensitive regex', { pattern: 'FOO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'foo', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_, allNamesMatchPattern) => {
+        let conditionalOptions = [
+          {
+            ...options,
+            useConfigurationIf: {
+              allNamesMatchPattern,
+            },
+          },
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^r$',
+                groupName: 'r',
+              },
+              {
+                elementNamePattern: '^g$',
+                groupName: 'g',
+              },
+              {
+                elementNamePattern: '^b$',
+                groupName: 'b',
+              },
+            ],
+            useConfigurationIf: {
+              allNamesMatchPattern: '^r|g|b$',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ]
+
+        await invalid({
           errors: [
             {
               data: {
-                right: 'a',
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
                 left: 'b',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'r',
+              'g',
+              'b',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'b',
+              'g',
+              'r',
+            ].includes(value)
+          `,
+          options: conditionalOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        let newlinesOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          code: dedent`
+            [
+              'a',
+
+
+             'y',
+            'z',
+
+                'b'
+            ].includes(value)
+          `,
+          output: dedent`
+            [
+              'a',
+             'b',
+            'y',
+                'z'
+            ].includes(value)
+          `,
+          options: newlinesOptions,
+        })
+      },
+    )
+
+    it('adds newlines between multiple groups', async () => {
+      let multiGroupOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+          ],
+          newlinesBetween: 'always' as const,
+          groups: ['a', 'unknown', 'b'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+
+           'y',
+          'z',
+
+              'b',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+
+
+           'z',
+          'y',
+              'b',
+          ].includes(value)
+        `,
+        options: multiGroupOptions,
+      })
+    })
+
+    it('applies inline newline settings between specific groups', async () => {
+      let inlineNewlineOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+            {
+              elementNamePattern: 'c',
+              groupName: 'c',
+            },
+            {
+              elementNamePattern: 'd',
+              groupName: 'd',
+            },
+            {
+              elementNamePattern: 'e',
+              groupName: 'e',
+            },
+          ],
+          groups: [
+            'a',
+            {
+              newlinesBetween: 'always',
+            },
+            'b',
+            {
+              newlinesBetween: 'always',
+            },
+            'c',
+            {
+              newlinesBetween: 'never',
+            },
+            'd',
+            {
+              newlinesBetween: 'ignore',
+            },
+            'e',
+          ],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+
+            'b',
+
+            'c',
+            'd',
+
+
+            'e'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'b',
+
+
+            'c',
+
+            'd',
+
+
+            'e'
+          ].includes(value)
+        `,
+        options: inlineNewlineOptions,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let mixedNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenArrayIncludesMembers',
             },
           ],
           output: dedent`
             [
-              'b',
+              a,
 
+
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          options: mixedNewlineOptions,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        let neverBetweenGroupsOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
               'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          output: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              a,
+
+              b,
+            ].includes(value)
+          `,
+          options: neverBetweenGroupsOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let ignoreNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await valid({
+          code: dedent`
+            [
+              a,
+
+              b,
+            ].includes(value)
+          `,
+          options: ignoreNewlineOptions,
+        })
+
+        await valid({
+          code: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          options: ignoreNewlineOptions,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      let commentOptions = [
+        {
+          customGroups: [
+            {
+              elementNamePattern: 'b|c',
+              groupName: 'b|c',
+            },
+          ],
+          groups: ['unknown', 'b|c'],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+
+        output: dedent`
+          [
+            'a', // Comment after
+
+            'b',
+            'c'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a', // Comment after
+
+            'c'
+          ].includes(value)
+        `,
+        options: commentOptions,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        let partitionOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'a',
+
+              // Partition comment
+
+              'b',
+              'c',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'a',
+
+              // Partition comment
+
+              'c',
+              'b',
+            ].includes(value)
+          `,
+          options: partitionOptions,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('accepts sorted arrays in includes() calls', async () => {
+      await valid({
+        code: dedent`
+          ['aaa', 'bb', 'c'].includes('aaa')
+        `,
+        options: [options],
+      })
+    })
+
+    it('reports error when array in includes() is not sorted', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['aaa', 'bb', 'c'].includes('aaa')
+        `,
+        code: dedent`
+          ['bb', 'c', 'aaa'].includes('aaa')
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves array structure when fixing sort order', async () => {
+      await valid({
+        code: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'c',
+            'b',
+            'd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts spread elements in includes() calls', async () => {
+      await valid({
+        code: dedent`
+          [
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...bbbb',
+              left: '...ccc',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            ...aaa,
+            ...ccc,
+            ...bbbb,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles arrays with empty slots correctly', async () => {
+      await valid({
+        code: dedent`
+          ['a', 'b', 'c',, 'd'].includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['a', 'b', 'c',, 'd'].includes(value)
+        `,
+        code: dedent`
+          ['b', 'a', 'c',, 'd'].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('places spread elements after literals with literals-first option', async () => {
+      let literalsFirstOptions = [
+        {
+          ...options,
+          groupKind: 'literals-first',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          ['a', 'b', 'c', ...other].includes(value)
+        `,
+        options: literalsFirstOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '...other',
+              right: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['a', 'b', 'c', ...other].includes(value)
+        `,
+        code: dedent`
+          ['a', 'b', ...other, 'c'].includes(value)
+        `,
+        options: literalsFirstOptions,
+      })
+    })
+
+    it('sorts elements in Array constructor calls', async () => {
+      await valid({
+        code: dedent`
+          new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ).includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ).includes(value)
+        `,
+        code: dedent`
+          new Array(
+            'a',
+            'c',
+            'b',
+            'd',
+          ).includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts mixed literals and spread elements together with mixed grouping', async () => {
+      let mixedOptions = [
+        {
+          ...options,
+          groupKind: 'mixed',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ).includes(value)
+        `,
+        options: mixedOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'bbb',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ).includes(value)
+        `,
+        code: dedent`
+          new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ).includes(value)
+        `,
+        options: mixedOptions,
+      })
+    })
+
+    it('sorts elements within newline-separated groups independently', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+            'd',
+
+            'c',
+
+            'b',
+            'e',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'd',
+            'a',
+
+            'c',
+
+            'e',
+            'b',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats each newline-separated section as independent partition', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...d,
+            'c',
+
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...d,
+
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('applies grouping rules within each partition separately', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          [
+            ...a,
+            ...b,
+            'c',
+            'd',
+
+            ...e,
+            'f',
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            // Part: A
+            // Not partition comment
+            'bbb',
+            'cc',
+            'd',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            // Not partition comment
+            'fff',
+            'gg',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            // Part: A
+            'cc',
+            'd',
+            // Not partition comment
+            'bbb',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            'gg',
+            // Not partition comment
+            'fff',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          [
+            // Comment
+            'bb',
+            // Other comment
+            'a',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      let multiplePatternOptions = [
+        {
+          ...options,
+          partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+        },
+      ]
+
+      await invalid({
+        output: dedent`
+          [
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'bb',
+            'c',
+            /* Other */
+            'e',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'c',
+            'bb',
+            /* Other */
+            'e',
+          ].includes(value)
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        options: multiplePatternOptions,
+      })
+    })
+
+    it('applies grouping within comment-defined partitions', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part:',
+          groupKind: 'spreads-first',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...d,
+            'c',
+            // Part: 1
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...d,
+            // Part: 1
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      let lineCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            line: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            /* Comment */
+            'a',
+            'b'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            /* Comment */
+            'a'
+          ].includes(value)
+        `,
+        options: lineCommentsOnlyOptions,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'b',
+            // Comment
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'c',
+            // b
+            'b',
+            // a
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'b',
+            // I am a partition comment because I don't have f o o
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      let blockCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            block: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            // Comment
+            'a',
+            'b'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            // Comment
+            'a'
+          ].includes(value)
+        `,
+        options: blockCommentsOnlyOptions,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'b',
+            /* Comment */
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          [
+            'c',
+            /* b */
+            'b',
+            /* a */
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'b',
+            /* I am a partition comment because I don't have f o o */
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'e',
+            'f',
+            // I am a partition comment because I don't have f o o
+            'a',
+            'b',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          [
+            '$a',
+            'b',
+            '$c',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          [
+            'ab',
+            'a$c',
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          [
+            '你好',
+            '世界',
+            'a',
+            'A',
+            'b',
+            'B'
+          ].includes(value)
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts single-line arrays correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            a, b
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            b, a
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles trailing commas in single-line arrays', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            a, b,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            b, a,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'spread',
+              leftGroup: 'literal',
+              right: '...b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['spread', 'literal'],
+            groupKind: 'mixed',
+          },
+        ],
+        output: dedent`
+          [
+            ...b,
+            'a',
+            'c'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...b,
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      let customGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'literalElements',
+              selector: 'literal',
+            },
+          ],
+          groups: ['literalElements', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literalElements',
+              leftGroup: 'unknown',
+              left: '...b',
+              right: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        options: customGroupOptions,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        let customGroupOptions = [
+          {
+            customGroups: [
+              {
+                groupName: 'literalsStartingWithHello',
+                selector: 'literal',
+                elementNamePattern,
+              },
+            ],
+            groups: ['literalsStartingWithHello', 'unknown'],
+            groupKind: 'mixed',
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'literalsStartingWithHello',
+                right: 'helloLiteral',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'helloLiteral',
+              'a',
+              'b',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'a',
+              'b',
+              'helloLiteral',
+            ].includes(value)
+          `,
+          options: customGroupOptions,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      let customSortOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'reversedLiteralsByLineLength',
+              selector: 'literal',
+              type: 'line-length',
+              order: 'desc',
+            },
+          ],
+          groups: ['reversedLiteralsByLineLength', 'unknown'],
+          type: 'alphabetical',
+          groupKind: 'mixed',
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedLiteralsByLineLength',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'eee',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'dddd',
+            'ccc',
+            'eee',
+            'bb',
+            'ff',
+            'a',
+            'g',
+            ...m,
+            ...o,
+            ...p,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'bb',
+            'ccc',
+            'dddd',
+            ...m,
+            'eee',
+            'ff',
+            'g',
+            ...o,
+            ...p,
+          ].includes(value)
+        `,
+        options: customSortOptions,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      let fallbackSortOptions = [
+        {
+          customGroups: [
+            {
+              fallbackSort: {
+                type: 'alphabetical',
+                order: 'asc',
+              },
+              elementNamePattern: '^foo',
+              type: 'line-length',
+              groupName: 'foo',
+              order: 'desc',
+            },
+          ],
+          type: 'alphabetical',
+          groups: ['foo'],
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'fooBar',
+            'fooZar',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'fooZar',
+            'fooBar',
+          ].includes(value)
+        `,
+        options: fallbackSortOptions,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      let unsortedGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'unsortedLiterals',
+              selector: 'literal',
+              type: 'unsorted',
+            },
+          ],
+          groups: ['unsortedLiterals', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedLiterals',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'b',
+            'a',
+            'd',
+            'e',
+            'c',
+            ...m,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a',
+            'd',
+            'e',
+            ...m,
+            'c',
+          ].includes(value)
+        `,
+        options: unsortedGroupOptions,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      let anyOfOptions = [
+        {
+          customGroups: [
+            {
+              anyOf: [
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'literal',
+                },
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'spread',
+                },
+              ],
+              groupName: 'elementsIncludingFoo',
+            },
+          ],
+          groups: ['elementsIncludingFoo', 'unknown'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: '...foo',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            '...foo',
+            'cFoo',
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            '...foo',
+            'cFoo',
+          ].includes(value)
+        `,
+        options: anyOfOptions,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          [
+            'iHaveFooInMyName',
+            'meTooIHaveFoo',
+            'a',
+            'b',
+          ].includes(value)
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array of patterns', ['noMatch', 'foo']],
+      ['case-insensitive regex', { pattern: 'FOO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'foo', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_, allNamesMatchPattern) => {
+        let conditionalOptions = [
+          {
+            ...options,
+            useConfigurationIf: {
+              allNamesMatchPattern,
+            },
+          },
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^r$',
+                groupName: 'r',
+              },
+              {
+                elementNamePattern: '^g$',
+                groupName: 'g',
+              },
+              {
+                elementNamePattern: '^b$',
+                groupName: 'b',
+              },
+            ],
+            useConfigurationIf: {
+              allNamesMatchPattern: '^r|g|b$',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'r',
+              'g',
+              'b',
             ].includes(value)
           `,
           code: dedent`
             [
               'b',
-              'a',
+              'g',
+              'r',
             ].includes(value)
           `,
+          options: conditionalOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        let newlinesOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          code: dedent`
+            [
+              'a',
+
+
+             'y',
+            'z',
+
+                'b'
+            ].includes(value)
+          `,
+          output: dedent`
+            [
+              'a',
+             'b',
+            'y',
+                'z'
+            ].includes(value)
+          `,
+          options: newlinesOptions,
+        })
+      },
+    )
+
+    it('adds newlines between multiple groups', async () => {
+      let multiGroupOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+          ],
+          newlinesBetween: 'always' as const,
+          groups: ['a', 'unknown', 'b'],
         },
-      ],
-      valid: [],
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+
+           'y',
+          'z',
+
+              'b',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+
+
+           'z',
+          'y',
+              'b',
+          ].includes(value)
+        `,
+        options: multiGroupOptions,
+      })
+    })
+
+    it('applies inline newline settings between specific groups', async () => {
+      let inlineNewlineOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+            {
+              elementNamePattern: 'c',
+              groupName: 'c',
+            },
+            {
+              elementNamePattern: 'd',
+              groupName: 'd',
+            },
+            {
+              elementNamePattern: 'e',
+              groupName: 'e',
+            },
+          ],
+          groups: [
+            'a',
+            {
+              newlinesBetween: 'always',
+            },
+            'b',
+            {
+              newlinesBetween: 'always',
+            },
+            'c',
+            {
+              newlinesBetween: 'never',
+            },
+            'd',
+            {
+              newlinesBetween: 'ignore',
+            },
+            'e',
+          ],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+
+            'b',
+
+            'c',
+            'd',
+
+
+            'e'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'b',
+
+
+            'c',
+
+            'd',
+
+
+            'e'
+          ].includes(value)
+        `,
+        options: inlineNewlineOptions,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let mixedNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          output: dedent`
+            [
+              a,
+
+
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          options: mixedNewlineOptions,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        let neverBetweenGroupsOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          output: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              a,
+
+              b,
+            ].includes(value)
+          `,
+          options: neverBetweenGroupsOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let ignoreNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await valid({
+          code: dedent`
+            [
+              a,
+
+              b,
+            ].includes(value)
+          `,
+          options: ignoreNewlineOptions,
+        })
+
+        await valid({
+          code: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          options: ignoreNewlineOptions,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      let commentOptions = [
+        {
+          customGroups: [
+            {
+              elementNamePattern: 'b|c',
+              groupName: 'b|c',
+            },
+          ],
+          groups: ['unknown', 'b|c'],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+
+        output: dedent`
+          [
+            'a', // Comment after
+
+            'b',
+            'c'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a', // Comment after
+
+            'c'
+          ].includes(value)
+        `,
+        options: commentOptions,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        let partitionOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'a',
+
+              // Partition comment
+
+              'b',
+              'c',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'a',
+
+              // Partition comment
+
+              'c',
+              'b',
+            ].includes(value)
+          `,
+          options: partitionOptions,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('accepts sorted arrays in includes() calls', async () => {
+      await valid({
+        code: dedent`
+          ['aaa', 'bb', 'c'].includes('aaa')
+        `,
+        options: [options],
+      })
+    })
+
+    it('reports error when array in includes() is not sorted', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['aaa', 'bb', 'c'].includes('aaa')
+        `,
+        code: dedent`
+          ['bb', 'c', 'aaa'].includes('aaa')
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves array structure when fixing sort order', async () => {
+      await valid({
+        code: dedent`
+          [
+            'aaaaa',
+            'bbbb',
+            'ccc',
+            'dd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbbb',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'aaaaa',
+            'bbbb',
+            'ccc',
+            'dd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'aaaaa',
+            'ccc',
+            'bbbb',
+            'dd',
+            'e',
+            ...other,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts spread elements in includes() calls', async () => {
+      await valid({
+        code: dedent`
+          [
+            ...bbbb,
+            ...aaa,
+            ...ccc,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...bbbb',
+              left: '...aaa',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...bbbb,
+            ...aaa,
+            ...ccc,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles arrays with empty slots correctly', async () => {
+      await valid({
+        code: dedent`
+          ['a', 'b', 'c',, 'd'].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('places spread elements after literals with literals-first option', async () => {
+      let literalsFirstOptions = [
+        {
+          ...options,
+          groupKind: 'literals-first',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          ['a', 'b', 'c', ...other].includes(value)
+        `,
+        options: literalsFirstOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '...other',
+              right: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          ['a', 'b', 'c', ...other].includes(value)
+        `,
+        code: dedent`
+          ['a', 'b', ...other, 'c'].includes(value)
+        `,
+        options: literalsFirstOptions,
+      })
+    })
+
+    it('sorts elements in Array constructor calls', async () => {
+      await valid({
+        code: dedent`
+          new Array(
+            'aaaa',
+            'bbb',
+            'cc',
+            'd',
+          ).includes(value)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          new Array(
+            'aaaa',
+            'bbb',
+            'cc',
+            'd',
+          ).includes(value)
+        `,
+        code: dedent`
+          new Array(
+            'aaaa',
+            'cc',
+            'bbb',
+            'd',
+          ).includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts mixed literals and spread elements together with mixed grouping', async () => {
+      let mixedOptions = [
+        {
+          ...options,
+          groupKind: 'mixed',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ).includes(value)
+        `,
+        options: mixedOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '...d',
+              right: 'bbb',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ).includes(value)
+        `,
+        code: dedent`
+          new Array(
+            'aaaa',
+            ...d,
+            'bbb',
+            'cc',
+          ).includes(value)
+        `,
+        options: mixedOptions,
+      })
+    })
+
+    it('sorts elements within newline-separated groups independently', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaaaa',
+              left: 'dd',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'bbbb',
+              left: 'e',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'aaaaa',
+            'dd',
+
+            'ccc',
+
+            'bbbb',
+            'e',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'dd',
+            'aaaaa',
+
+            'ccc',
+
+            'e',
+            'bbbb',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats each newline-separated section as independent partition', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...d,
+            'c',
+
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...d,
+
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('applies grouping rules within each partition separately', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          [
+            ...a,
+            ...b,
+            'c',
+            'd',
+
+            ...e,
+            'f',
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            // Part: A
+            // Not partition comment
+            'bbb',
+            'cc',
+            'd',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            // Not partition comment
+            'fff',
+            'gg',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            // Part: A
+            'cc',
+            'd',
+            // Not partition comment
+            'bbb',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            'gg',
+            // Not partition comment
+            'fff',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          [
+            // Comment
+            'bb',
+            // Other comment
+            'a',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      let multiplePatternOptions = [
+        {
+          ...options,
+          partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+        },
+      ]
+
+      await invalid({
+        output: dedent`
+          [
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'bb',
+            'c',
+            /* Other */
+            'e',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'c',
+            'bb',
+            /* Other */
+            'e',
+          ].includes(value)
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        options: multiplePatternOptions,
+      })
+    })
+
+    it('applies grouping within comment-defined partitions', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part:',
+          groupKind: 'spreads-first',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            ...d,
+            'c',
+            // Part: 1
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...d,
+            // Part: 1
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      let lineCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            line: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            /* Comment */
+            'aa',
+            'b'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            /* Comment */
+            'aa'
+          ].includes(value)
+        `,
+        options: lineCommentsOnlyOptions,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'b',
+            // Comment
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'c',
+            // b
+            'b',
+            // a
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'b',
+            // I am a partition comment because I don't have f o o
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      let blockCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            block: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            // Comment
+            'aa',
+            'b'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            // Comment
+            'aa'
+          ].includes(value)
+        `,
+        options: blockCommentsOnlyOptions,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          [
+            'b',
+            /* Comment */
+            'a'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          [
+            'c',
+            /* b */
+            'b',
+            /* a */
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'b',
+            /* I am a partition comment because I don't have f o o */
+            'a'
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          [
+            'e',
+            'f',
+            // I am a partition comment because I don't have f o o
+            'a',
+            'b',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          [
+            '$aa',
+            'bb',
+            '$c',
+          ].includes(value)
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          [
+            'abc',
+            'a$c',
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          [
+            '你好',
+            '世界',
+            'a',
+            'A',
+            'b',
+            'B'
+          ].includes(value)
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts single-line arrays correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            aa, b
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            b, aa
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles trailing commas in single-line arrays', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            aa, b,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            b, aa,
+          ].includes(value)
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'spread',
+              leftGroup: 'literal',
+              right: '...b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['spread', 'literal'],
+            groupKind: 'mixed',
+          },
+        ],
+        output: dedent`
+          [
+            ...b,
+            'aa',
+            'c'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'c',
+            ...b,
+            'aa'
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      let customGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'literalElements',
+              selector: 'literal',
+            },
+          ],
+          groups: ['literalElements', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literalElements',
+              leftGroup: 'unknown',
+              left: '...b',
+              right: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+            ...b,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            ...b,
+            'a',
+          ].includes(value)
+        `,
+        options: customGroupOptions,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        let customGroupOptions = [
+          {
+            customGroups: [
+              {
+                groupName: 'literalsStartingWithHello',
+                selector: 'literal',
+                elementNamePattern,
+              },
+            ],
+            groups: ['literalsStartingWithHello', 'unknown'],
+            groupKind: 'mixed',
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'literalsStartingWithHello',
+                right: 'helloLiteral',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'helloLiteral',
+              'a',
+              'b',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'a',
+              'b',
+              'helloLiteral',
+            ].includes(value)
+          `,
+          options: customGroupOptions,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      let customSortOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'reversedLiteralsByLineLength',
+              selector: 'literal',
+              type: 'line-length',
+              order: 'desc',
+            },
+          ],
+          groups: ['reversedLiteralsByLineLength', 'unknown'],
+          type: 'alphabetical',
+          groupKind: 'mixed',
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedLiteralsByLineLength',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'eee',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'dddd',
+            'ccc',
+            'eee',
+            'bb',
+            'ff',
+            'a',
+            'g',
+            ...m,
+            ...o,
+            ...p,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'bb',
+            'ccc',
+            'dddd',
+            ...m,
+            'eee',
+            'ff',
+            'g',
+            ...o,
+            ...p,
+          ].includes(value)
+        `,
+        options: customSortOptions,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      let fallbackSortOptions = [
+        {
+          customGroups: [
+            {
+              fallbackSort: {
+                type: 'alphabetical',
+                order: 'asc',
+              },
+              elementNamePattern: '^foo',
+              type: 'line-length',
+              groupName: 'foo',
+              order: 'desc',
+            },
+          ],
+          type: 'alphabetical',
+          groups: ['foo'],
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'fooBar',
+            'fooZar',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'fooZar',
+            'fooBar',
+          ].includes(value)
+        `,
+        options: fallbackSortOptions,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      let unsortedGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'unsortedLiterals',
+              selector: 'literal',
+              type: 'unsorted',
+            },
+          ],
+          groups: ['unsortedLiterals', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedLiterals',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'b',
+            'a',
+            'd',
+            'e',
+            'c',
+            ...m,
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a',
+            'd',
+            'e',
+            ...m,
+            'c',
+          ].includes(value)
+        `,
+        options: unsortedGroupOptions,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      let anyOfOptions = [
+        {
+          customGroups: [
+            {
+              anyOf: [
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'literal',
+                },
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'spread',
+                },
+              ],
+              groupName: 'elementsIncludingFoo',
+            },
+          ],
+          groups: ['elementsIncludingFoo', 'unknown'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: '...foo',
+              left: 'a',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            '...foo',
+            'cFoo',
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            '...foo',
+            'cFoo',
+          ].includes(value)
+        `,
+        options: anyOfOptions,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          [
+            'iHaveFooInMyName',
+            'meTooIHaveFoo',
+            'a',
+            'b',
+          ].includes(value)
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array of patterns', ['noMatch', 'foo']],
+      ['case-insensitive regex', { pattern: 'FOO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'foo', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_, allNamesMatchPattern) => {
+        let conditionalOptions = [
+          {
+            ...options,
+            useConfigurationIf: {
+              allNamesMatchPattern,
+            },
+          },
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^r$',
+                groupName: 'r',
+              },
+              {
+                elementNamePattern: '^g$',
+                groupName: 'g',
+              },
+              {
+                elementNamePattern: '^b$',
+                groupName: 'b',
+              },
+            ],
+            useConfigurationIf: {
+              allNamesMatchPattern: '^r|g|b$',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedArrayIncludesGroupOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'r',
+              'g',
+              'b',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'b',
+              'g',
+              'r',
+            ].includes(value)
+          `,
+          options: conditionalOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        let newlinesOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aa',
+                groupName: 'aa',
+              },
+            ],
+            groups: ['aa', 'unknown'],
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          code: dedent`
+            [
+              'aaaa',
+
+
+             'yy',
+            'z',
+
+                'bbb'
+            ].includes(value)
+          `,
+          output: dedent`
+            [
+              'aaaa',
+             'bbb',
+            'yy',
+                'z'
+            ].includes(value)
+          `,
+          options: newlinesOptions,
+        })
+      },
+    )
+
+    it('adds newlines between multiple groups', async () => {
+      let multiGroupOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'aa',
+              groupName: 'aa',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+          ],
+          newlinesBetween: 'always' as const,
+          groups: ['aa', 'unknown', 'b'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'z',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'yy',
+              left: 'z',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'yy',
+            },
+            messageId: 'missedSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        output: dedent`
+          [
+            'aaaa',
+
+           'yy',
+          'z',
+
+              'bbb',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'aaaa',
+
+
+           'z',
+          'yy',
+              'bbb',
+          ].includes(value)
+        `,
+        options: multiGroupOptions,
+      })
+    })
+
+    it('applies inline newline settings between specific groups', async () => {
+      let inlineNewlineOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+            {
+              elementNamePattern: 'c',
+              groupName: 'c',
+            },
+            {
+              elementNamePattern: 'd',
+              groupName: 'd',
+            },
+            {
+              elementNamePattern: 'e',
+              groupName: 'e',
+            },
+          ],
+          groups: [
+            'a',
+            {
+              newlinesBetween: 'always',
+            },
+            'b',
+            {
+              newlinesBetween: 'always',
+            },
+            'c',
+            {
+              newlinesBetween: 'never',
+            },
+            'd',
+            {
+              newlinesBetween: 'ignore',
+            },
+            'e',
+          ],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+
+            'b',
+
+            'c',
+            'd',
+
+
+            'e'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'b',
+
+
+            'c',
+
+            'd',
+
+
+            'e'
+          ].includes(value)
+        `,
+        options: inlineNewlineOptions,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let mixedNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          output: dedent`
+            [
+              a,
+
+
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          options: mixedNewlineOptions,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        let neverBetweenGroupsOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+            },
+          ],
+          output: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              a,
+
+              b,
+            ].includes(value)
+          `,
+          options: neverBetweenGroupsOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let ignoreNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await valid({
+          code: dedent`
+            [
+              a,
+
+              b,
+            ].includes(value)
+          `,
+          options: ignoreNewlineOptions,
+        })
+
+        await valid({
+          code: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          options: ignoreNewlineOptions,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      let commentOptions = [
+        {
+          customGroups: [
+            {
+              elementNamePattern: 'b|c',
+              groupName: 'b|c',
+            },
+          ],
+          groups: ['unknown', 'b|c'],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+
+        output: dedent`
+          [
+            'a', // Comment after
+
+            'b',
+            'c'
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a', // Comment after
+
+            'c'
+          ].includes(value)
+        `,
+        options: commentOptions,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        let partitionOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+          ],
+          output: dedent`
+            [
+              'aaa',
+
+              // Partition comment
+
+              'bb',
+              'c',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'aaa',
+
+              // Partition comment
+
+              'c',
+              'bb',
+            ].includes(value)
+          `,
+          options: partitionOptions,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    it('sorts elements according to custom alphabet order', async () => {
+      let alphabet = Alphabet.generateRecommendedAlphabet()
+        .sortByLocaleCompare('en-US')
+        .getCharacters()
+
+      let customAlphabetOptions = [
+        {
+          type: 'custom' as const,
+          order: 'asc' as const,
+          alphabet,
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+          ].includes(value)
+        `,
+        options: customAlphabetOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
+            'c',
+            'b',
+            'd',
+          ].includes(value)
+        `,
+        options: customAlphabetOptions,
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('unsorted', () => {
+    let unsortedOptions = {
+      type: 'unsorted' as const,
+      order: 'asc' as const,
+    }
+
+    it('allows any order when type is unsorted', async () => {
+      await valid({
+        code: dedent`
+          [
+            'b',
+            'c',
+            'a'
+          ].includes(value)
+        `,
+        options: [unsortedOptions],
+      })
+    })
+
+    it('enforces grouping even with unsorted type', async () => {
+      let groupingOptions = [
+        {
+          ...unsortedOptions,
+          customGroups: [
+            {
+              elementNamePattern: '^a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: '^b',
+              groupName: 'b',
+            },
+          ],
+          groups: ['b', 'a'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedArrayIncludesGroupOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'ba',
+            'bb',
+            'ab',
+            'aa',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'ab',
+            'aa',
+            'ba',
+            'bb',
+          ].includes(value)
+        `,
+        options: groupingOptions,
+      })
+    })
+
+    it('enforces newlines between groups with unsorted type', async () => {
+      let newlinesOptions = [
+        {
+          ...unsortedOptions,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+          ],
+          newlinesBetween: 'always' as const,
+          groups: ['b', 'a'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        output: dedent`
+          [
+            'b',
+
+            'a',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a',
+          ].includes(value)
+        `,
+        options: newlinesOptions,
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
+    it('uses alphabetical ascending order by default', async () => {
+      await valid({
+        code: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+          ].includes(value)
+        `,
+      })
+
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedArrayIncludesOrder',
-              },
-            ],
-            output: dedent`
-              [
-                'a',
-                'b',
-                'c',
-                'd',
-              ].includes(value)
-            `,
-            code: dedent`
-              [
-                'b',
-                'a',
-                'd',
-                'c',
-              ].includes(value)
-            `,
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
           },
         ],
-        valid: [
-          dedent`
-            [
-              'a',
-              'b',
-              'c',
-              'd',
-            ].includes(value)
-          `,
+        output: dedent`
+          [
+            'a',
+            'b',
+            'c',
+            'd',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'b',
+            'a',
+            'd',
+            'c',
+          ].includes(value)
+        `,
+      })
+    })
+
+    it('respects natural sorting with numbers', async () => {
+      await valid({
+        code: dedent`
+          [
+            'v1.png',
+            'v10.png',
+            'v12.png',
+            'v2.png',
+          ].includes(value)
+        `,
+        options: [
           {
-            code: dedent`
-              [
-                'v1.png',
-                'v10.png',
-                'v12.png',
-                'v2.png',
-              ].includes(value)
-            `,
-            options: [
-              {
-                ignoreCase: false,
-              },
-            ],
+            ignoreCase: false,
           },
         ],
-      },
-    )
+      })
+    })
 
-    ruleTester.run(
-      `${ruleName}: works consistently with an empty array or an array with one element`,
-      rule,
-      {
-        valid: ['[].includes(value)', "['a'].includes(value)"],
-        invalid: [],
-      },
-    )
+    it('handles empty arrays and single-element arrays', async () => {
+      await valid({
+        code: '[].includes(value)',
+      })
 
-    ruleTester.run(`${ruleName}: ignores quotes of strings`, rule, {
-      valid: [
-        dedent`
+      await valid({
+        code: "['a'].includes(value)",
+      })
+    })
+
+    it('treats different quote styles as equivalent', async () => {
+      await valid({
+        code: dedent`
           ['a', "b", 'c'].includes(value)
         `,
-      ],
-      invalid: [],
+      })
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
+    describe('with eslint-disable comments', () => {
+      it('excludes disabled elements from sorting', async () => {
+        await valid({
+          code: dedent`
+            [
+              'b',
+              'c',
+              // eslint-disable-next-line
+              'a',
+            ].includes(value)
+          `,
+        })
+
+        await invalid({
           errors: [
             {
               data: {
@@ -3053,90 +5931,11 @@ describe(ruleName, () => {
             ].includes(value)
           `,
           options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              'b',
-              'c',
-              // eslint-disable-next-line
-              'a',
-              'd'
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'd',
-              'c',
-              // eslint-disable-next-line
-              'a',
-              'b'
-            ].includes(value)
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-            {
-              data: {
-                right: '...anotherArray',
-                left: 'a',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              ...anotherArray,
-              'b',
-              // eslint-disable-next-line
-              'a',
-              'c'
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'c',
-              'b',
-              // eslint-disable-next-line
-              'a',
-              ...anotherArray
-            ].includes(value)
-          `,
-          options: [
-            {
-              groupKind: 'mixed',
-            },
-          ],
-        },
-        {
+        })
+      })
+
+      it('handles inline eslint-disable comments', async () => {
+        await invalid({
           errors: [
             {
               data: {
@@ -3161,62 +5960,11 @@ describe(ruleName, () => {
             ].includes(value)
           `,
           options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              'b',
-              'c',
-              /* eslint-disable-next-line */
-              'a',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'c',
-              'b',
-              /* eslint-disable-next-line */
-              'a',
-            ].includes(value)
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              'b',
-              'c',
-              'a', /* eslint-disable-line */
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'c',
-              'b',
-              'a', /* eslint-disable-line */
-            ].includes(value)
-          `,
-          options: [{}],
-        },
-        {
+        })
+      })
+
+      it('respects eslint-disable blocks', async () => {
+        await invalid({
           output: dedent`
             [
               'a',
@@ -3251,184 +5999,39 @@ describe(ruleName, () => {
             },
           ],
           options: [{}],
-        },
-        {
-          output: dedent`
-            [
-              'b',
-              'c',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              'a',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'c',
-              'b',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              'a',
-            ].includes(value)
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              'b',
-              'c',
-              'a', // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'c',
-              'b',
-              'a', // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            ].includes(value)
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            [
-              'b',
-              'c',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              'a',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'c',
-              'b',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              'a',
-            ].includes(value)
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          output: dedent`
-            [
-              'b',
-              'c',
-              'a', /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'c',
-              'b',
-              'a', /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            ].includes(value)
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            [
-              'a',
-              'd',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              'c',
-              'b',
-              // Shouldn't move
-              /* eslint-enable */
-              'e',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'd',
-              'e',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              'c',
-              'b',
-              // Shouldn't move
-              /* eslint-enable */
-              'a',
-            ].includes(value)
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            [
-              'b',
-              'c',
-              // eslint-disable-next-line
-              'a',
-            ].includes(value)
-          `,
-        },
-      ],
-    })
+        })
+      })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
-          {
-            code: dedent`
-              [
-                'a',
-                'b',
-                'c',
-              ].includes(value)
-            `,
-            options: [{}],
-          },
-        ],
-        invalid: [],
-      },
-    )
+      it('handles rule-specific eslint-disable comments', async () => {
+        await invalid({
+          output: dedent`
+            [
+              'b',
+              'c',
+              // eslint-disable-next-line rule-to-test/sort-array-includes
+              'a',
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              'c',
+              'b',
+              // eslint-disable-next-line rule-to-test/sort-array-includes
+              'a',
+            ].includes(value)
+          `,
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+          ],
+          options: [{}],
+        })
+      })
+    })
   })
 })

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -1,8752 +1,4300 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
-import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-classes'
 
-let ruleName = 'sort-classes'
+describe('sort-classes', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-classes',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts class members`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'protected-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'static-protected-method',
-                'protected-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'd',
-                left: 'e',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                leftGroup: 'static-method',
-                rightGroup: 'constructor',
-                right: 'constructor',
-                left: 'f',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              d = 'd'
-
-              e = 'e'
-
-              constructor() {}
-
-              static f() {}
-
-              protected static g() {}
-
-              protected h() {}
-
-              private i() {}
-
-              j() {}
-
-              k() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              e = 'e'
-
-              d = 'd'
-
-              static f() {}
-
-              constructor() {}
-
-              protected static g() {}
-
-              protected h() {}
-
-              private i() {}
-
-              j() {}
-
-              k() {}
-            }
-          `,
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            class Class {
-              a
-            }
-          `,
-          options: [options],
-        },
-        {
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'protected-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'static-protected-method',
-                'protected-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              d = 'd'
-
-              e = 'e'
-
-              constructor() {}
-
-              static f() {}
-
-              protected static g() {}
-
-              protected h() {}
-
-              private i() {}
-
-              j() {}
-
-              k() {}
-            }
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts complex official groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'public-optional-async-method',
-                  rightGroup: 'public-optional-property',
-                  right: 'o',
-                  left: 'p',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'public-optional-property',
-                  rightGroup: 'static-block',
-                  right: 'static',
-                  left: 'o',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'static-readonly-index-signature',
-                  right: 'static readonly [key: string]',
-                  leftGroup: 'static-block',
-                  left: 'static',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'static-readonly-index-signature',
-                  left: 'static readonly [key: string]',
-                  rightGroup: 'async-function-property',
-                  right: 'n',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: 'm',
-                  left: 'n',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'declare-private-static-readonly-property',
-                  leftGroup: 'async-function-property',
-                  right: 'l',
-                  left: 'm',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'declare-private-static-readonly-property',
-                  rightGroup: 'private-property',
-                  right: 'k',
-                  left: 'l',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'protected-property',
-                  leftGroup: 'private-property',
-                  right: 'j',
-                  left: 'k',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'protected-property',
-                  rightGroup: 'public-property',
-                  right: 'i',
-                  left: 'j',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'private-readonly-property',
-                  leftGroup: 'public-property',
-                  right: 'h',
-                  left: 'i',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'protected-readonly-property',
-                  leftGroup: 'private-readonly-property',
-                  right: 'g',
-                  left: 'h',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'protected-readonly-property',
-                  rightGroup: 'public-readonly-property',
-                  right: 'f',
-                  left: 'g',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'static-private-override-readonly-property',
-                  leftGroup: 'public-readonly-property',
-                  right: 'e',
-                  left: 'f',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'static-protected-override-readonly-property',
-                  leftGroup: 'static-private-override-readonly-property',
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'static-protected-override-readonly-property',
-                  rightGroup: 'static-public-override-readonly-property',
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup:
-                    'protected-abstract-override-readonly-decorated-property',
-                  leftGroup: 'static-public-override-readonly-property',
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup:
-                    'protected-abstract-override-readonly-decorated-property',
-                  rightGroup:
-                    'public-abstract-override-readonly-decorated-property',
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'unknown',
-                  'public-abstract-override-readonly-decorated-property',
-                  'protected-abstract-override-readonly-decorated-property',
-                  'static-public-override-readonly-property',
-                  'static-protected-override-readonly-property',
-                  'static-private-override-readonly-property',
-                  'public-readonly-property',
-                  'protected-readonly-property',
-                  'private-readonly-property',
-                  'public-property',
-                  'protected-property',
-                  'private-property',
-                  'declare-private-static-readonly-property',
-                  'async-function-property',
-                  'static-readonly-index-signature',
-                  'static-block',
-                  'public-optional-property',
-                  'public-optional-async-method',
-                ],
-              },
-            ],
-            output: dedent`
-              abstract class Class {
-
-                @Decorator
-                abstract override readonly a;
-
-                @Decorator
-                protected abstract override readonly b;
-
-                static override readonly c = 'c';
-
-                protected static override readonly d = 'd';
-
-                private static override readonly e = 'e';
-
-                public readonly f = 'f';
-
-                protected readonly g = 'g';
-
-                private readonly h = 'h';
-
-                public i = 'i';
-
-                protected j = 'j';
-
-                private k = 'k';
-
-                declare private static readonly l;
-
-                private m = async () => {};
-
-                private n = async function() {};
-
-                static readonly [key: string]: string;
-
-                static {}
-
-                o?;
-
-                async p?(): Promise<void>;
-              }
-            `,
-            code: dedent`
-              abstract class Class {
-
-                async p?(): Promise<void>;
-
-                o?;
-
-                static {}
-
-                static readonly [key: string]: string;
-
-                private n = async function() {};
-
-                private m = async () => {};
-
-                declare private static readonly l;
-
-                private k = 'k';
-
-                protected j = 'j';
-
-                public i = 'i';
-
-                private readonly h = 'h';
-
-                protected readonly g = 'g';
-
-                public readonly f = 'f';
-
-                private static override readonly e = 'e';
-
-                protected static override readonly d = 'd';
-
-                static override readonly c = 'c';
-
-                @Decorator
-                protected abstract override readonly b;
-
-                @Decorator
-                abstract override readonly a;
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): prioritize selectors over modifiers quantity`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'public-abstract-override-method',
-                  rightGroup: 'get-method',
-                  right: 'fields',
-                  left: 'method',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              export abstract class Class extends Class2 {
-
-                public abstract override get fields(): string;
-
-                public abstract override method(): string;
-              }
-            `,
-            code: dedent`
-              export abstract class Class extends Class2 {
-
-                public abstract override method(): string;
-
-                public abstract override get fields(): string;
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['get-method', 'public-abstract-override-method'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): index-signature modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize static over readonly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'static readonly [key: string]',
-                    rightGroup: 'static-index-signature',
-                    leftGroup: 'property',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'static-index-signature',
-                    'property',
-                    'readonly-index-signature',
-                  ],
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  static readonly [key: string]: string;
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export class Class {
-
-                  a: string;
-
-                  static readonly [key: string]: string;
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): method selectors priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize constructor over method`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'constructor',
-                    right: 'constructor',
-                    leftGroup: 'method',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  constructor() {}
-
-                  a(): void;
-                }
-              `,
-              code: dedent`
-                export class Class {
-
-                  a(): void;
-
-                  constructor() {}
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['constructor', 'method'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize get-method over method`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'get-method',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  get z() {}
-
-                  a(): void;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['get-method', 'method'],
-                },
-              ],
-              code: dedent`
-                export class Class {
-
-                  a(): void;
-
-                  get z() {}
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize set-method over method`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'set-method',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  set z() {}
-
-                  a(): void;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['set-method', 'method'],
-                },
-              ],
-              code: dedent`
-                export class Class {
-
-                  a(): void;
-
-                  set z() {}
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): method modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize static over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'static-method',
-                    leftGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export class Class extends Class2 {
-
-                  static override z(): string;
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export class Class extends Class2 {
-
-                  a: string;
-
-                  static override z(): string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['static-method', 'property', 'override-method'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize abstract over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'abstract-method',
-                    leftGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  abstract override z(): string;
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a: string;
-
-                  abstract override z(): string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['abstract-method', 'property', 'override-method'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize decorated over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'decorated-method',
-                    leftGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  @Decorator
-                  override z(): void {}
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a: string;
-
-                  @Decorator
-                  override z(): void {}
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['decorated-method', 'property', 'override-method'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let accessibilityModifier of ['public', 'protected', 'private']) {
-        ruleTester.run(
-          `${ruleName}(${type}): prioritize override over ${accessibilityModifier} accessibility`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'override-method',
-                      leftGroup: 'property',
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'unexpectedClassesGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'override-method',
-                      'property',
-                      `${accessibilityModifier}-method`,
-                    ],
-                  },
-                ],
-                output: dedent`
-                  export class Class {
-
-                    ${accessibilityModifier} override z(): string;
-
-                    a: string;
-                  }
-                `,
-                code: dedent`
-                  export class Class {
-
-                    a: string;
-
-                    ${accessibilityModifier} override z(): string;
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritize ${accessibilityModifier} accessibility over optional`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: `${accessibilityModifier}-method`,
-                      leftGroup: 'property',
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'unexpectedClassesGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      `${accessibilityModifier}-method`,
-                      'property',
-                      'optional-method',
-                    ],
-                  },
-                ],
-                output: dedent`
-                  export class Class {
-
-                    ${accessibilityModifier} z?(): string;
-
-                    a: string;
-                  }
-                `,
-                code: dedent`
-                  export class Class {
-
-                    a: string;
-
-                    ${accessibilityModifier} z?(): string;
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize optional over async`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: `optional-method`,
-                    leftGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [`optional-method`, 'property', 'async-method'],
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  async z?(): Promise<string>;
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export class Class {
-
-                  a: string;
-
-                  async z?(): Promise<string>;
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): accessor modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize static over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'static-accessor-property',
-                    leftGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'static-accessor-property',
-                    'property',
-                    'override-accessor-property',
-                  ],
-                },
-              ],
-              output: dedent`
-                export class Class extends Class2 {
-
-                  static override accessor z: string;
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export class Class extends Class2 {
-
-                  a: string;
-
-                  static override accessor z: string;
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize abstract over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'abstract-accessor-property',
-                    leftGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'abstract-accessor-property',
-                    'property',
-                    'override-accessor-property',
-                  ],
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  abstract override accessor z: string;
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a: string;
-
-                  abstract override accessor z: string;
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize decorated over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'decorated-accessor-property',
-                    leftGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [
-                    'decorated-accessor-property',
-                    'property',
-                    'override-accessor-property',
-                  ],
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  @Decorator
-                  override accessor z: string;
-
-                  a: string;
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a: string;
-
-                  @Decorator
-                  override accessor z: string;
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let accessibilityModifier of ['public', 'protected', 'private']) {
-        ruleTester.run(
-          `${ruleName}(${type}): prioritize override over ${accessibilityModifier} accessibility`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'override-accessor-property',
-                      leftGroup: 'property',
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'unexpectedClassesGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'override-accessor-property',
-                      'property',
-                      `${accessibilityModifier}-accessor-property`,
-                    ],
-                  },
-                ],
-                output: dedent`
-                  export class Class {
-
-                    ${accessibilityModifier} override accessor z: string;
-
-                    a: string;
-                  }
-                `,
-                code: dedent`
-                  export class Class {
-
-                    a: string;
-
-                    ${accessibilityModifier} override accessor z: string;
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    describe(`${ruleName}(${type}): property selectors priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize function property over property`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    leftGroup: 'function-property',
-                    rightGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['property', 'function-property'],
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  z: string;
-
-                  a = function() {}
-                }
-              `,
-              code: dedent`
-                export class Class {
-
-                  a = function() {}
-
-                  z: string;
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize function property over property for arrow functions`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    leftGroup: 'function-property',
-                    rightGroup: 'property',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['property', 'function-property'],
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  z: string;
-
-                  a = () => {}
-                }
-              `,
-              code: dedent`
-                export class Class {
-
-                  a = () => {}
-
-                  z: string;
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): property modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize static over declare`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'static-property',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export class Class extends Class2 {
-
-                  declare static z: string;
-
-                  a(): void {}
-                }
-              `,
-              code: dedent`
-                export class Class extends Class2 {
-
-                  a(): void {}
-
-                  declare static z: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['static-property', 'method', 'declare-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize declare over abstract`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'declare-property',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export class Class extends Class2 {
-
-                  declare abstract z: string;
-
-                  a(): void {}
-                }
-              `,
-              code: dedent`
-                export class Class extends Class2 {
-
-                  a(): void {}
-
-                  declare abstract z: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['declare-property', 'method', 'abstract-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize abstract over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'abstract-property',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  abstract override z: string;
-
-                  a(): void {}
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a(): void {}
-
-                  abstract override z: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['abstract-property', 'method', 'override-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize decorated over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'decorated-property',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  @Decorator
-                  override z: string;
-
-                  a(): void {}
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a(): void {}
-
-                  @Decorator
-                  override z: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['decorated-property', 'method', 'override-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize decorated over override`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'decorated-property',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  @Decorator
-                  override z: string;
-
-                  a(): void {}
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a(): void {}
-
-                  @Decorator
-                  override z: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['decorated-property', 'method', 'override-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize override over readonly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'override-property',
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export abstract class Class extends Class2 {
-
-                  override readonly z: string;
-
-                  a(): void {}
-                }
-              `,
-              code: dedent`
-                export abstract class Class extends Class2 {
-
-                  a(): void {}
-
-                  override readonly z: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['override-property', 'method', 'readonly-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let accessibilityModifier of ['public', 'protected', 'private']) {
-        ruleTester.run(
-          `${ruleName}(${type}): prioritize readonly over ${accessibilityModifier} accessibility`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'readonly-property',
-                      leftGroup: 'method',
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'unexpectedClassesGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'readonly-property',
-                      'method',
-                      `${accessibilityModifier}-property`,
-                    ],
-                  },
-                ],
-                output: dedent`
-                  export class Class {
-
-                    ${accessibilityModifier} readonly z: string;
-
-                    a(): void {}
-                  }
-                `,
-                code: dedent`
-                  export class Class {
-
-                    a(): void {}
-
-                    ${accessibilityModifier} readonly z: string;
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritize ${accessibilityModifier} accessibility over optional`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: `${accessibilityModifier}-property`,
-                      leftGroup: 'method',
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'unexpectedClassesGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      `${accessibilityModifier}-property`,
-                      'method',
-                      'optional-property',
-                    ],
-                  },
-                ],
-                output: dedent`
-                  export class Class {
-
-                    ${accessibilityModifier} z?: string;
-
-                    a(): void {}
-                  }
-                `,
-                code: dedent`
-                  export class Class {
-
-                    a(): void {}
-
-                    ${accessibilityModifier} z?: string;
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize optional over async`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: `optional-property`,
-                    leftGroup: 'method',
-                    right: 'z',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                export class Class {
-
-                  z?: Promise<string> = async () => {};
-
-                  a(): void {}
-                }
-              `,
-              code: dedent`
-                export class Class {
-
-                  a(): void {}
-
-                  z?: Promise<string> = async () => {};
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['optional-property', 'method', `async-property`],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class and group members`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'key in O',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                  ['static-method', 'private-method', 'method'],
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                static a
-
-                static b = 'b'
-
-                [key in O]
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                [key in O]
-
-                static b = 'b'
-
-                static a
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                  ['static-method', 'private-method', 'method'],
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              class Class {
-                static a
-
-                static b = 'b'
-
-                [key in O]
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class with attributes having the same name`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'static-property',
-                  rightGroup: 'property',
-                  right: 'a',
-                  left: 'a',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['property', 'static-property'],
-              },
-            ],
-            output: dedent`
-              class Class {
-                a;
-
-                static a;
-              }
-            `,
-            code: dedent`
-              class Class {
-                static a;
-
-                a;
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class with ts index signatures`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-property',
-                  leftGroup: 'index-signature',
-                  left: '[k: string];',
-                  right: 'a',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'index-signature',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                static a = 'a';
-
-                [k: string]: any;
-
-                [k: string];
-              }
-            `,
-            code: dedent`
-              class Class {
-                [k: string]: any;
-
-                [k: string];
-
-                static a = 'a';
-              }
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                ],
-              },
-            ],
-            code: dedent`
-              class Class {
-                static a = 'a';
-
-                [k: string]: any;
-
-                [k: string];
-              }
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class with ts index signatures`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              class Decorations {
-                setBackground(color: number, hexFlag: boolean): this
-                setBackground(color: Color | string | CSSColor): this
-                setBackground(r: number, g: number, b: number, a?: number): this
-                setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
-                    /* ... */
-                }
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                ],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts private methods with hash`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'private-property',
-                  left: '#aPrivateStaticMethod',
-                  right: '#somePrivateProperty',
-                  leftGroup: 'static-method',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: '#someOtherPrivateProperty',
-                  left: '#somePrivateProperty',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  left: '#someOtherPrivateProperty',
-                  leftGroup: 'private-property',
-                  rightGroup: 'static-property',
-                  right: 'someStaticProperty',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: '#someStaticPrivateProperty',
-                  left: 'someStaticProperty',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: '#aPrivateInstanceMethod',
-                  rightGroup: 'private-method',
-                  leftGroup: 'static-method',
-                  left: 'aStaticMethod',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class MyUnsortedClass {
-                static #someStaticPrivateProperty = 4
-
-                static someStaticProperty = 3
-
-                #someOtherPrivateProperty = 2
-
-                #somePrivateProperty
-
-                someOtherProperty
-
-                someProperty = 1
-
-                constructor() {}
-
-                aInstanceMethod () {}
-
-                #aPrivateInstanceMethod () {}
-
-                static #aPrivateStaticMethod () {}
-
-                static aStaticMethod () {}
-              }
-            `,
-            code: dedent`
-              class MyUnsortedClass {
-                someOtherProperty
-
-                someProperty = 1
-
-                constructor() {}
-
-                static #aPrivateStaticMethod () {}
-
-                #somePrivateProperty
-
-                #someOtherPrivateProperty = 2
-
-                static someStaticProperty = 3
-
-                static #someStaticPrivateProperty = 4
-
-                aInstanceMethod () {}
-
-                static aStaticMethod () {}
-
-                #aPrivateInstanceMethod () {}
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: [
-                  'static-property',
-                  'private-property',
-                  'property',
-                  'constructor',
-                  'method',
-                  'private-method',
-                  'static-method',
-                  'unknown',
-                ],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows split methods with getters and setters`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'index-signature',
-                  'static-property',
-                  'private-property',
-                  'property',
-                  'constructor',
-                  'static-method',
-                  'private-method',
-                  'method',
-                  ['get-method', 'set-method'],
-                  'unknown',
-                ],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'x',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'z',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            output: dedent`
-              class A {
-                b() {}
-                x() {}
-                get c() {}
-                set c() {}
-                get z() {}
-              }
-            `,
-            code: dedent`
-              class A {
-                x() {}
-                b() {}
-                get z() {}
-                get c() {}
-                set c() {}
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated properties`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            class User {
-              firstName: string
-
-              id: number
-
-              lastName: string
-
-              @Index({ name: 'born_index' })
-              @Property()
-              born: string
-
-              @Property()
-              @Unique()
-              email: string
-            }
-          `,
-          code: dedent`
-            class User {
-              firstName: string
-
-              id: number
-
-              @Index({ name: 'born_index' })
-              @Property()
-              born: string
-
-              @Property()
-              @Unique()
-              email: string
-
-              lastName: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                leftGroup: 'decorated-property',
-                rightGroup: 'property',
-                right: 'lastName',
-                left: 'email',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['property', 'decorated-property', 'unknown'],
-            },
-          ],
-        },
-        {
-          output: dedent`
-            class MyElement {
-              @property({ attribute: false })
-              data = {}
-
-              @property()
-              greeting: string = 'Hello'
-
-              @property()
-              protected type = ''
-
-              @state()
-              private _counter = 0
-
-              private _message = ''
-
-              private _prop = 0
-
-              constructor() {}
-
-              @property()
-              get message(): string {
-                return this._message
-              }
-
-              @property()
-              set prop(val: number) {
-                this._prop = Math.floor(val)
-              }
-
-              set message(message: string) {
-                this._message = message
-              }
-
-              get prop() {
-                return this._prop
-              }
-
-              render() {}
-            }
-          `,
-          code: dedent`
-            class MyElement {
-              @property({ attribute: false })
-              data = {}
-
-              @property()
-              greeting: string = 'Hello'
-
-              @property()
-              protected type = ''
-
-              @state()
-              private _counter = 0
-
-              private _message = ''
-
-              private _prop = 0
-
-              constructor() {}
-
-              @property()
-              get message(): string {
-                return this._message
-              }
-
-              set message(message: string) {
-                this._message = message
-              }
-
-              @property()
-              set prop(val: number) {
-                this._prop = Math.floor(val)
-              }
-
-              get prop() {
-                return this._prop
-              }
-
-              render() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'decorated-property',
-                'property',
-                'protected-decorated-property',
-                'private-decorated-property',
-                'private-property',
-                'constructor',
-                ['decorated-get-method', 'decorated-set-method'],
-                ['get-method', 'set-method'],
-                'unknown',
-              ],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                rightGroup: 'decorated-set-method',
-                leftGroup: 'set-method',
-                left: 'message',
-                right: 'prop',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated accessors`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'private-decorated-accessor-property',
-                leftGroup: 'decorated-method',
-                right: '#active',
-                left: 'toggle',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'private-decorated-accessor-property',
-                rightGroup: 'decorated-accessor-property',
-                right: 'finished',
-                left: '#active',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Todo {
-              @observable
-              accessor finished = false
-
-              @observable
-              accessor title = ''
-
-              @observable
-              protected accessor type = ''
-
-              @observable
-              accessor #active = false
-
-              id = Math.random()
-
-              constructor() {}
-
-              @action
-              toggle() {}
-            }
-          `,
-          code: dedent`
-            class Todo {
-              id = Math.random()
-
-              constructor() {}
-
-              @action
-              toggle() {}
-
-              @observable
-              accessor #active = false
-
-              @observable
-              accessor finished = false
-
-              @observable
-              accessor title = ''
-
-              @observable
-              protected accessor type = ''
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'decorated-accessor-property',
-                'protected-decorated-accessor-property',
-                'private-decorated-accessor-property',
-                'property',
-                'constructor',
-                'decorated-method',
-                'unknown',
-              ],
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated accessors`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'onSortChanged',
-                left: 'updateTable',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                right: 'onPaginationChanged',
-                left: 'onSortChanged',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                right: 'onValueChanged',
-                left: 'setFormValue',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              // Region: Table
-              protected onChangeColumns() {}
-
-              protected onPaginationChanged() {}
-
-              protected onSortChanged() {}
-
-              protected updateTable() {}
-
-              // Region: Form
-              protected clearForm() {}
-
-              protected disableForm() {}
-
-              // Regular Comment
-              protected onValueChanged() {}
-
-              protected setFormValue() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              // Region: Table
-              protected onChangeColumns() {}
-
-              protected updateTable() {}
-
-              protected onSortChanged() {}
-
-              protected onPaginationChanged() {}
-
-              // Region: Form
-              protected clearForm() {}
-
-              protected disableForm() {}
-
-              protected setFormValue() {}
-
-              // Regular Comment
-              protected onValueChanged() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              partitionByComment: 'Region:',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            class Class {
-              // Region: Table
-              protected onChangeColumns() {}
-
-              protected onPaginationChanged() {}
-
-              protected onSortChanged() {}
-
-              protected updateTable() {}
-
-              // Region: Form
-              protected clearForm() {}
-
-              protected disableForm() {}
-
-              // Regular Comment
-              protected onValueChanged() {}
-
-              protected setFormValue() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              partitionByComment: 'Region:',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort properties if the right value depends on the left value`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'aaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesDependencyOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                b = 'b'
-
-                aaa = [this.b]
-              }
-            `,
-            code: dedent`
-              class Class {
-                aaa = [this.b]
-
-                b = 'b'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'property',
-                  leftGroup: 'method',
-                  left: 'getAaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                b = 'b'
-
-                getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                getAaa() {
-                  return this.b;
-                }
-
-                b = 'b'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-property',
-                  leftGroup: 'property',
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                static c = 'c'
-
-                b = Example.c
-              }
-            `,
-            code: dedent`
-              class Class {
-                b = Example.c
-
-                static c = 'c'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'private-property',
-                  leftGroup: 'method',
-                  left: 'getAaa',
-                  right: '#b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                #b = 'b'
-
-                getAaa() {
-                  return this.#b;
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                getAaa() {
-                  return this.#b;
-                }
-
-                #b = 'b'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-property',
-                  leftGroup: 'static-method',
-                  left: 'getAaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                static b = 'b'
-
-                static getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                static getAaa() {
-                  return this.b;
-                }
-
-                static b = 'b'
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              class Class {
-                b = 'b'
-
-                aaa = [this.b]
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                b = 'b'
-
-                getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                static c = 'c'
-
-                b = Example.c
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                #b = 'b'
-
-                getAaa() {
-                  return this.#b;
-                }
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                static b = 'b'
-
-                static getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    describe(`${ruleName}(${type}): detects dependencies`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}) ignores function expression dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  a = this.b()
-                  static a = this.b()
-                  b() {
-                    return 1
-                  }
-                  static b() {
-                    return 1
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  a = this.b()
-                  static a = Class.b()
-                  b() {
-                    return 1
-                  }
-                  static b() {
-                    return 1
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  a = [1].map(this.b)
-                  static a = [1].map(this.b)
-                  b() {
-                    return 1
-                  }
-                  static b() {
-                    return 1
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  a = [1].map(this.b)
-                  static a = [1].map(Class.b)
-                  b() {
-                    return 1
-                  }
-                  static b() {
-                    return 1
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class MyClass {
-                  a = () => this.b()
-                  b = () => null
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects function property dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  b = () => {
-                    return 1
-                  }
-                  a = this.b()
-                  static b = () => {
-                    return 1
-                  }
-                  static a = this.b()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = function() {
-                    return 1
-                  }
-                  a = this.b()
-                  static b = function() {
-                    return 1
-                  }
-                  static a = this.b()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = () => {
-                    return 1
-                  }
-                  a = [1].map(this.b)
-                  static b = () => {
-                    return 1
-                  }
-                  static a = [1].map(this.b)
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = function() {
-                    return 1
-                  }
-                  a = [1].map(this.b)
-                  static b = function() {
-                    return 1
-                  }
-                  static a = [1].map(this.b)
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = () => {
-                    return 1
-                  }
-                  a = [1].map(this.b)
-                  static b = () => {
-                    return 1
-                  }
-                  static a = [1].map(Class.b)
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = function() {
-                    return 1
-                  }
-                  a = [1].map(this.b)
-                  static b = function() {
-                    return 1
-                  }
-                  static a = [1].map(Class.b)
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  querystring = createQueryString();
-                  state = createState((set) => {
-                      set('query', this.queryString.value);
-                   });
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['property', 'method']],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects static block dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  static {
-                    return true || OtherClass.z;
-                  }
-                  static z = true;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['static-block', 'static-property']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  static z = true;
-                  static {
-                    const method = () => {
-                      return (Class.z || true) && (false || this.z);
-                    };
-                    method();
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['static-block', 'static-property']],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  static z = true;
-                  static {
-                    const method = () => {
-                      return (Class.z || true) && (false || this.z);
-                    };
-                    method();
-                    return (Class.z || true) && (false || this.z);
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['static-block', 'static-property']],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects property expression dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'd',
-                    left: 'e',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-                {
-                  data: {
-                    right: 'a',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'd',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'e',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'z',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  static a = 10 + OtherClass.z
-
-                  static z = 1
-
-                  b = 10 + Class.z
-
-                  static c = 10 + this.z
-
-                  d = this.b
-
-                  static e = 10 + this.c
-                }
-              `,
-              code: dedent`
-                class Class {
-                  static e = 10 + this.c
-
-                  d = this.b
-
-                  static a = 10 + OtherClass.z
-
-                  b = 10 + Class.z
-
-                  static c = 10 + this.z
-
-                  static z = 1
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'a',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  c = 10
-                  a = this.c
-                  b = 10
-                }
-              `,
-              code: dedent`
-                class Class {
-                  a = this.c
-                  b = 10
-                  c = 10
-                }
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in objects`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = {
-                    b: this.b
-                  }
-                  static b = 1
-                  static a = {
-                    b: this.b
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = {
-                    b: this.b
-                  }
-                  static b = 1
-                  static a = {
-                    b: Class.b
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = {
-                    [this.b]: 1
-                  }
-                  static b = 1
-                  static a = {
-                    [this.b]: A
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = {
-                    [this.b]: 1
-                  }
-                  static b = 1
-                  static a = {
-                    [Class.b]: 1
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects nested property references`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                   b = new Subject()
-                   a = this.b.asObservable()
-                   static b = new Subject()
-                   static a = this.b.asObservable()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = new Subject()
-                   a = this.b.asObservable()
-                   static b = new Subject()
-                   static a = Class.b.asObservable()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = new WhateverObject()
-                   a = this.b.bProperty
-                   static b = new WhateverObject()
-                   static a = this.b.bProperty
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = new WhateverObject()
-                   a = this.b.bProperty
-                   static b = new WhateverObject()
-                   static a = Class.b.bProperty
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   static c = 1
-                   static b = new WhateverObject(this.c)
-                   static a = Class.b.bMethod().anotherNestedMethod(this.c).finalMethod()
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects optional chained dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                   b = new Subject()
-                   a = this.b?.asObservable()
-                   static b = new Subject()
-                   static a = this.b?.asObservable()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = new Subject()
-                   a = this.b?.asObservable()
-                   static b = new Subject()
-                   static a = Class.b?.asObservable()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects non-null asserted dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                   b = new Subject()
-                   a = this.b!.asObservable()
-                   static b = new Subject()
-                   static a = this.b!.asObservable()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = new Subject()
-                   a = this.b!.asObservable()
-                   static b = new Subject()
-                   static a = Class.b!.asObservable()
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}) detects unary dependencies`, rule, {
-        valid: [
-          {
-            code: dedent`
-              class Class {
-                 b = true
-                 a = !this.b
-                 static b = true
-                 static a = !this.b
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['property'],
-              },
-            ],
-          },
-          {
-            code: dedent`
-              class Class {
-                 b = true
-                 a = !this.b
-                 static b = true
-                 static a = !Class.b
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['property'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
+    it('sorts class members', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            a
+          }
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}) detects spread elements dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                   b = {}
-                   a = {...this.b}
-                   static b = {}
-                   static a = {...this.b}
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = {}
-                   a = {...this.b}
-                   static b = {}
-                   static a = {...Class.b}
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = []
-                   a = [...this.b]
-                   static b = []
-                   static a = [...this.b]
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                   b = []
-                   a = [...this.b]
-                   static b = []
-                   static a = [...Class.b]
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in conditional expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  b = 1;
-                  a = this.b ? 1 : 0;
-                  static b = 1;
-                  static a = this.b ? 1 : 0;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1;
-                  a = this.b ? 1 : 0;
-                  static b = 1;
-                  static a = Class.b ? 1 : 0;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1;
-                  a = someCondition ? this.b : 0;
-                  static b = 1;
-                  static a = someCondition ? this.b : 0;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1;
-                  a = someCondition ? this.b : 0;
-                  static b = 1;
-                  static a = someCondition ? Class.b : 0;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1;
-                  a = someCondition ? 0 : this.b;
-                  static b = 1;
-                  static a = someCondition ? 0 : this.b;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1;
-                  a = someCondition ? 0 : this.b;
-                  static b = 1;
-                  static a = someCondition ? 0 : Class.b;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in 'as' expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = this.b as any
-                  static b = 1
-                  static a = this.b as any
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = this.b as any
-                  static b = 1
-                  static a = Class.b as any
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in type assertion expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = <any>this.b
-                  static b = 1
-                  static a = <any>this.b
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                  b = 1
-                  a = <any>this.b
-                  static b = 1
-                  static a = <any>Class.b
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in template literal expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                 b = 1
-                 a = \`\${this.b}\`
-                 static b = 1
-                 static a = \`\${this.b}\`
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class Class {
-                 b = 1
-                 a = \`\${this.b}\`
-                 static b = 1
-                 static a = \`\${Class.b}\`
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}): detects # dependencies`, rule, {
-        valid: [
+      await valid({
+        options: [
           {
-            code: dedent`
-              class Class {
-               static a = Class.a
-               static b = 1
-               static #b = 1
-               static #a = this.#b
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-               static #b = () => 1
-               static #a = this.#b()
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-               static #a = this.#b()
-               static #b() {}
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown'],
-              },
+            ...options,
+            groups: [
+              'static-property',
+              'protected-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'static-protected-method',
+              'protected-method',
+              'private-method',
+              'method',
+              'unknown',
             ],
           },
         ],
-        invalid: [],
+        code: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            d = 'd'
+
+            e = 'e'
+
+            constructor() {}
+
+            static f() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}) separates static from non-static dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'a',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  static c = 10
-                  static a = Class.c
-                  c = 10
-                  b = this.c
-                  static b = this.c
-                }
-              `,
-              code: dedent`
-                class Class {
-                  static a = Class.c
-                  b = this.c
-                  static b = this.c
-                  c = 10
-                  static c = 10
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          valid: [
-            {
-              code: dedent`
-                export class Class{
-                  b = 1;
-                  a = this.b;
-                  static b = 1;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects and ignores circular dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  a
-                  b = this.e
-                  e = this.g
-                  f
-                  g = this.b
-                }
-              `,
-              code: dedent`
-                class Class {
-                  b = this.e
-                  a
-                  e = this.g
-                  f
-                  g = this.b
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) ignores function body dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  static a = true;
-
-                  static b() {
-                     return this.a || Class.a
-                  }
-
-                  static c = () => {
-                     return this.a || Class.a
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['method', 'property']],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over group configuration`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  groups: ['private-property', 'public-property'],
-                },
-              ],
-              code: dedent`
-                class Class {
-                  public b = 1;
-                  private a = this.b;
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'a',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  a
-                  // Part1
-                  b = this.a
-                }
-              `,
-              code: dedent`
-                class Class {
-                  b = this.a
-                  // Part1
-                  a
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: 'Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'a',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByNewLine: true,
-                },
-              ],
-              output: dedent`
-                class Class {
-                  a
-
-                  b = this.a
-                }
-              `,
-              code: dedent`
-                class Class {
-                  b = this.a
-
-                  a
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): works with left and right dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aaa',
-                    right: 'left',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'aaa',
-                    right: 'right',
-                  },
-                  messageId: 'unexpectedClassesDependencyOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  left = 'left'
-
-                  right = 'right'
-
-                  aaa = this.left + this.right
-                }
-              `,
-              code: dedent`
-                class Class {
-                  aaa = this.left + this.right
-
-                  left = 'left'
-
-                  right = 'right'
-                }
-              `,
-              options: [options],
-            },
-          ],
-          valid: [
-            {
-              code: dedent`
-                class Class {
-                  left = 'left'
-                  right = 'right'
-
-                  aaa = this.left + this.right
-                }
-              `,
-              options: [options],
-            },
-          ],
-        },
-      )
-
-      for (let ignoreCallbackDependenciesPatterns of [
-        '^computed$',
-        ['noMatch', '^computed$'],
-        { pattern: '^COMPUTED$', flags: 'i' },
-        ['noMatch', { pattern: '^COMPUTED$', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): should ignore callback dependencies in 'ignoreCallbackDependenciesPatterns'`,
-          rule,
+      await invalid({
+        options: [
           {
-            valid: [
-              {
-                code: dedent`
-                  class Class {
-                    a = computed(() => this.c)
-                    c
-                    b = notComputed(() => this.c)
-                  }
-                `,
-                options: [
-                  {
-                    ignoreCallbackDependenciesPatterns,
-                  },
-                ],
-              },
+            ...options,
+            groups: [
+              'static-property',
+              'protected-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'static-protected-method',
+              'protected-method',
+              'private-method',
+              'method',
+              'unknown',
             ],
-            invalid: [],
           },
-        )
-      }
+        ],
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-method',
+              rightGroup: 'constructor',
+              right: 'constructor',
+              left: 'f',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            d = 'd'
+
+            e = 'e'
+
+            constructor() {}
+
+            static f() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            e = 'e'
+
+            d = 'd'
+
+            static f() {}
+
+            constructor() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
-      invalid: [
-        {
+    it('sorts complex official groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'public-optional-async-method',
+              rightGroup: 'public-optional-property',
+              right: 'o',
+              left: 'p',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'public-optional-property',
+              rightGroup: 'static-block',
+              right: 'static',
+              left: 'o',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-readonly-index-signature',
+              right: 'static readonly [key: string]',
+              leftGroup: 'static-block',
+              left: 'static',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-readonly-index-signature',
+              left: 'static readonly [key: string]',
+              rightGroup: 'async-function-property',
+              right: 'n',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: 'm',
+              left: 'n',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'declare-private-static-readonly-property',
+              leftGroup: 'async-function-property',
+              right: 'l',
+              left: 'm',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'declare-private-static-readonly-property',
+              rightGroup: 'private-property',
+              right: 'k',
+              left: 'l',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-property',
+              leftGroup: 'private-property',
+              right: 'j',
+              left: 'k',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-property',
+              rightGroup: 'public-property',
+              right: 'i',
+              left: 'j',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-readonly-property',
+              leftGroup: 'public-property',
+              right: 'h',
+              left: 'i',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-readonly-property',
+              leftGroup: 'private-readonly-property',
+              right: 'g',
+              left: 'h',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-readonly-property',
+              rightGroup: 'public-readonly-property',
+              right: 'f',
+              left: 'g',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-private-override-readonly-property',
+              leftGroup: 'public-readonly-property',
+              right: 'e',
+              left: 'f',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-protected-override-readonly-property',
+              leftGroup: 'static-private-override-readonly-property',
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-protected-override-readonly-property',
+              rightGroup: 'static-public-override-readonly-property',
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup:
+                'protected-abstract-override-readonly-decorated-property',
+              leftGroup: 'static-public-override-readonly-property',
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup:
+                'protected-abstract-override-readonly-decorated-property',
+              rightGroup:
+                'public-abstract-override-readonly-decorated-property',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'public-abstract-override-readonly-decorated-property',
+              'protected-abstract-override-readonly-decorated-property',
+              'static-public-override-readonly-property',
+              'static-protected-override-readonly-property',
+              'static-private-override-readonly-property',
+              'public-readonly-property',
+              'protected-readonly-property',
+              'private-readonly-property',
+              'public-property',
+              'protected-property',
+              'private-property',
+              'declare-private-static-readonly-property',
+              'async-function-property',
+              'static-readonly-index-signature',
+              'static-block',
+              'public-optional-property',
+              'public-optional-async-method',
+            ],
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+
+            @Decorator
+            abstract override readonly a;
+
+            @Decorator
+            protected abstract override readonly b;
+
+            static override readonly c = 'c';
+
+            protected static override readonly d = 'd';
+
+            private static override readonly e = 'e';
+
+            public readonly f = 'f';
+
+            protected readonly g = 'g';
+
+            private readonly h = 'h';
+
+            public i = 'i';
+
+            protected j = 'j';
+
+            private k = 'k';
+
+            declare private static readonly l;
+
+            private m = async () => {};
+
+            private n = async function() {};
+
+            static readonly [key: string]: string;
+
+            static {}
+
+            o?;
+
+            async p?(): Promise<void>;
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+
+            async p?(): Promise<void>;
+
+            o?;
+
+            static {}
+
+            static readonly [key: string]: string;
+
+            private n = async function() {};
+
+            private m = async () => {};
+
+            declare private static readonly l;
+
+            private k = 'k';
+
+            protected j = 'j';
+
+            public i = 'i';
+
+            private readonly h = 'h';
+
+            protected readonly g = 'g';
+
+            public readonly f = 'f';
+
+            private static override readonly e = 'e';
+
+            protected static override readonly d = 'd';
+
+            static override readonly c = 'c';
+
+            @Decorator
+            protected abstract override readonly b;
+
+            @Decorator
+            abstract override readonly a;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'public-abstract-override-method',
+              rightGroup: 'get-method',
+              right: 'fields',
+              left: 'method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            public abstract override get fields(): string;
+
+            public abstract override method(): string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            public abstract override method(): string;
+
+            public abstract override get fields(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['get-method', 'public-abstract-override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes static over readonly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'static readonly [key: string]',
+              rightGroup: 'static-index-signature',
+              leftGroup: 'property',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-index-signature',
+              'property',
+              'readonly-index-signature',
+            ],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            static readonly [key: string]: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a: string;
+
+            static readonly [key: string]: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes constructor over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'constructor',
+              right: 'constructor',
+              leftGroup: 'method',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            constructor() {}
+
+            a(): void;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            constructor() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['constructor', 'method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes get-method over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'get-method',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            get z() {}
+
+            a(): void;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['get-method', 'method'],
+          },
+        ],
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            get z() {}
+          }
+        `,
+      })
+    })
+
+    it('prioritizes set-method over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'set-method',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            set z() {}
+
+            a(): void;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['set-method', 'method'],
+          },
+        ],
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            set z() {}
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            static override z(): string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a: string;
+
+            static override z(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['static-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes abstract over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override z(): string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            abstract override z(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['abstract-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes decorated over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override z(): void {}
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            @Decorator
+            override z(): void {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['decorated-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes override over %s accessibility',
+      async (_name, accessibilityModifier) => {
+        await invalid({
           errors: [
             {
               data: {
-                rightGroup: 'private-method',
+                rightGroup: 'override-method',
                 leftGroup: 'property',
                 right: 'z',
-                left: 'i',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'private-method',
-                rightGroup: 'unknown',
-                right: 'method3',
-                left: 'z',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'unknown',
-                left: 'method3',
-                right: 'y',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'unknown',
-                left: 'method1',
-                right: 'x',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-
-              private x() {}
-              private y() {}
-              public method3() {}
-              private z() {}
-              public method4() {}
-              public method1() {}
-              public i = 'i';
-            }
-          `,
-          code: dedent`
-            class Class {
-
-              public i = 'i';
-              private z() {}
-              public method3() {}
-              private y() {}
-              public method4() {}
-              public method1() {}
-              private x() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['private-method', 'property'],
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'property',
-                rightGroup: 'unknown',
-                right: 'someMethod',
-                left: 'b',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'property',
-                leftGroup: 'unknown',
-                left: 'someMethod',
-                right: 'a',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              a
-              someMethod() {
-              }
-              b
-            }
-          `,
-          code: dedent`
-            class Class {
-              b
-              someMethod() {
-              }
-              a
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['property'],
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              class Class {
-                _a
-                b
-                _c
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              class Class {
-                ab
-                a_c
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            class Class {
-              你好 = '你好'
-
-              世界 = '世界'
-
-              a = 'a'
-
-              A = 'A'
-
-              b = 'b'
-
-              B = 'B'
-            }
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedClassesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                ],
-                code: dedent`
-                  class Class {
-                    a = () => null
-
-
-                   y = "y"
-                  z = "z"
-
-                      b = "b"
-                  }
-                `,
-                output: dedent`
-                  class Class {
-                    a = () => null
-                   b = "b"
-                  y = "y"
-                      z = "z"
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    groups: ['method', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenClassMembers',
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    a; 
-
-                  b;
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    a; b;
-                  }
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedClassesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenClassMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['function-property', 'unknown', 'method'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    a = () => null
-
-                   y = "y"
-                  z = "z"
-
-                      b() {}
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    a = () => null
-
-
-                   z = "z"
-                  y = "y"
-                      b() {}
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of [
-        'always',
-        1,
-        'ignore',
-        'never',
-        0,
-      ] as const) {
-        ruleTester.run(
-          `${ruleName}: enforces no newline between overload signatures when newlinesBetween is "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'method',
-                      left: 'method',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                  {
-                    data: {
-                      right: 'method',
-                      left: 'method',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    method(a: string): void {}
-                    method(a: number): void {}
-                    method(a: string | number): void {}
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    method(a: string): void {}
-
-                    method(a: number): void {}
-
-                    method(a: string | number): void {}
-                  }
-                `,
-                options: [
-                  {
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenClassMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    a: string
-
-                    b: string
-
-                    c: string
-                    d: string
-
-
-                    e: string
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    a: string
-                    b: string
-
-
-                    c: string
-
-                    d: string
-
-
-                    e: string
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenClassMembers',
-                      },
-                    ],
-                    output: dedent`
-                      class Class {
-                        a: string
-
-
-                        b: string
-                      }
-                    `,
-                    code: dedent`
-                      class Class {
-                        a: string
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenClassMembers',
-                      },
-                    ],
-                    output: dedent`
-                      class Class {
-                        a
-                        b
-                      }
-                    `,
-                    code: dedent`
-                      class Class {
-                        a
-
-                        b
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      class Class {
-                        a: string
-
-                        b: string
-                      }
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      class Class {
-                        a: string
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  class Class {
-                    a // Comment after
-                    b() {}
-
-                    c() {}
-                  }
-                `,
-                dedent`
-                  class Class {
-                    a // Comment after
-
-                    b() {}
-                    c() {}
-                  }
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'property',
-                    leftGroup: 'method',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              code: dedent`
-                class Class {
-                  b() {}
-                  a // Comment after
-
-                  c() {}
-                }
-              `,
-              options: [
-                {
-                  groups: ['property', 'method'],
-                  newlinesBetween: 'always',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedClassesOrder',
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    a
-
-                    // Partition comment
-
-                    b
-                    c
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    a
-
-                    // Partition comment
-
-                    c
-                    b
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    describe(`${ruleName}(${type}): sorts inline elements correctly`, () => {
-      describe(`${ruleName}(${type}): methods`, () => {
-        describe(`${ruleName}(${type}): non-abstract methods`, () => {
-          ruleTester.run(
-            `${ruleName}(${type}): sorts inline non-abstract methods correctly`,
-            rule,
-            {
-              invalid: [
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedClassesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    class Class {
-                      a(){} b(){}
-                    }
-                  `,
-                  code: dedent`
-                    class Class {
-                      b(){} a(){}
-                    }
-                  `,
-                  options: [options],
-                },
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedClassesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    class Class {
-                      a(){} b(){};
-                    }
-                  `,
-                  code: dedent`
-                    class Class {
-                      b(){} a(){};
-                    }
-                  `,
-                  options: [options],
-                },
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedClassesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    class Class {
-                      a(){}; b(){}
-                    }
-                  `,
-                  code: dedent`
-                    class Class {
-                      b(){}; a(){}
-                    }
-                  `,
-                  options: [options],
-                },
-              ],
-              valid: [],
-            },
-          )
-        })
-
-        describe(`${ruleName}(${type}): abstract methods`, () => {
-          ruleTester.run(
-            `${ruleName}(${type}): sorts inline abstract methods correctly`,
-            rule,
-            {
-              invalid: [
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedClassesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    abstract class Class {
-                      abstract a(); abstract b();
-                    }
-                  `,
-                  code: dedent`
-                    abstract class Class {
-                      abstract b(); abstract a()
-                    }
-                  `,
-                  options: [options],
-                },
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedClassesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    abstract class Class {
-                      abstract a(); abstract b();
-                    }
-                  `,
-                  code: dedent`
-                    abstract class Class {
-                      abstract b(); abstract a();
-                    }
-                  `,
-                  options: [options],
-                },
-              ],
-              valid: [],
-            },
-          )
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline declare class methods correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                declare class Class {
-                  a(); b();
-                }
-              `,
-              code: dedent`
-                declare class Class {
-                  b(); a()
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                abstract class Class {
-                  abstract a(); abstract b();
-                }
-              `,
-              code: dedent`
-                abstract class Class {
-                  abstract b(); abstract a();
-                }
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline properties correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  a; b;
-                }
-              `,
-              code: dedent`
-                class Class {
-                  b; a
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  a; b;
-                }
-              `,
-              code: dedent`
-                class Class {
-                  b; a;
-                }
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline accessors correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  accessor a; accessor b;
-                }
-              `,
-              code: dedent`
-                class Class {
-                  accessor b; accessor a
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  accessor a; accessor b;
-                }
-              `,
-              code: dedent`
-                class Class {
-                  accessor b; accessor a;
-                }
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline index-signatures correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '[key: number]',
-                    left: '[key: string]',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  [key: number]: string; [key: string]: string;
-                }
-              `,
-              code: dedent`
-                class Class {
-                  [key: string]: string; [key: number]: string
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: '[key: number]',
-                    left: '[key: string]',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  [key: number]: string; [key: string]: string;
-                }
-              `,
-              code: dedent`
-                class Class {
-                  [key: string]: string; [key: number]: string;
-                }
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline static-block correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'static-block',
-                    leftGroup: 'property',
-                    right: 'static',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedClassesGroupOrder',
-                },
-              ],
-              output: dedent`
-                class Class {
-                  static {} a;
-                }
-              `,
-              code: dedent`
-                class Class {
-                  a; static {}
-                }
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts class members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'd',
-                left: 'e',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                leftGroup: 'static-method',
-                rightGroup: 'constructor',
-                right: 'constructor',
-                left: 'f',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'protected-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'protected-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          output: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              d = 'd'
-
-              e = 'e'
-
-              constructor() {}
-
-              static f() {}
-
-              protected g() {}
-
-              private h() {}
-
-              i() {}
-
-              j() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              e = 'e'
-
-              d = 'd'
-
-              static f() {}
-
-              constructor() {}
-
-              protected g() {}
-
-              private h() {}
-
-              i() {}
-
-              j() {}
-            }
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'protected-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'protected-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              d = 'd'
-
-              e = 'e'
-
-              constructor() {}
-
-              static f() {}
-
-              protected g() {}
-
-              private h() {}
-
-              i() {}
-
-              j() {}
-            }
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class and group members`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'key in O',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                  ['static-method', 'private-method', 'method'],
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                static a
-
-                static b = 'b'
-
-                [key in O]
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                [key in O]
-
-                static b = 'b'
-
-                static a
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                  ['static-method', 'private-method', 'method'],
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              class Class {
-                static a
-
-                static b = 'b'
-
-                [key in O]
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class with ts index signatures`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-property',
-                  leftGroup: 'index-signature',
-                  left: '[k: string];',
-                  right: 'a',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'index-signature',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                static a = 'a';
-
-                [k: string]: any;
-
-                [k: string];
-              }
-            `,
-            code: dedent`
-              class Class {
-                [k: string]: any;
-
-                [k: string];
-
-                static a = 'a';
-              }
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                ],
-              },
-            ],
-            code: dedent`
-              class Class {
-                static a = 'a';
-
-                [k: string]: any;
-
-                [k: string];
-              }
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class with ts index signatures`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              class Decorations {
-                setBackground(color: number, hexFlag: boolean): this
-                setBackground(color: Color | string | CSSColor): this
-                setBackground(r: number, g: number, b: number, a?: number): this
-                setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
-                    /* ... */
-                }
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                ],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts private methods with hash`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'private-property',
-                  left: '#aPrivateStaticMethod',
-                  right: '#somePrivateProperty',
-                  leftGroup: 'static-method',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: '#someOtherPrivateProperty',
-                  left: '#somePrivateProperty',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  left: '#someOtherPrivateProperty',
-                  leftGroup: 'private-property',
-                  rightGroup: 'static-property',
-                  right: 'someStaticProperty',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: '#someStaticPrivateProperty',
-                  left: 'someStaticProperty',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: '#aPrivateInstanceMethod',
-                  rightGroup: 'private-method',
-                  leftGroup: 'static-method',
-                  left: 'aStaticMethod',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class MyUnsortedClass {
-                static #someStaticPrivateProperty = 4
-
-                static someStaticProperty = 3
-
-                #someOtherPrivateProperty = 2
-
-                #somePrivateProperty
-
-                someOtherProperty
-
-                someProperty = 1
-
-                constructor() {}
-
-                aInstanceMethod () {}
-
-                #aPrivateInstanceMethod () {}
-
-                static #aPrivateStaticMethod () {}
-
-                static aStaticMethod () {}
-              }
-            `,
-            code: dedent`
-              class MyUnsortedClass {
-                someOtherProperty
-
-                someProperty = 1
-
-                constructor() {}
-
-                static #aPrivateStaticMethod () {}
-
-                #somePrivateProperty
-
-                #someOtherPrivateProperty = 2
-
-                static someStaticProperty = 3
-
-                static #someStaticPrivateProperty = 4
-
-                aInstanceMethod () {}
-
-                static aStaticMethod () {}
-
-                #aPrivateInstanceMethod () {}
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: [
-                  'static-property',
-                  'private-property',
-                  'property',
-                  'constructor',
-                  'method',
-                  'private-method',
-                  'static-method',
-                  'unknown',
-                ],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows split methods with getters and setters`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'index-signature',
-                  'static-property',
-                  'private-property',
-                  'property',
-                  'constructor',
-                  'static-method',
-                  'private-method',
-                  'method',
-                  ['get-method', 'set-method'],
-                  'unknown',
-                ],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'x',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'z',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            output: dedent`
-              class A {
-                b() {}
-                x() {}
-                get c() {}
-                set c() {}
-                get z() {}
-              }
-            `,
-            code: dedent`
-              class A {
-                x() {}
-                b() {}
-                get z() {}
-                get c() {}
-                set c() {}
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated properties`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            class User {
-              firstName: string
-
-              id: number
-
-              lastName: string
-
-              @Index({ name: 'born_index' })
-              @Property()
-              born: string
-
-              @Property()
-              @Unique()
-              email: string
-            }
-          `,
-          code: dedent`
-            class User {
-              firstName: string
-
-              id: number
-
-              @Index({ name: 'born_index' })
-              @Property()
-              born: string
-
-              @Property()
-              @Unique()
-              email: string
-
-              lastName: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                leftGroup: 'decorated-property',
-                rightGroup: 'property',
-                right: 'lastName',
-                left: 'email',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['property', 'decorated-property', 'unknown'],
-            },
-          ],
-        },
-        {
-          output: dedent`
-            class MyElement {
-              @property({ attribute: false })
-              data = {}
-
-              @property()
-              greeting: string = 'Hello'
-
-              @property()
-              protected type = ''
-
-              @state()
-              private _counter = 0
-
-              private _message = ''
-
-              private _prop = 0
-
-              constructor() {}
-
-              @property()
-              get message(): string {
-                return this._message
-              }
-
-              @property()
-              set prop(val: number) {
-                this._prop = Math.floor(val)
-              }
-
-              set message(message: string) {
-                this._message = message
-              }
-
-              get prop() {
-                return this._prop
-              }
-
-              render() {}
-            }
-          `,
-          code: dedent`
-            class MyElement {
-              @property({ attribute: false })
-              data = {}
-
-              @property()
-              greeting: string = 'Hello'
-
-              @property()
-              protected type = ''
-
-              @state()
-              private _counter = 0
-
-              private _message = ''
-
-              private _prop = 0
-
-              constructor() {}
-
-              @property()
-              get message(): string {
-                return this._message
-              }
-
-              set message(message: string) {
-                this._message = message
-              }
-
-              @property()
-              set prop(val: number) {
-                this._prop = Math.floor(val)
-              }
-
-              get prop() {
-                return this._prop
-              }
-
-              render() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'decorated-property',
-                'property',
-                'protected-decorated-property',
-                'private-decorated-property',
-                'private-property',
-                'constructor',
-                ['decorated-get-method', 'decorated-set-method'],
-                ['get-method', 'set-method'],
-                'unknown',
-              ],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                rightGroup: 'decorated-set-method',
-                leftGroup: 'set-method',
-                left: 'message',
-                right: 'prop',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated accessors`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'private-decorated-accessor-property',
-                leftGroup: 'decorated-method',
-                right: '#active',
-                left: 'toggle',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'private-decorated-accessor-property',
-                rightGroup: 'decorated-accessor-property',
-                right: 'finished',
-                left: '#active',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Todo {
-              @observable
-              accessor finished = false
-
-              @observable
-              accessor title = ''
-
-              @observable
-              protected accessor type = ''
-
-              @observable
-              accessor #active = false
-
-              id = Math.random()
-
-              constructor() {}
-
-              @action
-              toggle() {}
-            }
-          `,
-          code: dedent`
-            class Todo {
-              id = Math.random()
-
-              constructor() {}
-
-              @action
-              toggle() {}
-
-              @observable
-              accessor #active = false
-
-              @observable
-              accessor finished = false
-
-              @observable
-              accessor title = ''
-
-              @observable
-              protected accessor type = ''
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'decorated-accessor-property',
-                'protected-decorated-accessor-property',
-                'private-decorated-accessor-property',
-                'property',
-                'constructor',
-                'decorated-method',
-                'unknown',
-              ],
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated accessors`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'onSortChanged',
-                left: 'updateTable',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                right: 'onPaginationChanged',
-                left: 'onSortChanged',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                right: 'onValueChanged',
-                left: 'setFormValue',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              // Region: Table
-              protected onChangeColumns() {}
-
-              protected onPaginationChanged() {}
-
-              protected onSortChanged() {}
-
-              protected updateTable() {}
-
-              // Region: Form
-              protected clearForm() {}
-
-              protected disableForm() {}
-
-              // Regular Comment
-              protected onValueChanged() {}
-
-              protected setFormValue() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              // Region: Table
-              protected onChangeColumns() {}
-
-              protected updateTable() {}
-
-              protected onSortChanged() {}
-
-              protected onPaginationChanged() {}
-
-              // Region: Form
-              protected clearForm() {}
-
-              protected disableForm() {}
-
-              protected setFormValue() {}
-
-              // Regular Comment
-              protected onValueChanged() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              partitionByComment: 'Region:',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            class Class {
-              // Region: Table
-              protected onChangeColumns() {}
-
-              protected onPaginationChanged() {}
-
-              protected onSortChanged() {}
-
-              protected updateTable() {}
-
-              // Region: Form
-              protected clearForm() {}
-
-              protected disableForm() {}
-
-              // Regular Comment
-              protected onValueChanged() {}
-
-              protected setFormValue() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              partitionByComment: 'Region:',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort properties if the right value depends on the left value`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'aaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesDependencyOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                b = 'b'
-
-                aaa = [this.b]
-              }
-            `,
-            code: dedent`
-              class Class {
-                aaa = [this.b]
-
-                b = 'b'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'property',
-                  leftGroup: 'method',
-                  left: 'getAaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                b = 'b'
-
-                getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                getAaa() {
-                  return this.b;
-                }
-
-                b = 'b'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-property',
-                  leftGroup: 'property',
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                static c = 'c'
-
-                b = Example.c
-              }
-            `,
-            code: dedent`
-              class Class {
-                b = Example.c
-
-                static c = 'c'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'private-property',
-                  leftGroup: 'method',
-                  left: 'getAaa',
-                  right: '#b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                #b = 'b'
-
-                getAaa() {
-                  return this.#b;
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                getAaa() {
-                  return this.#b;
-                }
-
-                #b = 'b'
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-property',
-                  leftGroup: 'static-method',
-                  left: 'getAaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                static b = 'b'
-
-                static getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                static getAaa() {
-                  return this.b;
-                }
-
-                static b = 'b'
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              class Class {
-                b = 'b'
-
-                aaa = [this.b]
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                b = 'b'
-
-                getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                static c = 'c'
-
-                b = Example.c
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                #b = 'b'
-
-                getAaa() {
-                  return this.#b;
-                }
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              class Class {
-                static b = 'b'
-
-                static getAaa() {
-                  return this.b;
-                }
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with left and right dependencies`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'aaa',
-                  right: 'left',
-                },
-                messageId: 'unexpectedClassesDependencyOrder',
-              },
-              {
-                data: {
-                  nodeDependentOnRight: 'aaa',
-                  right: 'right',
-                },
-                messageId: 'unexpectedClassesDependencyOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                left = 'left'
-
-                right = 'right'
-
-                aaa = this.left + this.right
-              }
-            `,
-            code: dedent`
-              class Class {
-                aaa = this.left + this.right
-
-                left = 'left'
-
-                right = 'right'
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              class Class {
-                left = 'left'
-                right = 'right'
-
-                aaa = this.left + this.right
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'property',
-                right: 'z',
-                left: 'i',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'private-method',
-                rightGroup: 'unknown',
-                right: 'method3',
-                left: 'z',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'unknown',
-                left: 'method3',
-                right: 'y',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'unknown',
-                left: 'method1',
-                right: 'x',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-
-              private x() {}
-              private y() {}
-              public method3() {}
-              private z() {}
-              public method4() {}
-              public method1() {}
-              public i = 'i';
-            }
-          `,
-          code: dedent`
-            class Class {
-
-              public i = 'i';
-              private z() {}
-              public method3() {}
-              private y() {}
-              public method4() {}
-              public method1() {}
-              private x() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['private-method', 'property'],
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'property',
-                rightGroup: 'unknown',
-                right: 'someMethod',
-                left: 'b',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'property',
-                leftGroup: 'unknown',
-                left: 'someMethod',
-                right: 'a',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              a
-              someMethod() {
-              }
-              b
-            }
-          `,
-          code: dedent`
-            class Class {
-              b
-              someMethod() {
-              }
-              a
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['property'],
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts class members`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'protected-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'static-protected-method',
-                'protected-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'd',
-                left: 'e',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                leftGroup: 'static-method',
-                rightGroup: 'constructor',
-                right: 'constructor',
-                left: 'f',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              d = 'd'
-
-              e = 'e'
-
-              constructor() {}
-
-              static f() {}
-
-              protected static g() {}
-
-              protected h() {}
-
-              private i() {}
-
-              j() {}
-
-              k() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              e = 'e'
-
-              d = 'd'
-
-              static f() {}
-
-              constructor() {}
-
-              protected static g() {}
-
-              protected h() {}
-
-              private i() {}
-
-              j() {}
-
-              k() {}
-            }
-          `,
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            class Class {
-              a
-            }
-          `,
-          options: [options],
-        },
-        {
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'protected-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'static-protected-method',
-                'protected-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              protected b = 'b'
-
-              private c = 'c'
-
-              d = 'd'
-
-              e = 'e'
-
-              constructor() {}
-
-              static f() {}
-
-              protected static g() {}
-
-              protected h() {}
-
-              private i() {}
-
-              j() {}
-
-              k() {}
-            }
-          `,
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts class members`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          output: dedent`
-            class Class {
-              static a = 'a'
-
-              private b = 'b'
-
-              d = 'd'
-
-              c = 'c'
-
-              constructor() {}
-
-              static e() {}
-
-              private f() {}
-
-              g() {}
-
-              h() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              private b = 'b'
-
-              d = 'd'
-
-              c = 'c'
-
-              static e() {}
-
-              constructor() {}
-
-              private f() {}
-
-              g() {}
-
-              h() {}
-            }
-          `,
-          errors: [
-            {
-              data: {
-                leftGroup: 'static-method',
-                rightGroup: 'constructor',
-                right: 'constructor',
-                left: 'e',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: [
-                'static-property',
-                'private-property',
-                'property',
-                'constructor',
-                'static-method',
-                'private-method',
-                'method',
-                'unknown',
-              ],
-            },
-          ],
-          code: dedent`
-            class Class {
-              static a = 'a'
-
-              private b = 'b'
-
-              c = 'c'
-
-              d = 'd'
-
-              constructor() {}
-
-              static e() {}
-
-              private f() {}
-
-              g() {}
-
-              h() {}
-            }
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class and group members`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                  ['static-method', 'private-method', 'method'],
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                static b = 'b'
-
-                [key in O]
-
-                static a
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-            code: dedent`
-              class Class {
-                [key in O]
-
-                static b = 'b'
-
-                static a
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  left: 'key in O',
-                  right: 'b',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                  ['static-method', 'private-method', 'method'],
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              class Class {
-                static b = 'b'
-
-                [key in O]
-
-                static a
-
-                static {
-                  this.a = 'd'
-                }
-              }
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class with ts index signatures`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-property',
-                  leftGroup: 'index-signature',
-                  left: '[k: string];',
-                  right: 'a',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'index-signature',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                static a = 'a';
-
-                [k: string]: any;
-
-                [k: string];
-              }
-            `,
-            code: dedent`
-              class Class {
-                [k: string]: any;
-
-                [k: string];
-
-                static a = 'a';
-              }
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                ],
-              },
-            ],
-            code: dedent`
-              class Class {
-                static a = 'a';
-
-                [k: string]: any;
-
-                [k: string];
-              }
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts class with ts index signatures`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              class Decorations {
-
-                a
-                static setBackground(r: number, g: number, b: number, a?: number): this
-                static setBackground(color: number, hexFlag: boolean): this
-                static setBackground(color: Color | string | CSSColor): this
-                static setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
-                  /* ... */
-                }
-                setBackground(r: number, g: number, b: number, a?: number): this
-                setBackground(color: number, hexFlag: boolean): this
-                setBackground(color: Color | string | CSSColor): this
-                setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
-                  /* ... */
-                }
-              }
-            `,
-            code: dedent`
-              class Decorations {
-
-                setBackground(r: number, g: number, b: number, a?: number): this
-                setBackground(color: number, hexFlag: boolean): this
-                setBackground(color: Color | string | CSSColor): this
-                setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
-                  /* ... */
-                }
-
-                static setBackground(r: number, g: number, b: number, a?: number): this
-                static setBackground(color: number, hexFlag: boolean): this
-                static setBackground(color: Color | string | CSSColor): this
-                static setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
-                  /* ... */
-                }
-
-                a
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  rightGroup: 'static-method',
-                  right: 'setBackground',
-                  left: 'setBackground',
-                  leftGroup: 'method',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'static-method',
-                  rightGroup: 'property',
-                  left: 'setBackground',
-                  right: 'a',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              class Decorations {
-                setBackground(color: number, hexFlag: boolean): this
-                setBackground(color: Color | string | CSSColor): this
-                setBackground(r: number, g: number, b: number, a?: number): this
-                setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
-                    /* ... */
-                }
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: [
-                  ['static-property', 'private-property', 'property'],
-                  'constructor',
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts private methods with hash`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'private-property',
-                  left: '#aPrivateStaticMethod',
-                  right: '#somePrivateProperty',
-                  leftGroup: 'static-method',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: '#someOtherPrivateProperty',
-                  left: '#somePrivateProperty',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  left: '#someOtherPrivateProperty',
-                  leftGroup: 'private-property',
-                  rightGroup: 'static-property',
-                  right: 'someStaticProperty',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: '#someStaticPrivateProperty',
-                  left: 'someStaticProperty',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: '#aPrivateInstanceMethod',
-                  rightGroup: 'private-method',
-                  leftGroup: 'static-method',
-                  left: 'aStaticMethod',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class MyUnsortedClass {
-                static #someStaticPrivateProperty = 4
-
-                static someStaticProperty = 3
-
-                #someOtherPrivateProperty = 2
-
-                #somePrivateProperty
-
-                someOtherProperty
-
-                someProperty = 1
-
-                constructor() {}
-
-                aInstanceMethod () {}
-
-                #aPrivateInstanceMethod () {}
-
-                static #aPrivateStaticMethod () {}
-
-                static aStaticMethod () {}
-              }
-            `,
-            code: dedent`
-              class MyUnsortedClass {
-                someOtherProperty
-
-                someProperty = 1
-
-                constructor() {}
-
-                static #aPrivateStaticMethod () {}
-
-                #somePrivateProperty
-
-                #someOtherPrivateProperty = 2
-
-                static someStaticProperty = 3
-
-                static #someStaticPrivateProperty = 4
-
-                aInstanceMethod () {}
-
-                static aStaticMethod () {}
-
-                #aPrivateInstanceMethod () {}
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: [
-                  'static-property',
-                  'private-property',
-                  'property',
-                  'constructor',
-                  'method',
-                  'private-method',
-                  'static-method',
-                  'unknown',
-                ],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated properties`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            class User {
-              firstName: string
-
-              lastName: string
-
-              id: number
-
-              @Index({ name: 'born_index' })
-              @Property()
-              born: string
-
-              @Property()
-              @Unique()
-              email: string
-            }
-          `,
-          code: dedent`
-            class User {
-              firstName: string
-
-              id: number
-
-              @Index({ name: 'born_index' })
-              @Property()
-              born: string
-
-              @Property()
-              @Unique()
-              email: string
-
-              lastName: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                leftGroup: 'decorated-property',
-                rightGroup: 'property',
-                right: 'lastName',
-                left: 'email',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['property', 'decorated-property', 'unknown'],
-            },
-          ],
-        },
-        {
-          output: dedent`
-            class MyElement {
-              @property({ attribute: false })
-              data = {}
-
-              @property()
-              greeting: string = 'Hello'
-
-              @property()
-              protected type = ''
-
-              @state()
-              private _counter = 0
-
-              private _message = ''
-
-              private _prop = 0
-
-              constructor() {}
-
-              @property()
-              set prop(val: number) {
-                this._prop = Math.floor(val)
-              }
-
-              @property()
-              get message(): string {
-                return this._message
-              }
-
-              set message(message: string) {
-                this._message = message
-              }
-
-              get prop() {
-                return this._prop
-              }
-
-              render() {}
-            }
-          `,
-          code: dedent`
-            class MyElement {
-              @property({ attribute: false })
-              data = {}
-
-              @property()
-              greeting: string = 'Hello'
-
-              @property()
-              protected type = ''
-
-              @state()
-              private _counter = 0
-
-              private _message = ''
-
-              private _prop = 0
-
-              constructor() {}
-
-              @property()
-              get message(): string {
-                return this._message
-              }
-
-              set message(message: string) {
-                this._message = message
-              }
-
-              @property()
-              set prop(val: number) {
-                this._prop = Math.floor(val)
-              }
-
-              get prop() {
-                return this._prop
-              }
-
-              render() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'decorated-property',
-                'property',
-                'private-decorated-property',
-                'private-property',
-                'constructor',
-                ['decorated-get-method', 'decorated-set-method'],
-                ['get-method', 'set-method'],
-                'unknown',
-              ],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                rightGroup: 'decorated-set-method',
-                leftGroup: 'set-method',
-                left: 'message',
-                right: 'prop',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts decorated accessors`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: 'customLastGroupProperty',
-                leftGroup: 'my-last-group',
-                rightGroup: 'property',
-                right: 'id',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                right: 'customFirstGroupProperty',
-                rightGroup: 'my-first-group',
-                leftGroup: 'constructor',
-                left: 'constructor',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-decorated-accessor-property',
-                leftGroup: 'decorated-method',
-                right: '#active',
-                left: 'toggle',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'private-decorated-accessor-property',
-                rightGroup: 'decorated-accessor-property',
-                right: 'finished',
-                left: '#active',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: [
-                'my-first-group',
-                'decorated-accessor-property',
-                'protected-decorated-accessor-property',
-                'private-decorated-accessor-property',
-                'property',
-                'constructor',
-                'decorated-method',
-                'unknown',
-                'my-last-group',
-              ],
-              customGroups: [
-                {
-                  elementNamePattern: 'customFirst',
-                  groupName: 'my-first-group',
-                },
-                {
-                  elementNamePattern: 'customLast',
-                  groupName: 'my-last-group',
-                },
-              ],
-            },
-          ],
-          output: dedent`
-            class Todo {
-              @observable
-              customFirstGroupProperty = 1
-
-              @observable
-              accessor finished = false
-
-              @observable
-              accessor title = ''
-
-              @observable
-              protected accessor type = ''
-
-              @observable
-              accessor #active = false
-
-              id = Math.random()
-
-              constructor() {}
-
-              @action
-              toggle() {}
-
-              @observable
-              customLastGroupProperty = 1
-
-            }
-          `,
-          code: dedent`
-            class Todo {
-              @observable
-              customLastGroupProperty = 1
-
-              id = Math.random()
-
-              constructor() {}
-
-              @observable
-              customFirstGroupProperty = 1
-
-              @action
-              toggle() {}
-
-              @observable
-              accessor #active = false
-
-              @observable
-              accessor finished = false
-
-              @observable
-              accessor title = ''
-
-              @observable
-              protected accessor type = ''
-
-            }
-          `,
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'property',
-                right: 'z',
-                left: 'i',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'unknown',
-                left: 'method3',
-                right: 'y',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-method',
-                leftGroup: 'unknown',
-                left: 'method1',
-                right: 'x',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-
-              private z() {}
-              private y() {}
-              public method3() {}
-              private x() {}
-              public method4() {}
-              public method1() {}
-              public i = 'i';
-            }
-          `,
-          code: dedent`
-            class Class {
-
-              public i = 'i';
-              private z() {}
-              public method3() {}
-              private y() {}
-              public method4() {}
-              public method1() {}
-              private x() {}
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['private-method', 'property'],
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              class Class {
-                bb: string;
-                c: string;
-                a: string;
-              }
-            `,
-            code: dedent`
-              class Class {
-                a: string;
-                bb: string;
-                c: string;
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              class Class {
-                bb: string;
-                a: string;
-                c: string;
-              }
-            `,
-            code: dedent`
-              class Class {
-                c: string;
-                bb: string;
-                a: string;
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: custom groups`, () => {
-    ruleTester.run(`${ruleName}: filters on selector and modifiers`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'unusedCustomGroup',
-                  modifiers: ['private'],
-                  selector: 'property',
-                },
-                {
-                  groupName: 'privatePropertyGroup',
-                  modifiers: ['private'],
-                  selector: 'property',
-                },
-                {
-                  groupName: 'propertyGroup',
-                  selector: 'property',
-                },
-              ],
-              groups: ['propertyGroup', 'constructor', 'privatePropertyGroup'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                leftGroup: 'privatePropertyGroup',
-                rightGroup: 'propertyGroup',
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              c;
-              constructor() {}
-              private a;
-              private b;
-            }
-          `,
-          code: dedent`
-            class Class {
-              private a;
-              private b;
-              c;
-              constructor() {}
-            }
-          `,
-        },
-      ],
-      valid: [],
-    })
-
-    for (let elementNamePattern of [
-      'hello',
-      ['noMatch', 'hello'],
-      { pattern: 'HELLO', flags: 'i' },
-      ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-    ]) {
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'constructor',
-                  leftGroup: 'unknown',
-                  right: 'constructor',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'propertiesStartingWithHello',
-                  right: 'helloProperty',
-                  leftGroup: 'unknown',
-                  left: 'method',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'propertiesStartingWithHello',
-                    selector: 'property',
-                    elementNamePattern,
-                  },
-                ],
-                groups: [
-                  'propertiesStartingWithHello',
-                  'constructor',
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                helloProperty;
-
-                constructor() {}
-
-                a;
-
-                b;
-
-                method() {}
-              }
-            `,
-            code: dedent`
-              class Class {
-                a;
-
-                b;
-
-                constructor() {}
-
-                method() {}
-
-                helloProperty;
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-    }
-
-    for (let injectElementValuePattern of [
-      'inject',
-      ['noMatch', 'inject'],
-      { pattern: 'INJECT', flags: 'i' },
-      ['noMatch', { pattern: 'INJECT', flags: 'i' }],
-    ]) {
-      ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    elementValuePattern: injectElementValuePattern,
-                    groupName: 'inject',
-                  },
-                  {
-                    elementValuePattern: 'computed',
-                    groupName: 'computed',
-                  },
-                ],
-                groups: ['computed', 'inject', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'computed',
-                  leftGroup: 'inject',
-                  right: 'z',
-                  left: 'y',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                a = computed(A)
-                z = computed(Z)
-                b = inject(B)
-                y = inject(Y)
-                c() {}
-              }
-            `,
-            code: dedent`
-              class Class {
-                a = computed(A)
-                b = inject(B)
-                y = inject(Y)
-                z = computed(Z)
-                c() {}
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-    }
-
-    for (let decoratorNamePattern of [
-      'Hello',
-      ['noMatch', 'Hello'],
-      { pattern: 'HELLO', flags: 'i' },
-      ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-    ]) {
-      ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'constructor',
-                  leftGroup: 'unknown',
-                  right: 'constructor',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'propertiesWithDecoratorStartingWithHello',
-                  leftGroup: 'unknown',
-                  right: 'property',
-                  left: 'method',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  right: 'anotherProperty',
-                  left: 'property',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'propertiesWithDecoratorStartingWithHello',
-                    decoratorNamePattern,
-                    selector: 'property',
-                  },
-                ],
-                groups: [
-                  'propertiesWithDecoratorStartingWithHello',
-                  'constructor',
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              class Class {
-                @HelloDecorator()
-                anotherProperty;
-
-                @HelloDecorator
-                property;
-
-                constructor() {}
-
-                @Decorator
-                a;
-
-                b;
-
-                method() {}
-              }
-            `,
-            code: dedent`
-              class Class {
-                @Decorator
-                a;
-
-                b;
-
-                constructor() {}
-
-                method() {}
-
-                @HelloDecorator
-                property;
-
-                @HelloDecorator()
-                anotherProperty;
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-    }
-
-    ruleTester.run(
-      `${ruleName}: filters on complex decoratorNamePattern`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    decoratorNamePattern: 'B',
-                    groupName: 'B',
-                  },
-                  {
-                    decoratorNamePattern: 'A',
-                    groupName: 'A',
-                  },
-                ],
-                type: 'alphabetical',
-                groups: ['B', 'A'],
-                order: 'asc',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'B',
-                  leftGroup: 'A',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                @B.B()
-                b() {}
-
-                @A.A.A(() => A)
-                a() {}
-              }
-            `,
-            code: dedent`
-              class Class {
-                @A.A.A(() => A)
-                a() {}
-
-                @B.B()
-                b() {}
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: 'ccc',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: 'dddd',
-                  left: 'ccc',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'reversedPropertiesByLineLength',
-                  leftGroup: 'unknown',
-                  left: 'method',
-                  right: 'eee',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'reversedPropertiesByLineLength',
-                    selector: 'property',
-                    type: 'line-length',
-                    order: 'desc',
-                  },
-                ],
-                groups: [
-                  'reversedPropertiesByLineLength',
-                  'constructor',
-                  'unknown',
-                ],
-                type: 'alphabetical',
-                order: 'asc',
-              },
-            ],
-            output: dedent`
-              class Class {
-
-                dddd;
-
-                ccc;
-
-                eee;
-
-                bb;
-
-                ff;
-
-                a;
-
-                g;
-
-                constructor() {}
-
-                anotherMethod() {}
-
-                method() {}
-
-                yetAnotherMethod() {}
-              }
-            `,
-            code: dedent`
-              class Class {
-
-                a;
-
-                bb;
-
-                ccc;
-
-                dddd;
-
-                method() {}
-
-                eee;
-
-                ff;
-
-                g;
-
-                constructor() {}
-
-                anotherMethod() {}
-
-                yetAnotherMethod() {}
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    fallbackSort: {
-                      type: 'alphabetical',
-                      order: 'asc',
-                    },
-                    elementNamePattern: '^foo',
-                    type: 'line-length',
-                    groupName: 'foo',
-                    order: 'desc',
-                  },
-                ],
-                type: 'alphabetical',
-                groups: ['foo'],
-                order: 'asc',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: 'fooBar',
-                  left: 'fooZar',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                fooBar: string
-                fooZar: string
-              }
-            `,
-            code: dedent`
-              class Class {
-                fooZar: string
-                fooBar: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: does not sort custom groups with 'unsorted' type`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'unsortedProperties',
-                  leftGroup: 'constructor',
-                  left: 'constructor',
-                  right: 'd',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'unsortedProperties',
-                  leftGroup: 'unknown',
-                  left: 'method',
-                  right: 'c',
-                },
-                messageId: 'unexpectedClassesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'unsortedProperties',
-                    selector: 'property',
-                    type: 'unsorted',
-                  },
-                ],
-                groups: ['unsortedProperties', 'constructor', 'unknown'],
-              },
-            ],
-            output: dedent`
-              class Class {
-                b;
-
-                a;
-
-                d
-
-                e
-
-                c
-
-                constructor() {}
-
-                method() {}
-              }
-            `,
-            code: dedent`
-              class Class {
-                b;
-
-                a;
-
-                constructor() {}
-
-                d
-
-                e
-
-                method() {}
-
-                c
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'privatePropertiesAndProtectedMethods',
-                leftGroup: 'unknown',
-                right: 'b',
                 left: 'a',
               },
               messageId: 'unexpectedClassesGroupOrder',
             },
-            {
-              data: {
-                rightGroup: 'privatePropertiesAndProtectedMethods',
-                leftGroup: 'unknown',
-                left: 'method',
-                right: 'c',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'privatePropertiesAndProtectedMethods',
-                right: 'anotherProtectedMethod',
-                leftGroup: 'unknown',
-                left: 'd',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
           ],
           options: [
             {
-              customGroups: [
-                {
-                  anyOf: [
-                    {
-                      modifiers: ['private'],
-                      selector: 'property',
-                    },
-                    {
-                      modifiers: ['protected'],
-                      selector: 'method',
-                    },
-                  ],
-                  groupName: 'privatePropertiesAndProtectedMethods',
-                },
-              ],
+              ...options,
               groups: [
-                [
-                  'privatePropertiesAndProtectedMethods',
-                  'decorated-protected-property',
-                ],
-                'constructor',
-                'unknown',
+                'override-method',
+                'property',
+                `${accessibilityModifier}-method`,
               ],
             },
           ],
           output: dedent`
-            class Class {
-              protected anotherProtectedMethod() {}
+            export class Class {
 
-              private b;
+              ${accessibilityModifier} override z(): string;
 
-              private c;
-
-              @Decorator
-              protected e;
-
-              protected protectedMethod() {}
-
-              constructor() {}
-
-              protected a;
-
-              protected d;
-
-              method() {}
+              a: string;
             }
           `,
           code: dedent`
-            class Class {
-              constructor() {}
+            export class Class {
 
-              protected a;
+              a: string;
 
-              private b;
-
-              @Decorator
-              protected e;
-
-              method() {}
-
-              private c;
-
-              protected protectedMethod() {}
-
-              protected d;
-
-              protected anotherProtectedMethod() {}
+              ${accessibilityModifier} override z(): string;
             }
           `,
-        },
+        })
+      },
+    )
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes %s accessibility over optional',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: `${accessibilityModifier}-method`,
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                `${accessibilityModifier}-method`,
+                'property',
+                'optional-method',
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} z?(): string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} z?(): string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes optional over async', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'optional-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['optional-method', 'property', 'async-method'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            async z?(): Promise<string>;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a: string;
+
+            async z?(): Promise<string>;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            static override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a: string;
+
+            static override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes abstract over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'abstract-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            abstract override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes decorated over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            @Decorator
+            override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes override over %s accessibility for accessor properties',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'override-accessor-property',
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'override-accessor-property',
+                'property',
+                `${accessibilityModifier}-accessor-property`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} override accessor z: string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} override accessor z: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes function property over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function-property',
+              rightGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'function-property'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z: string;
+
+            a = function() {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a = function() {}
+
+            z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes function property over property for arrow functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function-property',
+              rightGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'function-property'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z: string;
+
+            a = () => {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a = () => {}
+
+            z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over declare', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            declare static z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a(): void {}
+
+            declare static z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['static-property', 'method', 'declare-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes declare over abstract', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            declare abstract z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a(): void {}
+
+            declare abstract z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['declare-property', 'method', 'abstract-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes abstract over override for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            abstract override z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['abstract-property', 'method', 'override-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes decorated over override for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            @Decorator
+            override z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['decorated-property', 'method', 'override-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes override over readonly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'override-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            override readonly z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            override readonly z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['override-property', 'method', 'readonly-property'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes readonly over %s accessibility',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'readonly-property',
+                leftGroup: 'method',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'readonly-property',
+                'method',
+                `${accessibilityModifier}-property`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} readonly z: string;
+
+              a(): void {}
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a(): void {}
+
+              ${accessibilityModifier} readonly z: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes %s accessibility over optional for properties',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: `${accessibilityModifier}-property`,
+                leftGroup: 'method',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                `${accessibilityModifier}-property`,
+                'method',
+                'optional-property',
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} z?: string;
+
+              a(): void {}
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a(): void {}
+
+              ${accessibilityModifier} z?: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes optional over async for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'optional-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z?: Promise<string> = async () => {};
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a(): void {}
+
+            z?: Promise<string> = async () => {};
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['optional-property', 'method', 'async-property'],
+          },
+        ],
+      })
+    })
+
+    it('sorts class and group members', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+              ['static-method', 'private-method', 'method'],
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static a
+
+            static b = 'b'
+
+            [key in O]
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'key in O',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+              ['static-method', 'private-method', 'method'],
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a
+
+            static b = 'b'
+
+            [key in O]
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key in O]
+
+            static b = 'b'
+
+            static a
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+      })
+    })
+
+    it('sorts class with attributes having the same name', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'static-property',
+              rightGroup: 'property',
+              right: 'a',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'static-property'],
+          },
+        ],
+        output: dedent`
+          class Class {
+            a;
+
+            static a;
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a;
+
+            a;
+          }
+        `,
+      })
+    })
+
+    it('sorts class with ts index signatures', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static a = 'a';
+
+            [k: string]: any;
+
+            [k: string];
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'index-signature',
+              left: '[k: string];',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'index-signature',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 'a';
+
+            [k: string]: any;
+
+            [k: string];
+          }
+        `,
+        code: dedent`
+          class Class {
+            [k: string]: any;
+
+            [k: string];
+
+            static a = 'a';
+          }
+        `,
+      })
+    })
+
+    it('allows multiple method signatures', async () => {
+      await valid({
+        code: dedent`
+          class Decorations {
+            setBackground(color: number, hexFlag: boolean): this
+            setBackground(color: Color | string | CSSColor): this
+            setBackground(r: number, g: number, b: number, a?: number): this
+            setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
+                /* ... */
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts private methods with hash', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-property',
+              left: '#aPrivateStaticMethod',
+              right: '#somePrivateProperty',
+              leftGroup: 'static-method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: '#someOtherPrivateProperty',
+              left: '#somePrivateProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              left: '#someOtherPrivateProperty',
+              leftGroup: 'private-property',
+              rightGroup: 'static-property',
+              right: 'someStaticProperty',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: '#someStaticPrivateProperty',
+              left: 'someStaticProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: '#aPrivateInstanceMethod',
+              rightGroup: 'private-method',
+              leftGroup: 'static-method',
+              left: 'aStaticMethod',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class MyUnsortedClass {
+            static #someStaticPrivateProperty = 4
+
+            static someStaticProperty = 3
+
+            #someOtherPrivateProperty = 2
+
+            #somePrivateProperty
+
+            someOtherProperty
+
+            someProperty = 1
+
+            constructor() {}
+
+            aInstanceMethod () {}
+
+            #aPrivateInstanceMethod () {}
+
+            static #aPrivateStaticMethod () {}
+
+            static aStaticMethod () {}
+          }
+        `,
+        code: dedent`
+          class MyUnsortedClass {
+            someOtherProperty
+
+            someProperty = 1
+
+            constructor() {}
+
+            static #aPrivateStaticMethod () {}
+
+            #somePrivateProperty
+
+            #someOtherPrivateProperty = 2
+
+            static someStaticProperty = 3
+
+            static #someStaticPrivateProperty = 4
+
+            aInstanceMethod () {}
+
+            static aStaticMethod () {}
+
+            #aPrivateInstanceMethod () {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-property',
+              'private-property',
+              'property',
+              'constructor',
+              'method',
+              'private-method',
+              'static-method',
+              'unknown',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('allows split methods with getters and setters', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'index-signature',
+              'static-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'private-method',
+              'method',
+              ['get-method', 'set-method'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'x',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'z',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class A {
+            b() {}
+            x() {}
+            get c() {}
+            set c() {}
+            get z() {}
+          }
+        `,
+        code: dedent`
+          class A {
+            x() {}
+            b() {}
+            get z() {}
+            get c() {}
+            set c() {}
+          }
+        `,
+      })
+    })
+
+    it('sorts decorated properties', async () => {
+      await invalid({
+        output: dedent`
+          class User {
+            firstName: string
+
+            id: number
+
+            lastName: string
+
+            @Index({ name: 'born_index' })
+            @Property()
+            born: string
+
+            @Property()
+            @Unique()
+            email: string
+          }
+        `,
+        code: dedent`
+          class User {
+            firstName: string
+
+            id: number
+
+            @Index({ name: 'born_index' })
+            @Property()
+            born: string
+
+            @Property()
+            @Unique()
+            email: string
+
+            lastName: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              leftGroup: 'decorated-property',
+              rightGroup: 'property',
+              right: 'lastName',
+              left: 'email',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'decorated-property', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        output: dedent`
+          class MyElement {
+            @property({ attribute: false })
+            data = {}
+
+            @property()
+            greeting: string = 'Hello'
+
+            @property()
+            protected type = ''
+
+            @state()
+            private _counter = 0
+
+            private _message = ''
+
+            private _prop = 0
+
+            constructor() {}
+
+            @property()
+            get message(): string {
+              return this._message
+            }
+
+            @property()
+            set prop(val: number) {
+              this._prop = Math.floor(val)
+            }
+
+            set message(message: string) {
+              this._message = message
+            }
+
+            get prop() {
+              return this._prop
+            }
+
+            render() {}
+          }
+        `,
+        code: dedent`
+          class MyElement {
+            @property({ attribute: false })
+            data = {}
+
+            @property()
+            greeting: string = 'Hello'
+
+            @property()
+            protected type = ''
+
+            @state()
+            private _counter = 0
+
+            private _message = ''
+
+            private _prop = 0
+
+            constructor() {}
+
+            @property()
+            get message(): string {
+              return this._message
+            }
+
+            set message(message: string) {
+              this._message = message
+            }
+
+            @property()
+            set prop(val: number) {
+              this._prop = Math.floor(val)
+            }
+
+            get prop() {
+              return this._prop
+            }
+
+            render() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-property',
+              'property',
+              'protected-decorated-property',
+              'private-decorated-property',
+              'private-property',
+              'constructor',
+              ['decorated-get-method', 'decorated-set-method'],
+              ['get-method', 'set-method'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-set-method',
+              leftGroup: 'set-method',
+              left: 'message',
+              right: 'prop',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+      })
+    })
+
+    it('sorts decorated accessors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-decorated-accessor-property',
+              leftGroup: 'decorated-method',
+              right: '#active',
+              left: 'toggle',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'private-decorated-accessor-property',
+              rightGroup: 'decorated-accessor-property',
+              right: 'finished',
+              left: '#active',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Todo {
+            @observable
+            accessor finished = false
+
+            @observable
+            accessor title = ''
+
+            @observable
+            protected accessor type = ''
+
+            @observable
+            accessor #active = false
+
+            id = Math.random()
+
+            constructor() {}
+
+            @action
+            toggle() {}
+          }
+        `,
+        code: dedent`
+          class Todo {
+            id = Math.random()
+
+            constructor() {}
+
+            @action
+            toggle() {}
+
+            @observable
+            accessor #active = false
+
+            @observable
+            accessor finished = false
+
+            @observable
+            accessor title = ''
+
+            @observable
+            protected accessor type = ''
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-accessor-property',
+              'protected-decorated-accessor-property',
+              'private-decorated-accessor-property',
+              'property',
+              'constructor',
+              'decorated-method',
+              'unknown',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts class members with partition comments', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            // Region: Table
+            protected onChangeColumns() {}
+
+            protected onPaginationChanged() {}
+
+            protected onSortChanged() {}
+
+            protected updateTable() {}
+
+            // Region: Form
+            protected clearForm() {}
+
+            protected disableForm() {}
+
+            // Regular Comment
+            protected onValueChanged() {}
+
+            protected setFormValue() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Region:',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'onSortChanged',
+              left: 'updateTable',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'onPaginationChanged',
+              left: 'onSortChanged',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'onValueChanged',
+              left: 'setFormValue',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            // Region: Table
+            protected onChangeColumns() {}
+
+            protected onPaginationChanged() {}
+
+            protected onSortChanged() {}
+
+            protected updateTable() {}
+
+            // Region: Form
+            protected clearForm() {}
+
+            protected disableForm() {}
+
+            // Regular Comment
+            protected onValueChanged() {}
+
+            protected setFormValue() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            // Region: Table
+            protected onChangeColumns() {}
+
+            protected updateTable() {}
+
+            protected onSortChanged() {}
+
+            protected onPaginationChanged() {}
+
+            // Region: Form
+            protected clearForm() {}
+
+            protected disableForm() {}
+
+            protected setFormValue() {}
+
+            // Regular Comment
+            protected onValueChanged() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Region:',
+          },
+        ],
+      })
+    })
+
+    it('does not sort properties if the right value depends on the left value', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 'b'
+
+            aaa = [this.b]
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 'b'
+
+            getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static c = 'c'
+
+            b = Example.c
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            #b = 'b'
+
+            getAaa() {
+              return this.#b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 'b'
+
+            static getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = 'b'
+
+            aaa = [this.b]
+          }
+        `,
+        code: dedent`
+          class Class {
+            aaa = [this.b]
+
+            b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              left: 'getAaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = 'b'
+
+            getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            getAaa() {
+              return this.b;
+            }
+
+            b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'property',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static c = 'c'
+
+            b = Example.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = Example.c
+
+            static c = 'c'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-property',
+              leftGroup: 'method',
+              left: 'getAaa',
+              right: '#b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            #b = 'b'
+
+            getAaa() {
+              return this.#b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            getAaa() {
+              return this.#b;
+            }
+
+            #b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'static-method',
+              left: 'getAaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static b = 'b'
+
+            static getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            static getAaa() {
+              return this.b;
+            }
+
+            static b = 'b'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            a = this.b()
+            static a = this.b()
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            a = this.b()
+            static a = Class.b()
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            a = [1].map(this.b)
+            static a = [1].map(this.b)
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            a = [1].map(this.b)
+            static a = [1].map(Class.b)
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class MyClass {
+            a = () => this.b()
+            b = () => null
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function property dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = () => {
+              return 1
+            }
+            a = this.b()
+            static b = () => {
+              return 1
+            }
+            static a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = function() {
+              return 1
+            }
+            a = this.b()
+            static b = function() {
+              return 1
+            }
+            static a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = () => {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = () => {
+              return 1
+            }
+            static a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = function() {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = function() {
+              return 1
+            }
+            static a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = () => {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = () => {
+              return 1
+            }
+            static a = [1].map(Class.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = function() {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = function() {
+              return 1
+            }
+            static a = [1].map(Class.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            querystring = createQueryString();
+            state = createState((set) => {
+                set('query', this.queryString.value);
+             });
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+    })
+
+    it('detects static block dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static {
+              return true || OtherClass.z;
+            }
+            static z = true;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static z = true;
+            static {
+              const method = () => {
+                return (Class.z || true) && (false || this.z);
+              };
+              method();
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static z = true;
+            static {
+              const method = () => {
+                return (Class.z || true) && (false || this.z);
+              };
+              method();
+              return (Class.z || true) && (false || this.z);
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+    })
+
+    it('detects property expression dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'd',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'e',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'z',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 10 + OtherClass.z
+
+            static z = 1
+
+            b = 10 + Class.z
+
+            static c = 10 + this.z
+
+            d = this.b
+
+            static e = 10 + this.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            static e = 10 + this.c
+
+            d = this.b
+
+            static a = 10 + OtherClass.z
+
+            b = 10 + Class.z
+
+            static c = 10 + this.z
+
+            static z = 1
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            c = 10
+            a = this.c
+            b = 10
+          }
+        `,
+        code: dedent`
+          class Class {
+            a = this.c
+            b = 10
+            c = 10
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in objects', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              b: this.b
+            }
+            static b = 1
+            static a = {
+              b: this.b
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              b: this.b
+            }
+            static b = 1
+            static a = {
+              b: Class.b
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              [this.b]: 1
+            }
+            static b = 1
+            static a = {
+              [this.b]: A
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              [this.b]: 1
+            }
+            static b = 1
+            static a = {
+              [Class.b]: 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects nested property references', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b.asObservable()
+            static b = new Subject()
+            static a = this.b.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b.asObservable()
+            static b = new Subject()
+            static a = Class.b.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new WhateverObject()
+            a = this.b.bProperty
+            static b = new WhateverObject()
+            static a = this.b.bProperty
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new WhateverObject()
+            a = this.b.bProperty
+            static b = new WhateverObject()
+            static a = Class.b.bProperty
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static c = 1
+            static b = new WhateverObject(this.c)
+            static a = Class.b.bMethod().anotherNestedMethod(this.c).finalMethod()
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chained dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b?.asObservable()
+            static b = new Subject()
+            static a = this.b?.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b?.asObservable()
+            static b = new Subject()
+            static a = Class.b?.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects non-null asserted dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b!.asObservable()
+            static b = new Subject()
+            static a = this.b!.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b!.asObservable()
+            static b = new Subject()
+            static a = Class.b!.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects unary dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = true
+            a = !this.b
+            static b = true
+            static a = !this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = true
+            a = !this.b
+            static b = true
+            static a = !Class.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects spread elements dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = {}
+            a = {...this.b}
+            static b = {}
+            static a = {...this.b}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = {}
+            a = {...this.b}
+            static b = {}
+            static a = {...Class.b}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = []
+            a = [...this.b]
+            static b = []
+            static a = [...this.b]
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = []
+            a = [...this.b]
+            static b = []
+            static a = [...Class.b]
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = this.b ? 1 : 0;
+            static b = 1;
+            static a = this.b ? 1 : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = this.b ? 1 : 0;
+            static b = 1;
+            static a = Class.b ? 1 : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? this.b : 0;
+            static b = 1;
+            static a = someCondition ? this.b : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? this.b : 0;
+            static b = 1;
+            static a = someCondition ? Class.b : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? 0 : this.b;
+            static b = 1;
+            static a = someCondition ? 0 : this.b;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? 0 : this.b;
+            static b = 1;
+            static a = someCondition ? 0 : Class.b;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it("detects dependencies in 'as' expressions", async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = this.b as any
+            static b = 1
+            static a = this.b as any
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = this.b as any
+            static b = 1
+            static a = Class.b as any
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in type assertion expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = <any>this.b
+            static b = 1
+            static a = <any>this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = <any>this.b
+            static b = 1
+            static a = <any>Class.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in template literal expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+           b = 1
+           a = \`\${this.b}\`
+           static b = 1
+           static a = \`\${this.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           b = 1
+           a = \`\${this.b}\`
+           static b = 1
+           static a = \`\${Class.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects # dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+           static a = Class.a
+           static b = 1
+           static #b = 1
+           static #a = this.#b
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           static #b = () => 1
+           static #a = this.#b()
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           static #a = this.#b()
+           static #b() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('separates static from non-static dependencies', async () => {
+      await valid({
+        code: dedent`
+          export class Class{
+            b = 1;
+            a = this.b;
+            static b = 1;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static c = 10
+            static a = Class.c
+            c = 10
+            b = this.c
+            static b = this.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a = Class.c
+            b = this.c
+            static b = this.c
+            c = 10
+            static c = 10
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects and ignores circular dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            b = this.e
+            e = this.g
+            f
+            g = this.b
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.e
+            a
+            e = this.g
+            f
+            g = this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('ignores function body dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static a = true;
+
+            static b() {
+               return this.a || Class.a
+            }
+
+            static c = () => {
+               return this.a || Class.a
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['method', 'property']],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['private-property', 'public-property'],
+          },
+        ],
+        code: dedent`
+          class Class {
+            public b = 1;
+            private a = this.b;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partitionByComment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            // Part1
+            b = this.a
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.a
+            // Part1
+            a
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over partitionByNewLine', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+
+            b = this.a
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.a
+
+            a
+          }
+        `,
+      })
+    })
+
+    it('works with left and right dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            left = 'left'
+            right = 'right'
+
+            aaa = this.left + this.right
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'left',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'right',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            left = 'left'
+
+            right = 'right'
+
+            aaa = this.left + this.right
+          }
+        `,
+        code: dedent`
+          class Class {
+            aaa = this.left + this.right
+
+            left = 'left'
+
+            right = 'right'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['computed function pattern as string', '^computed$'],
+      ['computed function pattern in array', ['noMatch', '^computed$']],
+      [
+        'computed function pattern as object',
+        { pattern: '^COMPUTED$', flags: 'i' },
       ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}: allows to use regex for element names in custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    elementNamePattern: '^(?!.*Foo).*$',
-                    groupName: 'elementsWithoutFoo',
-                  },
-                ],
-                groups: ['unknown', 'elementsWithoutFoo'],
-                type: 'alphabetical',
-              },
-            ],
-            code: dedent`
-              class Class {
-                iHaveFooInMyName: string
-                meTooIHaveFoo: string
-                a: string
-                b: string
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: allows to use regex for element values in custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    elementValuePattern: '^(?!.*Foo).*$',
-                    groupName: 'elementsWithoutFoo',
-                  },
-                ],
-                groups: ['unknown', 'elementsWithoutFoo'],
-                type: 'alphabetical',
-              },
-            ],
-            code: dedent`
-              class Class {
-                x = "iHaveFooInMyName"
-                z = "MeTooIHaveFoo"
-                a = "a"
-                b = "b"
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: allows to use regex for decorator names in custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    decoratorNamePattern: '^.*Foo.*$',
-                    groupName: 'decoratorsWithFoo',
-                  },
-                ],
-                groups: ['decoratorsWithFoo', 'unknown'],
-                type: 'alphabetical',
-              },
-            ],
-            code: dedent`
-              class Class {
-                @IHaveFooInMyName
-                x: string
-                @MeTooIHaveFoo
-                y: string
-                a: string
-                b: string
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe('newlinesInside', () => {
-      for (let newlinesInside of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'missedSpacingBetweenClassMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                ],
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'methodsWithNewlinesInside',
-                        selector: 'method',
-                        newlinesInside,
-                      },
-                    ],
-                    groups: ['unknown', 'methodsWithNewlinesInside'],
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    a
-                    b() {}
-
-                    c() {}
-
-                    d() {}
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    a
-                    b() {}
-                    c() {}
-
-
-                    d() {}
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesInside of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'methodsWithoutNewlinesInside',
-                        selector: 'method',
-                        newlinesInside,
-                      },
-                    ],
-                    groups: ['unknown', 'methodsWithoutNewlinesInside'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    a
-
-                    c() {}
-                    d() {}
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    a
-
-                    c() {}
-
-                    d() {}
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesInside of ['always', 1, 'never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}: enforces no newline between overload signatures when newlinesBetween is "${newlinesInside}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'method',
-                      left: 'method',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                  {
-                    data: {
-                      right: 'method',
-                      left: 'method',
-                    },
-                    messageId: 'extraSpacingBetweenClassMembers',
-                  },
-                ],
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'methods',
-                        selector: 'method',
-                        newlinesInside,
-                      },
-                    ],
-                    groups: ['methods'],
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    method(a: string): void {}
-                    method(a: number): void {}
-                    method(a: string | number): void {}
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    method(a: string): void {}
-
-                    method(a: number): void {}
-
-                    method(a: string | number): void {}
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
+      [
+        'computed function pattern as object in array',
+        ['noMatch', { pattern: '^COMPUTED$', flags: 'i' }],
+      ],
+    ])(
+      'ignores callback dependencies matching %s',
+      async (_name, ignoreCallbackDependenciesPatterns) => {
+        await valid({
           code: dedent`
             class Class {
-              b
+              a = computed(() => this.c)
               c
-              a
+              b = notComputed(() => this.c)
             }
           `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+          options: [
+            {
+              ignoreCallbackDependenciesPatterns,
+            },
+          ],
+        })
+      },
+    )
+
+    it('ignores unknown group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'i',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'private-method',
+              rightGroup: 'unknown',
+              right: 'method3',
+              left: 'z',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'unknown',
+              left: 'method3',
+              right: 'y',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'unknown',
+              left: 'method1',
+              right: 'x',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+
+            private x() {}
+            private y() {}
+            public method3() {}
+            private z() {}
+            public method4() {}
+            public method1() {}
+            public i = 'i';
+          }
+        `,
+        code: dedent`
+          class Class {
+
+            public i = 'i';
+            private z() {}
+            public method3() {}
+            private y() {}
+            public method4() {}
+            public method1() {}
+            private x() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['private-method', 'property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'property',
+              rightGroup: 'unknown',
+              right: 'someMethod',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'unknown',
+              left: 'someMethod',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            someMethod() {
+            }
+            b
+          }
+        `,
+        code: dedent`
+          class Class {
+            b
+            someMethod() {
+            }
+            a
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          class Class {
+            _a
+            b
+            _c
+          }
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          class Class {
+            ab
+            a_c
+          }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            你好 = '你好'
+
+            世界 = '世界'
+
+            a = 'a'
+
+            A = 'A'
+
+            b = 'b'
+
+            B = 'B'
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          code: dedent`
+            class Class {
+              a = () => null
+
+
+             y = "y"
+            z = "z"
+
+                b = "b"
+            }
+          `,
+          output: dedent`
+            class Class {
+              a = () => null
+             b = "b"
+            y = "y"
+                z = "z"
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline between overload signatures when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          output: dedent`
+            class Class {
+              method(a: string): void {}
+              method(a: number): void {}
+              method(a: string | number): void {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              method(a: string): void {}
+
+              method(a: number): void {}
+
+              method(a: string | number): void {}
+            }
+          `,
+          options: [
+            {
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles "newlinesBetween" between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          class Class {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
               customGroups: [
-                {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
-                },
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
               ],
-              groups: ['b', 'a'],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                right: 'b',
+                left: 'a',
               },
-              messageId: 'unexpectedClassesGroupOrder',
+              messageId: 'missedSpacingBetweenClassMembers',
             },
           ],
           output: dedent`
             class Class {
-              ba
-              bb
-              ab
-              aa
+              a: string
+
+
+              b: string
             }
           `,
           code: dedent`
             class Class {
-              ab
-              aa
-              ba
-              bb
+              a: string
+              b: string
             }
           `,
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'enforces no newline if the global option is %s and "newlinesBetween: never" exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            class Class {
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'] as const,
+      ['ignore', 0] as const,
+      ['never', 'ignore'] as const,
+      [0, 'ignore'] as const,
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            class Class {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            class Class {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a // Comment after
+
+            b() {}
+            c() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b() {}
+            a // Comment after
+
+            c() {}
+          }
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
@@ -8755,1287 +4303,11775 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+
+              // Partition comment
+
+              b
+              c
+            }
+          `,
+          code: dedent`
+            class Class {
+              a
+
+              // Partition comment
+
+              c
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline non-abstract methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a(){} b(){}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){} a(){}
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a(){} b(){};
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){} a(){};
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a(){}; b(){}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){}; a(){}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline abstract methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract a(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract a()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract a(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract a();
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline declare class methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          declare class Class {
+            a(); b();
+          }
+        `,
+        code: dedent`
+          declare class Class {
+            b(); a()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract a(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract a();
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline properties correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a; b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            b; a
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a; b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            b; a;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline accessors correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            accessor a; accessor b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            accessor b; accessor a
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            accessor a; accessor b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            accessor b; accessor a;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline index-signatures correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: number]',
+              left: '[key: string]',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            [key: number]: string; [key: string]: string;
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key: string]: string; [key: number]: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: number]',
+              left: '[key: string]',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            [key: number]: string; [key: string]: string;
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key: string]: string; [key: number]: string;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline static-block correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-block',
+              leftGroup: 'property',
+              right: 'static',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static {} a;
+          }
+        `,
+        code: dedent`
+          class Class {
+            a; static {}
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts class members', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            a
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-property',
+              'protected-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'static-protected-method',
+              'protected-method',
+              'private-method',
+              'method',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            d = 'd'
+
+            e = 'e'
+
+            constructor() {}
+
+            static f() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-property',
+              'protected-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'static-protected-method',
+              'protected-method',
+              'private-method',
+              'method',
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-method',
+              rightGroup: 'constructor',
+              right: 'constructor',
+              left: 'f',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            d = 'd'
+
+            e = 'e'
+
+            constructor() {}
+
+            static f() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            e = 'e'
+
+            d = 'd'
+
+            static f() {}
+
+            constructor() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+      })
+    })
+
+    it('sorts complex official groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'public-optional-async-method',
+              rightGroup: 'public-optional-property',
+              right: 'o',
+              left: 'p',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'public-optional-property',
+              rightGroup: 'static-block',
+              right: 'static',
+              left: 'o',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-readonly-index-signature',
+              right: 'static readonly [key: string]',
+              leftGroup: 'static-block',
+              left: 'static',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-readonly-index-signature',
+              left: 'static readonly [key: string]',
+              rightGroup: 'async-function-property',
+              right: 'n',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: 'm',
+              left: 'n',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'declare-private-static-readonly-property',
+              leftGroup: 'async-function-property',
+              right: 'l',
+              left: 'm',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'declare-private-static-readonly-property',
+              rightGroup: 'private-property',
+              right: 'k',
+              left: 'l',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-property',
+              leftGroup: 'private-property',
+              right: 'j',
+              left: 'k',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-property',
+              rightGroup: 'public-property',
+              right: 'i',
+              left: 'j',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-readonly-property',
+              leftGroup: 'public-property',
+              right: 'h',
+              left: 'i',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-readonly-property',
+              leftGroup: 'private-readonly-property',
+              right: 'g',
+              left: 'h',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-readonly-property',
+              rightGroup: 'public-readonly-property',
+              right: 'f',
+              left: 'g',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-private-override-readonly-property',
+              leftGroup: 'public-readonly-property',
+              right: 'e',
+              left: 'f',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-protected-override-readonly-property',
+              leftGroup: 'static-private-override-readonly-property',
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-protected-override-readonly-property',
+              rightGroup: 'static-public-override-readonly-property',
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup:
+                'protected-abstract-override-readonly-decorated-property',
+              leftGroup: 'static-public-override-readonly-property',
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup:
+                'protected-abstract-override-readonly-decorated-property',
+              rightGroup:
+                'public-abstract-override-readonly-decorated-property',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'public-abstract-override-readonly-decorated-property',
+              'protected-abstract-override-readonly-decorated-property',
+              'static-public-override-readonly-property',
+              'static-protected-override-readonly-property',
+              'static-private-override-readonly-property',
+              'public-readonly-property',
+              'protected-readonly-property',
+              'private-readonly-property',
+              'public-property',
+              'protected-property',
+              'private-property',
+              'declare-private-static-readonly-property',
+              'async-function-property',
+              'static-readonly-index-signature',
+              'static-block',
+              'public-optional-property',
+              'public-optional-async-method',
+            ],
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+
+            @Decorator
+            abstract override readonly a;
+
+            @Decorator
+            protected abstract override readonly b;
+
+            static override readonly c = 'c';
+
+            protected static override readonly d = 'd';
+
+            private static override readonly e = 'e';
+
+            public readonly f = 'f';
+
+            protected readonly g = 'g';
+
+            private readonly h = 'h';
+
+            public i = 'i';
+
+            protected j = 'j';
+
+            private k = 'k';
+
+            declare private static readonly l;
+
+            private m = async () => {};
+
+            private n = async function() {};
+
+            static readonly [key: string]: string;
+
+            static {}
+
+            o?;
+
+            async p?(): Promise<void>;
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+
+            async p?(): Promise<void>;
+
+            o?;
+
+            static {}
+
+            static readonly [key: string]: string;
+
+            private n = async function() {};
+
+            private m = async () => {};
+
+            declare private static readonly l;
+
+            private k = 'k';
+
+            protected j = 'j';
+
+            public i = 'i';
+
+            private readonly h = 'h';
+
+            protected readonly g = 'g';
+
+            public readonly f = 'f';
+
+            private static override readonly e = 'e';
+
+            protected static override readonly d = 'd';
+
+            static override readonly c = 'c';
+
+            @Decorator
+            protected abstract override readonly b;
+
+            @Decorator
+            abstract override readonly a;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'public-abstract-override-method',
+              rightGroup: 'get-method',
+              right: 'fields',
+              left: 'method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            public abstract override get fields(): string;
+
+            public abstract override method(): string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            public abstract override method(): string;
+
+            public abstract override get fields(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['get-method', 'public-abstract-override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes static over readonly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'static readonly [key: string]',
+              rightGroup: 'static-index-signature',
+              leftGroup: 'property',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-index-signature',
+              'property',
+              'readonly-index-signature',
+            ],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            static readonly [key: string]: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a: string;
+
+            static readonly [key: string]: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes constructor over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'constructor',
+              right: 'constructor',
+              leftGroup: 'method',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            constructor() {}
+
+            a(): void;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            constructor() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['constructor', 'method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes get-method over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'get-method',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            get z() {}
+
+            a(): void;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['get-method', 'method'],
+          },
+        ],
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            get z() {}
+          }
+        `,
+      })
+    })
+
+    it('prioritizes set-method over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'set-method',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            set z() {}
+
+            a(): void;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['set-method', 'method'],
+          },
+        ],
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            set z() {}
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            static override z(): string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a: string;
+
+            static override z(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['static-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes abstract over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override z(): string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            abstract override z(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['abstract-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes decorated over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override z(): void {}
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            @Decorator
+            override z(): void {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['decorated-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes override over %s accessibility',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'override-method',
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'override-method',
+                'property',
+                `${accessibilityModifier}-method`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} override z(): string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} override z(): string;
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes %s accessibility over optional',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: `${accessibilityModifier}-method`,
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                `${accessibilityModifier}-method`,
+                'property',
+                'optional-method',
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} z?(): string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} z?(): string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes optional over async', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'optional-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['optional-method', 'property', 'async-method'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            async z?(): Promise<string>;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a: string;
+
+            async z?(): Promise<string>;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            static override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a: string;
+
+            static override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes abstract over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'abstract-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            abstract override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes decorated over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            @Decorator
+            override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes override over %s accessibility for accessor properties',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'override-accessor-property',
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'override-accessor-property',
+                'property',
+                `${accessibilityModifier}-accessor-property`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} override accessor z: string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} override accessor z: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes function property over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function-property',
+              rightGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'function-property'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z: string;
+
+            a = function() {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a = function() {}
+
+            z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes function property over property for arrow functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function-property',
+              rightGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'function-property'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z: string;
+
+            a = () => {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a = () => {}
+
+            z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over declare', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            declare static z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a(): void {}
+
+            declare static z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['static-property', 'method', 'declare-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes declare over abstract', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            declare abstract z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a(): void {}
+
+            declare abstract z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['declare-property', 'method', 'abstract-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes abstract over override for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            abstract override z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['abstract-property', 'method', 'override-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes decorated over override for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            @Decorator
+            override z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['decorated-property', 'method', 'override-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes override over readonly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'override-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            override readonly z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            override readonly z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['override-property', 'method', 'readonly-property'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes readonly over %s accessibility',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'readonly-property',
+                leftGroup: 'method',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'readonly-property',
+                'method',
+                `${accessibilityModifier}-property`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} readonly z: string;
+
+              a(): void {}
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a(): void {}
+
+              ${accessibilityModifier} readonly z: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes %s accessibility over optional for properties',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: `${accessibilityModifier}-property`,
+                leftGroup: 'method',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                `${accessibilityModifier}-property`,
+                'method',
+                'optional-property',
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} z?: string;
+
+              a(): void {}
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a(): void {}
+
+              ${accessibilityModifier} z?: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes optional over async for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'optional-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z?: Promise<string> = async () => {};
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a(): void {}
+
+            z?: Promise<string> = async () => {};
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['optional-property', 'method', 'async-property'],
+          },
+        ],
+      })
+    })
+
+    it('sorts class and group members', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+              ['static-method', 'private-method', 'method'],
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static a
+
+            static b = 'b'
+
+            [key in O]
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'key in O',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+              ['static-method', 'private-method', 'method'],
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a
+
+            static b = 'b'
+
+            [key in O]
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key in O]
+
+            static b = 'b'
+
+            static a
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+      })
+    })
+
+    it('sorts class with attributes having the same name', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'static-property',
+              rightGroup: 'property',
+              right: 'a',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'static-property'],
+          },
+        ],
+        output: dedent`
+          class Class {
+            a;
+
+            static a;
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a;
+
+            a;
+          }
+        `,
+      })
+    })
+
+    it('sorts class with ts index signatures', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static a = 'a';
+
+            [k: string]: any;
+
+            [k: string];
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'index-signature',
+              left: '[k: string];',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'index-signature',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 'a';
+
+            [k: string]: any;
+
+            [k: string];
+          }
+        `,
+        code: dedent`
+          class Class {
+            [k: string]: any;
+
+            [k: string];
+
+            static a = 'a';
+          }
+        `,
+      })
+    })
+
+    it('allows multiple method signatures', async () => {
+      await valid({
+        code: dedent`
+          class Decorations {
+            setBackground(color: number, hexFlag: boolean): this
+            setBackground(color: Color | string | CSSColor): this
+            setBackground(r: number, g: number, b: number, a?: number): this
+            setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
+                /* ... */
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts private methods with hash', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-property',
+              left: '#aPrivateStaticMethod',
+              right: '#somePrivateProperty',
+              leftGroup: 'static-method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: '#someOtherPrivateProperty',
+              left: '#somePrivateProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              left: '#someOtherPrivateProperty',
+              leftGroup: 'private-property',
+              rightGroup: 'static-property',
+              right: 'someStaticProperty',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: '#someStaticPrivateProperty',
+              left: 'someStaticProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: '#aPrivateInstanceMethod',
+              rightGroup: 'private-method',
+              leftGroup: 'static-method',
+              left: 'aStaticMethod',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class MyUnsortedClass {
+            static #someStaticPrivateProperty = 4
+
+            static someStaticProperty = 3
+
+            #someOtherPrivateProperty = 2
+
+            #somePrivateProperty
+
+            someOtherProperty
+
+            someProperty = 1
+
+            constructor() {}
+
+            aInstanceMethod () {}
+
+            #aPrivateInstanceMethod () {}
+
+            static #aPrivateStaticMethod () {}
+
+            static aStaticMethod () {}
+          }
+        `,
+        code: dedent`
+          class MyUnsortedClass {
+            someOtherProperty
+
+            someProperty = 1
+
+            constructor() {}
+
+            static #aPrivateStaticMethod () {}
+
+            #somePrivateProperty
+
+            #someOtherPrivateProperty = 2
+
+            static someStaticProperty = 3
+
+            static #someStaticPrivateProperty = 4
+
+            aInstanceMethod () {}
+
+            static aStaticMethod () {}
+
+            #aPrivateInstanceMethod () {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-property',
+              'private-property',
+              'property',
+              'constructor',
+              'method',
+              'private-method',
+              'static-method',
+              'unknown',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('allows split methods with getters and setters', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'index-signature',
+              'static-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'private-method',
+              'method',
+              ['get-method', 'set-method'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'x',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'z',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class A {
+            b() {}
+            x() {}
+            get c() {}
+            set c() {}
+            get z() {}
+          }
+        `,
+        code: dedent`
+          class A {
+            x() {}
+            b() {}
+            get z() {}
+            get c() {}
+            set c() {}
+          }
+        `,
+      })
+    })
+
+    it('sorts decorated properties', async () => {
+      await invalid({
+        output: dedent`
+          class User {
+            firstName: string
+
+            id: number
+
+            lastName: string
+
+            @Index({ name: 'born_index' })
+            @Property()
+            born: string
+
+            @Property()
+            @Unique()
+            email: string
+          }
+        `,
+        code: dedent`
+          class User {
+            firstName: string
+
+            id: number
+
+            @Index({ name: 'born_index' })
+            @Property()
+            born: string
+
+            @Property()
+            @Unique()
+            email: string
+
+            lastName: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              leftGroup: 'decorated-property',
+              rightGroup: 'property',
+              right: 'lastName',
+              left: 'email',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'decorated-property', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        output: dedent`
+          class MyElement {
+            @property({ attribute: false })
+            data = {}
+
+            @property()
+            greeting: string = 'Hello'
+
+            @property()
+            protected type = ''
+
+            @state()
+            private _counter = 0
+
+            private _message = ''
+
+            private _prop = 0
+
+            constructor() {}
+
+            @property()
+            get message(): string {
+              return this._message
+            }
+
+            @property()
+            set prop(val: number) {
+              this._prop = Math.floor(val)
+            }
+
+            set message(message: string) {
+              this._message = message
+            }
+
+            get prop() {
+              return this._prop
+            }
+
+            render() {}
+          }
+        `,
+        code: dedent`
+          class MyElement {
+            @property({ attribute: false })
+            data = {}
+
+            @property()
+            greeting: string = 'Hello'
+
+            @property()
+            protected type = ''
+
+            @state()
+            private _counter = 0
+
+            private _message = ''
+
+            private _prop = 0
+
+            constructor() {}
+
+            @property()
+            get message(): string {
+              return this._message
+            }
+
+            set message(message: string) {
+              this._message = message
+            }
+
+            @property()
+            set prop(val: number) {
+              this._prop = Math.floor(val)
+            }
+
+            get prop() {
+              return this._prop
+            }
+
+            render() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-property',
+              'property',
+              'protected-decorated-property',
+              'private-decorated-property',
+              'private-property',
+              'constructor',
+              ['decorated-get-method', 'decorated-set-method'],
+              ['get-method', 'set-method'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-set-method',
+              leftGroup: 'set-method',
+              left: 'message',
+              right: 'prop',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+      })
+    })
+
+    it('sorts decorated accessors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-decorated-accessor-property',
+              leftGroup: 'decorated-method',
+              right: '#active',
+              left: 'toggle',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'private-decorated-accessor-property',
+              rightGroup: 'decorated-accessor-property',
+              right: 'finished',
+              left: '#active',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Todo {
+            @observable
+            accessor finished = false
+
+            @observable
+            accessor title = ''
+
+            @observable
+            protected accessor type = ''
+
+            @observable
+            accessor #active = false
+
+            id = Math.random()
+
+            constructor() {}
+
+            @action
+            toggle() {}
+          }
+        `,
+        code: dedent`
+          class Todo {
+            id = Math.random()
+
+            constructor() {}
+
+            @action
+            toggle() {}
+
+            @observable
+            accessor #active = false
+
+            @observable
+            accessor finished = false
+
+            @observable
+            accessor title = ''
+
+            @observable
+            protected accessor type = ''
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-accessor-property',
+              'protected-decorated-accessor-property',
+              'private-decorated-accessor-property',
+              'property',
+              'constructor',
+              'decorated-method',
+              'unknown',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts class members with partition comments', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            // Region: Table
+            protected onChangeColumns() {}
+
+            protected onPaginationChanged() {}
+
+            protected onSortChanged() {}
+
+            protected updateTable() {}
+
+            // Region: Form
+            protected clearForm() {}
+
+            protected disableForm() {}
+
+            // Regular Comment
+            protected onValueChanged() {}
+
+            protected setFormValue() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Region:',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'onSortChanged',
+              left: 'updateTable',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'onPaginationChanged',
+              left: 'onSortChanged',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'onValueChanged',
+              left: 'setFormValue',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            // Region: Table
+            protected onChangeColumns() {}
+
+            protected onPaginationChanged() {}
+
+            protected onSortChanged() {}
+
+            protected updateTable() {}
+
+            // Region: Form
+            protected clearForm() {}
+
+            protected disableForm() {}
+
+            // Regular Comment
+            protected onValueChanged() {}
+
+            protected setFormValue() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            // Region: Table
+            protected onChangeColumns() {}
+
+            protected updateTable() {}
+
+            protected onSortChanged() {}
+
+            protected onPaginationChanged() {}
+
+            // Region: Form
+            protected clearForm() {}
+
+            protected disableForm() {}
+
+            protected setFormValue() {}
+
+            // Regular Comment
+            protected onValueChanged() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Region:',
+          },
+        ],
+      })
+    })
+
+    it('does not sort properties if the right value depends on the left value', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 'b'
+
+            aaa = [this.b]
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 'b'
+
+            getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static c = 'c'
+
+            b = Example.c
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            #b = 'b'
+
+            getAaa() {
+              return this.#b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 'b'
+
+            static getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = 'b'
+
+            aaa = [this.b]
+          }
+        `,
+        code: dedent`
+          class Class {
+            aaa = [this.b]
+
+            b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              left: 'getAaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = 'b'
+
+            getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            getAaa() {
+              return this.b;
+            }
+
+            b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'property',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static c = 'c'
+
+            b = Example.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = Example.c
+
+            static c = 'c'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-property',
+              leftGroup: 'method',
+              left: 'getAaa',
+              right: '#b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            #b = 'b'
+
+            getAaa() {
+              return this.#b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            getAaa() {
+              return this.#b;
+            }
+
+            #b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'static-method',
+              left: 'getAaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static b = 'b'
+
+            static getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            static getAaa() {
+              return this.b;
+            }
+
+            static b = 'b'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            a = this.b()
+            static a = this.b()
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            a = this.b()
+            static a = Class.b()
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            a = [1].map(this.b)
+            static a = [1].map(this.b)
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            a = [1].map(this.b)
+            static a = [1].map(Class.b)
+            b() {
+              return 1
+            }
+            static b() {
+              return 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class MyClass {
+            a = () => this.b()
+            b = () => null
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function property dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = () => {
+              return 1
+            }
+            a = this.b()
+            static b = () => {
+              return 1
+            }
+            static a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = function() {
+              return 1
+            }
+            a = this.b()
+            static b = function() {
+              return 1
+            }
+            static a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = () => {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = () => {
+              return 1
+            }
+            static a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = function() {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = function() {
+              return 1
+            }
+            static a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = () => {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = () => {
+              return 1
+            }
+            static a = [1].map(Class.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = function() {
+              return 1
+            }
+            a = [1].map(this.b)
+            static b = function() {
+              return 1
+            }
+            static a = [1].map(Class.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            querystring = createQueryString();
+            state = createState((set) => {
+                set('query', this.queryString.value);
+             });
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+    })
+
+    it('detects static block dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static {
+              return true || OtherClass.z;
+            }
+            static z = true;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static z = true;
+            static {
+              const method = () => {
+                return (Class.z || true) && (false || this.z);
+              };
+              method();
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static z = true;
+            static {
+              const method = () => {
+                return (Class.z || true) && (false || this.z);
+              };
+              method();
+              return (Class.z || true) && (false || this.z);
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+    })
+
+    it('detects property expression dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'd',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'e',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'z',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 10 + OtherClass.z
+
+            static z = 1
+
+            b = 10 + Class.z
+
+            static c = 10 + this.z
+
+            d = this.b
+
+            static e = 10 + this.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            static e = 10 + this.c
+
+            d = this.b
+
+            static a = 10 + OtherClass.z
+
+            b = 10 + Class.z
+
+            static c = 10 + this.z
+
+            static z = 1
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            c = 10
+            a = this.c
+            b = 10
+          }
+        `,
+        code: dedent`
+          class Class {
+            a = this.c
+            b = 10
+            c = 10
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in objects', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              b: this.b
+            }
+            static b = 1
+            static a = {
+              b: this.b
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              b: this.b
+            }
+            static b = 1
+            static a = {
+              b: Class.b
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              [this.b]: 1
+            }
+            static b = 1
+            static a = {
+              [this.b]: A
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = {
+              [this.b]: 1
+            }
+            static b = 1
+            static a = {
+              [Class.b]: 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects nested property references', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b.asObservable()
+            static b = new Subject()
+            static a = this.b.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b.asObservable()
+            static b = new Subject()
+            static a = Class.b.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new WhateverObject()
+            a = this.b.bProperty
+            static b = new WhateverObject()
+            static a = this.b.bProperty
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new WhateverObject()
+            a = this.b.bProperty
+            static b = new WhateverObject()
+            static a = Class.b.bProperty
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static c = 1
+            static b = new WhateverObject(this.c)
+            static a = Class.b.bMethod().anotherNestedMethod(this.c).finalMethod()
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chained dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b?.asObservable()
+            static b = new Subject()
+            static a = this.b?.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b?.asObservable()
+            static b = new Subject()
+            static a = Class.b?.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects non-null asserted dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b!.asObservable()
+            static b = new Subject()
+            static a = this.b!.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = new Subject()
+            a = this.b!.asObservable()
+            static b = new Subject()
+            static a = Class.b!.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects unary dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = true
+            a = !this.b
+            static b = true
+            static a = !this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = true
+            a = !this.b
+            static b = true
+            static a = !Class.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects spread elements dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = {}
+            a = {...this.b}
+            static b = {}
+            static a = {...this.b}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = {}
+            a = {...this.b}
+            static b = {}
+            static a = {...Class.b}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = []
+            a = [...this.b]
+            static b = []
+            static a = [...this.b]
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = []
+            a = [...this.b]
+            static b = []
+            static a = [...Class.b]
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = this.b ? 1 : 0;
+            static b = 1;
+            static a = this.b ? 1 : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = this.b ? 1 : 0;
+            static b = 1;
+            static a = Class.b ? 1 : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? this.b : 0;
+            static b = 1;
+            static a = someCondition ? this.b : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? this.b : 0;
+            static b = 1;
+            static a = someCondition ? Class.b : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? 0 : this.b;
+            static b = 1;
+            static a = someCondition ? 0 : this.b;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1;
+            a = someCondition ? 0 : this.b;
+            static b = 1;
+            static a = someCondition ? 0 : Class.b;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it("detects dependencies in 'as' expressions", async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = this.b as any
+            static b = 1
+            static a = this.b as any
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = this.b as any
+            static b = 1
+            static a = Class.b as any
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in type assertion expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = <any>this.b
+            static b = 1
+            static a = <any>this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 1
+            a = <any>this.b
+            static b = 1
+            static a = <any>Class.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in template literal expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+           b = 1
+           a = \`\${this.b}\`
+           static b = 1
+           static a = \`\${this.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           b = 1
+           a = \`\${this.b}\`
+           static b = 1
+           static a = \`\${Class.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects # dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+           static a = Class.a
+           static b = 1
+           static #b = 1
+           static #a = this.#b
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           static #b = () => 1
+           static #a = this.#b()
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           static #a = this.#b()
+           static #b() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('separates static from non-static dependencies', async () => {
+      await valid({
+        code: dedent`
+          export class Class{
+            b = 1;
+            a = this.b;
+            static b = 1;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static c = 10
+            static a = Class.c
+            c = 10
+            b = this.c
+            static b = this.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a = Class.c
+            b = this.c
+            static b = this.c
+            c = 10
+            static c = 10
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects and ignores circular dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            b = this.e
+            e = this.g
+            f
+            g = this.b
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.e
+            a
+            e = this.g
+            f
+            g = this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('ignores function body dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static a = true;
+
+            static b() {
+               return this.a || Class.a
+            }
+
+            static c = () => {
+               return this.a || Class.a
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['method', 'property']],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['private-property', 'public-property'],
+          },
+        ],
+        code: dedent`
+          class Class {
+            public b = 1;
+            private a = this.b;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partitionByComment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            // Part1
+            b = this.a
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.a
+            // Part1
+            a
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over partitionByNewLine', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+
+            b = this.a
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.a
+
+            a
+          }
+        `,
+      })
+    })
+
+    it('works with left and right dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            left = 'left'
+            right = 'right'
+
+            aaa = this.left + this.right
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'left',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'right',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            left = 'left'
+
+            right = 'right'
+
+            aaa = this.left + this.right
+          }
+        `,
+        code: dedent`
+          class Class {
+            aaa = this.left + this.right
+
+            left = 'left'
+
+            right = 'right'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['computed function pattern as string', '^computed$'],
+      ['computed function pattern in array', ['noMatch', '^computed$']],
+      [
+        'computed function pattern as object',
+        { pattern: '^COMPUTED$', flags: 'i' },
+      ],
+      [
+        'computed function pattern as object in array',
+        ['noMatch', { pattern: '^COMPUTED$', flags: 'i' }],
+      ],
+    ])(
+      'ignores callback dependencies matching %s',
+      async (_name, ignoreCallbackDependenciesPatterns) => {
+        await valid({
+          code: dedent`
+            class Class {
+              a = computed(() => this.c)
+              c
+              b = notComputed(() => this.c)
+            }
+          `,
+          options: [
+            {
+              ignoreCallbackDependenciesPatterns,
+            },
+          ],
+        })
+      },
+    )
+
+    it('ignores unknown group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'i',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'private-method',
+              rightGroup: 'unknown',
+              right: 'method3',
+              left: 'z',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'unknown',
+              left: 'method3',
+              right: 'y',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'unknown',
+              left: 'method1',
+              right: 'x',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+
+            private x() {}
+            private y() {}
+            public method3() {}
+            private z() {}
+            public method4() {}
+            public method1() {}
+            public i = 'i';
+          }
+        `,
+        code: dedent`
+          class Class {
+
+            public i = 'i';
+            private z() {}
+            public method3() {}
+            private y() {}
+            public method4() {}
+            public method1() {}
+            private x() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['private-method', 'property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'property',
+              rightGroup: 'unknown',
+              right: 'someMethod',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'unknown',
+              left: 'someMethod',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            someMethod() {
+            }
+            b
+          }
+        `,
+        code: dedent`
+          class Class {
+            b
+            someMethod() {
+            }
+            a
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          class Class {
+            _a
+            b
+            _c
+          }
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          class Class {
+            ab
+            a_c
+          }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            你好 = '你好'
+
+            世界 = '世界'
+
+            a = 'a'
+
+            A = 'A'
+
+            b = 'b'
+
+            B = 'B'
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          code: dedent`
+            class Class {
+              a = () => null
+
+
+             y = "y"
+            z = "z"
+
+                b = "b"
+            }
+          `,
+          output: dedent`
+            class Class {
+              a = () => null
+             b = "b"
+            y = "y"
+                z = "z"
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline between overload signatures when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          output: dedent`
+            class Class {
+              method(a: string): void {}
+              method(a: number): void {}
+              method(a: string | number): void {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              method(a: string): void {}
+
+              method(a: number): void {}
+
+              method(a: string | number): void {}
+            }
+          `,
+          options: [
+            {
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles "newlinesBetween" between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          class Class {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenClassMembers',
             },
           ],
           output: dedent`
             class Class {
-              b
+              a: string
 
-              a
+
+              b: string
             }
           `,
           code: dedent`
             class Class {
-              b
-              a
+              a: string
+              b: string
             }
           `,
-        },
-      ],
-      valid: [],
-    })
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}(${type}): enforces dependency sorting`, rule, {
-      invalid: [
-        {
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'enforces no newline if the global option is %s and "newlinesBetween: never" exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
           errors: [
             {
               data: {
-                nodeDependentOnRight: 'a',
                 right: 'b',
+                left: 'a',
               },
-              messageId: 'unexpectedClassesDependencyOrder',
+              messageId: 'extraSpacingBetweenClassMembers',
             },
           ],
           output: dedent`
             class Class {
+              a
               b
-              a = this.b
             }
           `,
           code: dedent`
             class Class {
-              a = this.b
+              a
+
               b
             }
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'] as const,
+      ['ignore', 0] as const,
+      ['never', 'ignore'] as const,
+      [0, 'ignore'] as const,
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            class Class {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            class Class {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a // Comment after
+
+            b() {}
+            c() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b() {}
+            a // Comment after
+
+            c() {}
+          }
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+
+              // Partition comment
+
+              b
+              c
+            }
+          `,
+          code: dedent`
+            class Class {
+              a
+
+              // Partition comment
+
+              c
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline non-abstract methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a(){} b(){}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){} a(){}
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a(){} b(){};
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){} a(){};
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a(){}; b(){}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){}; a(){}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline abstract methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract a(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract a()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract a(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract a();
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline declare class methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          declare class Class {
+            a(); b();
+          }
+        `,
+        code: dedent`
+          declare class Class {
+            b(); a()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract a(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract a();
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline properties correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a; b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            b; a
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a; b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            b; a;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline accessors correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            accessor a; accessor b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            accessor b; accessor a
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            accessor a; accessor b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            accessor b; accessor a;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline index-signatures correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: number]',
+              left: '[key: string]',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            [key: number]: string; [key: string]: string;
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key: string]: string; [key: number]: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: number]',
+              left: '[key: string]',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            [key: number]: string; [key: string]: string;
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key: string]: string; [key: number]: string;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline static-block correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-block',
+              leftGroup: 'property',
+              right: 'static',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static {} a;
+          }
+        `,
+        code: dedent`
+          class Class {
+            a; static {}
+          }
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts class members', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            a
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-property',
+              'protected-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'static-protected-method',
+              'protected-method',
+              'private-method',
+              'method',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            d = 'd'
+
+            e = 'e'
+
+            constructor() {}
+
+            static f() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-property',
+              'protected-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'static-protected-method',
+              'protected-method',
+              'private-method',
+              'method',
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            e = 'e'
+
+            d = 'd'
+
+            constructor() {}
+
+            static f() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a = 'a'
+
+            protected b = 'b'
+
+            private c = 'c'
+
+            e = 'e'
+
+            d = 'd'
+
+            static f() {}
+
+            constructor() {}
+
+            protected static g() {}
+
+            protected h() {}
+
+            private i() {}
+
+            j() {}
+
+            k() {}
+          }
+        `,
+        errors: [
+          {
+            data: {
+              leftGroup: 'static-method',
+              rightGroup: 'constructor',
+              right: 'constructor',
+              left: 'f',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+      })
+    })
+
+    it('sorts complex official groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'public-optional-async-method',
+              rightGroup: 'public-optional-property',
+              right: 'o',
+              left: 'p',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'public-optional-property',
+              rightGroup: 'static-block',
+              right: 'static',
+              left: 'o',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-readonly-index-signature',
+              right: 'static readonly [key: string]',
+              leftGroup: 'static-block',
+              left: 'static',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-readonly-index-signature',
+              left: 'static readonly [key: string]',
+              rightGroup: 'async-function-property',
+              right: 'n',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'declare-private-static-readonly-property',
+              leftGroup: 'async-function-property',
+              right: 'l',
+              left: 'm',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'declare-private-static-readonly-property',
+              rightGroup: 'private-property',
+              right: 'k',
+              left: 'l',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-property',
+              leftGroup: 'private-property',
+              right: 'j',
+              left: 'k',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-property',
+              rightGroup: 'public-property',
+              right: 'i',
+              left: 'j',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-readonly-property',
+              leftGroup: 'public-property',
+              right: 'h',
+              left: 'i',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-readonly-property',
+              leftGroup: 'private-readonly-property',
+              right: 'g',
+              left: 'h',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-readonly-property',
+              rightGroup: 'public-readonly-property',
+              right: 'f',
+              left: 'g',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-private-override-readonly-property',
+              leftGroup: 'public-readonly-property',
+              right: 'e',
+              left: 'f',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'static-protected-override-readonly-property',
+              leftGroup: 'static-private-override-readonly-property',
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'static-protected-override-readonly-property',
+              rightGroup: 'static-public-override-readonly-property',
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup:
+                'protected-abstract-override-readonly-decorated-property',
+              leftGroup: 'static-public-override-readonly-property',
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup:
+                'protected-abstract-override-readonly-decorated-property',
+              rightGroup:
+                'public-abstract-override-readonly-decorated-property',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'public-abstract-override-readonly-decorated-property',
+              'protected-abstract-override-readonly-decorated-property',
+              'static-public-override-readonly-property',
+              'static-protected-override-readonly-property',
+              'static-private-override-readonly-property',
+              'public-readonly-property',
+              'protected-readonly-property',
+              'private-readonly-property',
+              'public-property',
+              'protected-property',
+              'private-property',
+              'declare-private-static-readonly-property',
+              'async-function-property',
+              'static-readonly-index-signature',
+              'static-block',
+              'public-optional-property',
+              'public-optional-async-method',
+            ],
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+
+            @Decorator
+            abstract override readonly a;
+
+            @Decorator
+            protected abstract override readonly b;
+
+            static override readonly c = 'c';
+
+            protected static override readonly d = 'd';
+
+            private static override readonly e = 'e';
+
+            public readonly f = 'f';
+
+            protected readonly g = 'g';
+
+            private readonly h = 'h';
+
+            public i = 'i';
+
+            protected j = 'j';
+
+            private k = 'k';
+
+            declare private static readonly l;
+
+            private n = async function() {};
+
+            private m = async () => {};
+
+            static readonly [key: string]: string;
+
+            static {}
+
+            o?;
+
+            async p?(): Promise<void>;
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+
+            async p?(): Promise<void>;
+
+            o?;
+
+            static {}
+
+            static readonly [key: string]: string;
+
+            private n = async function() {};
+
+            private m = async () => {};
+
+            declare private static readonly l;
+
+            private k = 'k';
+
+            protected j = 'j';
+
+            public i = 'i';
+
+            private readonly h = 'h';
+
+            protected readonly g = 'g';
+
+            public readonly f = 'f';
+
+            private static override readonly e = 'e';
+
+            protected static override readonly d = 'd';
+
+            static override readonly c = 'c';
+
+            @Decorator
+            protected abstract override readonly b;
+
+            @Decorator
+            abstract override readonly a;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'public-abstract-override-method',
+              rightGroup: 'get-method',
+              right: 'fields',
+              left: 'method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            public abstract override get fields(): string;
+
+            public abstract override method(): string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            public abstract override method(): string;
+
+            public abstract override get fields(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['get-method', 'public-abstract-override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes static over readonly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'static readonly [key: string]',
+              rightGroup: 'static-index-signature',
+              leftGroup: 'property',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-index-signature',
+              'property',
+              'readonly-index-signature',
+            ],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            static readonly [key: string]: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a: string;
+
+            static readonly [key: string]: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes constructor over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'constructor',
+              right: 'constructor',
+              leftGroup: 'method',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            constructor() {}
+
+            a(): void;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            constructor() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['constructor', 'method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes get-method over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'get-method',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            get z() {}
+
+            a(): void;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['get-method', 'method'],
+          },
+        ],
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            get z() {}
+          }
+        `,
+      })
+    })
+
+    it('prioritizes set-method over method', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'set-method',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            set z() {}
+
+            a(): void;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['set-method', 'method'],
+          },
+        ],
+        code: dedent`
+          export class Class {
+
+            a(): void;
+
+            set z() {}
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            static override z(): string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a: string;
+
+            static override z(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['static-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes abstract over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override z(): string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            abstract override z(): string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['abstract-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes decorated over override', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override z(): void {}
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            @Decorator
+            override z(): void {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['decorated-method', 'property', 'override-method'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes override over %s accessibility',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'override-method',
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'override-method',
+                'property',
+                `${accessibilityModifier}-method`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} override z(): string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} override z(): string;
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes %s accessibility over optional',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: `${accessibilityModifier}-method`,
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                `${accessibilityModifier}-method`,
+                'property',
+                'optional-method',
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} z?(): string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} z?(): string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes optional over async', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'optional-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['optional-method', 'property', 'async-method'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            async z?(): Promise<string>;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a: string;
+
+            async z?(): Promise<string>;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            static override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a: string;
+
+            static override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes abstract over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'abstract-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            abstract override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes decorated over override for accessor properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-accessor-property',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-accessor-property',
+              'property',
+              'override-accessor-property',
+            ],
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override accessor z: string;
+
+            a: string;
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a: string;
+
+            @Decorator
+            override accessor z: string;
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes override over %s accessibility for accessor properties',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'override-accessor-property',
+                leftGroup: 'property',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'override-accessor-property',
+                'property',
+                `${accessibilityModifier}-accessor-property`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} override accessor z: string;
+
+              a: string;
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a: string;
+
+              ${accessibilityModifier} override accessor z: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes function property over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function-property',
+              rightGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'function-property'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z: string;
+
+            a = function() {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a = function() {}
+
+            z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes function property over property for arrow functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function-property',
+              rightGroup: 'property',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'function-property'],
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z: string;
+
+            a = () => {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a = () => {}
+
+            z: string;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes static over declare', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            declare static z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a(): void {}
+
+            declare static z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['static-property', 'method', 'declare-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes declare over abstract', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class extends Class2 {
+
+            declare abstract z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class extends Class2 {
+
+            a(): void {}
+
+            declare abstract z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['declare-property', 'method', 'abstract-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes abstract over override for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'abstract-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            abstract override z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            abstract override z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['abstract-property', 'method', 'override-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes decorated over override for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            @Decorator
+            override z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            @Decorator
+            override z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['decorated-property', 'method', 'override-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes override over readonly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'override-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export abstract class Class extends Class2 {
+
+            override readonly z: string;
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export abstract class Class extends Class2 {
+
+            a(): void {}
+
+            override readonly z: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['override-property', 'method', 'readonly-property'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes readonly over %s accessibility',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'readonly-property',
+                leftGroup: 'method',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                'readonly-property',
+                'method',
+                `${accessibilityModifier}-property`,
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} readonly z: string;
+
+              a(): void {}
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a(): void {}
+
+              ${accessibilityModifier} readonly z: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['public', 'public'],
+      ['protected', 'protected'],
+      ['private', 'private'],
+    ])(
+      'prioritizes %s accessibility over optional for properties',
+      async (_name, accessibilityModifier) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: `${accessibilityModifier}-property`,
+                leftGroup: 'method',
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: [
+                `${accessibilityModifier}-property`,
+                'method',
+                'optional-property',
+              ],
+            },
+          ],
+          output: dedent`
+            export class Class {
+
+              ${accessibilityModifier} z?: string;
+
+              a(): void {}
+            }
+          `,
+          code: dedent`
+            export class Class {
+
+              a(): void {}
+
+              ${accessibilityModifier} z?: string;
+            }
+          `,
+        })
+      },
+    )
+
+    it('prioritizes optional over async for properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'optional-property',
+              leftGroup: 'method',
+              right: 'z',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          export class Class {
+
+            z?: Promise<string> = async () => {};
+
+            a(): void {}
+          }
+        `,
+        code: dedent`
+          export class Class {
+
+            a(): void {}
+
+            z?: Promise<string> = async () => {};
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['optional-property', 'method', 'async-property'],
+          },
+        ],
+      })
+    })
+
+    it('sorts class and group members', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+              ['static-method', 'private-method', 'method'],
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static b = 'b'
+
+            [key in O]
+
+            static a
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+              ['static-method', 'private-method', 'method'],
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            static b = 'b'
+
+            [key in O]
+
+            static a
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key in O]
+
+            static b = 'b'
+
+            static a
+
+            static {
+              this.a = 'd'
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              left: 'key in O',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+      })
+    })
+
+    it('sorts class with attributes having the same name', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'static-property',
+              rightGroup: 'property',
+              right: 'a',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'static-property'],
+          },
+        ],
+        output: dedent`
+          class Class {
+            a;
+
+            static a;
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a;
+
+            a;
+          }
+        `,
+      })
+    })
+
+    it('sorts class with ts index signatures', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+            ],
+          },
+        ],
+        code: dedent`
+          class Class {
+            static a = 'a';
+
+            [k: string]: any;
+
+            [k: string];
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'index-signature',
+              left: '[k: string];',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'index-signature',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 'a';
+
+            [k: string]: any;
+
+            [k: string];
+          }
+        `,
+        code: dedent`
+          class Class {
+            [k: string]: any;
+
+            [k: string];
+
+            static a = 'a';
+          }
+        `,
+      })
+    })
+
+    it('allows multiple method signatures', async () => {
+      await valid({
+        code: dedent`
+          class Decorations {
+            setBackground(color: number, hexFlag: boolean): this
+            setBackground(color: Color | string | CSSColor): this
+            setBackground(r: number, g: number, b: number, a?: number): this
+            setBackground(color: ColorArgument, arg1?: boolean | number, arg2?: number, arg3?: number): this {
+                /* ... */
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              ['static-property', 'private-property', 'property'],
+              'constructor',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts private methods with hash', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-property',
+              left: '#aPrivateStaticMethod',
+              right: '#somePrivateProperty',
+              leftGroup: 'static-method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: '#someOtherPrivateProperty',
+              left: '#somePrivateProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              left: '#someOtherPrivateProperty',
+              leftGroup: 'private-property',
+              rightGroup: 'static-property',
+              right: 'someStaticProperty',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: '#someStaticPrivateProperty',
+              left: 'someStaticProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: '#aPrivateInstanceMethod',
+              rightGroup: 'private-method',
+              leftGroup: 'static-method',
+              left: 'aStaticMethod',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class MyUnsortedClass {
+            static #someStaticPrivateProperty = 4
+
+            static someStaticProperty = 3
+
+            #someOtherPrivateProperty = 2
+
+            #somePrivateProperty
+
+            someOtherProperty
+
+            someProperty = 1
+
+            constructor() {}
+
+            aInstanceMethod () {}
+
+            #aPrivateInstanceMethod () {}
+
+            static #aPrivateStaticMethod () {}
+
+            static aStaticMethod () {}
+          }
+        `,
+        code: dedent`
+          class MyUnsortedClass {
+            someOtherProperty
+
+            someProperty = 1
+
+            constructor() {}
+
+            static #aPrivateStaticMethod () {}
+
+            #somePrivateProperty
+
+            #someOtherPrivateProperty = 2
+
+            static someStaticProperty = 3
+
+            static #someStaticPrivateProperty = 4
+
+            aInstanceMethod () {}
+
+            static aStaticMethod () {}
+
+            #aPrivateInstanceMethod () {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'static-property',
+              'private-property',
+              'property',
+              'constructor',
+              'method',
+              'private-method',
+              'static-method',
+              'unknown',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('allows split methods with getters and setters', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'index-signature',
+              'static-property',
+              'private-property',
+              'property',
+              'constructor',
+              'static-method',
+              'private-method',
+              'method',
+              ['get-method', 'set-method'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'x',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class A {
+            bb() {}
+            x() {}
+            get z() {}
+            get c() {}
+            set c() {}
+          }
+        `,
+        code: dedent`
+          class A {
+            x() {}
+            bb() {}
+            get z() {}
+            get c() {}
+            set c() {}
+          }
+        `,
+      })
+    })
+
+    it('sorts decorated properties', async () => {
+      await invalid({
+        output: dedent`
+          class User {
+            firstName: string
+
+            lastName: string
+
+            id: number
+
+            @Index({ name: 'born_index' })
+            @Property()
+            born: string
+
+            @Property()
+            @Unique()
+            email: string
+          }
+        `,
+        code: dedent`
+          class User {
+            firstName: string
+
+            id: number
+
+            @Index({ name: 'born_index' })
+            @Property()
+            born: string
+
+            @Property()
+            @Unique()
+            email: string
+
+            lastName: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              leftGroup: 'decorated-property',
+              rightGroup: 'property',
+              right: 'lastName',
+              left: 'email',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'decorated-property', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        output: dedent`
+          class MyElement {
+            @property({ attribute: false })
+            data = {}
+
+            @property()
+            greeting: string = 'Hello'
+
+            @property()
+            protected type = ''
+
+            @state()
+            private _counter = 0
+
+            private _message = ''
+
+            private _prop = 0
+
+            constructor() {}
+
+            @property()
+            set prop(val: number) {
+              this._prop = Math.floor(val)
+            }
+
+            @property()
+            get message(): string {
+              return this._message
+            }
+
+            set message(message: string) {
+              this._message = message
+            }
+
+            get prop() {
+              return this._prop
+            }
+
+            render() {}
+          }
+        `,
+        code: dedent`
+          class MyElement {
+            @property({ attribute: false })
+            data = {}
+
+            @property()
+            greeting: string = 'Hello'
+
+            @property()
+            protected type = ''
+
+            @state()
+            private _counter = 0
+
+            private _message = ''
+
+            private _prop = 0
+
+            constructor() {}
+
+            @property()
+            get message(): string {
+              return this._message
+            }
+
+            set message(message: string) {
+              this._message = message
+            }
+
+            @property()
+            set prop(val: number) {
+              this._prop = Math.floor(val)
+            }
+
+            get prop() {
+              return this._prop
+            }
+
+            render() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-property',
+              'property',
+              'protected-decorated-property',
+              'private-decorated-property',
+              'private-property',
+              'constructor',
+              ['decorated-get-method', 'decorated-set-method'],
+              ['get-method', 'set-method'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'decorated-set-method',
+              leftGroup: 'set-method',
+              left: 'message',
+              right: 'prop',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+      })
+    })
+
+    it('sorts decorated accessors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-decorated-accessor-property',
+              leftGroup: 'decorated-method',
+              right: '#active',
+              left: 'toggle',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'private-decorated-accessor-property',
+              rightGroup: 'decorated-accessor-property',
+              right: 'finished',
+              left: '#active',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Todo {
+            @observable
+            accessor finished = false
+
+            @observable
+            accessor title = ''
+
+            @observable
+            protected accessor type = ''
+
+            @observable
+            accessor #active = false
+
+            id = Math.random()
+
+            constructor() {}
+
+            @action
+            toggle() {}
+          }
+        `,
+        code: dedent`
+          class Todo {
+            id = Math.random()
+
+            constructor() {}
+
+            @action
+            toggle() {}
+
+            @observable
+            accessor #active = false
+
+            @observable
+            accessor finished = false
+
+            @observable
+            accessor title = ''
+
+            @observable
+            protected accessor type = ''
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'decorated-accessor-property',
+              'protected-decorated-accessor-property',
+              'private-decorated-accessor-property',
+              'property',
+              'constructor',
+              'decorated-method',
+              'unknown',
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts class members with partition comments', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            // Region: Table
+            protected onPaginationChanged() {}
+
+            protected onChangeColumns() {}
+
+            protected onSortChanged() {}
+
+            protected updateTable() {}
+
+            // Region: Form
+            protected onValueChanged() {}
+
+            protected setFormValue() {}
+
+            // Regular Comment
+            protected disableForm() {}
+
+            protected clearForm() {}
+
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Region:',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'onSortChanged',
+              left: 'updateTable',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'onPaginationChanged',
+              left: 'onSortChanged',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'disableForm',
+              left: 'clearForm',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'setFormValue',
+              left: 'disableForm',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'onValueChanged',
+              left: 'setFormValue',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            // Region: Table
+            protected onPaginationChanged() {}
+
+            protected onChangeColumns() {}
+
+            protected onSortChanged() {}
+
+            protected updateTable() {}
+
+            // Region: Form
+            protected onValueChanged() {}
+
+            protected setFormValue() {}
+
+            // Regular Comment
+            protected disableForm() {}
+
+            protected clearForm() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            // Region: Table
+            protected onChangeColumns() {}
+
+            protected updateTable() {}
+
+            protected onSortChanged() {}
+
+            protected onPaginationChanged() {}
+
+            // Region: Form
+            protected clearForm() {}
+
+            // Regular Comment
+            protected disableForm() {}
+
+            protected setFormValue() {}
+
+            protected onValueChanged() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Region:',
+          },
+        ],
+      })
+    })
+
+    it('does not sort properties if the right value depends on the left value', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b = 'b'
+
+            aaa = [this.b]
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            b = 'b'
+
+            getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static c = 'c'
+
+            b = Example.c
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            #b = 'b'
+
+            getAaa() {
+              return this.#b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 'b'
+
+            static getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = 'b'
+
+            aaa = [this.b]
+          }
+        `,
+        code: dedent`
+          class Class {
+            aaa = [this.b]
+
+            b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              left: 'getAaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = 'b'
+
+            getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            getAaa() {
+              return this.b;
+            }
+
+            b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'property',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static c = 'c'
+
+            b = Example.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = Example.c
+
+            static c = 'c'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-property',
+              leftGroup: 'method',
+              left: 'getAaa',
+              right: '#b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            #b = 'b'
+
+            getAaa() {
+              return this.#b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            getAaa() {
+              return this.#b;
+            }
+
+            #b = 'b'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-property',
+              leftGroup: 'static-method',
+              left: 'getAaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static b = 'b'
+
+            static getAaa() {
+              return this.b;
+            }
+          }
+        `,
+        code: dedent`
+          class Class {
+            static getAaa() {
+              return this.b;
+            }
+
+            static b = 'b'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b() {
+              return 1
+            }
+            b() {
+              return 1
+            }
+            static a = this.b()
+            a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b() {
+              return 1
+            }
+            b() {
+              return 1
+            }
+            static a = Class.b()
+            a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b() {
+              return 1
+            }
+            static a = [1].map(this.b)
+            b() {
+              return 1
+            }
+            a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b() {
+              return 1
+            }
+            static a = [1].map(Class.b)
+            b() {
+              return 1
+            }
+            a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class MyClass {
+            a = () => this.b()
+            b = () => null
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function property dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = () => {
+              return 1
+            }
+            b = () => {
+              return 1
+            }
+            static a = this.b()
+            a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = function() {
+              return 1
+            }
+            b = function() {
+              return 1
+            }
+            static a = this.b()
+            a = this.b()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = () => {
+              return 1
+            }
+            b = () => {
+              return 1
+            }
+            static a = [1].map(this.b)
+            a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = function() {
+              return 1
+            }
+            b = function() {
+              return 1
+            }
+            static a = [1].map(this.b)
+            a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = () => {
+              return 1
+            }
+            b = () => {
+              return 1
+            }
+            static a = [1].map(Class.b)
+            a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = function() {
+              return 1
+            }
+            b = function() {
+              return 1
+            }
+            static a = [1].map(Class.b)
+            a = [1].map(this.b)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            state = createState((set) => {
+              set('query', this.queryString.value);
+            });
+            querystring = createQueryString();
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['property', 'method']],
+          },
+        ],
+      })
+    })
+
+    it('detects static block dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static {
+              return true || OtherClass.z;
+            }
+            static z = true;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static z = true;
+            static {
+              const method = () => {
+                return (Class.z || true) && (false || this.z);
+              };
+              method();
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static z = true;
+            static {
+              const method = () => {
+                return (Class.z || true) && (false || this.z);
+              };
+              method();
+              return (Class.z || true) && (false || this.z);
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['static-block', 'static-property']],
+          },
+        ],
+      })
+    })
+
+    it('detects property expression dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'd',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'e',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'z',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static a = 10 + OtherClass.z
+
+            static z = 1
+
+            static c = 10 + this.z
+
+            static e = 10 + this.c
+
+            b = 10 + Class.z
+
+            d = this.b
+          }
+        `,
+        code: dedent`
+          class Class {
+            static e = 10 + this.c
+
+            d = this.b
+
+            static a = 10 + OtherClass.z
+
+            b = 10 + Class.z
+
+            static c = 10 + this.z
+
+            static z = 1
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            c = 10
+            a = this.c
+            b = 10
+          }
+        `,
+        code: dedent`
+          class Class {
+            a = this.c
+            b = 10
+            c = 10
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in objects', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = {
+              b: this.b
+            }
+            b = 1
+            a = {
+              b: this.b
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = {
+              b: Class.b
+            }
+            b = 1
+            a = {
+              b: this.b
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = {
+              [this.b]: A
+            }
+            b = 1
+            a = {
+              [this.b]: 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = {
+              [Class.b]: 1
+            }
+            b = 1
+            a = {
+              [this.b]: 1
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects nested property references', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new Subject()
+            static a = this.b.asObservable()
+            b = new Subject()
+            a = this.b.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new Subject()
+            static a = Class.b.asObservable()
+            b = new Subject()
+            a = this.b.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new WhateverObject()
+            static a = this.b.bProperty
+            b = new WhateverObject()
+            a = this.b.bProperty
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new WhateverObject()
+            static a = Class.b.bProperty
+            b = new WhateverObject()
+            a = this.b.bProperty
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+             static c = 1
+             static b = new WhateverObject(this.c)
+             static a = Class.b.bMethod().anotherNestedMethod(this.c).finalMethod()
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chained dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new Subject()
+            static a = this.b?.asObservable()
+            b = new Subject()
+            a = this.b?.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new Subject()
+            static a = Class.b?.asObservable()
+            b = new Subject()
+            a = this.b?.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects non-null asserted dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new Subject()
+            static a = this.b!.asObservable()
+            b = new Subject()
+            a = this.b!.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = new Subject()
+            static a = Class.b!.asObservable()
+            b = new Subject()
+            a = this.b!.asObservable()
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects unary dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = true
+            static a = !this.b
+            b = true
+            a = !this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = true
+            static a = !Class.b
+            b = true
+            a = !this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects spread elements dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = {}
+            static a = {...this.b}
+            b = {}
+            a = {...this.b}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = {}
+            static a = {...Class.b}
+            b = {}
+            a = {...this.b}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = []
+            static a = [...this.b]
+            b = []
+            a = [...this.b]
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = []
+            static a = [...Class.b]
+            b = []
+            a = [...this.b]
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1;
+            static a = this.b ? 1 : 0;
+            b = 1;
+            a = this.b ? 1 : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1;
+            static a = Class.b ? 1 : 0;
+            b = 1;
+            a = this.b ? 1 : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1;
+            static a = someCondition ? this.b : 0;
+            b = 1;
+            a = someCondition ? this.b : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1;
+            static a = someCondition ? Class.b : 0;
+            b = 1;
+            a = someCondition ? this.b : 0;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1;
+            static a = someCondition ? 0 : this.b;
+            b = 1;
+            a = someCondition ? 0 : this.b;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1;
+            static a = someCondition ? 0 : Class.b;
+            b = 1;
+            a = someCondition ? 0 : this.b;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it("detects dependencies in 'as' expressions", async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = this.b as any
+            b = 1
+            a = this.b as any
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = Class.b as any
+            b = 1
+            a = this.b as any
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in type assertion expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = <any>this.b
+            b = 1
+            a = <any>this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = <any>Class.b
+            b = 1
+            a = <any>this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in template literal expressions', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = \`\${this.b}\`
+            b = 1
+            a = \`\${this.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+            static b = 1
+            static a = \`\${Class.b}\`
+            b = 1
+            a = \`\${this.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects # dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+           static a = Class.a
+           static b = 1
+           static #b = 1
+           static #a = this.#b
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           static #b = () => 1
+           static #a = this.#b()
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          class Class {
+           static #a = this.#b()
+           static #b() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('separates static from non-static dependencies', async () => {
+      await valid({
+        code: dedent`
+          export class Class{
+            static b = 1;
+            b = 1;
+            a = this.b;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static c = 10
+            static a = Class.c
+            static b = this.c
+            c = 10
+            b = this.c
+          }
+        `,
+        code: dedent`
+          class Class {
+            static a = Class.c
+            b = this.c
+            static b = this.c
+            c = 10
+            static c = 10
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('detects and ignores circular dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'g',
+              left: 'f',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = this.e
+            e = this.g
+            g = this.b
+            a
+            f
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.e
+            a
+            e = this.g
+            f
+            g = this.b
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property'],
+          },
+        ],
+      })
+    })
+
+    it('ignores function body dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            static c = () => {
+               return this.a || Class.a
+            }
+
+            static b() {
+               return this.a || Class.a
+            }
+
+            static a = true;
+
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['method', 'property']],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['private-property', 'public-property'],
+          },
+        ],
+        code: dedent`
+          class Class {
+            public b = 1;
+            private a = this.b;
+          }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partitionByComment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            // Part1
+            b = this.a
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.a
+            // Part1
+            a
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over partitionByNewLine', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+
+            b = this.a
+          }
+        `,
+        code: dedent`
+          class Class {
+            b = this.a
+
+            a
+          }
+        `,
+      })
+    })
+
+    it('works with left and right dependencies', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            right = 'right'
+            left = 'left'
+
+            aaa = this.left + this.right
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'left',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'right',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            right = 'right'
+
+            left = 'left'
+
+            aaa = this.left + this.right
+          }
+        `,
+        code: dedent`
+          class Class {
+            aaa = this.left + this.right
+
+            left = 'left'
+
+            right = 'right'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['computed function pattern as string', '^computed$'],
+      ['computed function pattern in array', ['noMatch', '^computed$']],
+      [
+        'computed function pattern as object',
+        { pattern: '^COMPUTED$', flags: 'i' },
+      ],
+      [
+        'computed function pattern as object in array',
+        ['noMatch', { pattern: '^COMPUTED$', flags: 'i' }],
+      ],
+    ])(
+      'ignores callback dependencies matching %s',
+      async (_name, ignoreCallbackDependenciesPatterns) => {
+        await valid({
+          code: dedent`
+            class Class {
+              a = computed(() => this.c)
+              c
+              b = notComputed(() => this.c)
+            }
+          `,
+          options: [
+            {
+              ignoreCallbackDependenciesPatterns,
+            },
+          ],
+        })
+      },
+    )
+
+    it('ignores unknown group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'property',
+              right: 'z',
+              left: 'i',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'unknown',
+              left: 'method3',
+              right: 'y',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-method',
+              leftGroup: 'unknown',
+              left: 'method1',
+              right: 'x',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+
+            private z() {}
+            private y() {}
+            public method3() {}
+            private x() {}
+            public method4() {}
+            public method1() {}
+            public i = 'i';
+          }
+        `,
+        code: dedent`
+          class Class {
+
+            public i = 'i';
+            private z() {}
+            public method3() {}
+            private y() {}
+            public method4() {}
+            public method1() {}
+            private x() {}
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['private-method', 'property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          class Class {
+            _a
+            _c
+            b
+          }
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          class Class {
+            a_c
+            ab
+          }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            你好 = '你好'
+
+            世界 = '世界'
+
+            a = 'a'
+
+            A = 'A'
+
+            b = 'b'
+
+            B = 'B'
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+            {
+              data: {
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          code: dedent`
+            class Class {
+              a = () => null
+
+
+             b = "b"
+            y = "y"
+
+                z = "z"
+            }
+          `,
+          output: dedent`
+            class Class {
+              a = () => null
+             b = "b"
+            y = "y"
+                z = "z"
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline between overload signatures when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          output: dedent`
+            class Class {
+              method(a: string): void {}
+              method(a: number): void {}
+              method(a: string | number): void {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              method(a: string): void {}
+
+              method(a: number): void {}
+
+              method(a: string | number): void {}
+            }
+          `,
+          options: [
+            {
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles "newlinesBetween" between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          class Class {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenClassMembers',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a: string
+
+
+              b: string
+            }
+          `,
+          code: dedent`
+            class Class {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'enforces no newline if the global option is %s and "newlinesBetween: never" exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            class Class {
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'] as const,
+      ['ignore', 0] as const,
+      ['never', 'ignore'] as const,
+      [0, 'ignore'] as const,
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            class Class {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            class Class {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a // Comment after
+
+            b() {}
+            c() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b() {}
+            a // Comment after
+
+            c() {}
+          }
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_name, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaa',
+                  groupName: 'aaa',
+                },
+              ],
+              groups: ['aaa', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+          ],
+          output: dedent`
+            class Class {
+              aaa
+
+              // Partition comment
+
+              bb
+              c
+            }
+          `,
+          code: dedent`
+            class Class {
+              aaa
+
+              // Partition comment
+
+              c
+              bb
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline non-abstract methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            aa(){} b(){}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){} aa(){}
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            aa(){} b(){};
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){} aa(){};
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            aa(){}; b(){}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b(){}; aa(){}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline abstract methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract aa(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract aa()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract aa(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract aa();
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline declare class methods correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          declare class Class {
+            aa(); b();
+          }
+        `,
+        code: dedent`
+          declare class Class {
+            b(); aa()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          abstract class Class {
+            abstract aa(); abstract b();
+          }
+        `,
+        code: dedent`
+          abstract class Class {
+            abstract b(); abstract aa();
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline properties correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            aa; b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            b; aa
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            aa; b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            b; aa;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline accessors correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            accessor aa; accessor b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            accessor b; accessor aa
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            accessor aa; accessor b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            accessor b; accessor aa;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline static-block correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'static-block',
+              leftGroup: 'property',
+              right: 'static',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            static {} a;
+          }
+        `,
+        code: dedent`
+          class Class {
+            a; static {}
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b
+            c
+            a
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces grouping', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: '^b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            ba
+            bb
+            ab
+            aa
+          }
+        `,
+        code: dedent`
+          class Class {
+            ab
+            aa
+            ba
+            bb
+          }
+        `,
+      })
+    })
+
+    it('enforces newlines between', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenClassMembers',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+
+            a
+          }
+        `,
+        code: dedent`
+          class Class {
+            b
+            a
+          }
+        `,
+      })
+    })
+
+    it('enforces dependency sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            a = this.b
+          }
+        `,
+        code: dedent`
+          class Class {
+            a = this.b
+            b
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
+    it('filters on selector and modifiers', async () => {
+      await invalid({
+        options: [
           {
-            output: dedent`
-              class Calculator {
-                static log(x) {
-                  return 0;
-                }
-
-                static log10(x) {
-                  return 0;
-                }
-
-                static log1p(x) {
-                  return 0;
-                }
-
-                static log2(x) {
-                  return 0;
-                }
-              }
-            `,
-            code: dedent`
-              class Calculator {
-                static log(x) {
-                  return 0;
-                }
-
-                static log1p(x) {
-                  return 0;
-                }
-
-                static log10(x) {
-                  return 0;
-                }
-
-                static log2(x) {
-                  return 0;
-                }
-              }
-            `,
-            errors: [
+            customGroups: [
               {
-                data: {
-                  right: 'log10',
-                  left: 'log1p',
-                },
-                messageId: 'unexpectedClassesOrder',
+                groupName: 'unusedCustomGroup',
+                modifiers: ['private'],
+                selector: 'property',
+              },
+              {
+                groupName: 'privatePropertyGroup',
+                modifiers: ['private'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
               },
             ],
+            groups: ['propertyGroup', 'constructor', 'privatePropertyGroup'],
           },
         ],
-        valid: [
+        errors: [
           {
-            code: dedent`
-              class Calculator {
-                static log(x) {
-                  return 0;
-                }
-
-                static log10(x) {
-                  return 0;
-                }
-
-                static log1p(x) {
-                  return 0;
-                }
-
-                static log2(x) {
-                  return 0;
-                }
-              }
-            `,
-            options: [{}],
+            data: {
+              leftGroup: 'privatePropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
           },
         ],
-      },
-    )
+        output: dedent`
+          class Class {
+            c;
+            constructor() {}
+            private a;
+            private b;
+          }
+        `,
+        code: dedent`
+          class Class {
+            private a;
+            private b;
+            c;
+            constructor() {}
+          }
+        `,
+      })
+    })
 
-    ruleTester.run(`${ruleName}: sorts using default groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'protected-method',
-                leftGroup: 'private-method',
-                right: 'protectedMethod',
-                left: 'privateMethod',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'protected-method',
-                left: 'protectedMethod',
-                right: 'publicMethod',
-                rightGroup: 'method',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-static-method',
-                right: 'privateStaticMethod',
-                left: 'publicMethod',
-                leftGroup: 'method',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'protected-static-method',
-                leftGroup: 'private-static-method',
-                right: 'protectedStaticMethod',
-                left: 'privateStaticMethod',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'protected-static-method',
-                left: 'protectedStaticMethod',
-                right: 'publicStaticMethod',
-                rightGroup: 'static-method',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                left: 'publicStaticMethod',
-                leftGroup: 'static-method',
-                rightGroup: 'constructor',
-                right: 'constructor',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-property',
-                leftGroup: 'constructor',
-                right: 'privateProperty',
-                left: 'constructor',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                right: 'privateAccessorProperty',
-                left: 'privateProperty',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                leftGroup: 'private-accessor-property',
-                rightGroup: 'protected-property',
-                left: 'privateAccessorProperty',
-                right: 'protectedProperty',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'protected-property',
-                left: 'protectedProperty',
-                right: 'publicProperty',
-                rightGroup: 'property',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                right: 'publicAccessorProperty',
-                left: 'publicProperty',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                right: 'publicGetMethod',
-                left: 'publicSetMethod',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-            {
-              data: {
-                leftGroup: 'protected-accessor-property',
-                left: 'protectedAccessorProperty',
-                rightGroup: 'static-block',
-                right: 'static',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'private-static-property',
-                right: 'privateStaticProperty',
-                leftGroup: 'static-block',
-                left: 'static',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'protected-static-property',
-                leftGroup: 'private-static-property',
-                right: 'protectedStaticProperty',
-                left: 'privateStaticProperty',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'protected-static-property',
-                left: 'protectedStaticProperty',
-                right: 'publicStaticProperty',
-                rightGroup: 'static-property',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'index-signature',
-                left: 'publicStaticProperty',
-                leftGroup: 'static-property',
-                right: '[key: string]',
-              },
-              messageId: 'unexpectedClassesGroupOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              [key: string]: string
-
-              public static publicStaticProperty
-
-              protected static protectedStaticProperty
-
-              private static privateStaticProperty
-
-              static {}
-
-              public accessor publicAccessorProperty
-
-              public publicProperty
-
-              public get publicGetMethod() {}
-
-              public set publicSetMethod() {}
-
-              protected accessor protectedAccessorProperty
-
-              protected protectedProperty
-
-              private accessor privateAccessorProperty
-
-              private privateProperty
-
-              constructor() {}
-
-              public static publicStaticMethod() {}
-
-              protected static protectedStaticMethod() {}
-
-              private static privateStaticMethod() {}
-
-              public publicMethod() {}
-
-              protected protectedMethod() {}
-
-              private privateMethod() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              private privateMethod() {}
-
-              protected protectedMethod() {}
-
-              public publicMethod() {}
-
-              private static privateStaticMethod() {}
-
-              protected static protectedStaticMethod() {}
-
-              public static publicStaticMethod() {}
-
-              constructor() {}
-
-              private privateProperty
-
-              private accessor privateAccessorProperty
-
-              protected protectedProperty
-
-              public publicProperty
-
-              public accessor publicAccessorProperty
-
-              public set publicSetMethod() {}
-
-              public get publicGetMethod() {}
-
-              protected accessor protectedAccessorProperty
-
-              static {}
-
-              private static privateStaticProperty
-
-              protected static protectedStaticProperty
-
-              public static publicStaticProperty
-
-              [key: string]: string
-            }
-          `,
-        },
+    it.each([
+      ['string pattern', 'hello'],
+      ['array pattern', ['noMatch', 'hello']],
+      ['object pattern', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'object pattern in array',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
       ],
-      valid: [],
-    })
-
-    describe('handles complex comment cases', () => {
-      ruleTester.run(`keeps comments associated to their node`, rule, {
-        invalid: [
-          {
-            output: dedent`
-              class Class {
-                // Ignore this comment
-
-                // A4
-                // A3
-                /*
-                 * A2
-                 */
-                // A1
-                a
-
-                /**
-                 * Ignore this comment as well
-                 */
-
-                // B1
-                b
-              }
-            `,
-            code: dedent`
-              class Class {
-                // Ignore this comment
-
-                // B1
-                b
-
-                /**
-                 * Ignore this comment as well
-                 */
-
-                // A4
-                // A3
-                /*
-                 * A2
-                 */
-                // A1
-                a
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      })
-
-      describe('partition comments', () => {
-        ruleTester.run(`handles partition comments`, rule, {
-          invalid: [
-            {
-              output: dedent`
-                class Class {
-                  // Ignore this comment
-
-                  // B2
-                  /**
-                    * B1
-                    */
-                  b
-
-                  // C2
-                  // C1
-                  c
-
-                  // Above a partition comment ignore me
-                  // PartitionComment: 1
-                  a
-
-                  /**
-                    * D2
-                    */
-                  // D1
-                  d
-                }
-              `,
-              code: dedent`
-                class Class {
-                  // Ignore this comment
-
-                  // C2
-                  // C1
-                  c
-
-                  // B2
-                  /**
-                    * B1
-                    */
-                  b
-
-                  // Above a partition comment ignore me
-                  // PartitionComment: 1
-                  /**
-                    * D2
-                    */
-                  // D1
-                  d
-
-                  a
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-                {
-                  data: {
-                    right: 'a',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedClassesOrder',
-                },
-              ],
-              options: [
-                {
-                  partitionByComment: 'PartitionComment:',
-                  type: 'alphabetical',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}: allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  class Class {
-                    e
-                    f
-                    // I am a partition comment because I don't have f o o
-                    a
-                    b
-                  }
-                `,
-                options: [
-                  {
-                    partitionByComment: ['^(?!.*foo).*$'],
-                    type: 'alphabetical',
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        describe(`${ruleName}: allows to use "partitionByComment.line"`, () => {
-          ruleTester.run(`${ruleName}: ignores block comments`, rule, {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'a',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedClassesOrder',
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    /* Comment */
-                    a() {}
-                    b() {}
-                  }
-                `,
-                code: dedent`
-                  class Class {
-                    b() {}
-                    /* Comment */
-                    a() {}
-                  }
-                `,
-                options: [
-                  {
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          })
-
-          ruleTester.run(
-            `${ruleName}: allows to use all comments as parts`,
-            rule,
-            {
-              valid: [
-                {
-                  options: [
-                    {
-                      partitionByComment: {
-                        line: true,
-                      },
-                    },
-                  ],
-                  code: dedent`
-                    class Class {
-                      b() {}
-                      // Comment
-                      a() {}
-                    }
-                  `,
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use multiple partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  code: dedent`
-                    class Class {
-                      c() {}
-                      // b
-                      b() {}
-                      // a
-                      a() {}
-                    }
-                  `,
-                  options: [
-                    {
-                      partitionByComment: {
-                        line: ['a', 'b'],
-                      },
-                    },
-                  ],
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use regex for partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  code: dedent`
-                    class Class {
-                      b() {}
-                      // I am a partition comment because I don't have f o o
-                      a() {}
-                    }
-                  `,
-                  options: [
-                    {
-                      partitionByComment: {
-                        line: ['^(?!.*foo).*$'],
-                      },
-                    },
-                  ],
-                },
-              ],
-              invalid: [],
-            },
-          )
-        })
-
-        describe(`${ruleName}: allows to use "partitionByComment.block"`, () => {
-          ruleTester.run(`${ruleName}: ignores line comments`, rule, {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'a',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedClassesOrder',
-                  },
-                ],
-                output: dedent`
-                  class Class {
-                    // Comment
-                    a() {}
-                    b() {}
-                  }
-                `,
-                options: [
-                  {
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  class Class {
-                    b() {}
-                    // Comment
-                    a() {}
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          })
-
-          ruleTester.run(
-            `${ruleName}: allows to use all comments as parts`,
-            rule,
-            {
-              valid: [
-                {
-                  code: dedent`
-                    class Class {
-                      b() {}
-                      /* Comment */
-                      a() {}
-                    }
-                  `,
-                  options: [
-                    {
-                      partitionByComment: {
-                        block: true,
-                      },
-                    },
-                  ],
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use multiple partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  code: dedent`
-                    class Class {
-                      c() {}
-                      /* b */
-                      b() {}
-                      /* a */
-                      a() {}
-                    }
-                  `,
-                  options: [
-                    {
-                      partitionByComment: {
-                        block: ['a', 'b'],
-                      },
-                    },
-                  ],
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use regex for partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  code: dedent`
-                    class Class {
-                      b() {}
-                      /* I am a partition comment because I don't have f o o */
-                      a() {}
-                    }
-                  `,
-                  options: [
-                    {
-                      partitionByComment: {
-                        block: ['^(?!.*foo).*$'],
-                      },
-                    },
-                  ],
-                },
-              ],
-              invalid: [],
-            },
-          )
-        })
-      })
-
-      ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedClassesOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                d = 'dd'
-                e = 'e'
-
-                c = 'ccc'
-
-                a = 'aaaaa'
-                b = 'bbbb'
-              }
-            `,
-            code: dedent`
-              class Class {
-                e = 'e'
-                d = 'dd'
-
-                c = 'ccc'
-
-                b = 'bbbb'
-                a = 'aaaaa'
-              }
-            `,
-            options: [
-              {
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              class Class {
-                d = 'dd'
-                e = 'e'
-
-                c = 'ccc'
-
-                a = 'aaaaa'
-                b = 'bbbb'
-              }
-            `,
-            options: [
-              {
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      })
-    })
-
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
+    ])(
+      'filters on elementNamePattern with %s',
+      async (_name, elementNamePattern) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'b',
-                left: 'c',
+                rightGroup: 'constructor',
+                leftGroup: 'unknown',
+                right: 'constructor',
+                left: 'b',
               },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              b
-              c
-              // eslint-disable-next-line
-              a
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              // eslint-disable-next-line
-              a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
             },
             {
               data: {
-                right: 'b',
-                left: 'a',
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
               },
-              messageId: 'unexpectedClassesOrder',
+              messageId: 'unexpectedClassesGroupOrder',
             },
           ],
-          output: dedent`
-            class Class {
-              b
-              c
-              // eslint-disable-next-line
-              a
-              d
-            }
-          `,
-          code: dedent`
-            class Class {
-              d
-              c
-              // eslint-disable-next-line
-              a
-              b
-            }
-          `,
           options: [
             {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'constructor', 'unknown'],
             },
           ],
           output: dedent`
             class Class {
-              b = this.a
-              c
-              // eslint-disable-next-line
-              a
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b = this.a
-              // eslint-disable-next-line
-              a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              b
-              c
-              a // eslint-disable-line
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              a // eslint-disable-line
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              b
-              c
-              /* eslint-disable-next-line */
-              a
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              /* eslint-disable-next-line */
-              a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              b
-              c
-              a /* eslint-disable-line */
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              a /* eslint-disable-line */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            class Class {
-              a
-              d
-              /* eslint-disable */
-              c
-              b
-              // Shouldn't move
-              /* eslint-enable */
-              e
-            }
-          `,
-          code: dedent`
-            class Class {
-              d
-              e
-              /* eslint-disable */
-              c
-              b
-              // Shouldn't move
-              /* eslint-enable */
-              a
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            class Class {
-              b
-              c
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              b
-              c
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            class Class {
-              b
-              c
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          output: dedent`
-            class Class {
-              b
-              c
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          code: dedent`
-            class Class {
-              c
-              b
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            class Class {
-              a
-              d
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c
-              b
-              // Shouldn't move
-              /* eslint-enable */
-              e
-            }
-          `,
-          code: dedent`
-            class Class {
-              d
-              e
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c
-              b
-              // Shouldn't move
-              /* eslint-enable */
-              a
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedClassesOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            class Class {
-              b
-              c
-              // eslint-disable-next-line
-              a
-            }
-          `,
-        },
-      ],
-    })
+              helloProperty;
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
-          {
-            code: dedent`
-              class A {
+              constructor() {}
 
-                static {}
+              a;
 
-                b
-                a = this.b
+              b;
 
-                constructor() {}
+              method() {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              a;
 
-                method() {}
-              }
-            `,
-            options: [{}],
-          },
-        ],
-        invalid: [],
+              b;
+
+              constructor() {}
+
+              method() {}
+
+              helloProperty;
+            }
+          `,
+        })
       },
     )
+
+    it.each([
+      ['string pattern', 'inject'],
+      ['array pattern', ['noMatch', 'inject']],
+      ['object pattern', { pattern: 'INJECT', flags: 'i' }],
+      [
+        'object pattern in array',
+        ['noMatch', { pattern: 'INJECT', flags: 'i' }],
+      ],
+    ])(
+      'filters on elementValuePattern with %s',
+      async (_name, injectElementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: injectElementValuePattern,
+                  groupName: 'inject',
+                },
+                {
+                  elementValuePattern: 'computed',
+                  groupName: 'computed',
+                },
+              ],
+              groups: ['computed', 'inject', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'computed',
+                leftGroup: 'inject',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a = computed(A)
+              z = computed(Z)
+              b = inject(B)
+              y = inject(Y)
+              c() {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              a = computed(A)
+              b = inject(B)
+              y = inject(Y)
+              z = computed(Z)
+              c() {}
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Hello'],
+      ['array pattern', ['noMatch', 'Hello']],
+      ['object pattern', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'object pattern in array',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters on decoratorNamePattern with %s',
+      async (_name, decoratorNamePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'constructor',
+                leftGroup: 'unknown',
+                right: 'constructor',
+                left: 'b',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'propertiesWithDecoratorStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'property',
+                left: 'method',
+              },
+              messageId: 'unexpectedClassesGroupOrder',
+            },
+            {
+              data: {
+                right: 'anotherProperty',
+                left: 'property',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesWithDecoratorStartingWithHello',
+                  decoratorNamePattern,
+                  selector: 'property',
+                },
+              ],
+              groups: [
+                'propertiesWithDecoratorStartingWithHello',
+                'constructor',
+                'unknown',
+              ],
+            },
+          ],
+          output: dedent`
+            class Class {
+              @HelloDecorator()
+              anotherProperty;
+
+              @HelloDecorator
+              property;
+
+              constructor() {}
+
+              @Decorator
+              a;
+
+              b;
+
+              method() {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              @Decorator
+              a;
+
+              b;
+
+              constructor() {}
+
+              method() {}
+
+              @HelloDecorator
+              property;
+
+              @HelloDecorator()
+              anotherProperty;
+            }
+          `,
+        })
+      },
+    )
+
+    it('filters on complex decoratorNamePattern', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: 'B',
+                groupName: 'B',
+              },
+              {
+                decoratorNamePattern: 'A',
+                groupName: 'A',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['B', 'A'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'B',
+              leftGroup: 'A',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            @B.B()
+            b() {}
+
+            @A.A.A(() => A)
+            a() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            @A.A.A(() => A)
+            a() {}
+
+            @B.B()
+            b() {}
+          }
+        `,
+      })
+    })
+
+    it("sorts custom groups by overriding 'type' and 'order'", async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: [
+              'reversedPropertiesByLineLength',
+              'constructor',
+              'unknown',
+            ],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          class Class {
+
+            dddd;
+
+            ccc;
+
+            eee;
+
+            bb;
+
+            ff;
+
+            a;
+
+            g;
+
+            constructor() {}
+
+            anotherMethod() {}
+
+            method() {}
+
+            yetAnotherMethod() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+
+            a;
+
+            bb;
+
+            ccc;
+
+            dddd;
+
+            method() {}
+
+            eee;
+
+            ff;
+
+            g;
+
+            constructor() {}
+
+            anotherMethod() {}
+
+            yetAnotherMethod() {}
+          }
+        `,
+      })
+    })
+
+    it("sorts custom groups by overriding 'fallbackSort'", async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          class Class {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+    })
+
+    it("does not sort custom groups with 'unsorted' type", async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'constructor',
+              left: 'constructor',
+              right: 'd',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'constructor', 'unknown'],
+          },
+        ],
+        output: dedent`
+          class Class {
+            b;
+
+            a;
+
+            d
+
+            e
+
+            c
+
+            constructor() {}
+
+            method() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b;
+
+            a;
+
+            constructor() {}
+
+            d
+
+            e
+
+            method() {}
+
+            c
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'privatePropertiesAndProtectedMethods',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'privatePropertiesAndProtectedMethods',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'privatePropertiesAndProtectedMethods',
+              right: 'anotherProtectedMethod',
+              leftGroup: 'unknown',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['private'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['protected'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'privatePropertiesAndProtectedMethods',
+              },
+            ],
+            groups: [
+              [
+                'privatePropertiesAndProtectedMethods',
+                'decorated-protected-property',
+              ],
+              'constructor',
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          class Class {
+            protected anotherProtectedMethod() {}
+
+            private b;
+
+            private c;
+
+            @Decorator
+            protected e;
+
+            protected protectedMethod() {}
+
+            constructor() {}
+
+            protected a;
+
+            protected d;
+
+            method() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            constructor() {}
+
+            protected a;
+
+            private b;
+
+            @Decorator
+            protected e;
+
+            method() {}
+
+            private c;
+
+            protected protectedMethod() {}
+
+            protected d;
+
+            protected anotherProtectedMethod() {}
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          class Class {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element values in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementValuePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          class Class {
+            x = "iHaveFooInMyName"
+            z = "MeTooIHaveFoo"
+            a = "a"
+            b = "b"
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for decorator names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: '^.*Foo.*$',
+                groupName: 'decoratorsWithFoo',
+              },
+            ],
+            groups: ['decoratorsWithFoo', 'unknown'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          class Class {
+            @IHaveFooInMyName
+            x: string
+            @MeTooIHaveFoo
+            y: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])('allows to use newlinesInside: %s', async (_name, newlinesInside) => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'methodsWithNewlinesInside',
+                selector: 'method',
+                newlinesInside,
+              },
+            ],
+            groups: ['unknown', 'methodsWithNewlinesInside'],
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            b() {}
+
+            c() {}
+
+            d() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            a
+            b() {}
+            c() {}
+
+
+            d() {}
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])('allows to use newlinesInside: %s', async (_name, newlinesInside) => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'methodsWithoutNewlinesInside',
+                selector: 'method',
+                newlinesInside,
+              },
+            ],
+            groups: ['unknown', 'methodsWithoutNewlinesInside'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+
+            c() {}
+            d() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            a
+
+            c() {}
+
+            d() {}
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline between overload signatures when newlinesInside is %s',
+      async (_name, newlinesInside) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+            {
+              data: {
+                right: 'method',
+                left: 'method',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'methods',
+                  selector: 'method',
+                  newlinesInside,
+                },
+              ],
+              groups: ['methods'],
+            },
+          ],
+          output: dedent`
+            class Class {
+              method(a: string): void {}
+              method(a: number): void {}
+              method(a: string | number): void {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              method(a: string): void {}
+
+              method(a: number): void {}
+
+              method(a: string | number): void {}
+            }
+          `,
+        })
+      },
+    )
+
+    it('sets alphabetical asc sorting as default', async () => {
+      await valid({
+        code: dedent`
+          class Calculator {
+            static log(x) {
+              return 0;
+            }
+
+            static log10(x) {
+              return 0;
+            }
+
+            static log1p(x) {
+              return 0;
+            }
+
+            static log2(x) {
+              return 0;
+            }
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          class Calculator {
+            static log(x) {
+              return 0;
+            }
+
+            static log10(x) {
+              return 0;
+            }
+
+            static log1p(x) {
+              return 0;
+            }
+
+            static log2(x) {
+              return 0;
+            }
+          }
+        `,
+        code: dedent`
+          class Calculator {
+            static log(x) {
+              return 0;
+            }
+
+            static log1p(x) {
+              return 0;
+            }
+
+            static log10(x) {
+              return 0;
+            }
+
+            static log2(x) {
+              return 0;
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'log10',
+              left: 'log1p',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+      })
+    })
+
+    it('sorts using default groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'protected-method',
+              leftGroup: 'private-method',
+              right: 'protectedMethod',
+              left: 'privateMethod',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-method',
+              left: 'protectedMethod',
+              right: 'publicMethod',
+              rightGroup: 'method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-static-method',
+              right: 'privateStaticMethod',
+              left: 'publicMethod',
+              leftGroup: 'method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-static-method',
+              leftGroup: 'private-static-method',
+              right: 'protectedStaticMethod',
+              left: 'privateStaticMethod',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-static-method',
+              left: 'protectedStaticMethod',
+              right: 'publicStaticMethod',
+              rightGroup: 'static-method',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              left: 'publicStaticMethod',
+              leftGroup: 'static-method',
+              rightGroup: 'constructor',
+              right: 'constructor',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-property',
+              leftGroup: 'constructor',
+              right: 'privateProperty',
+              left: 'constructor',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: 'privateAccessorProperty',
+              left: 'privateProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              leftGroup: 'private-accessor-property',
+              rightGroup: 'protected-property',
+              left: 'privateAccessorProperty',
+              right: 'protectedProperty',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-property',
+              left: 'protectedProperty',
+              right: 'publicProperty',
+              rightGroup: 'property',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              right: 'publicAccessorProperty',
+              left: 'publicProperty',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'publicGetMethod',
+              left: 'publicSetMethod',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-accessor-property',
+              left: 'protectedAccessorProperty',
+              rightGroup: 'static-block',
+              right: 'static',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'private-static-property',
+              right: 'privateStaticProperty',
+              leftGroup: 'static-block',
+              left: 'static',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'protected-static-property',
+              leftGroup: 'private-static-property',
+              right: 'protectedStaticProperty',
+              left: 'privateStaticProperty',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'protected-static-property',
+              left: 'protectedStaticProperty',
+              right: 'publicStaticProperty',
+              rightGroup: 'static-property',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'index-signature',
+              left: 'publicStaticProperty',
+              leftGroup: 'static-property',
+              right: '[key: string]',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            [key: string]: string
+
+            public static publicStaticProperty
+
+            protected static protectedStaticProperty
+
+            private static privateStaticProperty
+
+            static {}
+
+            public accessor publicAccessorProperty
+
+            public publicProperty
+
+            public get publicGetMethod() {}
+
+            public set publicSetMethod() {}
+
+            protected accessor protectedAccessorProperty
+
+            protected protectedProperty
+
+            private accessor privateAccessorProperty
+
+            private privateProperty
+
+            constructor() {}
+
+            public static publicStaticMethod() {}
+
+            protected static protectedStaticMethod() {}
+
+            private static privateStaticMethod() {}
+
+            public publicMethod() {}
+
+            protected protectedMethod() {}
+
+            private privateMethod() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            private privateMethod() {}
+
+            protected protectedMethod() {}
+
+            public publicMethod() {}
+
+            private static privateStaticMethod() {}
+
+            protected static protectedStaticMethod() {}
+
+            public static publicStaticMethod() {}
+
+            constructor() {}
+
+            private privateProperty
+
+            private accessor privateAccessorProperty
+
+            protected protectedProperty
+
+            public publicProperty
+
+            public accessor publicAccessorProperty
+
+            public set publicSetMethod() {}
+
+            public get publicGetMethod() {}
+
+            protected accessor protectedAccessorProperty
+
+            static {}
+
+            private static privateStaticProperty
+
+            protected static protectedStaticProperty
+
+            public static publicStaticProperty
+
+            [key: string]: string
+          }
+        `,
+      })
+    })
+
+    it('keeps comments associated to their node', async () => {
+      await invalid({
+        output: dedent`
+          class Class {
+            // Ignore this comment
+
+            // A4
+            // A3
+            /*
+             * A2
+             */
+            // A1
+            a
+
+            /**
+             * Ignore this comment as well
+             */
+
+            // B1
+            b
+          }
+        `,
+        code: dedent`
+          class Class {
+            // Ignore this comment
+
+            // B1
+            b
+
+            /**
+             * Ignore this comment as well
+             */
+
+            // A4
+            // A3
+            /*
+             * A2
+             */
+            // A1
+            a
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('handles partition comments', async () => {
+      await invalid({
+        output: dedent`
+          class Class {
+            // Ignore this comment
+
+            // B2
+            /**
+              * B1
+              */
+            b
+
+            // C2
+            // C1
+            c
+
+            // Above a partition comment ignore me
+            // PartitionComment: 1
+            a
+
+            /**
+              * D2
+              */
+            // D1
+            d
+          }
+        `,
+        code: dedent`
+          class Class {
+            // Ignore this comment
+
+            // C2
+            // C1
+            c
+
+            // B2
+            /**
+              * B1
+              */
+            b
+
+            // Above a partition comment ignore me
+            // PartitionComment: 1
+            /**
+              * D2
+              */
+            // D1
+            d
+
+            a
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        options: [
+          {
+            partitionByComment: 'PartitionComment:',
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            e
+            f
+            // I am a partition comment because I don't have f o o
+            a
+            b
+          }
+        `,
+        options: [
+          {
+            partitionByComment: ['^(?!.*foo).*$'],
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            /* Comment */
+            a() {}
+            b() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            b() {}
+            /* Comment */
+            a() {}
+          }
+        `,
+        options: [
+          {
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          class Class {
+            b() {}
+            // Comment
+            a() {}
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            c() {}
+            // b
+            b() {}
+            // a
+            a() {}
+          }
+        `,
+        options: [
+          {
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments with line option', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b() {}
+            // I am a partition comment because I don't have f o o
+            a() {}
+          }
+        `,
+        options: [
+          {
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            // Comment
+            a() {}
+            b() {}
+          }
+        `,
+        options: [
+          {
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          class Class {
+            b() {}
+            // Comment
+            a() {}
+          }
+        `,
+      })
+    })
+
+    it('allows to use all comments as parts with block option', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b() {}
+            /* Comment */
+            a() {}
+          }
+        `,
+        options: [
+          {
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments with block option', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            c() {}
+            /* b */
+            b() {}
+            /* a */
+            a() {}
+          }
+        `,
+        options: [
+          {
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments with block option', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b() {}
+            /* I am a partition comment because I don't have f o o */
+            a() {}
+          }
+        `,
+        options: [
+          {
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            d = 'dd'
+            e = 'e'
+
+            c = 'ccc'
+
+            a = 'aaaaa'
+            b = 'bbbb'
+          }
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            d = 'dd'
+            e = 'e'
+
+            c = 'ccc'
+
+            a = 'aaaaa'
+            b = 'bbbb'
+          }
+        `,
+        code: dedent`
+          class Class {
+            e = 'e'
+            d = 'dd'
+
+            c = 'ccc'
+
+            b = 'bbbb'
+            a = 'aaaaa'
+          }
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it("supports 'eslint-disable' for individual nodes", async () => {
+      await valid({
+        code: dedent`
+          class Class {
+            b
+            c
+            // eslint-disable-next-line
+            a
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            // eslint-disable-next-line
+            a
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            // eslint-disable-next-line
+            a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            // eslint-disable-next-line
+            a
+            d
+          }
+        `,
+        code: dedent`
+          class Class {
+            d
+            c
+            // eslint-disable-next-line
+            a
+            b
+          }
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = this.a
+            c
+            // eslint-disable-next-line
+            a
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b = this.a
+            // eslint-disable-next-line
+            a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            a // eslint-disable-line
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            a // eslint-disable-line
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            /* eslint-disable-next-line */
+            a
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            /* eslint-disable-next-line */
+            a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            a /* eslint-disable-line */
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            a /* eslint-disable-line */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          class Class {
+            a
+            d
+            /* eslint-disable */
+            c
+            b
+            // Shouldn't move
+            /* eslint-enable */
+            e
+          }
+        `,
+        code: dedent`
+          class Class {
+            d
+            e
+            /* eslint-disable */
+            c
+            b
+            // Shouldn't move
+            /* eslint-enable */
+            a
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            // eslint-disable-next-line rule-to-test/sort-classes
+            a
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            // eslint-disable-next-line rule-to-test/sort-classes
+            a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            a // eslint-disable-line rule-to-test/sort-classes
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            a // eslint-disable-line rule-to-test/sort-classes
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            /* eslint-disable-next-line rule-to-test/sort-classes */
+            a
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            /* eslint-disable-next-line rule-to-test/sort-classes */
+            a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            b
+            c
+            a /* eslint-disable-line rule-to-test/sort-classes */
+          }
+        `,
+        code: dedent`
+          class Class {
+            c
+            b
+            a /* eslint-disable-line rule-to-test/sort-classes */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          class Class {
+            a
+            d
+            /* eslint-disable rule-to-test/sort-classes */
+            c
+            b
+            // Shouldn't move
+            /* eslint-enable */
+            e
+          }
+        `,
+        code: dedent`
+          class Class {
+            d
+            e
+            /* eslint-disable rule-to-test/sort-classes */
+            c
+            b
+            // Shouldn't move
+            /* eslint-enable */
+            a
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles non typescript-eslint parser', async () => {
+      await valid({
+        code: dedent`
+          class A {
+
+            static {}
+
+            b
+            a = this.b
+
+            constructor() {}
+
+            method() {}
+          }
+        `,
+        options: [{}],
+      })
+    })
   })
 })

--- a/test/rules/sort-classes/type.test.ts
+++ b/test/rules/sort-classes/type.test.ts
@@ -15,74 +15,66 @@ let ruleName = 'sort-classes'
 
 describe(`${ruleName}: test types`, () => {
   it('test get method or set method group type', () => {
-    expectTypeOf(
-      'get-method' as const,
-    ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+    expectTypeOf('get-method' as const).toExtend<GetMethodOrSetMethodGroup>()
 
-    expectTypeOf(
-      'set-method' as const,
-    ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+    expectTypeOf('set-method' as const).toExtend<GetMethodOrSetMethodGroup>()
 
     expectTypeOf(
       'protected-get-method' as const,
-    ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+    ).toExtend<GetMethodOrSetMethodGroup>()
 
     expectTypeOf(
       'public-decorated-get-method' as const,
-    ).toMatchTypeOf<GetMethodOrSetMethodGroup>()
+    ).toExtend<GetMethodOrSetMethodGroup>()
   })
 
   it('test non declare property group type', () => {
     expectTypeOf(
       'public-static-override-property' as const,
-    ).toMatchTypeOf<NonDeclarePropertyGroup>()
+    ).toExtend<NonDeclarePropertyGroup>()
   })
 
   it('test function property group type', () => {
     expectTypeOf(
       'private-static-function-property' as const,
-    ).toMatchTypeOf<FunctionPropertyGroup>()
+    ).toExtend<FunctionPropertyGroup>()
   })
 
   it('test accessor property group type', () => {
     expectTypeOf(
       'static-accessor-property' as const,
-    ).toMatchTypeOf<AccessorPropertyGroup>()
+    ).toExtend<AccessorPropertyGroup>()
 
     expectTypeOf(
       'protected-static-accessor-property' as const,
-    ).toMatchTypeOf<AccessorPropertyGroup>()
+    ).toExtend<AccessorPropertyGroup>()
 
-    expectTypeOf(
-      'accessor-property' as const,
-    ).toMatchTypeOf<AccessorPropertyGroup>()
+    expectTypeOf('accessor-property' as const).toExtend<AccessorPropertyGroup>()
 
     expectTypeOf(
       'protected-accessor-property' as const,
-    ).toMatchTypeOf<AccessorPropertyGroup>()
+    ).toExtend<AccessorPropertyGroup>()
   })
 
   it('test declare property group type', () => {
     expectTypeOf(
       'declare-protected-static-readonly-property' as const,
-    ).toMatchTypeOf<DeclarePropertyGroup>()
+    ).toExtend<DeclarePropertyGroup>()
   })
 
   it('test declare method group type', () => {
-    expectTypeOf('public-method' as const).toMatchTypeOf<MethodGroup>()
+    expectTypeOf('public-method' as const).toExtend<MethodGroup>()
 
-    expectTypeOf('protected-method' as const).toMatchTypeOf<MethodGroup>()
+    expectTypeOf('protected-method' as const).toExtend<MethodGroup>()
 
-    expectTypeOf('private-method' as const).toMatchTypeOf<MethodGroup>()
+    expectTypeOf('private-method' as const).toExtend<MethodGroup>()
   })
 
   it('test constructor group type', () => {
-    expectTypeOf('constructor' as const).toMatchTypeOf<ConstructorGroup>()
+    expectTypeOf('constructor' as const).toExtend<ConstructorGroup>()
   })
 
   it('test index signature group type', () => {
-    expectTypeOf(
-      'index-signature' as const,
-    ).toMatchTypeOf<IndexSignatureGroup>()
+    expectTypeOf('index-signature' as const).toExtend<IndexSignatureGroup>()
   })
 })

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1,4259 +1,5909 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
-
-import type { Options } from '../../rules/sort-enums/types'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-enums'
 
-let ruleName = 'sort-enums'
+describe('sort-enums', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-enums',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts enum members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              cc = 'c',
-              bbb = 'b',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts enum members with number keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '12',
-                  left: '8',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                1 = 'a',
-                12 = 'b',
-                2 = 'c',
-                8 = 'c',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                1 = 'a',
-                2 = 'c',
-                8 = 'c',
-                12 = 'b',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                1 = 'a',
-                12 = 'b',
-                2 = 'c',
-                8 = 'c',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): doesn't sorts enum members without initializer`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                aaa,
-                bb = 'bb',
-                c,
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts enum members with boolean ids`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'false',
-                  left: 'true',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                false = 'b',
-                true = 'a',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                true = 'a',
-                false = 'b',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                false = 'b',
-                true = 'a',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break interface docs`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                /**
-                 * Comment A
-                 */
-                'aaa' = 'a',
-                /**
-                 * Comment B
-                 */
-                b = 'b',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                /**
-                 * Comment B
-                 */
-                b = 'b',
-                /**
-                 * Comment A
-                 */
-                'aaa' = 'a',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'b',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort enums with implicit values`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              export enum Enum {
-                d, // implicit value: 0
-                cc, // implicit value: 1
-                bbb, // implicit value: 2
-                aaaa, // implicit value: 3
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                // Part: A
-                // Not partition comment
-                bbb = 'b',
-                cc = 'c',
-                d = 'd',
-                // Part: B
-                aaaa = 'a',
-                e = 'e',
-                // Part: C
-                // Not partition comment
-                fff = 'f',
-                'gg' = 'g',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                // Part: A
-                cc = 'c',
-                d = 'd',
-                // Not partition comment
-                bbb = 'b',
-                // Part: B
-                aaaa = 'a',
-                e = 'e',
-                // Part: C
-                'gg' = 'g',
-                // Not partition comment
-                fff = 'f',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bbb',
-                  left: 'd',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-              {
-                data: {
-                  right: 'fff',
-                  left: 'gg',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                // Comment
-                bb = 'b',
-                // Other comment
-                a = 'a',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                /* Partition Comment */
-                // Part: A
-                d = 'd',
-                // Part: B
-                aaa = 'a',
-                bb = 'b',
-                c = 'c',
-                /* Other */
-                e = 'e',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                /* Partition Comment */
-                // Part: A
-                d = 'd',
-                // Part: B
-                aaa = 'a',
-                c = 'c',
-                bb = 'b',
-                /* Other */
-                e = 'e',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for partition comments`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                E = 'E',
-                F = 'F',
-                // I am a partition comment because I don't have f o o
-                A = 'A',
-                B = 'B',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  line: true,
-                },
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                /* Comment */
-                A = "A",
-                B = "B",
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                B = "B",
-                /* Comment */
-                A = "A",
-              }
-            `,
-          },
-        ],
-        valid: [],
+    it('sorts enum members', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              code: dedent`
-                enum Enum {
-                  B = "B",
-                  // Comment
-                  A = "A",
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                enum Enum {
-                   C = "C",
-                   // B
-                   B = "B",
-                   // A
-                   A = "A",
-                 }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['A', 'B'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                enum Enum {
-                  B = 'B',
-                  // I am a partition comment because I don't have f o o
-                  A = 'A',
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  block: true,
-                },
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                // Comment
-                A = "A",
-                B = "B",
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                B = "B",
-                // Comment
-                A = "A",
-              }
-            `,
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedEnumsOrder',
           },
         ],
-        valid: [],
+        output: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            cc = 'c',
+            bbb = 'b',
+            d = 'd',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts enum members with number keys', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            1 = 'a',
+            12 = 'b',
+            2 = 'c',
+            8 = 'c',
+          }
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              code: dedent`
-                enum Enum {
-                  B = "B",
-                  /* Comment */
-                  A = "A",
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                enum Enum {
-                   C = "C",
-                   /* B */
-                   B = "B",
-                   /* A */
-                   A = "A",
-                 }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['A', 'B'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                enum Enum {
-                  B = 'B',
-                  /* I am a partition comment because I don't have f o o */
-                  A = 'A',
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    ruleTester.run(`${ruleName}: sort enum values correctly`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'd',
-                left: 'c',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'e',
-                left: 'd',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'f',
-                left: 'e',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'g',
-                left: 'f',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'h',
-                left: 'g',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'i',
-                left: 'h',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'j',
-                left: 'i',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              'j' = null,
-              'k' = undefined,
-              'i' = 'a',
-              'h' = 'b',
-              'g' = 'c',
-              'f' = 'd',
-              'e' = 'e',
-              'd' = 'f',
-              'c' = 'g',
-              'b' = 'h',
-              'a' = 'i',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              'a' = 'i',
-              'b' = 'h',
-              'c' = 'g',
-              'd' = 'f',
-              'e' = 'e',
-              'f' = 'd',
-              'g' = 'c',
-              'h' = 'b',
-              'i' = 'a',
-              'j' = null,
-              'k' = undefined,
-            }
-          `,
-          options: [
-            {
-              ...options,
-              sortByValue: true,
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              enum Enum {
-                _A = 'A',
-                B = 'B',
-                _C = 'C',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
+            data: {
+              right: '12',
+              left: '8',
+            },
+            messageId: 'unexpectedEnumsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              enum Enum {
-                AB = 'AB',
-                A_C = 'AC',
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            enum Enum {
-              你好 = '你好',
-              世界 = '世界',
-              a = 'a',
-              A = 'A',
-              b = 'b',
-              B = 'B',
-            }
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
+        output: dedent`
+          enum Enum {
+            1 = 'a',
+            12 = 'b',
+            2 = 'c',
+            8 = 'c',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            1 = 'a',
+            2 = 'c',
+            8 = 'c',
+            12 = 'b',
+          }
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
+    it('preserves enum members without initializer', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            aaa,
+            bb = 'bb',
+            c,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts enum members with boolean identifiers', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            false = 'b',
+            true = 'a',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                A = "A", B = "B"
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                B = "B", A = "A"
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                A = "A", B = "B",
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                B = "B", A = "A",
-              }
-            `,
-            options: [options],
+            data: {
+              right: 'false',
+              left: 'true',
+            },
+            messageId: 'unexpectedEnumsOrder',
           },
         ],
-        valid: [],
-      },
-    )
+        output: dedent`
+          enum Enum {
+            false = 'b',
+            true = 'a',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            true = 'a',
+            false = 'b',
+          }
+        `,
+        options: [options],
+      })
+    })
 
-    describe(`${ruleName}: custom groups`, () => {
-      for (let elementNamePattern of [
-        'HELLO',
-        ['noMatch', 'HELLO'],
-        { pattern: 'hello', flags: 'i' },
+    it('preserves documentation comments when sorting', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            /**
+             * Comment A
+             */
+            'aaa' = 'a',
+            /**
+             * Comment B
+             */
+            b = 'b',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            /**
+             * Comment B
+             */
+            b = 'b',
+            /**
+             * Comment A
+             */
+            'aaa' = 'a',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'b',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('preserves implicit values in enums', async () => {
+      await valid({
+        code: dedent`
+          export enum Enum {
+            d, // implicit value: 0
+            cc, // implicit value: 1
+            bbb, // implicit value: 2
+            aaaa, // implicit value: 3
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts within partition comments', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            // Part: A
+            // Not partition comment
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+            // Part: B
+            aaaa = 'a',
+            e = 'e',
+            // Part: C
+            // Not partition comment
+            fff = 'f',
+            'gg' = 'g',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            // Part: A
+            cc = 'c',
+            d = 'd',
+            // Not partition comment
+            bbb = 'b',
+            // Part: B
+            aaaa = 'a',
+            e = 'e',
+            // Part: C
+            'gg' = 'g',
+            // Not partition comment
+            fff = 'f',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition delimiters', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            // Comment
+            bb = 'b',
+            // Other comment
+            a = 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('handles multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            /* Partition Comment */
+            // Part: A
+            d = 'd',
+            // Part: B
+            aaa = 'a',
+            bb = 'b',
+            c = 'c',
+            /* Other */
+            e = 'e',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            /* Partition Comment */
+            // Part: A
+            d = 'd',
+            // Part: B
+            aaa = 'a',
+            c = 'c',
+            bb = 'b',
+            /* Other */
+            e = 'e',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            E = 'E',
+            F = 'F',
+            // I am a partition comment because I don't have f o o
+            A = 'A',
+            B = 'B',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line partition is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            /* Comment */
+            A = "A",
+            B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B",
+            /* Comment */
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('treats line comments as partition delimiters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = "B",
+            // Comment
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('handles multiple line comment patterns', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+             C = "C",
+             // B
+             B = "B",
+             // A
+             A = "A",
+           }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            // I am a partition comment because I don't have f o o
+            A = 'A',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block partition is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            // Comment
+            A = "A",
+            B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B",
+            // Comment
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('treats block comments as partition delimiters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = "B",
+            /* Comment */
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('handles multiple block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+             C = "C",
+             /* B */
+             B = "B",
+             /* A */
+             A = "A",
+           }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            /* I am a partition comment because I don't have f o o */
+            A = 'A',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('sorts enum members by their values', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'e',
+              left: 'd',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'f',
+              left: 'e',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'g',
+              left: 'f',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'h',
+              left: 'g',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'i',
+              left: 'h',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'j',
+              left: 'i',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            'j' = null,
+            'k' = undefined,
+            'i' = 'a',
+            'h' = 'b',
+            'g' = 'c',
+            'f' = 'd',
+            'e' = 'e',
+            'd' = 'f',
+            'c' = 'g',
+            'b' = 'h',
+            'a' = 'i',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            'a' = 'i',
+            'b' = 'h',
+            'c' = 'g',
+            'd' = 'f',
+            'e' = 'e',
+            'f' = 'd',
+            'g' = 'c',
+            'h' = 'b',
+            'i' = 'a',
+            'j' = null,
+            'k' = undefined,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            sortByValue: true,
+          },
+        ],
+      })
+    })
+
+    it('trims special characters when sorting', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            _A = 'A',
+            B = 'B',
+            _C = 'C',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('removes special characters when sorting', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            AB = 'AB',
+            A_C = 'AC',
+          }
+        `,
+      })
+    })
+
+    it('sorts using specified locale', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B',
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline enum members correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = "A", B = "B"
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B", A = "A"
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = "A", B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B", A = "A",
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array with string pattern', ['noMatch', 'HELLO']],
+      ['object pattern with flags', { pattern: 'hello', flags: 'i' }],
+      [
+        'array with object pattern',
         ['noMatch', { pattern: 'hello', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'keysStartingWithHello',
-                    leftGroup: 'unknown',
-                    right: 'HELLO_KEY',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedEnumsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'keysStartingWithHello',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['keysStartingWithHello', 'unknown'],
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  HELLO_KEY = 3,
-                  A = 1,
-                  B = 2,
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  A = 1,
-                  B = 2,
-                  HELLO_KEY = 3,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      for (let elementValuePattern of [
-        'HELLO',
-        ['noMatch', 'HELLO'],
-        { pattern: 'hello', flags: 'i' },
-        ['noMatch', { pattern: 'hello', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'valuesStartingWithHello',
-                      elementValuePattern,
-                    },
-                  ],
-                  groups: ['valuesStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'valuesStartingWithHello',
-                    leftGroup: 'unknown',
-                    right: 'Z',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedEnumsGroupOrder',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  Z = 'HELLO_KEY',
-                  A = 'A',
-                  B = 'B',
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  A = 'A',
-                  B = 'B',
-                  Z = 'HELLO_KEY',
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '_BB',
-                    left: '_A',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-                {
-                  data: {
-                    right: '_CCC',
-                    left: '_BB',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-                {
-                  data: {
-                    right: '_DDDD',
-                    left: '_CCC',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedStartingWith_ByLineLength',
-                    leftGroup: 'unknown',
-                    right: '_EEE',
-                    left: 'M',
-                  },
-                  messageId: 'unexpectedEnumsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedStartingWith_ByLineLength',
-                      elementNamePattern: '_',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedStartingWith_ByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  _DDDD = null,
-                  _CCC = null,
-                  _EEE = null,
-                  _BB = null,
-                  _FF = null,
-                  _A = null,
-                  _G = null,
-                  M = null,
-                  O = null,
-                  P = null,
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  _A = null,
-                  _BB = null,
-                  _CCC = null,
-                  _DDDD = null,
-                  M = null,
-                  _EEE = null,
-                  _FF = null,
-                  _G = null,
-                  O = null,
-                  P = null,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  fooBar = 'fooBar',
-                  fooZar = 'fooZar',
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  fooZar = 'fooZar',
-                  fooBar = 'fooBar',
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedStartingWith_',
-                      elementNamePattern: '_',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedStartingWith_', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedStartingWith_',
-                    leftGroup: 'unknown',
-                    right: '_C',
-                    left: 'M',
-                  },
-                  messageId: 'unexpectedEnumsGroupOrder',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  _B = null,
-                  _A = null,
-                  _D = null,
-                  _E = null,
-                  _C = null,
-                  M = null,
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  _B = null,
-                  _A = null,
-                  _D = null,
-                  _E = null,
-                  M = null,
-                  _C = null,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'FOO',
-                      },
-                      {
-                        elementNamePattern: 'Foo',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: 'C_FOO',
-                  left: 'A',
-                },
-                messageId: 'unexpectedEnumsGroupOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                C_FOO = null,
-                FOO = null,
-                A = null,
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                A = null,
-                C_FOO = null,
-                FOO = null,
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*FOO).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                enum Enum {
-                  I_HAVE_FOO_IN_MY_NAME = null,
-                  ME_TOO_I_HAVE_FOO = null,
-                  A = null,
-                  B = null,
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'Y',
-                      left: 'A',
-                    },
-                    messageId: 'extraSpacingBetweenEnumsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'Z',
-                    },
-                    messageId: 'unexpectedEnumsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'Z',
-                    },
-                    messageId: 'extraSpacingBetweenEnumsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'A',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  enum Enum {
-                    A = null,
-
-
-                   Y = null,
-                  Z = null,
-
-                      B = null,
-                  }
-                `,
-                output: dedent`
-                  enum Enum {
-                    A = null,
-                   B = null,
-                  Y = null,
-                      Z = null,
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'A',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'B',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'A',
-                    },
-                    messageId: 'missedSpacingBetweenEnumsMembers',
-                  },
-                ],
-                output: dedent`
-                  enum Enum {
-                    A = 'A', 
-
-                  B = 'B',
-                  }
-                `,
-                code: dedent`
-                  enum Enum {
-                    A = 'A', B = 'B',
-                  }
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'Z',
-                      left: 'A',
-                    },
-                    messageId: 'extraSpacingBetweenEnumsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'Y',
-                      left: 'Z',
-                    },
-                    messageId: 'unexpectedEnumsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'Y',
-                    },
-                    messageId: 'missedSpacingBetweenEnumsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'A',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'B',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  enum Enum {
-                    A = null,
-
-                   Y = null,
-                  Z = null,
-
-                      B = null,
-                  }
-                `,
-                code: dedent`
-                  enum Enum {
-                    A = null,
-
-
-                   Z = null,
-                  Y = null,
-                      B = null,
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'A', groupName: 'a' },
-                      { elementNamePattern: 'B', groupName: 'b' },
-                      { elementNamePattern: 'C', groupName: 'c' },
-                      { elementNamePattern: 'D', groupName: 'd' },
-                      { elementNamePattern: 'E', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'A',
-                    },
-                    messageId: 'missedSpacingBetweenEnumsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'C',
-                      left: 'B',
-                    },
-                    messageId: 'extraSpacingBetweenEnumsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'D',
-                      left: 'C',
-                    },
-                    messageId: 'extraSpacingBetweenEnumsMembers',
-                  },
-                ],
-                output: dedent`
-                  enum Enum {
-                    A = null,
-
-                    B = null,
-
-                    C = null,
-                    D = null,
-
-
-                    E = null,
-                  }
-                `,
-                code: dedent`
-                  enum Enum {
-                    A = null,
-                    B = null,
-
-
-                    C = null,
-
-                    D = null,
-
-
-                    E = null,
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'A', groupName: 'A' },
-                          { elementNamePattern: 'B', groupName: 'B' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'A',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'B',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'B',
-                          left: 'A',
-                        },
-                        messageId: 'missedSpacingBetweenEnumsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      enum Enum {
-                        A = 'A',
-
-
-                        B = 'B',
-                      }
-                    `,
-                    code: dedent`
-                      enum Enum {
-                        A = 'A',
-                        B = 'B',
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'A', groupName: 'a' },
-                          { elementNamePattern: 'B', groupName: 'b' },
-                          { elementNamePattern: 'C', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'B',
-                          left: 'A',
-                        },
-                        messageId: 'extraSpacingBetweenEnumsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      enum Enum {
-                        A = 'A',
-                        B = 'B',
-                      }
-                    `,
-                    code: dedent`
-                      enum Enum {
-                        A = 'A',
-
-                        B = 'B',
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'A', groupName: 'A' },
-                          { elementNamePattern: 'B', groupName: 'B' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'A',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'B',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      enum Enum {
-                        A = 'A',
-
-                        B = 'B',
-                      }
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      enum Enum {
-                        A = 'A',
-                        B = 'B',
-                      }
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  enum Enum {
-                    A = null, // Comment after
-                    B = null,
-
-                    C = null,
-                  }
-                `,
-                dedent`
-                  enum Enum {
-                    A = null, // Comment after
-
-                    B = null,
-                    C = null,
-                  }
-                `,
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'B|C',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedEnumsGroupOrder',
-                },
-              ],
-              code: dedent`
-                enum Enum {
-                  B = null,
-                  A = null, // Comment after
-
-                  C = null,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'A',
-                        groupName: 'A',
-                      },
-                    ],
-                    groups: ['A', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'C',
-                    },
-                    messageId: 'unexpectedEnumsOrder',
-                  },
-                ],
-                output: dedent`
-                  enum Enum {
-                    A = 'A',
-
-                    // Partition comment
-
-                    B = 'B',
-                    C = 'C',
-                  }
-                `,
-                code: dedent`
-                  enum Enum {
-                    A = 'A',
-
-                    // Partition comment
-
-                    C = 'C',
-                    B = 'B',
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts enum members`, rule, {
-      invalid: [
-        {
+      ],
+    ])(
+      'groups enum members by name pattern (%s)',
+      async (_description, elementNamePattern) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'bbb',
-                left: 'cc',
+                rightGroup: 'keysStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'HELLO_KEY',
+                left: 'B',
               },
-              messageId: 'unexpectedEnumsOrder',
+              messageId: 'unexpectedEnumsGroupOrder',
             },
           ],
-          output: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              cc = 'c',
-              bbb = 'b',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts enum members with number keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '12',
-                  right: '2',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                1 = 'a',
-                2 = 'c',
-                8 = 'c',
-                12 = 'b',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                1 = 'a',
-                12 = 'b',
-                2 = 'c',
-                8 = 'c',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                1 = 'a',
-                2 = 'c',
-                8 = 'c',
-                12 = 'b',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): doesn't sorts enum members without initializer`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                aaa,
-                bb = 'bb',
-                c,
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts enum members with boolean ids`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'false',
-                  left: 'true',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                false = 'b',
-                true = 'a',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                true = 'a',
-                false = 'b',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                false = 'b',
-                true = 'a',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break interface docs`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                /**
-                 * Comment A
-                 */
-                'aaa' = 'a',
-                /**
-                 * Comment B
-                 */
-                b = 'b',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                /**
-                 * Comment B
-                 */
-                b = 'b',
-                /**
-                 * Comment A
-                 */
-                'aaa' = 'a',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'b',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort enums with implicit values`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              export enum Enum {
-                d, // implicit value: 0
-                cc, // implicit value: 1
-                bbb, // implicit value: 2
-                aaaa, // implicit value: 3
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                // Part: A
-                // Not partition comment
-                bbb = 'b',
-                cc = 'c',
-                d = 'd',
-                // Part: B
-                aaaa = 'a',
-                e = 'e',
-                // Part: C
-                // Not partition comment
-                fff = 'f',
-                'gg' = 'g',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                // Part: A
-                cc = 'c',
-                d = 'd',
-                // Not partition comment
-                bbb = 'b',
-                // Part: B
-                aaaa = 'a',
-                e = 'e',
-                // Part: C
-                'gg' = 'g',
-                // Not partition comment
-                fff = 'f',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bbb',
-                  left: 'd',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-              {
-                data: {
-                  right: 'fff',
-                  left: 'gg',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                // Comment
-                bb = 'b',
-                // Other comment
-                a = 'a',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                /* Partition Comment */
-                // Part: A
-                d = 'd',
-                // Part: B
-                aaa = 'a',
-                bb = 'b',
-                c = 'c',
-                /* Other */
-                e = 'e',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                /* Partition Comment */
-                // Part: A
-                d = 'd',
-                // Part: B
-                aaa = 'a',
-                c = 'c',
-                bb = 'b',
-                /* Other */
-                e = 'e',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: sort enum values correctly`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'd',
-                left: 'c',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'e',
-                left: 'd',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'f',
-                left: 'e',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'g',
-                left: 'f',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'h',
-                left: 'g',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'i',
-                left: 'h',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              'i' = '',
-              'j' = null,
-              'k' = undefined,
-              'h' = 1,
-              'g' = 2,
-              'f' = '3',
-              'e' = 4,
-              'd' = 5,
-              'c' = 6,
-              'b' = 4444,
-              'a' = 'ffffff',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              'a' = 'ffffff',
-              'b' = 4444,
-              'c' = 6,
-              'd' = 5,
-              'e' = 4,
-              'f' = '3',
-              'g' = 2,
-              'h' = 1,
-              'i' = '',
-              'j' = null,
-              'k' = undefined,
-            }
-          `,
           options: [
             {
-              ...options,
-              sortByValue: true,
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts enum members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              cc = 'c',
-              bbb = 'b',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts enum members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              cc = 'c',
-              bbb = 'b',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            enum Enum {
-              aaaa = 'a',
-              bbb = 'b',
-              cc = 'c',
-              d = 'd',
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts enum members with number keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '12',
-                  left: '1',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                12 = 'b',
-                1 = 'a',
-                2 = 'c',
-                8 = 'c',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                1 = 'a',
-                12 = 'b',
-                2 = 'c',
-                8 = 'c',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                12 = 'b',
-                1 = 'a',
-                2 = 'c',
-                8 = 'c',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): doesn't sorts enum members without initializer`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                aaa,
-                bb = 'bb',
-                c,
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts enum members with boolean ids`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'false',
-                  left: 'true',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                false = 'b',
-                true = 'a',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                true = 'a',
-                false = 'b',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                false = 'b',
-                true = 'a',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break interface docs`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                /**
-                 * Comment A
-                 */
-                'aaa' = 'a',
-                /**
-                 * Comment B
-                 */
-                b = 'b',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                /**
-                 * Comment B
-                 */
-                b = 'b',
-                /**
-                 * Comment A
-                 */
-                'aaa' = 'a',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'b',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort enums with implicit values`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              export enum Enum {
-                d, // implicit value: 0
-                cc, // implicit value: 1
-                bbb, // implicit value: 2
-                aaaa, // implicit value: 3
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                // Part: A
-                // Not partition comment
-                bbb = 'b',
-                cc = 'c',
-                d = 'd',
-                // Part: B
-                aaaa = 'a',
-                e = 'e',
-                // Part: C
-                'gg' = 'g',
-                // Not partition comment
-                fff = 'f',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                // Part: A
-                cc = 'c',
-                d = 'd',
-                // Not partition comment
-                bbb = 'b',
-                // Part: B
-                aaaa = 'a',
-                e = 'e',
-                // Part: C
-                'gg' = 'g',
-                // Not partition comment
-                fff = 'f',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bbb',
-                  left: 'd',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              enum Enum {
-                // Comment
-                bb = 'b',
-                // Other comment
-                a = 'a',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              enum Enum {
-                /* Partition Comment */
-                // Part: A
-                d = 'd',
-                // Part: B
-                aaa = 'a',
-                bb = 'b',
-                c = 'c',
-                /* Other */
-                e = 'e',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                /* Partition Comment */
-                // Part: A
-                d = 'd',
-                // Part: B
-                aaa = 'a',
-                c = 'c',
-                bb = 'b',
-                /* Other */
-                e = 'e',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: sort enum values correctly`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'd',
-                left: 'c',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'e',
-                left: 'd',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'f',
-                left: 'e',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'g',
-                left: 'f',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'h',
-                left: 'g',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'i',
-                left: 'h',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              'i' = 'iiiiiiii',
-              'h' = 'hhhhhhh',
-              'g' = 'gggggg',
-              'f' = 'fffff',
-              'e' = 'eeee',
-              'd' = 'ddd',
-              'c' = 'cc',
-              'j' = 'jj',
-              'b' = 'b',
-              'a' = '',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              'a' = '',
-              'b' = 'b',
-              'c' = 'cc',
-              'd' = 'ddd',
-              'e' = 'eeee',
-              'f' = 'fffff',
-              'g' = 'gggggg',
-              'h' = 'hhhhhhh',
-              'i' = 'iiiiiiii',
-              'j' = 'jj',
-            }
-          `,
-          options: [
-            {
-              ...options,
-              sortByValue: true,
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                bb = 'bb',
-                c = 'c',
-                a = 'a',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                a = 'a',
-                bb = 'bb',
-                c = 'c',
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                bb = 'bb',
-                a = 'a',
-                c = 'c'
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                c = 'c',
-                bb = 'bb',
-                a = 'a'
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            enum Enum {
-              b = 'b',
-              c = 'c',
-              a = 'a',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
               customGroups: [
                 {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
+                  groupName: 'keysStartingWithHello',
+                  elementNamePattern,
                 },
               ],
-              groups: ['b', 'a'],
+              groups: ['keysStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              HELLO_KEY = 3,
+              A = 1,
+              B = 2,
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 1,
+              B = 2,
+              HELLO_KEY = 3,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array with string pattern', ['noMatch', 'HELLO']],
+      ['object pattern with flags', { pattern: 'hello', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
+      ],
+    ])(
+      'groups enum members by value pattern (%s)',
+      async (_description, elementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  elementValuePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
             },
           ],
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                rightGroup: 'valuesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'Z',
+                left: 'B',
               },
               messageId: 'unexpectedEnumsGroupOrder',
             },
           ],
           output: dedent`
             enum Enum {
-              ba = 'ba',
-              bb = 'bb',
-              ab = 'ab',
-              aa = 'aa',
+              Z = 'HELLO_KEY',
+              A = 'A',
+              B = 'B',
             }
           `,
           code: dedent`
             enum Enum {
-              ab = 'ab',
-              aa = 'aa',
-              ba = 'ba',
-              bb = 'bb',
+              A = 'A',
+              B = 'B',
+              Z = 'HELLO_KEY',
             }
           `,
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it('overrides sorting type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '_BB',
+              left: '_A',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: '_CCC',
+              left: '_BB',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: '_DDDD',
+              left: '_CCC',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedStartingWith_ByLineLength',
+              leftGroup: 'unknown',
+              right: '_EEE',
+              left: 'M',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedStartingWith_ByLineLength',
+                elementNamePattern: '_',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedStartingWith_ByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            _DDDD = null,
+            _CCC = null,
+            _EEE = null,
+            _BB = null,
+            _FF = null,
+            _A = null,
+            _G = null,
+            M = null,
+            O = null,
+            P = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            _A = null,
+            _BB = null,
+            _CCC = null,
+            _DDDD = null,
+            M = null,
+            _EEE = null,
+            _FF = null,
+            _G = null,
+            O = null,
+            P = null,
+          }
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
+    it('applies fallback sorting within custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            fooBar = 'fooBar',
+            fooZar = 'fooZar',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            fooZar = 'fooZar',
+            fooBar = 'fooBar',
+          }
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedStartingWith_',
+                elementNamePattern: '_',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedStartingWith_', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedStartingWith_',
+              leftGroup: 'unknown',
+              right: '_C',
+              left: 'M',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            _B = null,
+            _A = null,
+            _D = null,
+            _E = null,
+            _C = null,
+            M = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            _B = null,
+            _A = null,
+            _D = null,
+            _E = null,
+            M = null,
+            _C = null,
+          }
+        `,
+      })
+    })
+
+    it('groups elements matching any pattern in anyOf block', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'FOO',
+                  },
+                  {
+                    elementNamePattern: 'Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'C_FOO',
+              left: 'A',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            C_FOO = null,
+            FOO = null,
+            A = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
+            C_FOO = null,
+            FOO = null,
+          }
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*FOO).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            I_HAVE_FOO_IN_MY_NAME = null,
+            ME_TOO_I_HAVE_FOO = null,
+            A = null,
+            B = null,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'Y',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+          ],
           options: [
             {
               ...options,
               customGroups: [
                 {
-                  elementNamePattern: 'a',
+                  elementNamePattern: 'A',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = null,
+
+
+             Y = null,
+            Z = null,
+
+                B = null,
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              A = null,
+             B = null,
+            Y = null,
+                Z = null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces single newline between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'Z',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+            {
+              data: {
+                right: 'Y',
+                left: 'Z',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Y',
+              },
+              messageId: 'missedSpacingBetweenEnumsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'A',
                   groupName: 'a',
                 },
                 {
-                  elementNamePattern: 'b',
+                  elementNamePattern: 'B',
                   groupName: 'b',
                 },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = null,
+
+             Y = null,
+            Z = null,
+
+                B = null,
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = null,
+
+
+             Z = null,
+            Y = null,
+                B = null,
+            }
+          `,
+        })
+      },
+    )
+
+    it('applies newlinesBetween rules between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'B',
+                groupName: 'b',
+              },
+              {
+                elementNamePattern: 'C',
+                groupName: 'c',
+              },
+              {
+                elementNamePattern: 'D',
+                groupName: 'd',
+              },
+              {
+                elementNamePattern: 'E',
+                groupName: 'e',
+              },
+            ],
+            groups: [
+              'a',
+              {
+                newlinesBetween: 'always',
+              },
+              'b',
+              {
+                newlinesBetween: 'always',
+              },
+              'c',
+              {
+                newlinesBetween: 'never',
+              },
+              'd',
+              {
+                newlinesBetween: 'ignore',
+              },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
+            },
+            messageId: 'missedSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'C',
+              left: 'B',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'D',
+              left: 'C',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = null,
+
+            B = null,
+
+            C = null,
+            D = null,
+
+
+            E = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
+            B = null,
+
+
+            C = null,
+
+            D = null,
+
+
+            E = null,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines between non-consecutive groups when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'A' },
+                { elementNamePattern: 'B', groupName: 'B' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'A',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'B',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'B',
+                left: 'A',
               },
               messageId: 'missedSpacingBetweenEnumsMembers',
             },
           ],
           output: dedent`
             enum Enum {
-              b = 'b',
+              A = 'A',
 
-              a = 'a',
+
+              B = 'B',
             }
           `,
           code: dedent`
             enum Enum {
-              b = 'b',
-              a = 'a',
+              A = 'A',
+              B = 'B',
             }
           `,
-        },
-      ],
-      valid: [],
-    })
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}(${type}): enforces dependency sorting`, rule, {
-      invalid: [
-        {
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when never is set between all groups (global: %s)',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'a' },
+                { elementNamePattern: 'B', groupName: 'b' },
+                { elementNamePattern: 'C', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
           errors: [
             {
               data: {
-                nodeDependentOnRight: 'a',
-                right: 'b',
+                right: 'B',
+                left: 'A',
               },
-              messageId: 'unexpectedEnumsDependencyOrder',
+              messageId: 'extraSpacingBetweenEnumsMembers',
             },
           ],
           output: dedent`
             enum Enum {
-              b = 1,
-              a = b,
+              A = 'A',
+              B = 'B',
             }
           `,
           code: dedent`
             enum Enum {
-              a = b,
-              b = 1,
+              A = 'A',
+
+              B = 'B',
             }
           `,
-          options: [options],
-        },
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'allows any spacing when both options allow flexibility (global: %s, group: %s)',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'A' },
+                { elementNamePattern: 'B', groupName: 'B' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'A',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'B',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = 'A',
+
+              B = 'B',
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween setting (%s)',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'A',
+                  groupName: 'A',
+                },
+              ],
+              groups: ['A', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'C',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = 'A',
+
+              // Partition comment
+
+              B = 'B',
+              C = 'C',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+
+              // Partition comment
+
+              C = 'C',
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts enum members', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            cc = 'c',
+            bbb = 'b',
+            d = 'd',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts enum members with number keys', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            1 = 'a',
+            2 = 'c',
+            8 = 'c',
+            12 = 'b',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '8',
+              left: '12',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            1 = 'a',
+            2 = 'c',
+            8 = 'c',
+            12 = 'b',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            1 = 'a',
+            2 = 'c',
+            12 = 'b',
+            8 = 'c',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves enum members without initializer', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            aaa,
+            bb = 'bb',
+            c,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts enum members with boolean identifiers', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            false = 'b',
+            true = 'a',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'false',
+              left: 'true',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            false = 'b',
+            true = 'a',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            true = 'a',
+            false = 'b',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves documentation comments when sorting', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            /**
+             * Comment A
+             */
+            'aaa' = 'a',
+            /**
+             * Comment B
+             */
+            b = 'b',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            /**
+             * Comment B
+             */
+            b = 'b',
+            /**
+             * Comment A
+             */
+            'aaa' = 'a',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'b',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('preserves implicit values in enums', async () => {
+      await valid({
+        code: dedent`
+          export enum Enum {
+            d, // implicit value: 0
+            cc, // implicit value: 1
+            bbb, // implicit value: 2
+            aaaa, // implicit value: 3
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts within partition comments', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            // Part: A
+            // Not partition comment
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+            // Part: B
+            aaaa = 'a',
+            e = 'e',
+            // Part: C
+            // Not partition comment
+            fff = 'f',
+            'gg' = 'g',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            // Part: A
+            cc = 'c',
+            d = 'd',
+            // Not partition comment
+            bbb = 'b',
+            // Part: B
+            aaaa = 'a',
+            e = 'e',
+            // Part: C
+            'gg' = 'g',
+            // Not partition comment
+            fff = 'f',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition delimiters', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            // Comment
+            bb = 'b',
+            // Other comment
+            a = 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('handles multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            /* Partition Comment */
+            // Part: A
+            d = 'd',
+            // Part: B
+            aaa = 'a',
+            bb = 'b',
+            c = 'c',
+            /* Other */
+            e = 'e',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            /* Partition Comment */
+            // Part: A
+            d = 'd',
+            // Part: B
+            aaa = 'a',
+            c = 'c',
+            bb = 'b',
+            /* Other */
+            e = 'e',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            E = 'E',
+            F = 'F',
+            // I am a partition comment because I don't have f o o
+            A = 'A',
+            B = 'B',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line partition is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            /* Comment */
+            A = "A",
+            B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B",
+            /* Comment */
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('treats line comments as partition delimiters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = "B",
+            // Comment
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('handles multiple line comment patterns', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+             C = "C",
+             // B
+             B = "B",
+             // A
+             A = "A",
+           }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            // I am a partition comment because I don't have f o o
+            A = 'A',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block partition is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            // Comment
+            A = "A",
+            B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B",
+            // Comment
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('treats block comments as partition delimiters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = "B",
+            /* Comment */
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('handles multiple block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+             C = "C",
+             /* B */
+             B = "B",
+             /* A */
+             A = "A",
+           }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            /* I am a partition comment because I don't have f o o */
+            A = 'A',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('sorts enum members by their values', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'e',
+              left: 'd',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'f',
+              left: 'e',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'g',
+              left: 'f',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'h',
+              left: 'g',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'i',
+              left: 'h',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'j',
+              left: 'i',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            'j' = null,
+            'k' = undefined,
+            'i' = 'a',
+            'h' = 'b',
+            'g' = 'c',
+            'f' = 'd',
+            'e' = 'e',
+            'd' = 'f',
+            'c' = 'g',
+            'b' = 'h',
+            'a' = 'i',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            'a' = 'i',
+            'b' = 'h',
+            'c' = 'g',
+            'd' = 'f',
+            'e' = 'e',
+            'f' = 'd',
+            'g' = 'c',
+            'h' = 'b',
+            'i' = 'a',
+            'j' = null,
+            'k' = undefined,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            sortByValue: true,
+          },
+        ],
+      })
+    })
+
+    it('trims special characters when sorting', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            _A = 'A',
+            B = 'B',
+            _C = 'C',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('removes special characters when sorting', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            AB = 'AB',
+            A_C = 'AC',
+          }
+        `,
+      })
+    })
+
+    it('sorts using specified locale', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B',
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline enum members correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = "A", B = "B"
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B", A = "A"
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = "A", B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B", A = "A",
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array with string pattern', ['noMatch', 'HELLO']],
+      ['object pattern with flags', { pattern: 'hello', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
       ],
-      valid: [],
+    ])(
+      'groups enum members by name pattern (%s)',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'keysStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'HELLO_KEY',
+                left: 'B',
+              },
+              messageId: 'unexpectedEnumsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'keysStartingWithHello',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['keysStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              HELLO_KEY = 3,
+              A = 1,
+              B = 2,
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 1,
+              B = 2,
+              HELLO_KEY = 3,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array with string pattern', ['noMatch', 'HELLO']],
+      ['object pattern with flags', { pattern: 'hello', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
+      ],
+    ])(
+      'groups enum members by value pattern (%s)',
+      async (_description, elementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  elementValuePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'valuesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'Z',
+                left: 'B',
+              },
+              messageId: 'unexpectedEnumsGroupOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              Z = 'HELLO_KEY',
+              A = 'A',
+              B = 'B',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+              Z = 'HELLO_KEY',
+            }
+          `,
+        })
+      },
+    )
+
+    it('overrides sorting type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '_BB',
+              left: '_A',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: '_CCC',
+              left: '_BB',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: '_DDDD',
+              left: '_CCC',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedStartingWith_ByLineLength',
+              leftGroup: 'unknown',
+              right: '_EEE',
+              left: 'M',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedStartingWith_ByLineLength',
+                elementNamePattern: '_',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedStartingWith_ByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            _DDDD = null,
+            _CCC = null,
+            _EEE = null,
+            _BB = null,
+            _FF = null,
+            _A = null,
+            _G = null,
+            M = null,
+            O = null,
+            P = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            _A = null,
+            _BB = null,
+            _CCC = null,
+            _DDDD = null,
+            M = null,
+            _EEE = null,
+            _FF = null,
+            _G = null,
+            O = null,
+            P = null,
+          }
+        `,
+      })
+    })
+
+    it('applies fallback sorting within custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            fooBar = 'fooBar',
+            fooZar = 'fooZar',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            fooZar = 'fooZar',
+            fooBar = 'fooBar',
+          }
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedStartingWith_',
+                elementNamePattern: '_',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedStartingWith_', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedStartingWith_',
+              leftGroup: 'unknown',
+              right: '_C',
+              left: 'M',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            _B = null,
+            _A = null,
+            _D = null,
+            _E = null,
+            _C = null,
+            M = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            _B = null,
+            _A = null,
+            _D = null,
+            _E = null,
+            M = null,
+            _C = null,
+          }
+        `,
+      })
+    })
+
+    it('groups elements matching any pattern in anyOf block', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'FOO',
+                  },
+                  {
+                    elementNamePattern: 'Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'C_FOO',
+              left: 'A',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            C_FOO = null,
+            FOO = null,
+            A = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
+            C_FOO = null,
+            FOO = null,
+          }
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*FOO).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            I_HAVE_FOO_IN_MY_NAME = null,
+            ME_TOO_I_HAVE_FOO = null,
+            A = null,
+            B = null,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'Y',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'A',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = null,
+
+
+             Y = null,
+            Z = null,
+
+                B = null,
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              A = null,
+             B = null,
+            Y = null,
+                Z = null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces single newline between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'Z',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+            {
+              data: {
+                right: 'Y',
+                left: 'Z',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Y',
+              },
+              messageId: 'missedSpacingBetweenEnumsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'A',
+                  groupName: 'a',
+                },
+                {
+                  elementNamePattern: 'B',
+                  groupName: 'b',
+                },
+              ],
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = null,
+
+             Y = null,
+            Z = null,
+
+                B = null,
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = null,
+
+
+             Z = null,
+            Y = null,
+                B = null,
+            }
+          `,
+        })
+      },
+    )
+
+    it('applies newlinesBetween rules between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'B',
+                groupName: 'b',
+              },
+              {
+                elementNamePattern: 'C',
+                groupName: 'c',
+              },
+              {
+                elementNamePattern: 'D',
+                groupName: 'd',
+              },
+              {
+                elementNamePattern: 'E',
+                groupName: 'e',
+              },
+            ],
+            groups: [
+              'a',
+              {
+                newlinesBetween: 'always',
+              },
+              'b',
+              {
+                newlinesBetween: 'always',
+              },
+              'c',
+              {
+                newlinesBetween: 'never',
+              },
+              'd',
+              {
+                newlinesBetween: 'ignore',
+              },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
+            },
+            messageId: 'missedSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'C',
+              left: 'B',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'D',
+              left: 'C',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = null,
+
+            B = null,
+
+            C = null,
+            D = null,
+
+
+            E = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
+            B = null,
+
+
+            C = null,
+
+            D = null,
+
+
+            E = null,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines between non-consecutive groups when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'A' },
+                { elementNamePattern: 'B', groupName: 'B' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'A',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'B',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenEnumsMembers',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = 'A',
+
+
+              B = 'B',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when never is set between all groups (global: %s)',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'a' },
+                { elementNamePattern: 'B', groupName: 'b' },
+                { elementNamePattern: 'C', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'allows any spacing when both options allow flexibility (global: %s, group: %s)',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'A' },
+                { elementNamePattern: 'B', groupName: 'B' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'A',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'B',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = 'A',
+
+              B = 'B',
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween setting (%s)',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'A',
+                  groupName: 'A',
+                },
+              ],
+              groups: ['A', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'C',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = 'A',
+
+              // Partition comment
+
+              B = 'B',
+              C = 'C',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+
+              // Partition comment
+
+              C = 'C',
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts enum members', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            cc = 'c',
+            bbb = 'b',
+            d = 'd',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts enum members with number keys', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            12 = 'b',
+            1 = 'a',
+            2 = 'c',
+            8 = 'c',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '12',
+              left: '8',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            12 = 'b',
+            1 = 'a',
+            2 = 'c',
+            8 = 'c',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            1 = 'a',
+            2 = 'c',
+            8 = 'c',
+            12 = 'b',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves enum members without initializer', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            aaa,
+            bb = 'bb',
+            c,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts enum members with boolean identifiers', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            false = 'b',
+            true = 'a',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'false',
+              left: 'true',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            false = 'b',
+            true = 'a',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            true = 'a',
+            false = 'b',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves documentation comments when sorting', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            /**
+             * Comment A
+             */
+            'aaa' = 'a',
+            /**
+             * Comment B
+             */
+            b = 'b',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            /**
+             * Comment B
+             */
+            b = 'b',
+            /**
+             * Comment A
+             */
+            'aaa' = 'a',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'b',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('preserves implicit values in enums', async () => {
+      await valid({
+        code: dedent`
+          export enum Enum {
+            d, // implicit value: 0
+            cc, // implicit value: 1
+            bbb, // implicit value: 2
+            aaaa, // implicit value: 3
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts within partition comments', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            // Part: A
+            // Not partition comment
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+            // Part: B
+            aaaa = 'a',
+            e = 'e',
+            // Part: C
+            'gg' = 'g',
+            // Not partition comment
+            fff = 'f',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            // Part: A
+            cc = 'c',
+            d = 'd',
+            // Not partition comment
+            bbb = 'b',
+            // Part: B
+            aaaa = 'a',
+            e = 'e',
+            // Part: C
+            'gg' = 'g',
+            // Not partition comment
+            fff = 'f',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition delimiters', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            // Comment
+            bb = 'b',
+            // Other comment
+            a = 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('handles multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            /* Partition Comment */
+            // Part: A
+            d = 'd',
+            // Part: B
+            aaa = 'a',
+            bb = 'b',
+            c = 'c',
+            /* Other */
+            e = 'e',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            /* Partition Comment */
+            // Part: A
+            d = 'd',
+            // Part: B
+            aaa = 'a',
+            c = 'c',
+            bb = 'b',
+            /* Other */
+            e = 'e',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            E = 'E',
+            F = 'F',
+            // I am a partition comment because I don't have f o o
+            A = 'A',
+            B = 'B',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line partition is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            /* Comment */
+            AA = "AA",
+            B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B",
+            /* Comment */
+            AA = "AA",
+          }
+        `,
+      })
+    })
+
+    it('treats line comments as partition delimiters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = "B",
+            // Comment
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('handles multiple line comment patterns', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+             C = "C",
+             // B
+             B = "B",
+             // A
+             A = "A",
+           }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            // I am a partition comment because I don't have f o o
+            A = 'A',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block partition is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            // Comment
+            AA = "AA",
+            B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B",
+            // Comment
+            AA = "AA",
+          }
+        `,
+      })
+    })
+
+    it('treats block comments as partition delimiters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = "B",
+            /* Comment */
+            A = "A",
+          }
+        `,
+      })
+    })
+
+    it('handles multiple block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+             C = "C",
+             /* B */
+             B = "B",
+             /* A */
+             A = "A",
+           }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            /* I am a partition comment because I don't have f o o */
+            A = 'A',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('sorts enum members by their values', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'j',
+              left: 'i',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'k',
+              left: 'j',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            'k' = undefined,
+            'j' = null,
+            'a' = 'i',
+            'b' = 'h',
+            'c' = 'g',
+            'd' = 'f',
+            'e' = 'e',
+            'f' = 'd',
+            'g' = 'c',
+            'h' = 'b',
+            'i' = 'a',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            'a' = 'i',
+            'b' = 'h',
+            'c' = 'g',
+            'd' = 'f',
+            'e' = 'e',
+            'f' = 'd',
+            'g' = 'c',
+            'h' = 'b',
+            'i' = 'a',
+            'j' = null,
+            'k' = undefined,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            sortByValue: true,
+          },
+        ],
+      })
+    })
+
+    it('trims special characters when sorting', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            _A = 'A',
+            BB = 'B',
+            _C = 'C',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('removes special characters when sorting', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            A_C = 'AC',
+            AB = 'AB',
+          }
+        `,
+      })
+    })
+
+    it('sorts using specified locale', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B',
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline enum members correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            AA = "AA", B = "B"
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B", AA = "AA"
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            AA = "AA", B = "B",
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = "B", AA = "AA",
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array with string pattern', ['noMatch', 'HELLO']],
+      ['object pattern with flags', { pattern: 'hello', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
+      ],
+    ])(
+      'groups enum members by name pattern (%s)',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'keysStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'HELLO_KEY',
+                left: 'B',
+              },
+              messageId: 'unexpectedEnumsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'keysStartingWithHello',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['keysStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              HELLO_KEY = 3,
+              A = 1,
+              B = 2,
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 1,
+              B = 2,
+              HELLO_KEY = 3,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array with string pattern', ['noMatch', 'HELLO']],
+      ['object pattern with flags', { pattern: 'hello', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'hello', flags: 'i' }],
+      ],
+    ])(
+      'groups enum members by value pattern (%s)',
+      async (_description, elementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  elementValuePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'valuesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'Z',
+                left: 'B',
+              },
+              messageId: 'unexpectedEnumsGroupOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              Z = 'HELLO_KEY',
+              A = 'A',
+              B = 'B',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+              Z = 'HELLO_KEY',
+            }
+          `,
+        })
+      },
+    )
+
+    it('overrides sorting type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '_BB',
+              left: '_A',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: '_CCC',
+              left: '_BB',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: '_DDDD',
+              left: '_CCC',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedStartingWith_ByLineLength',
+              leftGroup: 'unknown',
+              right: '_EEE',
+              left: 'M',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedStartingWith_ByLineLength',
+                elementNamePattern: '_',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedStartingWith_ByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            _DDDD = null,
+            _CCC = null,
+            _EEE = null,
+            _BB = null,
+            _FF = null,
+            _A = null,
+            _G = null,
+            M = null,
+            O = null,
+            P = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            _A = null,
+            _BB = null,
+            _CCC = null,
+            _DDDD = null,
+            M = null,
+            _EEE = null,
+            _FF = null,
+            _G = null,
+            O = null,
+            P = null,
+          }
+        `,
+      })
+    })
+
+    it('applies fallback sorting within custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            fooBar = 'fooBar',
+            fooZar = 'fooZar',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            fooZar = 'fooZar',
+            fooBar = 'fooBar',
+          }
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedStartingWith_',
+                elementNamePattern: '_',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedStartingWith_', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedStartingWith_',
+              leftGroup: 'unknown',
+              right: '_C',
+              left: 'M',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            _B = null,
+            _A = null,
+            _D = null,
+            _E = null,
+            _C = null,
+            M = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            _B = null,
+            _A = null,
+            _D = null,
+            _E = null,
+            M = null,
+            _C = null,
+          }
+        `,
+      })
+    })
+
+    it('groups elements matching any pattern in anyOf block', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'FOO',
+                  },
+                  {
+                    elementNamePattern: 'Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'C_FOO',
+              left: 'A',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            C_FOO = null,
+            FOO = null,
+            A = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
+            C_FOO = null,
+            FOO = null,
+          }
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*FOO).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            I_HAVE_FOO_IN_MY_NAME = null,
+            ME_TOO_I_HAVE_FOO = null,
+            A = null,
+            B = null,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'AAAA',
+                right: 'YY',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+            {
+              data: {
+                right: 'BBB',
+                left: 'Z',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'BBB',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'AAAA',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              AAAA = null,
+
+
+             YY = null,
+            Z = null,
+
+                BBB = null,
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              AAAA = null,
+             BBB = null,
+            YY = null,
+                Z = null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces single newline between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'AAAA',
+                right: 'Z',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+            {
+              data: {
+                right: 'YY',
+                left: 'Z',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'BBB',
+                left: 'YY',
+              },
+              messageId: 'missedSpacingBetweenEnumsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'AAAA',
+                  groupName: 'a',
+                },
+                {
+                  elementNamePattern: 'BBB',
+                  groupName: 'b',
+                },
+              ],
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              AAAA = null,
+
+             YY = null,
+            Z = null,
+
+                BBB = null,
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              AAAA = null,
+
+
+             Z = null,
+            YY = null,
+                BBB = null,
+            }
+          `,
+        })
+      },
+    )
+
+    it('applies newlinesBetween rules between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'B',
+                groupName: 'b',
+              },
+              {
+                elementNamePattern: 'C',
+                groupName: 'c',
+              },
+              {
+                elementNamePattern: 'D',
+                groupName: 'd',
+              },
+              {
+                elementNamePattern: 'E',
+                groupName: 'e',
+              },
+            ],
+            groups: [
+              'a',
+              {
+                newlinesBetween: 'always',
+              },
+              'b',
+              {
+                newlinesBetween: 'always',
+              },
+              'c',
+              {
+                newlinesBetween: 'never',
+              },
+              'd',
+              {
+                newlinesBetween: 'ignore',
+              },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
+            },
+            messageId: 'missedSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'C',
+              left: 'B',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'D',
+              left: 'C',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = null,
+
+            B = null,
+
+            C = null,
+            D = null,
+
+
+            E = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
+            B = null,
+
+
+            C = null,
+
+            D = null,
+
+
+            E = null,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines between non-consecutive groups when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'A' },
+                { elementNamePattern: 'B', groupName: 'B' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'A',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'B',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenEnumsMembers',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = 'A',
+
+
+              B = 'B',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when never is set between all groups (global: %s)',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'a' },
+                { elementNamePattern: 'B', groupName: 'b' },
+                { elementNamePattern: 'C', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenEnumsMembers',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              A = 'A',
+
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'allows any spacing when both options allow flexibility (global: %s, group: %s)',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'A', groupName: 'A' },
+                { elementNamePattern: 'B', groupName: 'B' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'A',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'B',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = 'A',
+
+              B = 'B',
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              A = 'A',
+              B = 'B',
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween setting (%s)',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'AAA',
+                  groupName: 'AAA',
+                },
+              ],
+              groups: ['AAA', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'BB',
+                left: 'C',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              AAA = 'AAA',
+
+              // Partition comment
+
+              BB = 'BB',
+              C = 'C',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              AAA = 'AAA',
+
+              // Partition comment
+
+              C = 'C',
+              BB = 'BB',
+            }
+          `,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts enum members', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            aaaa = 'a',
+            bbb = 'b',
+            cc = 'c',
+            d = 'd',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            aaaa = 'a',
+            cc = 'c',
+            bbb = 'b',
+            d = 'd',
+          }
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('preserves original order when sorting is disabled', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            b = 'b',
+            c = 'c',
+            a = 'a',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: '^b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedEnumsGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            ba = 'ba',
+            bb = 'bb',
+            ab = 'ab',
+            aa = 'aa',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            ab = 'ab',
+            aa = 'aa',
+            ba = 'ba',
+            bb = 'bb',
+          }
+        `,
+      })
+    })
+
+    it('adds newlines between groups when required', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenEnumsMembers',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            b = 'b',
+
+            a = 'a',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            b = 'b',
+            a = 'a',
+          }
+        `,
+      })
+    })
+
+    it('respects dependencies between enum members', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+            },
+            messageId: 'unexpectedEnumsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            b = 1,
+            a = b,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            a = b,
+            b = 1,
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
-    ruleTester.run(`${ruleName}: detects numeric enums`, rule, {
-      valid: [
-        {
+
+    it('detects numeric enums correctly', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            'a' = '1',
+            'b' = 2,
+            'c' = 0,
+          }
+        `,
+        options: [
+          {
+            forceNumericSort: true,
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+              'a' = 1,
+              'b' = 2,
+              'c' = 0,
+              d,
+            }
+        `,
+        options: [
+          {
+            forceNumericSort: true,
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+              'a' = 1,
+              'b' = 2,
+              'c' = 0,
+              d = undefined,
+            }
+        `,
+        options: [
+          {
+            forceNumericSort: true,
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+              'a' = 1,
+              'b' = 2,
+              'c' = 0,
+              d = null,
+            }
+        `,
+        options: [
+          {
+            forceNumericSort: true,
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+              'i' = ~2, // -3
+              'k' = -1,
+              'j' = - 0.1,
+              'e' = - (((1 + 1) * 2) ** 2) / 4 % 2, // 0
+              'f' = 0,
+              'h' = +1,
+              'g' = 3 - 1, // 2
+              'b' = 5^6, // 3
+              'l' = 1 + 3, // 4
+              'm' = 2.1 ** 2, // 4.41
+              'a' = 20 >> 2, // 5
+              'm' = 7 & 6, // 6
+              'c' = 5 | 6, // 7
+              'd' = 2 << 2, // 8
+            }
+        `,
+        options: [
+          {
+            forceNumericSort: true,
+          },
+        ],
+      })
+    })
+
+    it.each(['alphabetical', 'line-length', 'natural'])(
+      'sorts numeric enums by value when sortByValue is enabled (type: %s)',
+      async type => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'c',
+                left: 'a',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              'c' = 0,
+              'a' = 1,
+              'b' = 2,
+            }
+          `,
           code: dedent`
             enum Enum {
-              'a' = '1',
               'b' = 2,
+              'a' = 1,
+              'c' = 0,
+            }
+          `,
+          options: [
+            {
+              sortByValue: true,
+              type,
+            },
+          ],
+        })
+      },
+    )
+
+    it.each(['alphabetical', 'line-length', 'natural'])(
+      'forces numeric sorting when forceNumericSort is enabled (type: %s)',
+      async type => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+            {
+              data: {
+                right: 'c',
+                left: 'a',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              'c' = 0,
+              'a' = 1,
+              'b' = 2,
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              'b' = 2,
+              'a' = 1,
               'c' = 0,
             }
           `,
           options: [
             {
               forceNumericSort: true,
+              type,
             },
           ],
-        },
-        {
-          code: dedent`
-            enum Enum {
-                'a' = 1,
-                'b' = 2,
-                'c' = 0,
-                d,
-              }
-          `,
-          options: [
-            {
-              forceNumericSort: true,
-            },
-          ],
-        },
-        {
-          code: dedent`
-            enum Enum {
-                'a' = 1,
-                'b' = 2,
-                'c' = 0,
-                d = undefined,
-              }
-          `,
-          options: [
-            {
-              forceNumericSort: true,
-            },
-          ],
-        },
-        {
-          code: dedent`
-            enum Enum {
-                'a' = 1,
-                'b' = 2,
-                'c' = 0,
-                d = null,
-              }
-          `,
-          options: [
-            {
-              forceNumericSort: true,
-            },
-          ],
-        },
-        {
-          code: dedent`
-            enum Enum {
-                'i' = ~2, // -3
-                'k' = -1,
-                'j' = - 0.1,
-                'e' = - (((1 + 1) * 2) ** 2) / 4 % 2, // 0
-                'f' = 0,
-                'h' = +1,
-                'g' = 3 - 1, // 2
-                'b' = 5^6, // 3
-                'l' = 1 + 3, // 4
-                'm' = 2.1 ** 2, // 4.41
-                'a' = 20 >> 2, // 5
-                'm' = 7 & 6, // 6
-                'c' = 5 | 6, // 7
-                'd' = 2 << 2, // 8
-              }
-          `,
-          options: [
-            {
-              forceNumericSort: true,
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-
-    let sortTypes: Options[0]['type'][] = [
-      'alphabetical',
-      'line-length',
-      'natural',
-    ]
-
-    for (let type of sortTypes) {
-      ruleTester.run(
-        `${ruleName}: sortByValue = true => sorts numerical enums numerically for type ${type}`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  'c' = 0,
-                  'a' = 1,
-                  'b' = 2,
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  'b' = 2,
-                  'a' = 1,
-                  'c' = 0,
-                }
-              `,
-              options: [
-                {
-                  sortByValue: true,
-                  type,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: forceNumericSort = true => sorts numerical enums numerically regardless for type ${type}`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-                {
-                  data: {
-                    right: 'c',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  'c' = 0,
-                  'a' = 1,
-                  'b' = 2,
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  'b' = 2,
-                  'a' = 1,
-                  'c' = 0,
-                }
-              `,
-              options: [
-                {
-                  forceNumericSort: true,
-                  type,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    }
-
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                'a' = 'a',
-                'b' = 'b',
-                'c' = 'c',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                'b' = 'b',
-                'a' = 'a',
-                'c' = 'c',
-              }
-            `,
-          },
-        ],
-        valid: [
-          dedent`
-            enum Enum {
-              'a' = 'a',
-              'b' = 'b',
-              'c' = 'c',
-            }
-          `,
-          {
-            code: dedent`
-              enum NumberBase {
-                BASE_10 = 10,
-                BASE_16 = 16,
-                BASE_2 = 2,
-                BASE_8 = 8
-              }
-            `,
-            options: [{}],
-          },
-        ],
+        })
       },
     )
 
-    describe('detects dependencies', () => {
-      ruleTester.run(`${ruleName}: works with dependencies`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'B',
-                  left: 'C',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                B = 0,
-                A = B,
-                C = 'C',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                C = 'C',
-                B = 0,
-                A = B,
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'B',
-                  left: 'C',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                B = 0,
-                A = Enum.B,
-                C = 'C',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                C = 'C',
-                B = 0,
-                A = Enum.B,
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'B',
-                  left: 'C',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                B = 0,
-                A = 1 | 2 | B | Enum.B,
-                C = 3,
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                C = 3,
-                B = 0,
-                A = 1 | 2 | B | Enum.B,
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                A = AnotherEnum.B,
-                B = 'B',
-                C = 'C',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                B = 'B',
-                A = AnotherEnum.B,
-                C = 'C',
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'A',
-                  right: 'C',
-                },
-                messageId: 'unexpectedEnumsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              enum Enum {
-                C = 10,
-                A = Enum.C,
-                B = 10,
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                A = Enum.C,
-                B = 10,
-                C = 10,
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-        ],
-        valid: [],
+    it('applies default alphabetical ascending order', async () => {
+      await valid(
+        dedent`
+          enum Enum {
+            'a' = 'a',
+            'b' = 'b',
+            'c' = 'c',
+          }
+        `,
+      )
+
+      await valid({
+        code: dedent`
+          enum NumberBase {
+            BASE_10 = 10,
+            BASE_16 = 16,
+            BASE_2 = 2,
+            BASE_8 = 8
+          }
+        `,
+        options: [{}],
       })
 
-      ruleTester.run(
-        `${ruleName} detects dependencies in template literal expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                enum Enum {
-                  A = \`\${AnotherEnum.D}\`,
-                  D = 'D',
-                  B = \`\${Enum.D}\`,
-                  C = \`\${D}\`,
-                }
-              `,
-              options: [
-                {
-                  type: 'alphabetical',
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: detects and ignores circular dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                enum Enum {
-                  A = 'A',
-                  B = F,
-                  C = 'C',
-                  D = B,
-                  E = 'E',
-                  F = D
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  B = F,
-                  A = 'A',
-                  C = 'C',
-                  D = B,
-                  E = 'E',
-                  F = D
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-              ],
-              options: [
-                {
-                  type: 'alphabetical',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: prioritizes dependencies over partitionByComment`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'B',
-                    right: 'A',
-                  },
-                  messageId: 'unexpectedEnumsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                enum Enum {
-                  A = 'A',
-                  // Part: 1
-                  B = A,
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  B = A,
-                  // Part: 1
-                  A = 'A',
-                }
-              `,
-              options: [
-                {
-                  partitionByComment: '^Part',
-                  type: 'alphabetical',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: prioritizes dependencies over group configuration`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'attributesStartingWithA',
-                      elementNamePattern: 'A',
-                    },
-                    {
-                      groupName: 'attributesStartingWithB',
-                      elementNamePattern: 'B',
-                    },
-                  ],
-                  groups: [
-                    'attributesStartingWithA',
-                    'attributesStartingWithB',
-                  ],
-                },
-              ],
-              code: dedent`
-                enum Enum {
-                  B = 'B',
-                  A = B,
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}: handles complex comment cases`, () => {
-      ruleTester.run(
-        `${ruleName}: keeps comments associated to their node`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                enum Enum {
-                  // Ignore this comment
-
-                  // A3
-                  /**
-                    * A2
-                    */
-                  // A1
-                  A = 'A',
-
-                  // Ignore this comment
-
-                  // B2
-                  /**
-                    * B1
-                    */
-                  B = 'B',
-                }
-              `,
-              code: dedent`
-                enum Enum {
-                  // Ignore this comment
-
-                  // B2
-                  /**
-                    * B1
-                    */
-                  B = 'B',
-
-                  // Ignore this comment
-
-                  // A3
-                  /**
-                    * A2
-                    */
-                  // A1
-                  A = 'A',
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedEnumsOrder',
-                },
-              ],
-              options: [
-                {
-                  type: 'alphabetical',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: handles partition comments`, rule, {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            output: dedent`
-              enum Enum {
-                // Ignore this comment
-
-                // B2
-                /**
-                  * B1
-                  */
-                B = 'B',
-
-                // C2
-                // C1
-                C = 'C',
-
-                // Above a partition comment ignore me
-                // PartitionComment: 1
-                A = 'A',
-
-                /**
-                  * D2
-                  */
-                // D1
-                D = 'D',
-              }
-            `,
-            code: dedent`
-              enum Enum {
-                // Ignore this comment
-
-                // C2
-                // C1
-                C = 'C',
-
-                // B2
-                /**
-                  * B1
-                  */
-                B = 'B',
-
-                // Above a partition comment ignore me
-                // PartitionComment: 1
-                /**
-                  * D2
-                  */
-                // D1
-                D = 'D',
-
-                A = 'A',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'B',
-                  left: 'C',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-              {
-                data: {
-                  right: 'A',
-                  left: 'D',
-                },
-                messageId: 'unexpectedEnumsOrder',
-              },
-            ],
-            options: [
-              {
-                partitionByComment: 'PartitionComment:',
-                type: 'alphabetical',
-              },
-            ],
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedEnumsOrder',
           },
         ],
-        valid: [],
+        output: dedent`
+          enum Enum {
+            'a' = 'a',
+            'b' = 'b',
+            'c' = 'c',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            'b' = 'b',
+            'a' = 'a',
+            'c' = 'c',
+          }
+        `,
       })
     })
 
-    ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'C',
-                left: 'D',
-              },
-              messageId: 'unexpectedEnumsOrder',
+    it('handles dependencies between enum members', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-            {
-              data: {
-                right: 'A',
-                left: 'E',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 0,
+            A = B,
+            C = 'C',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 0,
+            A = B,
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              C = 'C',
-              D = 'D',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 0,
+            A = Enum.B,
+            C = 'C',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 0,
+            A = Enum.B,
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
 
-              B = 'B',
-
-              A = 'A',
-              E = 'E',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              D = 'D',
-              C = 'C',
-
-              B = 'B',
-
-              E = 'E',
-              A = 'A',
-            }
-          `,
-          options: [
-            {
-              partitionByNewLine: true,
-              type: 'alphabetical',
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 0,
+            A = 1 | 2 | B | Enum.B,
+            C = 3,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 3,
+            B = 0,
+            A = 1 | 2 | B | Enum.B,
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = AnotherEnum.B,
+            B = 'B',
+            C = 'C',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            A = AnotherEnum.B,
+            C = 'C',
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'C',
+            },
+            messageId: 'unexpectedEnumsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            C = 10,
+            A = Enum.C,
+            B = 10,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = Enum.C,
+            B = 10,
+            C = 10,
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
+    it('detects dependencies in template literal expressions', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            A = \`\${AnotherEnum.D}\`,
+            D = 'D',
+            B = \`\${Enum.D}\`,
+            C = \`\${D}\`,
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('ignores circular dependencies when sorting', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            A = 'A',
+            B = F,
+            C = 'C',
+            D = B,
+            E = 'E',
+            F = D
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = F,
+            A = 'A',
+            C = 'C',
+            D = B,
+            E = 'E',
+            F = D
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'B',
+              right: 'A',
+            },
+            messageId: 'unexpectedEnumsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = 'A',
+            // Part: 1
+            B = A,
+          }
+        `,
+        options: [
+          {
+            partitionByComment: '^Part',
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = A,
+            // Part: 1
+            A = 'A',
+          }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'attributesStartingWithA',
+                elementNamePattern: 'A',
               },
-              messageId: 'unexpectedEnumsOrder',
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              // eslint-disable-next-line
-              A = 'A'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              // eslint-disable-next-line
-              A = 'A'
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'C',
-                left: 'D',
+              {
+                groupName: 'attributesStartingWithB',
+                elementNamePattern: 'B',
               },
-              messageId: 'unexpectedEnumsOrder',
+            ],
+            groups: ['attributesStartingWithA', 'attributesStartingWithB'],
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            A = B,
+          }
+        `,
+      })
+    })
+
+    it('preserves comments with their associated nodes', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            // Ignore this comment
+
+            // A3
+            /**
+              * A2
+              */
+            // A1
+            A = 'A',
+
+            // Ignore this comment
+
+            // B2
+            /**
+              * B1
+              */
+            B = 'B',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            // Ignore this comment
+
+            // B2
+            /**
+              * B1
+              */
+            B = 'B',
+
+            // Ignore this comment
+
+            // A3
+            /**
+              * A2
+              */
+            // A1
+            A = 'A',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'A',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('handles partition comments correctly', async () => {
+      await invalid({
+        output: dedent`
+          enum Enum {
+            // Ignore this comment
+
+            // B2
+            /**
+              * B1
+              */
+            B = 'B',
+
+            // C2
+            // C1
+            C = 'C',
+
+            // Above a partition comment ignore me
+            // PartitionComment: 1
+            A = 'A',
+
+            /**
+              * D2
+              */
+            // D1
+            D = 'D',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            // Ignore this comment
+
+            // C2
+            // C1
+            C = 'C',
+
+            // B2
+            /**
+              * B1
+              */
+            B = 'B',
+
+            // Above a partition comment ignore me
+            // PartitionComment: 1
+            /**
+              * D2
+              */
+            // D1
+            D = 'D',
+
+            A = 'A',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              // eslint-disable-next-line
-              A = 'A',
-              D = 'D'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              D = 'D',
-              C = 'C',
-              // eslint-disable-next-line
-              A = 'A',
-              B = 'B'
-            }
-          `,
-          options: [
-            {
-              partitionByComment: true,
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'A',
+              left: 'D',
             },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [
+          {
+            partitionByComment: 'PartitionComment:',
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('uses new lines as partition boundaries', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'C',
+              left: 'D',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              B = A,
-              C = 'C',
-              // eslint-disable-next-line
-              A = 'A'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = A,
-              // eslint-disable-next-line
-              A = 'A'
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'A',
+              left: 'E',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              A = 'A' // eslint-disable-line
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              A = 'A' // eslint-disable-line
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            C = 'C',
+            D = 'D',
+
+            B = 'B',
+
+            A = 'A',
+            E = 'E',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            D = 'D',
+            C = 'C',
+
+            B = 'B',
+
+            E = 'E',
+            A = 'A',
+          }
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('supports eslint-disable comments for individual nodes', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            // eslint-disable-next-line
+            A = 'A',
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              /* eslint-disable-next-line */
-              A = 'A'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              /* eslint-disable-next-line */
-              A = 'A'
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            // eslint-disable-next-line
+            A = 'A'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            // eslint-disable-next-line
+            A = 'A'
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'C',
+              left: 'D',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              A = 'A' /* eslint-disable-line */
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              A = 'A' /* eslint-disable-line */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            enum Enum {
-              A = 'A',
-              D = 'D',
-              /* eslint-disable */
-              C = 'C',
-              B = 'B',
-              // Shouldn't move
-              /* eslint-enable */
-              E = 'E'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              D = 'D',
-              E = 'E',
-              /* eslint-disable */
-              C = 'C',
-              B = 'B',
-              // Shouldn't move
-              /* eslint-enable */
-              A = 'A'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              A = 'A'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              A = 'A'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            // eslint-disable-next-line
+            A = 'A',
+            D = 'D'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            D = 'D',
+            C = 'C',
+            // eslint-disable-next-line
+            A = 'A',
+            B = 'B'
+          }
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              A = 'A' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              A = 'A' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = A,
+            C = 'C',
+            // eslint-disable-next-line
+            A = 'A'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = A,
+            // eslint-disable-next-line
+            A = 'A'
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              A = 'A'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              A = 'A'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            A = 'A' // eslint-disable-line
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            A = 'A' // eslint-disable-line
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              A = 'A' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              C = 'C',
-              B = 'B',
-              A = 'A' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            /* eslint-disable-next-line */
+            A = 'A'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            /* eslint-disable-next-line */
+            A = 'A'
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            enum Enum {
-              A = 'A',
-              D = 'D',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              C = 'C',
-              B = 'B',
-              // Shouldn't move
-              /* eslint-enable */
-              E = 'E'
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              D = 'D',
-              E = 'E',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              C = 'C',
-              B = 'B',
-              // Shouldn't move
-              /* eslint-enable */
-              A = 'A'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedEnumsOrder',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            A = 'A' /* eslint-disable-line */
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            A = 'A' /* eslint-disable-line */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          enum Enum {
+            A = 'A',
+            D = 'D',
+            /* eslint-disable */
+            C = 'C',
+            B = 'B',
+            // Shouldn't move
+            /* eslint-enable */
+            E = 'E'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            D = 'D',
+            E = 'E',
+            /* eslint-disable */
+            C = 'C',
+            B = 'B',
+            // Shouldn't move
+            /* eslint-enable */
+            A = 'A'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
             },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            enum Enum {
-              B = 'B',
-              C = 'C',
-              // eslint-disable-next-line
-              A = 'A',
-            }
-          `,
-        },
-      ],
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            // eslint-disable-next-line rule-to-test/sort-enums
+            A = 'A'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            // eslint-disable-next-line rule-to-test/sort-enums
+            A = 'A'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            A = 'A' // eslint-disable-line rule-to-test/sort-enums
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            A = 'A' // eslint-disable-line rule-to-test/sort-enums
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            /* eslint-disable-next-line rule-to-test/sort-enums */
+            A = 'A'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            /* eslint-disable-next-line rule-to-test/sort-enums */
+            A = 'A'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            B = 'B',
+            C = 'C',
+            A = 'A' /* eslint-disable-line rule-to-test/sort-enums */
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            C = 'C',
+            B = 'B',
+            A = 'A' /* eslint-disable-line rule-to-test/sort-enums */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          enum Enum {
+            A = 'A',
+            D = 'D',
+            /* eslint-disable rule-to-test/sort-enums */
+            C = 'C',
+            B = 'B',
+            // Shouldn't move
+            /* eslint-enable */
+            E = 'E'
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            D = 'D',
+            E = 'E',
+            /* eslint-disable rule-to-test/sort-enums */
+            C = 'C',
+            B = 'B',
+            // Shouldn't move
+            /* eslint-enable */
+            A = 'A'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        options: [{}],
+      })
     })
   })
 })

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -1,2689 +1,973 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, it } from 'vitest'
 import dedent from 'dedent'
 
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-exports'
 
-let ruleName = 'sort-exports'
+describe('sort-exports', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-exports',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts exports`, rule, {
-      invalid: [
-        {
+    it('sorts exports', async () => {
+      await valid({
+        code: dedent`
+          export { a1 } from 'a'
+          export { b1, b2 } from 'b'
+          export { c1, c2, c3 } from 'c'
+          export { d1, d2 } from 'd'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a1 } from 'a'
+          export { b1, b2 } from 'b'
+          export { c1, c2, c3 } from 'c'
+          export { d1, d2 } from 'd'
+        `,
+        code: dedent`
+          export { b1, b2 } from 'b'
+          export { a1 } from 'a'
+          export { d1, d2 } from 'd'
+          export { c1, c2, c3 } from 'c'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts all-exports', async () => {
+      await valid({
+        code: dedent`
+          export { a1 } from './a'
+          export * as b from './b'
+          export { c1, c2 } from './c'
+          export { d } from './d'
+          export * from 'e'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: 'e',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a1 } from './a'
+          export * as b from './b'
+          export { c1, c2 } from './c'
+          export { d } from './d'
+          export * from 'e'
+        `,
+        code: dedent`
+          export * as b from './b'
+          export { a1 } from './a'
+          export { c1, c2 } from './c'
+          export * from 'e'
+          export { d } from './d'
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with export aliases', async () => {
+      await valid({
+        code: dedent`
+          export { a1 as aX } from './a'
+          export { default as b } from './b'
+          export { c1, c2 } from './c'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a1 as aX } from './a'
+          export { default as b } from './b'
+          export { c1, c2 } from './c'
+        `,
+        code: dedent`
+          export { a1 as aX } from './a'
+          export { c1, c2 } from './c'
+          export { default as b } from './b'
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './organisms',
+              right: './atoms',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              left: './second-folder',
+              right: './folder',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export * from "./atoms";
+          export * from "./organisms";
+          export * from "./shared";
+
+          export { Named } from './folder';
+          export { AnotherNamed } from './second-folder';
+        `,
+        code: dedent`
+          export * from "./organisms";
+          export * from "./atoms";
+          export * from "./shared";
+
+          export { AnotherNamed } from './second-folder';
+          export { Named } from './folder';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          // Part: A
+          // Not partition comment
+          export * from './bbb';
+          export * from './cc';
+          export * from './d';
+          // Part: B
+          export * from './aaaa';
+          export * from './e';
+          // Part: C
+          // Not partition comment
+          export * from './fff';
+          export * from './gg';
+        `,
+        code: dedent`
+          // Part: A
+          export * from './cc';
+          export * from './d';
+          // Not partition comment
+          export * from './bbb';
+          // Part: B
+          export * from './aaaa';
+          export * from './e';
+          // Part: C
+          export * from './gg';
+          // Not partition comment
+          export * from './fff';
+        `,
+        errors: [
+          {
+            data: {
+              right: './bbb',
+              left: './d',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './fff',
+              left: './gg',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          // Comment
+          export * from './bb';
+          // Other comment
+          export * from './a';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          /* Partition Comment */
+          // Part: A
+          export * from './d'
+          // Part: B
+          export * from './aaa'
+          export * from './bb'
+          export * from './c'
+          /* Other */
+          export * from './e'
+        `,
+        code: dedent`
+          /* Partition Comment */
+          // Part: A
+          export * from './d'
+          // Part: B
+          export * from './aaa'
+          export * from './c'
+          export * from './bb'
+          /* Other */
+          export * from './e'
+        `,
+        errors: [
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          export * from './e'
+          export * from './f'
+          // I am a partition comment because I don't have f o o
+          export * from './a'
+          export * from './b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block comment partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          // Comment
+          export * from './a'
+          export * from './b'
+        `,
+        code: dedent`
+          export * from './b'
+          // Comment
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          export * from './b'
+          /* Comment */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use multiple block comment patterns for partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          export * from './c'
+          /* b */
+          export * from './b'
+          /* a */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use regex patterns for block comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export * from './b'
+          /* I am a partition comment because I don't have f o o */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('sorts exports with values-first group kind', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './d',
+              left: './f',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './c',
+              left: './e',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './a',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { A } from "./a";
+          export { B } from "./b";
+          export { C } from "./c";
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export type { F } from "./f";
+        `,
+        code: dedent`
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'values-first',
+          },
+        ],
+      })
+    })
+
+    it('sorts exports with types-first group kind', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './f',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: './f',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export type { F } from "./f";
+          export { A } from "./a";
+          export { B } from "./b";
+          export { C } from "./c";
+        `,
+        code: dedent`
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          export { a } from '_a'
+          export { b } from 'b'
+          export { c } from '_c'
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          export { ab } from 'ab'
+          export { ac } from 'a_c'
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          export { 你好 } from '你好'
+          export { 世界 } from '世界'
+          export { a } from 'a'
+          export { A } from 'A'
+          export { b } from 'b'
+          export { B } from 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from "a"; export { b } from "b";
+        `,
+        code: dedent`
+          export { b } from "b"; export { a } from "a"
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline elements with semicolons correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from "a"; export { b } from "b";
+        `,
+        code: dedent`
+          export { b } from "b"; export { a } from "a";
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['value-export', 'type-export'],
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export type { a } from 'a';
+        `,
+        code: dedent`
+          export type { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'valueExports',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'valueExports',
+                modifiers: ['value'],
+              },
+            ],
+            groups: ['valueExports', 'unknown'],
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export type { a } from 'a';
+        `,
+        code: dedent`
+          export type { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'filters on elementNamePattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  modifiers: ['value'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
           errors: [
             {
               data: {
-                right: 'a',
+                rightGroup: 'valuesStartingWithHello',
+                right: 'helloExport',
+                leftGroup: 'unknown',
                 left: 'b',
               },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedExportsOrder',
+              messageId: 'unexpectedExportsGroupOrder',
             },
           ],
           output: dedent`
-            export { a1 } from 'a'
-            export { b1, b2 } from 'b'
-            export { c1, c2, c3 } from 'c'
-            export { d1, d2 } from 'd'
+            export { helloExport } from 'helloExport';
+            export { a } from 'a';
+            export { b } from 'b';
           `,
           code: dedent`
-            export { b1, b2 } from 'b'
-            export { a1 } from 'a'
-            export { d1, d2 } from 'd'
-            export { c1, c2, c3 } from 'c'
+            export { a } from 'a';
+            export { b } from 'b';
+            export { helloExport } from 'helloExport';
           `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a1 } from 'a'
-            export { b1, b2 } from 'b'
-            export { c1, c2, c3 } from 'c'
-            export { d1, d2 } from 'd'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts all-exports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: 'e',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { a1 } from './a'
-            export * as b from './b'
-            export { c1, c2 } from './c'
-            export { d } from './d'
-            export * from 'e'
-          `,
-          code: dedent`
-            export * as b from './b'
-            export { a1 } from './a'
-            export { c1, c2 } from './c'
-            export * from 'e'
-            export { d } from './d'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a1 } from './a'
-            export * as b from './b'
-            export { c1, c2 } from './c'
-            export { d } from './d'
-            export * from 'e'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): works with export aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { a1 as aX } from './a'
-            export { default as b } from './b'
-            export { c1, c2 } from './c'
-          `,
-          code: dedent`
-            export { a1 as aX } from './a'
-            export { c1, c2 } from './c'
-            export { default as b } from './b'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a1 as aX } from './a'
-            export { default as b } from './b'
-            export { c1, c2 } from './c'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: './organisms',
-                  right: './atoms',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-              {
-                data: {
-                  left: './second-folder',
-                  right: './folder',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export * from "./atoms";
-              export * from "./organisms";
-              export * from "./shared";
-
-              export { Named } from './folder';
-              export { AnotherNamed } from './second-folder';
-            `,
-            code: dedent`
-              export * from "./organisms";
-              export * from "./atoms";
-              export * from "./shared";
-
-              export { AnotherNamed } from './second-folder';
-              export { Named } from './folder';
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
+        })
       },
     )
 
-    describe(`${ruleName}(${type}): partition comments`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                // Part: A
-                // Not partition comment
-                export * from './bbb';
-                export * from './cc';
-                export * from './d';
-                // Part: B
-                export * from './aaaa';
-                export * from './e';
-                // Part: C
-                // Not partition comment
-                export * from './fff';
-                export * from './gg';
-              `,
-              code: dedent`
-                // Part: A
-                export * from './cc';
-                export * from './d';
-                // Not partition comment
-                export * from './bbb';
-                // Part: B
-                export * from './aaaa';
-                export * from './e';
-                // Part: C
-                export * from './gg';
-                // Not partition comment
-                export * from './fff';
-              `,
-              errors: [
-                {
-                  data: {
-                    right: './bbb',
-                    left: './d',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-                {
-                  data: {
-                    right: './fff',
-                    left: './gg',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                // Comment
-                export * from './bb';
-                // Other comment
-                export * from './a';
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                /* Partition Comment */
-                // Part: A
-                export * from './d'
-                // Part: B
-                export * from './aaa'
-                export * from './bb'
-                export * from './c'
-                /* Other */
-                export * from './e'
-              `,
-              code: dedent`
-                /* Partition Comment */
-                // Part: A
-                export * from './d'
-                // Part: B
-                export * from './aaa'
-                export * from './c'
-                export * from './bb'
-                /* Other */
-                export * from './e'
-              `,
-              errors: [
-                {
-                  data: {
-                    right: './bb',
-                    left: './c',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for partition comments`,
-      rule,
-      {
-        valid: [
+    it('handles complex regex in elementNamePattern', async () => {
+      await valid({
+        options: [
           {
-            code: dedent`
-              export * from './e'
-              export * from './f'
-              // I am a partition comment because I don't have f o o
-              export * from './a'
-              export * from './b'
-            `,
-            options: [
+            customGroups: [
               {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
               },
             ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: './a',
-                  left: './b',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  line: true,
-                },
-              },
-            ],
-            output: dedent`
-              /* Comment */
-              export * from './a'
-              export * from './b'
-            `,
-            code: dedent`
-              export * from './b'
-              /* Comment */
-              export * from './a'
-            `,
-          },
-        ],
-        valid: [],
+        code: dedent`
+          export { iHaveFooInMyName } from 'iHaveFooInMyName';
+          export { meTooIHaveFoo } from 'meTooIHaveFoo';
+          export { a } from 'a';
+          export { b } from 'b';
+        `,
       })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              code: dedent`
-                export * from './b'
-                // Comment
-                export * from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['a', 'b'],
-                  },
-                },
-              ],
-              code: dedent`
-                export * from './c'
-                // b
-                export * from './b'
-                // a
-                export * from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-              code: dedent`
-                export * from './b'
-                // I am a partition comment because I don't have f o o
-                export * from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
     })
 
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-        invalid: [
+    it('sort custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: './a',
-                  left: './b',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  block: true,
-                },
-              },
-            ],
-            output: dedent`
-              // Comment
-              export * from './a'
-              export * from './b'
-            `,
-            code: dedent`
-              export * from './b'
-              // Comment
-              export * from './a'
-            `,
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedValuesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
           },
         ],
-        valid: [],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedValuesByLineLength',
+                modifiers: ['value'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedValuesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            groupKind: 'mixed',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          export { dddd } from 'dddd';
+          export { ccc } from 'ccc';
+          export { eee } from 'eee';
+          export { bb } from 'bb';
+          export { ff } from 'ff';
+          export { a } from 'a';
+          export { g } from 'g';
+          export type { m } from 'm';
+          export type { o } from 'o';
+          export type { p } from 'p';
+        `,
+        code: dedent`
+          export { a } from 'a';
+          export { bb } from 'bb';
+          export { ccc } from 'ccc';
+          export { dddd } from 'dddd';
+          export type { m } from 'm';
+          export { eee } from 'eee';
+          export { ff } from 'ff';
+          export { g } from 'g';
+          export type { o } from 'o';
+          export type { p } from 'p';
+        `,
       })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              code: dedent`
-                export * from './b'
-                /* Comment */
-                export * from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['a', 'b'],
-                  },
-                },
-              ],
-              code: dedent`
-                export * from './c'
-                /* b */
-                export * from './b'
-                /* a */
-                export * from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-              code: dedent`
-                export * from './b'
-                /* I am a partition comment because I don't have f o o */
-                export * from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
     })
 
-    ruleTester.run(`${ruleName}(${type}): sorts by group kind`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './d',
-                left: './f',
+    it('sort custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
               },
-              messageId: 'unexpectedExportsOrder',
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
             },
-            {
-              data: {
-                right: './c',
-                left: './e',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './a',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { A } from "./a";
-            export { B } from "./b";
-            export { C } from "./c";
-            export type { D } from "./d";
-            export type { E } from "./e";
-            export type { F } from "./f";
-          `,
-          code: dedent`
-            export type { F } from "./f";
-            export type { D } from "./d";
-            export type { E } from "./e";
-            export { C } from "./c";
-            export { A } from "./a";
-            export { B } from "./b";
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'values-first',
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './f',
-                left: './b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: './f',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export type { D } from "./d";
-            export type { E } from "./e";
-            export type { F } from "./f";
-            export { A } from "./a";
-            export { B } from "./b";
-            export { C } from "./c";
-          `,
-          code: dedent`
-            export { C } from "./c";
-            export { A } from "./a";
-            export { B } from "./b";
-            export type { F } from "./f";
-            export type { D } from "./d";
-            export type { E } from "./e";
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'types-first',
-            },
-          ],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { fooBar } from 'fooBar';
+          export { fooZar } from 'fooZar';
+        `,
+        code: dedent`
+          export { fooZar } from 'fooZar';
+          export { fooBar } from 'fooBar';
+        `,
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
           {
-            code: dedent`
-              export { a } from '_a'
-              export { b } from 'b'
-              export { c } from '_c'
-            `,
-            options: [
+            customGroups: [
               {
-                ...options,
-                specialCharacters: 'trim',
+                groupName: 'unsortedValues',
+                modifiers: ['value'],
+                type: 'unsorted',
               },
             ],
+            groups: ['unsortedValues', 'unknown'],
+            groupKind: 'mixed',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
+        errors: [
           {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              export { ab } from 'ab'
-              export { ac } from 'a_c'
-            `,
+            data: {
+              rightGroup: 'unsortedValues',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            export { 你好 } from '你好'
-            export { 世界 } from '世界'
-            export { a } from 'a'
-            export { A } from 'A'
-            export { b } from 'b'
-            export { B } from 'B'
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
+        output: dedent`
+          export { b } from 'b';
+          export { a } from 'a';
+          export { d } from 'd';
+          export { e } from 'e';
+          export { c } from 'c';
+          export type { m } from 'm';
+        `,
+        code: dedent`
+          export { b } from 'b';
+          export { a } from 'a';
+          export { d } from 'd';
+          export { e } from 'e';
+          export type { m } from 'm';
+          export { c } from 'c';
+        `,
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
+    it('sort custom group blocks', async () => {
+      await invalid({
+        options: [
           {
-            errors: [
+            customGroups: [
               {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { a } from "a"; export { b } from "b";
-            `,
-            code: dedent`
-              export { b } from "b"; export { a } from "a"
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { a } from "a"; export { b } from "b";
-            `,
-            code: dedent`
-              export { b } from "b"; export { a } from "a";
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use predefined groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'value-export',
-                  leftGroup: 'type-export',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedExportsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['value-export', 'type-export'],
-              },
-            ],
-            output: dedent`
-              export { b } from 'b';
-              export type { a } from 'a';
-            `,
-            code: dedent`
-              export type { a } from 'a';
-              export { b } from 'b';
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on modifier`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'valueExports',
-                  leftGroup: 'unknown',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedExportsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
+                anyOf: [
                   {
-                    groupName: 'valueExports',
+                    elementNamePattern: 'foo|Foo',
                     modifiers: ['value'],
                   },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['type'],
+                  },
                 ],
-                groups: ['valueExports', 'unknown'],
+                groupName: 'elementsIncludingFoo',
               },
             ],
-            output: dedent`
-              export { b } from 'b';
-              export type { a } from 'a';
-            `,
-            code: dedent`
-              export type { a } from 'a';
-              export { b } from 'b';
-            `,
+            groups: ['elementsIncludingFoo', 'unknown'],
           },
         ],
-        valid: [],
-      })
-
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      groupName: 'valuesStartingWithHello',
-                      modifiers: ['value'],
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['valuesStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'valuesStartingWithHello',
-                    right: 'helloExport',
-                    leftGroup: 'unknown',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedExportsGroupOrder',
-                },
-              ],
-              output: dedent`
-                export { helloExport } from 'helloExport';
-                export { a } from 'a';
-                export { b } from 'b';
-              `,
-              code: dedent`
-                export { a } from 'a';
-                export { b } from 'b';
-                export { helloExport } from 'helloExport';
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: handles complex regex in elementNamePattern`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                export { iHaveFooInMyName } from 'iHaveFooInMyName';
-                export { meTooIHaveFoo } from 'meTooIHaveFoo';
-                export { a } from 'a';
-                export { b } from 'b';
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedValuesByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'eee',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedExportsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedValuesByLineLength',
-                      modifiers: ['value'],
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedValuesByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  groupKind: 'mixed',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                export { dddd } from 'dddd';
-                export { ccc } from 'ccc';
-                export { eee } from 'eee';
-                export { bb } from 'bb';
-                export { ff } from 'ff';
-                export { a } from 'a';
-                export { g } from 'g';
-                export type { m } from 'm';
-                export type { o } from 'o';
-                export type { p } from 'p';
-              `,
-              code: dedent`
-                export { a } from 'a';
-                export { bb } from 'bb';
-                export { ccc } from 'ccc';
-                export { dddd } from 'dddd';
-                export type { m } from 'm';
-                export { eee } from 'eee';
-                export { ff } from 'ff';
-                export { g } from 'g';
-                export type { o } from 'o';
-                export type { p } from 'p';
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-              ],
-              output: dedent`
-                export { fooBar } from 'fooBar';
-                export { fooZar } from 'fooZar';
-              `,
-              code: dedent`
-                export { fooZar } from 'fooZar';
-                export { fooBar } from 'fooBar';
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedValues',
-                      modifiers: ['value'],
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedValues', 'unknown'],
-                  groupKind: 'mixed',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedValues',
-                    leftGroup: 'unknown',
-                    right: 'c',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedExportsGroupOrder',
-                },
-              ],
-              output: dedent`
-                export { b } from 'b';
-                export { a } from 'a';
-                export { d } from 'd';
-                export { e } from 'e';
-                export { c } from 'c';
-                export type { m } from 'm';
-              `,
-              code: dedent`
-                export { b } from 'b';
-                export { a } from 'a';
-                export { d } from 'd';
-                export { e } from 'e';
-                export type { m } from 'm';
-                export { c } from 'c';
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
+        errors: [
           {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        modifiers: ['value'],
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        modifiers: ['type'],
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: 'cFoo',
-                  left: 'a',
-                },
-                messageId: 'unexpectedExportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              export { cFoo } from 'cFoo';
-              export type { foo } from 'foo';
-              export { a } from 'a';
-            `,
-            code: dedent`
-              export { a } from 'a';
-              export { cFoo } from 'cFoo';
-              export type { foo } from 'foo';
-            `,
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
           },
         ],
-        valid: [],
+        output: dedent`
+          export { cFoo } from 'cFoo';
+          export type { foo } from 'foo';
+          export { a } from 'a';
+        `,
+        code: dedent`
+          export { a } from 'a';
+          export { cFoo } from 'cFoo';
+          export type { foo } from 'foo';
+        `,
       })
     })
 
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenExports',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedExportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenExports',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                    export { a } from 'a'
-
-
-                   export { y } from 'y'
-                  export { z } from 'z'
-
-                      export { b } from 'b'
-                `,
-                output: dedent`
-                    export { a } from 'a'
-                   export { b } from 'b'
-                  export { y } from 'y'
-                      export { z } from 'z'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenExports',
-                  },
-                ],
-                output: dedent`
-                  export { a } from 'a'; 
-
-                  export { b } from 'b';
-                `,
-                code: dedent`
-                  export { a } from 'a'; export { b } from 'b';
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenExports',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedExportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenExports',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                    export { a } from 'a'
-
-                   export { y } from 'y'
-                  export { z } from 'z'
-
-                      export { b } from 'b'
-                `,
-                code: dedent`
-                    export { a } from 'a'
-
-
-                   export { z } from 'z'
-                  export { y } from 'y'
-                      export { b } from 'b'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenExports',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenExports',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenExports',
-                  },
-                ],
-                output: dedent`
-                  export { a } from 'a'
-
-                  export { b } from 'b'
-
-                  export { c } from 'c'
-                  export { d } from 'd'
-
-
-                  export { e } from 'e'
-                `,
-                code: dedent`
-                  export { a } from 'a'
-                  export { b } from 'b'
-
-
-                  export { c } from 'c'
-
-                  export { d } from 'd'
-
-
-                  export { e } from 'e'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenExports',
-                      },
-                    ],
-                    output: dedent`
-                      export { a } from 'a'
-
-
-                      export { b } from 'b'
-                    `,
-                    code: dedent`
-                      export { a } from 'a'
-                      export { b } from 'b'
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenExports',
-                      },
-                    ],
-                    output: dedent`
-                      export { a } from 'a'
-                      export { b } from 'b'
-                    `,
-                    code: dedent`
-                      export { a } from 'a'
-
-                      export { b } from 'b'
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      export { a } from 'a'
-
-                      export { b } from 'b'
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      export { a } from 'a'
-                      export { b } from 'b'
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  export { a } from 'a' // Comment after
-                  export { b } from 'b'
-
-                  export { c } from 'c'
-                `,
-                dedent`
-                  export { a } from 'a' // Comment after
-
-                  export { b } from 'b'
-                  export { c } from 'c'
-                `,
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'b|c',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedExportsGroupOrder',
-                },
-              ],
-              code: dedent`
-                export { b } from 'b'
-                export { a } from 'a' // Comment after
-
-                export { c } from 'c'
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedExportsOrder',
-                  },
-                ],
-                output: dedent`
-                  export { a } from 'a'
-
-                  // Partition comment
-
-                  export { b } from 'b'
-                  export { c } from 'c'
-                `,
-                code: dedent`
-                  export { a } from 'a'
-
-                  // Partition comment
-
-                  export { c } from 'c'
-                  export { b } from 'b'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    describe(`${ruleName}(${type}): "commentAbove" inside groups`, () => {
-      ruleTester.run(`${ruleName}(${type}): reports missing comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  missedCommentAbove: 'Type exports',
-                  right: './a',
-                },
-                messageId: 'missedCommentAboveExport',
-              },
-              {
-                data: {
-                  missedCommentAbove: 'Other exports',
-                  right: './b',
-                },
-                messageId: 'missedCommentAboveExport',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  { commentAbove: 'Type exports' },
-                  'type-export',
-                  { commentAbove: 'Other exports' },
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              // Type exports
-              export type { a } from "./a";
-
-              // Other exports
-              export { b } from "./b";
-            `,
-            code: dedent`
-              export type { a } from "./a";
-
-              export { b } from "./b";
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): reports missing comments for single nodes`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    missedCommentAbove: 'Comment above',
-                    right: 'a',
-                  },
-                  messageId: 'missedCommentAboveExport',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [{ commentAbove: 'Comment above' }, 'unknown'],
-                },
-              ],
-              output: dedent`
-                // Comment above
-                export { a } from "a";
-              `,
-              code: dedent`
-                export { a } from "a";
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): ignores shebangs and comments at the top of the file`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    missedCommentAbove: 'Comment above',
-                    right: './b',
-                  },
-                  messageId: 'missedCommentAboveExport',
-                },
-                {
-                  data: {
-                    right: './a',
-                    left: './b',
-                  },
-                  messageId: 'unexpectedExportsOrder',
-                },
-              ],
-              output: [
-                dedent`
-                  #!/usr/bin/node
-                  // Some disclaimer
-
-                  export { a } from "./a";
-                  export { b } from "./b";
-                `,
-                dedent`
-                  #!/usr/bin/node
-                  // Some disclaimer
-
-                  // Comment above
-                  export { a } from "./a";
-                  export { b } from "./b";
-                `,
-              ],
-              code: dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                export { b } from "./b";
-                export { a } from "./a";
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [{ commentAbove: 'Comment above' }, 'unknown'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      describe('comment detection', () => {
-        for (let comment of [
-          '//   Comment above  ',
-          '//   comment above  ',
-          `/**
-            * Comment above
-            */`,
-          `/**
-            * Something before
-            * CoMmEnT ABoVe
-            * Something after
-            */`,
-        ]) {
-          ruleTester.run(
-            `${ruleName}(${type}): detects existing comments correctly`,
-            rule,
-            {
-              valid: [
-                {
-                  options: [
-                    {
-                      ...options,
-                      groups: [
-                        'value-export',
-                        { commentAbove: 'Comment above' },
-                        'unknown',
-                      ],
-                    },
-                  ],
-                  code: dedent`
-                    export { a } from "a";
-
-                    ${comment}
-                    export type { b } from "./b";
-                  `,
-                },
-              ],
-              invalid: [],
-            },
-          )
-        }
-
-        ruleTester.run(
-          `${ruleName}(${type}): deletes invalid auto-added comments`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      missedCommentAbove: 'Type exports',
-                      right: './c',
-                    },
-                    messageId: 'missedCommentAboveExport',
-                  },
-                  {
-                    data: {
-                      right: './b',
-                      left: './c',
-                    },
-                    messageId: 'unexpectedExportsOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'value-export',
-                      leftGroup: 'type-export',
-                      right: './a',
-                      left: './b',
-                    },
-                    messageId: 'unexpectedExportsGroupOrder',
-                  },
-                ],
-                output: [
-                  dedent`
-                    // Type exports
-                    export { a } from './a';
-                    // Value exports
-                    export type { b } from './b';
-                    export type { c } from './c';
-                  `,
-                  dedent`
-                    // Value exports
-                    export { a } from './a';
-                    // Type exports
-                    export type { b } from './b';
-                    export type { c } from './c';
-                  `,
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      { commentAbove: 'Value exports' },
-                      'value-export',
-                      { commentAbove: 'Type exports' },
-                      'type-export',
-                    ],
-                  },
-                ],
-                code: dedent`
-                  export type { c } from './c';
-                  // Value exports
-                  export type { b } from './b';
-                  // Type exports
-                  export { a } from './a';
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      })
-
-      ruleTester.run(`${ruleName}(${type}): works with other errors`, rule, {
-        invalid: [
-          {
-            output: [
-              dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                // Comment above a
-                // Type exports
-                export { a } from "./a"; // Comment after a
-                // Comment above b
-                // Value exports
-                export type { b } from './b'; // Comment after b
-              `,
-              dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                // Comment above a
-                // Type exports
-                export { a } from "./a"; // Comment after a
-
-                // Comment above b
-                // Value exports
-                export type { b } from './b'; // Comment after b
-              `,
-              dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                // Comment above a
-                // Value exports
-                export { a } from "./a"; // Comment after a
-
-                // Type exports
-                // Comment above b
-                export type { b } from './b'; // Comment after b
-              `,
-            ],
-            errors: [
-              {
-                data: {
-                  missedCommentAbove: 'Type exports',
-                  right: './b',
-                },
-                messageId: 'missedCommentAboveExport',
-              },
-              {
-                data: {
-                  rightGroup: 'value-export',
-                  leftGroup: 'type-export',
-                  right: './a',
-                  left: './b',
-                },
-                messageId: 'unexpectedExportsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  { commentAbove: 'Value exports' },
-                  'value-export',
-                  {
-                    commentAbove: 'Type exports',
-                    newlinesBetween: 'always',
-                  },
-                  ['type-export'],
-                ],
-                newlinesBetween: 'never',
-              },
-            ],
-            code: dedent`
-              #!/usr/bin/node
-              // Some disclaimer
-
-              // Comment above b
-              // Value exports
-              export type { b } from './b'; // Comment after b
-              // Comment above a
-              // Type exports
-              export { a } from "./a"; // Comment after a
-            `,
-          },
-        ],
-        valid: [],
-      })
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts exports`, rule, {
-      invalid: [
-        {
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { a1 } from 'a'
-            export { b1, b2 } from 'b'
-            export { c1, c2, c3 } from 'c'
-            export { d1, d2 } from 'd'
-          `,
-          code: dedent`
-            export { b1, b2 } from 'b'
-            export { a1 } from 'a'
-            export { d1, d2 } from 'd'
-            export { c1, c2, c3 } from 'c'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a1 } from 'a'
-            export { b1, b2 } from 'b'
-            export { c1, c2, c3 } from 'c'
-            export { d1, d2 } from 'd'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts all-exports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: 'e',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { a1 } from './a'
-            export * as b from './b'
-            export { c1, c2 } from './c'
-            export { d } from './d'
-            export * from 'e'
-          `,
-          code: dedent`
-            export * as b from './b'
-            export { a1 } from './a'
-            export { c1, c2 } from './c'
-            export * from 'e'
-            export { d } from './d'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a1 } from './a'
-            export * as b from './b'
-            export { c1, c2 } from './c'
-            export { d } from './d'
-            export * from 'e'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): works with export aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { a1 as aX } from './a'
-            export { default as b } from './b'
-            export { c1, c2 } from './c'
-          `,
-          code: dedent`
-            export { a1 as aX } from './a'
-            export { c1, c2 } from './c'
-            export { default as b } from './b'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a1 as aX } from './a'
-            export { default as b } from './b'
-            export { c1, c2 } from './c'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: './organisms',
-                  right: './atoms',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-              {
-                data: {
-                  left: './second-folder',
-                  right: './folder',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export * from "./atoms";
-              export * from "./organisms";
-              export * from "./shared";
-
-              export { Named } from './folder';
-              export { AnotherNamed } from './second-folder';
-            `,
-            code: dedent`
-              export * from "./organisms";
-              export * from "./atoms";
-              export * from "./shared";
-
-              export { AnotherNamed } from './second-folder';
-              export { Named } from './folder';
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts by group kind`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './d',
-                left: './f',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './c',
-                left: './e',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './a',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { A } from "./a";
-            export { B } from "./b";
-            export { C } from "./c";
-            export type { D } from "./d";
-            export type { E } from "./e";
-            export type { F } from "./f";
-          `,
-          code: dedent`
-            export type { F } from "./f";
-            export type { D } from "./d";
-            export type { E } from "./e";
-            export { C } from "./c";
-            export { A } from "./a";
-            export { B } from "./b";
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'values-first',
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './f',
-                left: './b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: './f',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export type { D } from "./d";
-            export type { E } from "./e";
-            export type { F } from "./f";
-            export { A } from "./a";
-            export { B } from "./b";
-            export { C } from "./c";
-          `,
-          code: dedent`
-            export { C } from "./c";
-            export { A } from "./a";
-            export { B } from "./b";
-            export type { F } from "./f";
-            export type { D } from "./d";
-            export type { E } from "./e";
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'types-first',
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts exports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { a1 } from 'a'
-            export { b1, b2 } from 'b'
-            export { c1, c2, c3 } from 'c'
-            export { d1, d2 } from 'd'
-          `,
-          code: dedent`
-            export { b1, b2 } from 'b'
-            export { a1 } from 'a'
-            export { d1, d2 } from 'd'
-            export { c1, c2, c3 } from 'c'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a1 } from 'a'
-            export { b1, b2 } from 'b'
-            export { c1, c2, c3 } from 'c'
-            export { d1, d2 } from 'd'
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts exports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'd',
+                right: 'y',
                 left: 'a',
               },
+              messageId: 'extraSpacingBetweenExports',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
               messageId: 'unexpectedExportsOrder',
             },
             {
               data: {
-                right: 'c',
-                left: 'd',
+                right: 'b',
+                left: 'z',
               },
-              messageId: 'unexpectedExportsOrder',
+              messageId: 'extraSpacingBetweenExports',
             },
           ],
-          output: dedent`
-            export { c1, c2, c3 } from 'c'
-            export { b1, b2 } from 'b'
-            export { d1, d2 } from 'd'
-            export { a1 } from 'a'
-          `,
-          code: dedent`
-            export { b1, b2 } from 'b'
-            export { a1 } from 'a'
-            export { d1, d2 } from 'd'
-            export { c1, c2, c3 } from 'c'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { c1, c2, c3 } from 'c'
-            export { b1, b2 } from 'b'
-            export { d1, d2 } from 'd'
-            export { a1 } from 'a'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts all-exports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './c',
-                left: './a',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: 'e',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { c1, c2 } from './c'
-            export * as b from './b'
-            export { a1 } from './a'
-            export { d } from './d'
-            export * from 'e'
-          `,
-          code: dedent`
-            export * as b from './b'
-            export { a1 } from './a'
-            export { c1, c2 } from './c'
-            export * from 'e'
-            export { d } from './d'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { c1, c2 } from './c'
-            export { a1 } from './a'
-            export * as b from './b'
-            export { d } from './d'
-            export * from 'e'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): works with export aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { default as b } from './b'
-            export { a1 as aX } from './a'
-            export { c1, c2 } from './c'
-          `,
-          code: dedent`
-            export { a1 as aX } from './a'
-            export { c1, c2 } from './c'
-            export { default as b } from './b'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { default as b } from './b'
-            export { a1 as aX } from './a'
-            export { c1, c2 } from './c'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              export * from 'bb'
-              export * from 'c'
-              export * from 'a'
-            `,
-            code: dedent`
-              export * from 'a'
-              export * from 'bb'
-              export * from 'c'
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              export * from 'bb'
-              export * from 'a'
-              export * from 'c'
-            `,
-            code: dedent`
-              export * from 'c'
-              export * from 'bb'
-              export * from 'a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            export * from 'b'
-            export * from 'c'
-            export * from 'a'
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
           options: [
             {
               ...options,
@@ -2692,427 +976,4529 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+              export { a } from 'a'
+
+
+             export { y } from 'y'
+            export { z } from 'z'
+
+                export { b } from 'b'
+          `,
+          output: dedent`
+              export { a } from 'a'
+             export { b } from 'b'
+            export { y } from 'y'
+                export { z } from 'z'
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+              {
+                elementNamePattern: 'c',
+                groupName: 'c',
+              },
+              {
+                elementNamePattern: 'd',
+                groupName: 'd',
+              },
+              {
+                elementNamePattern: 'e',
+                groupName: 'e',
+              },
+            ],
+            groups: [
+              'a',
+              {
+                newlinesBetween: 'always',
+              },
+              'b',
+              {
+                newlinesBetween: 'always',
+              },
+              'c',
+              {
+                newlinesBetween: 'never',
+              },
+              'd',
+              {
+                newlinesBetween: 'ignore',
+              },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+        ],
+        output: dedent`
+          export { a } from 'a'
+
+          export { b } from 'b'
+
+          export { c } from 'c'
+          export { d } from 'd'
+
+
+          export { e } from 'e'
+        `,
+        code: dedent`
+          export { a } from 'a'
+          export { b } from 'b'
+
+
+          export { c } from 'c'
+
+          export { d } from 'd'
+
+
+          export { e } from 'e'
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenExports',
             },
           ],
           output: dedent`
-            export { b } from 'b'
-
             export { a } from 'a'
+
+
+            export { b } from 'b'
           `,
           code: dedent`
-            export { b } from 'b'
             export { a } from 'a'
+            export { b } from 'b'
           `,
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+
+            // Partition comment
+
+            export { b } from 'b'
+            export { c } from 'c'
+          `,
+          code: dedent`
+            export { a } from 'a'
+
+            // Partition comment
+
+            export { c } from 'c'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it('reports missing comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './a',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              missedCommentAbove: 'Other exports',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Type exports' },
+              'type-export',
+              { commentAbove: 'Other exports' },
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          // Type exports
+          export type { a } from "./a";
+
+          // Other exports
+          export { b } from "./b";
+        `,
+        code: dedent`
+          export type { a } from "./a";
+
+          export { b } from "./b";
+        `,
+      })
+    })
+
+    it('reports missing comments for single nodes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        output: dedent`
+          // Comment above
+          export { a } from "a";
+        `,
+        code: dedent`
+          export { a } from "a";
+        `,
+      })
+    })
+
+    it('ignores shebangs and comments at the top of the file', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above
+          export { a } from "./a";
+          export { b } from "./b";
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          export { b } from "./b";
+          export { a } from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      '//   Comment above  ',
+      '//   comment above  ',
+      dedent`
+        /**
+         * Comment above
+         */
+      `,
+      dedent`
+        /**
+         * Something before
+         * CoMmEnT ABoVe
+         * Something after
+         */
+      `,
+    ])(
+      'detects existing comments correctly with comment: %s',
+      async comment => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'value-export',
+                { commentAbove: 'Comment above' },
+                'unknown',
+              ],
+            },
+          ],
+          code: dedent`
+            export { a } from "a";
+
+            ${comment}
+            export type { b } from "./b";
+          `,
+        })
+      },
+    )
+
+    it('deletes invalid auto-added comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './c',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Value exports' },
+              'value-export',
+              { commentAbove: 'Type exports' },
+              'type-export',
+            ],
+          },
+        ],
+        output: dedent`
+          // Value exports
+          export { a } from './a';
+          // Type exports
+          export type { b } from './b';
+          export type { c } from './c';
+        `,
+        code: dedent`
+          export type { c } from './c';
+          // Value exports
+          export type { b } from './b';
+          // Type exports
+          export { a } from './a';
+        `,
+      })
+    })
+
+    it('works with other errors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Value exports' },
+              'value-export',
+              {
+                commentAbove: 'Type exports',
+                newlinesBetween: 'always',
+              },
+              ['type-export'],
+            ],
+            newlinesBetween: 'never',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above a
+          // Value exports
+          export { a } from "./a"; // Comment after a
+
+          // Type exports
+          // Comment above b
+          export type { b } from './b'; // Comment after b
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above b
+          // Value exports
+          export type { b } from './b'; // Comment after b
+          // Comment above a
+          // Type exports
+          export { a } from "./a"; // Comment after a
+        `,
+      })
+    })
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts exports', async () => {
+      await valid({
+        code: dedent`
+          export { a1 } from 'a'
+          export { b1, b2 } from 'b'
+          export { c1, c2, c3 } from 'c'
+          export { d1, d2 } from 'd'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a1 } from 'a'
+          export { b1, b2 } from 'b'
+          export { c1, c2, c3 } from 'c'
+          export { d1, d2 } from 'd'
+        `,
+        code: dedent`
+          export { b1, b2 } from 'b'
+          export { a1 } from 'a'
+          export { d1, d2 } from 'd'
+          export { c1, c2, c3 } from 'c'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts all-exports', async () => {
+      await valid({
+        code: dedent`
+          export { a1 } from './a'
+          export * as b from './b'
+          export { c1, c2 } from './c'
+          export { d } from './d'
+          export * from 'e'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: 'e',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a1 } from './a'
+          export * as b from './b'
+          export { c1, c2 } from './c'
+          export { d } from './d'
+          export * from 'e'
+        `,
+        code: dedent`
+          export * as b from './b'
+          export { a1 } from './a'
+          export { c1, c2 } from './c'
+          export * from 'e'
+          export { d } from './d'
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with export aliases', async () => {
+      await valid({
+        code: dedent`
+          export { a1 as aX } from './a'
+          export { default as b } from './b'
+          export { c1, c2 } from './c'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a1 as aX } from './a'
+          export { default as b } from './b'
+          export { c1, c2 } from './c'
+        `,
+        code: dedent`
+          export { a1 as aX } from './a'
+          export { c1, c2 } from './c'
+          export { default as b } from './b'
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './organisms',
+              right: './atoms',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              left: './second-folder',
+              right: './folder',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export * from "./atoms";
+          export * from "./organisms";
+          export * from "./shared";
+
+          export { Named } from './folder';
+          export { AnotherNamed } from './second-folder';
+        `,
+        code: dedent`
+          export * from "./organisms";
+          export * from "./atoms";
+          export * from "./shared";
+
+          export { AnotherNamed } from './second-folder';
+          export { Named } from './folder';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          // Part: A
+          // Not partition comment
+          export * from './bbb';
+          export * from './cc';
+          export * from './d';
+          // Part: B
+          export * from './aaaa';
+          export * from './e';
+          // Part: C
+          // Not partition comment
+          export * from './fff';
+          export * from './gg';
+        `,
+        code: dedent`
+          // Part: A
+          export * from './cc';
+          export * from './d';
+          // Not partition comment
+          export * from './bbb';
+          // Part: B
+          export * from './aaaa';
+          export * from './e';
+          // Part: C
+          export * from './gg';
+          // Not partition comment
+          export * from './fff';
+        `,
+        errors: [
+          {
+            data: {
+              right: './bbb',
+              left: './d',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './fff',
+              left: './gg',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          // Comment
+          export * from './bb';
+          // Other comment
+          export * from './a';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          /* Partition Comment */
+          // Part: A
+          export * from './d'
+          // Part: B
+          export * from './aaa'
+          export * from './bb'
+          export * from './c'
+          /* Other */
+          export * from './e'
+        `,
+        code: dedent`
+          /* Partition Comment */
+          // Part: A
+          export * from './d'
+          // Part: B
+          export * from './aaa'
+          export * from './c'
+          export * from './bb'
+          /* Other */
+          export * from './e'
+        `,
+        errors: [
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          export * from './e'
+          export * from './f'
+          // I am a partition comment because I don't have f o o
+          export * from './a'
+          export * from './b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block comment partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          // Comment
+          export * from './a'
+          export * from './b'
+        `,
+        code: dedent`
+          export * from './b'
+          // Comment
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          export * from './b'
+          /* Comment */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use multiple block comment patterns for partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          export * from './c'
+          /* b */
+          export * from './b'
+          /* a */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use regex patterns for block comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export * from './b'
+          /* I am a partition comment because I don't have f o o */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('sorts exports with values-first group kind', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './d',
+              left: './f',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './c',
+              left: './e',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './a',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { A } from "./a";
+          export { B } from "./b";
+          export { C } from "./c";
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export type { F } from "./f";
+        `,
+        code: dedent`
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'values-first',
+          },
+        ],
+      })
+    })
+
+    it('sorts exports with types-first group kind', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './f',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: './f',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export type { F } from "./f";
+          export { A } from "./a";
+          export { B } from "./b";
+          export { C } from "./c";
+        `,
+        code: dedent`
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          export { a } from '_a'
+          export { b } from 'b'
+          export { c } from '_c'
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          export { ab } from 'ab'
+          export { ac } from 'a_c'
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          export { 你好 } from '你好'
+          export { 世界 } from '世界'
+          export { a } from 'a'
+          export { A } from 'A'
+          export { b } from 'b'
+          export { B } from 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from "a"; export { b } from "b";
+        `,
+        code: dedent`
+          export { b } from "b"; export { a } from "a"
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline elements with semicolons correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from "a"; export { b } from "b";
+        `,
+        code: dedent`
+          export { b } from "b"; export { a } from "a";
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['value-export', 'type-export'],
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export type { a } from 'a';
+        `,
+        code: dedent`
+          export type { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'valueExports',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'valueExports',
+                modifiers: ['value'],
+              },
+            ],
+            groups: ['valueExports', 'unknown'],
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export type { a } from 'a';
+        `,
+        code: dedent`
+          export type { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'filters on elementNamePattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  modifiers: ['value'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'valuesStartingWithHello',
+                right: 'helloExport',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedExportsGroupOrder',
+            },
+          ],
+          output: dedent`
+            export { helloExport } from 'helloExport';
+            export { a } from 'a';
+            export { b } from 'b';
+          `,
+          code: dedent`
+            export { a } from 'a';
+            export { b } from 'b';
+            export { helloExport } from 'helloExport';
+          `,
+        })
+      },
+    )
+
+    it('handles complex regex in elementNamePattern', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          export { iHaveFooInMyName } from 'iHaveFooInMyName';
+          export { meTooIHaveFoo } from 'meTooIHaveFoo';
+          export { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it('sort custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedValuesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedValuesByLineLength',
+                modifiers: ['value'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedValuesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            groupKind: 'mixed',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          export { dddd } from 'dddd';
+          export { ccc } from 'ccc';
+          export { eee } from 'eee';
+          export { bb } from 'bb';
+          export { ff } from 'ff';
+          export { a } from 'a';
+          export { g } from 'g';
+          export type { m } from 'm';
+          export type { o } from 'o';
+          export type { p } from 'p';
+        `,
+        code: dedent`
+          export { a } from 'a';
+          export { bb } from 'bb';
+          export { ccc } from 'ccc';
+          export { dddd } from 'dddd';
+          export type { m } from 'm';
+          export { eee } from 'eee';
+          export { ff } from 'ff';
+          export { g } from 'g';
+          export type { o } from 'o';
+          export type { p } from 'p';
+        `,
+      })
+    })
+
+    it('sort custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { fooBar } from 'fooBar';
+          export { fooZar } from 'fooZar';
+        `,
+        code: dedent`
+          export { fooZar } from 'fooZar';
+          export { fooBar } from 'fooBar';
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedValues',
+                modifiers: ['value'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedValues', 'unknown'],
+            groupKind: 'mixed',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedValues',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export { a } from 'a';
+          export { d } from 'd';
+          export { e } from 'e';
+          export { c } from 'c';
+          export type { m } from 'm';
+        `,
+        code: dedent`
+          export { b } from 'b';
+          export { a } from 'a';
+          export { d } from 'd';
+          export { e } from 'e';
+          export type { m } from 'm';
+          export { c } from 'c';
+        `,
+      })
+    })
+
+    it('sort custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['value'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['type'],
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export { cFoo } from 'cFoo';
+          export type { foo } from 'foo';
+          export { a } from 'a';
+        `,
+        code: dedent`
+          export { a } from 'a';
+          export { cFoo } from 'cFoo';
+          export type { foo } from 'foo';
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedExportsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+              export { a } from 'a'
+
+
+             export { y } from 'y'
+            export { z } from 'z'
+
+                export { b } from 'b'
+          `,
+          output: dedent`
+              export { a } from 'a'
+             export { b } from 'b'
+            export { y } from 'y'
+                export { z } from 'z'
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+              {
+                elementNamePattern: 'c',
+                groupName: 'c',
+              },
+              {
+                elementNamePattern: 'd',
+                groupName: 'd',
+              },
+              {
+                elementNamePattern: 'e',
+                groupName: 'e',
+              },
+            ],
+            groups: [
+              'a',
+              {
+                newlinesBetween: 'always',
+              },
+              'b',
+              {
+                newlinesBetween: 'always',
+              },
+              'c',
+              {
+                newlinesBetween: 'never',
+              },
+              'd',
+              {
+                newlinesBetween: 'ignore',
+              },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+        ],
+        output: dedent`
+          export { a } from 'a'
+
+          export { b } from 'b'
+
+          export { c } from 'c'
+          export { d } from 'd'
+
+
+          export { e } from 'e'
+        `,
+        code: dedent`
+          export { a } from 'a'
+          export { b } from 'b'
+
+
+          export { c } from 'c'
+
+          export { d } from 'd'
+
+
+          export { e } from 'e'
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+
+
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+
+
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+
+            // Partition comment
+
+            export { b } from 'b'
+            export { c } from 'c'
+          `,
+          code: dedent`
+            export { a } from 'a'
+
+            // Partition comment
+
+            export { c } from 'c'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it('reports missing comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './a',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              missedCommentAbove: 'Other exports',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Type exports' },
+              'type-export',
+              { commentAbove: 'Other exports' },
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          // Type exports
+          export type { a } from "./a";
+
+          // Other exports
+          export { b } from "./b";
+        `,
+        code: dedent`
+          export type { a } from "./a";
+
+          export { b } from "./b";
+        `,
+      })
+    })
+
+    it('reports missing comments for single nodes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        output: dedent`
+          // Comment above
+          export { a } from "a";
+        `,
+        code: dedent`
+          export { a } from "a";
+        `,
+      })
+    })
+
+    it('ignores shebangs and comments at the top of the file', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above
+          export { a } from "./a";
+          export { b } from "./b";
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          export { b } from "./b";
+          export { a } from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      '//   Comment above  ',
+      '//   comment above  ',
+      dedent`
+        /**
+         * Comment above
+         */
+      `,
+      dedent`
+        /**
+         * Something before
+         * CoMmEnT ABoVe
+         * Something after
+         */
+      `,
+    ])(
+      'detects existing comments correctly with comment: %s',
+      async comment => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'value-export',
+                { commentAbove: 'Comment above' },
+                'unknown',
+              ],
+            },
+          ],
+          code: dedent`
+            export { a } from "a";
+
+            ${comment}
+            export type { b } from "./b";
+          `,
+        })
+      },
+    )
+
+    it('deletes invalid auto-added comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './c',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Value exports' },
+              'value-export',
+              { commentAbove: 'Type exports' },
+              'type-export',
+            ],
+          },
+        ],
+        output: dedent`
+          // Value exports
+          export { a } from './a';
+          // Type exports
+          export type { b } from './b';
+          export type { c } from './c';
+        `,
+        code: dedent`
+          export type { c } from './c';
+          // Value exports
+          export type { b } from './b';
+          // Type exports
+          export { a } from './a';
+        `,
+      })
+    })
+
+    it('works with other errors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Value exports' },
+              'value-export',
+              {
+                commentAbove: 'Type exports',
+                newlinesBetween: 'always',
+              },
+              ['type-export'],
+            ],
+            newlinesBetween: 'never',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above a
+          // Value exports
+          export { a } from "./a"; // Comment after a
+
+          // Type exports
+          // Comment above b
+          export type { b } from './b'; // Comment after b
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above b
+          // Value exports
+          export type { b } from './b'; // Comment after b
+          // Comment above a
+          // Type exports
+          export { a } from "./a"; // Comment after a
+        `,
+      })
+    })
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts exports', async () => {
+      await valid({
+        code: dedent`
+          export { c1, c2, c3 } from 'c'
+          export { d1, d2 } from 'd'
+          export { b1, b2 } from 'b'
+          export { a1 } from 'a'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { c1, c2, c3 } from 'c'
+          export { b1, b2 } from 'b'
+          export { d1, d2 } from 'd'
+          export { a1 } from 'a'
+        `,
+        code: dedent`
+          export { b1, b2 } from 'b'
+          export { a1 } from 'a'
+          export { d1, d2 } from 'd'
+          export { c1, c2, c3 } from 'c'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts all-exports', async () => {
+      await valid({
+        code: dedent`
+          export { c1, c2 } from './c'
+          export { a1 } from './a'
+          export * as b from './b'
+          export { d } from './d'
+          export * from 'e'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './c',
+              left: './a',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: 'e',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { c1, c2 } from './c'
+          export * as b from './b'
+          export { a1 } from './a'
+          export { d } from './d'
+          export * from 'e'
+        `,
+        code: dedent`
+          export * as b from './b'
+          export { a1 } from './a'
+          export { c1, c2 } from './c'
+          export * from 'e'
+          export { d } from './d'
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with export aliases', async () => {
+      await valid({
+        code: dedent`
+          export { default as b } from './b'
+          export { a1 as aX } from './a'
+          export { c1, c2 } from './c'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { default as b } from './b'
+          export { a1 as aX } from './a'
+          export { c1, c2 } from './c'
+        `,
+        code: dedent`
+          export { a1 as aX } from './a'
+          export { c1, c2 } from './c'
+          export { default as b } from './b'
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        output: dedent`
+          export * from "./organisms";
+          export * from "./shared";
+          export * from "./atoms";
+
+          export { AnotherNamed } from './second-folder';
+          export { Named } from './folder';
+        `,
+        code: dedent`
+          export * from "./organisms";
+          export * from "./atoms";
+          export * from "./shared";
+
+          export { AnotherNamed } from './second-folder';
+          export { Named } from './folder';
+        `,
+        errors: [
+          {
+            data: {
+              right: './shared',
+              left: './atoms',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          // Part: A
+          // Not partition comment
+          export * from './bbb';
+          export * from './cc';
+          export * from './d';
+          // Part: B
+          export * from './aaaa';
+          export * from './e';
+          // Part: C
+          // Not partition comment
+          export * from './fff';
+          export * from './gg';
+        `,
+        code: dedent`
+          // Part: A
+          export * from './cc';
+          export * from './d';
+          // Not partition comment
+          export * from './bbb';
+          // Part: B
+          export * from './aaaa';
+          export * from './e';
+          // Part: C
+          export * from './gg';
+          // Not partition comment
+          export * from './fff';
+        `,
+        errors: [
+          {
+            data: {
+              right: './bbb',
+              left: './d',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './fff',
+              left: './gg',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          // Comment
+          export * from './bb';
+          // Other comment
+          export * from './a';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          /* Partition Comment */
+          // Part: A
+          export * from './d'
+          // Part: B
+          export * from './aaa'
+          export * from './bb'
+          export * from './c'
+          /* Other */
+          export * from './e'
+        `,
+        code: dedent`
+          /* Partition Comment */
+          // Part: A
+          export * from './d'
+          // Part: B
+          export * from './aaa'
+          export * from './c'
+          export * from './bb'
+          /* Other */
+          export * from './e'
+        `,
+        errors: [
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          export * from './ee'
+          export * from './f'
+          // I am a partition comment because I don't have f o o
+          export * from './aaaa'
+          export * from './bbb'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block comment partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './aa',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          // Comment
+          export * from './aa'
+          export * from './b'
+        `,
+        code: dedent`
+          export * from './b'
+          // Comment
+          export * from './aa'
+        `,
+      })
+    })
+
+    it('allows to use block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          export * from './b'
+          /* Comment */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use multiple block comment patterns for partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          export * from './c'
+          /* b */
+          export * from './b'
+          /* a */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('allows to use regex patterns for block comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export * from './b'
+          /* I am a partition comment because I don't have f o o */
+          export * from './a'
+        `,
+      })
+    })
+
+    it('sorts exports with values-first group kind', async () => {
+      await invalid({
+        output: dedent`
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+        `,
+        code: dedent`
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+        `,
+        errors: [
+          {
+            data: {
+              right: './c',
+              left: './e',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groupKind: 'values-first',
+          },
+        ],
+      })
+    })
+
+    it('sorts exports with types-first group kind', async () => {
+      await invalid({
+        output: dedent`
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+        `,
+        code: dedent`
+          export { C } from "./c";
+          export { A } from "./a";
+          export { B } from "./b";
+          export type { F } from "./f";
+          export type { D } from "./d";
+          export type { E } from "./e";
+        `,
+        errors: [
+          {
+            data: {
+              right: './f',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          export { a } from '_a'
+          export { c } from '_c'
+          export { b } from 'b'
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          export { ac } from 'a_c'
+          export { ab } from 'ab'
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          export { 你好 } from '你好'
+          export { 世界 } from '世界'
+          export { a } from 'a'
+          export { A } from 'A'
+          export { b } from 'b'
+          export { B } from 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from "aa"; export { b } from "b";
+        `,
+        code: dedent`
+          export { b } from "b"; export { a } from "aa"
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline elements with semicolons correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from "aa"; export { b } from "b";
+        `,
+        code: dedent`
+          export { b } from "b"; export { a } from "aa";
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['value-export', 'type-export'],
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export type { a } from 'a';
+        `,
+        code: dedent`
+          export type { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'valueExports',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'valueExports',
+                modifiers: ['value'],
+              },
+            ],
+            groups: ['valueExports', 'unknown'],
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export type { a } from 'a';
+        `,
+        code: dedent`
+          export type { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'filters on elementNamePattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  modifiers: ['value'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'valuesStartingWithHello',
+                right: 'helloExport',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedExportsGroupOrder',
+            },
+          ],
+          output: dedent`
+            export { helloExport } from 'helloExport';
+            export { a } from 'a';
+            export { b } from 'b';
+          `,
+          code: dedent`
+            export { a } from 'a';
+            export { b } from 'b';
+            export { helloExport } from 'helloExport';
+          `,
+        })
+      },
+    )
+
+    it('handles complex regex in elementNamePattern', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          export { iHaveFooInMyName } from 'iHaveFooInMyName';
+          export { meTooIHaveFoo } from 'meTooIHaveFoo';
+          export { a } from 'a';
+          export { b } from 'b';
+        `,
+      })
+    })
+
+    it('sort custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedValuesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedValuesByLineLength',
+                modifiers: ['value'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedValuesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            groupKind: 'mixed',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          export { dddd } from 'dddd';
+          export { ccc } from 'ccc';
+          export { eee } from 'eee';
+          export { bb } from 'bb';
+          export { ff } from 'ff';
+          export { a } from 'a';
+          export { g } from 'g';
+          export type { m } from 'm';
+          export type { o } from 'o';
+          export type { p } from 'p';
+        `,
+        code: dedent`
+          export { a } from 'a';
+          export { bb } from 'bb';
+          export { ccc } from 'ccc';
+          export { dddd } from 'dddd';
+          export type { m } from 'm';
+          export { eee } from 'eee';
+          export { ff } from 'ff';
+          export { g } from 'g';
+          export type { o } from 'o';
+          export type { p } from 'p';
+        `,
+      })
+    })
+
+    it('sort custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { fooBar } from 'fooBar';
+          export { fooZar } from 'fooZar';
+        `,
+        code: dedent`
+          export { fooZar } from 'fooZar';
+          export { fooBar } from 'fooBar';
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedValues',
+                modifiers: ['value'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedValues', 'unknown'],
+            groupKind: 'mixed',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedValues',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from 'b';
+          export { a } from 'a';
+          export { d } from 'd';
+          export { e } from 'e';
+          export { c } from 'c';
+          export type { m } from 'm';
+        `,
+        code: dedent`
+          export { b } from 'b';
+          export { a } from 'a';
+          export { d } from 'd';
+          export { e } from 'e';
+          export type { m } from 'm';
+          export { c } from 'c';
+        `,
+      })
+    })
+
+    it('sort custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['value'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['type'],
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export { cFoo } from 'cFoo';
+          export type { foo } from 'foo';
+          export { a } from 'a';
+        `,
+        code: dedent`
+          export { a } from 'a';
+          export { cFoo } from 'cFoo';
+          export type { foo } from 'foo';
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+              export { a } from 'a'
+
+
+             export { y } from 'y'
+            export { z } from 'z'
+
+                export { b } from 'b'
+          `,
+          output: dedent`
+              export { a } from 'a'
+             export { y } from 'y'
+            export { z } from 'z'
+                export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+              {
+                elementNamePattern: 'c',
+                groupName: 'c',
+              },
+              {
+                elementNamePattern: 'd',
+                groupName: 'd',
+              },
+              {
+                elementNamePattern: 'e',
+                groupName: 'e',
+              },
+            ],
+            groups: [
+              'a',
+              {
+                newlinesBetween: 'always',
+              },
+              'b',
+              {
+                newlinesBetween: 'always',
+              },
+              'c',
+              {
+                newlinesBetween: 'never',
+              },
+              'd',
+              {
+                newlinesBetween: 'ignore',
+              },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+        ],
+        output: dedent`
+          export { a } from 'a'
+
+          export { b } from 'b'
+
+          export { c } from 'c'
+          export { d } from 'd'
+
+
+          export { e } from 'e'
+        `,
+        code: dedent`
+          export { a } from 'a'
+          export { b } from 'b'
+
+
+          export { c } from 'c'
+
+          export { d } from 'd'
+
+
+          export { e } from 'e'
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+
+
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces newlines if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+
+
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenExports',
+            },
+          ],
+          output: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline if the global option is %s and the group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+
+            export { b } from 'b'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export { a } from 'a'
+            export { b } from 'b'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaaa',
+                  groupName: 'aaaa',
+                },
+              ],
+              groups: ['aaaa', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bbb',
+                left: 'cc',
+              },
+              messageId: 'unexpectedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export { a } from 'aaaa'
+
+            // Partition comment
+
+            export { b } from 'bbb'
+            export { c } from 'cc'
+          `,
+          code: dedent`
+            export { a } from 'aaaa'
+
+            // Partition comment
+
+            export { c } from 'cc'
+            export { b } from 'bbb'
+          `,
+        })
+      },
+    )
+
+    it('reports missing comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './a',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              missedCommentAbove: 'Other exports',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Type exports' },
+              'type-export',
+              { commentAbove: 'Other exports' },
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          // Type exports
+          export type { a } from "./a";
+
+          // Other exports
+          export { b } from "./b";
+        `,
+        code: dedent`
+          export type { a } from "./a";
+
+          export { b } from "./b";
+        `,
+      })
+    })
+
+    it('reports missing comments for single nodes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        output: dedent`
+          // Comment above
+          export { a } from "a";
+        `,
+        code: dedent`
+          export { a } from "a";
+        `,
+      })
+    })
+
+    it('ignores shebangs and comments at the top of the file', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              right: './aa',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above
+          export { a } from "./aa";
+          export { b } from "./b";
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          export { b } from "./b";
+          export { a } from "./aa";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      '//   Comment above  ',
+      '//   comment above  ',
+      dedent`
+        /**
+         * Comment above
+         */
+      `,
+      dedent`
+        /**
+         * Something before
+         * CoMmEnT ABoVe
+         * Something after
+         */
+      `,
+    ])(
+      'detects existing comments correctly with comment: %s',
+      async comment => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'value-export',
+                { commentAbove: 'Comment above' },
+                'unknown',
+              ],
+            },
+          ],
+          code: dedent`
+            export { a } from "a";
+
+            ${comment}
+            export type { b } from "./b";
+          `,
+        })
+      },
+    )
+
+    it('deletes invalid auto-added comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './c',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: './aaa',
+              left: './bb',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Value exports' },
+              'value-export',
+              { commentAbove: 'Type exports' },
+              'type-export',
+            ],
+          },
+        ],
+        output: dedent`
+          // Value exports
+          export { a } from './aaa';
+          // Type exports
+          export type { b } from './bb';
+          export type { c } from './c';
+        `,
+        code: dedent`
+          export type { c } from './c';
+          // Value exports
+          export type { b } from './bb';
+          // Type exports
+          export { a } from './aaa';
+        `,
+      })
+    })
+
+    it('works with other errors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Type exports',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveExport',
+          },
+          {
+            data: {
+              rightGroup: 'value-export',
+              leftGroup: 'type-export',
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Value exports' },
+              'value-export',
+              {
+                commentAbove: 'Type exports',
+                newlinesBetween: 'always',
+              },
+              ['type-export'],
+            ],
+            newlinesBetween: 'never',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above a
+          // Value exports
+          export { a } from "./a"; // Comment after a
+
+          // Type exports
+          // Comment above b
+          export type { b } from './b'; // Comment after b
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above b
+          // Value exports
+          export type { b } from './b'; // Comment after b
+          // Comment above a
+          // Type exports
+          export { a } from "./a"; // Comment after a
+        `,
+      })
+    })
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts exports', async () => {
+      await valid({
+        code: dedent`
+          export { a1 } from 'a'
+          export { b1, b2 } from 'b'
+          export { c1, c2, c3 } from 'c'
+          export { d1, d2 } from 'd'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a1 } from 'a'
+          export { b1, b2 } from 'b'
+          export { c1, c2, c3 } from 'c'
+          export { d1, d2 } from 'd'
+        `,
+        code: dedent`
+          export { b1, b2 } from 'b'
+          export { a1 } from 'a'
+          export { d1, d2 } from 'd'
+          export { c1, c2, c3 } from 'c'
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          export * from 'b'
+          export * from 'c'
+          export * from 'a'
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces newlines between', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenExports',
+          },
+        ],
+        output: dedent`
+          export { b } from 'b'
+
+          export { a } from 'a'
+        `,
+        code: dedent`
+          export { b } from 'b'
+          export { a } from 'a'
+        `,
+      })
     })
   })
 
   describe('misc', () => {
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
+    it('sets alphabetical asc sorting as default', async () => {
+      await valid(
+        dedent`
+          export { a } from '~/a'
+          export { b } from '~/b'
+          export { c } from '~/c'
+          export { d } from '~/d'
+        `,
+      )
+
+      await valid({
+        code: dedent`
+          export { log } from './log'
+          export { log10 } from './log10'
+          export { log1p } from './log1p'
+          export { log2 } from './log2'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: '~/b',
-                  left: '~/c',
-                },
-                messageId: 'unexpectedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { a } from '~/a'
-              export { b } from '~/b'
-              export { c } from '~/c'
-              export { d } from '~/d'
-            `,
-            code: dedent`
-              export { a } from '~/a'
-              export { c } from '~/c'
-              export { b } from '~/b'
-              export { d } from '~/d'
-            `,
+            data: {
+              right: '~/b',
+              left: '~/c',
+            },
+            messageId: 'unexpectedExportsOrder',
           },
         ],
-        valid: [
-          dedent`
-            export { a } from '~/a'
-            export { b } from '~/b'
-            export { c } from '~/c'
-            export { d } from '~/d'
-          `,
-          {
-            code: dedent`
-              export { log } from './log'
-              export { log10 } from './log10'
-              export { log1p } from './log1p'
-              export { log2 } from './log2'
-            `,
-            options: [{}],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: ignores exported variables or functions`,
-      rule,
-      {
-        valid: [
-          dedent`
-            export let a = () => {
-              // ...
-            }
-
-            export let b = () => {
-              // ...
-            }
-
-            export let c = ''
-          `,
-        ],
-        invalid: [],
-      },
-    )
-
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            // eslint-disable-next-line
-            export { a } from './a'
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            // eslint-disable-next-line
-            export { a } from './a'
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './c',
-                left: './d',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: './b',
-                left: './a',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            // eslint-disable-next-line
-            export { a } from './a'
-            export { d } from './d'
-          `,
-          code: dedent`
-            export { d } from './d'
-            export { c } from './c'
-            // eslint-disable-next-line
-            export { a } from './a'
-            export { b } from './b'
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            export { a } from './a' // eslint-disable-line
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            export { a } from './a' // eslint-disable-line
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            /* eslint-disable-next-line */
-            export { a } from './a'
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            /* eslint-disable-next-line */
-            export { a } from './a'
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            export { a } from './a' /* eslint-disable-line */
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            export { a } from './a' /* eslint-disable-line */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export { a } from './a'
-            export { d } from './d'
-            /* eslint-disable */
-            export { c } from './c'
-            export { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            export { e } from './e'
-          `,
-          code: dedent`
-            export { d } from './d'
-            export { e } from './e'
-            /* eslint-disable */
-            export { c } from './c'
-            export { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            export { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-            export { a } from './a'
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-            export { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            export { a } from './a' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            export { a } from './a' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-            export { a } from './a'
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-            export { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export { b } from './b'
-            export { c } from './c'
-            export { a } from './a' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          code: dedent`
-            export { c } from './c'
-            export { b } from './b'
-            export { a } from './a' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export { a } from './a'
-            export { d } from './d'
-            /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-            export { c } from './c'
-            export { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            export { e } from './e'
-          `,
-          code: dedent`
-            export { d } from './d'
-            export { e } from './e'
-            /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-            export { c } from './c'
-            export { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            export { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './b',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { b } from "./b"
-            export { c } from "./c"
-            // eslint-disable-next-line
-            export { a } from "./a"
-          `,
-        },
-      ],
+        output: dedent`
+          export { a } from '~/a'
+          export { b } from '~/b'
+          export { c } from '~/c'
+          export { d } from '~/d'
+        `,
+        code: dedent`
+          export { a } from '~/a'
+          export { c } from '~/c'
+          export { b } from '~/b'
+          export { d } from '~/d'
+        `,
+      })
     })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+    it('ignores exported variables or functions', async () => {
+      await valid(
+        dedent`
+          export let a = () => {
+            // ...
+          }
+
+          export let b = () => {
+            // ...
+          }
+
+          export let c = ''
+        `,
+      )
+    })
+
+    it('handles eslint-disable-next-line comments', async () => {
+      await valid({
+        code: dedent`
+          export { b } from "./b"
+          export { c } from "./c"
+          // eslint-disable-next-line
+          export { a } from "./a"
+        `,
+      })
+
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              export { a } from 'a'
-              export * from 'b'
-              export { c } from 'c'
-            `,
-            options: [{}],
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          // eslint-disable-next-line
+          export { a } from './a'
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          // eslint-disable-next-line
+          export { a } from './a'
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles eslint-disable-next-line with partitionByComment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './c',
+              left: './d',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: './b',
+              left: './a',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          // eslint-disable-next-line
+          export { a } from './a'
+          export { d } from './d'
+        `,
+        code: dedent`
+          export { d } from './d'
+          export { c } from './c'
+          // eslint-disable-next-line
+          export { a } from './a'
+          export { b } from './b'
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('handles eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          export { a } from './a' // eslint-disable-line
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          export { a } from './a' // eslint-disable-line
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block eslint-disable-next-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          /* eslint-disable-next-line */
+          export { a } from './a'
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          /* eslint-disable-next-line */
+          export { a } from './a'
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          export { a } from './a' /* eslint-disable-line */
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          export { a } from './a' /* eslint-disable-line */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles eslint-disable/enable blocks', async () => {
+      await invalid({
+        output: dedent`
+          export { a } from './a'
+          export { d } from './d'
+          /* eslint-disable */
+          export { c } from './c'
+          export { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          export { e } from './e'
+        `,
+        code: dedent`
+          export { d } from './d'
+          export { e } from './e'
+          /* eslint-disable */
+          export { c } from './c'
+          export { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          export { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable-next-line comments', async () => {
+      await invalid({
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          // eslint-disable-next-line rule-to-test/sort-exports
+          export { a } from './a'
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          // eslint-disable-next-line rule-to-test/sort-exports
+          export { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          export { a } from './a' // eslint-disable-line rule-to-test/sort-exports
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          export { a } from './a' // eslint-disable-line rule-to-test/sort-exports
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific block eslint-disable-next-line comments', async () => {
+      await invalid({
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          /* eslint-disable-next-line rule-to-test/sort-exports */
+          export { a } from './a'
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          /* eslint-disable-next-line rule-to-test/sort-exports */
+          export { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific block eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { b } from './b'
+          export { c } from './c'
+          export { a } from './a' /* eslint-disable-line rule-to-test/sort-exports */
+        `,
+        code: dedent`
+          export { c } from './c'
+          export { b } from './b'
+          export { a } from './a' /* eslint-disable-line rule-to-test/sort-exports */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable/enable blocks', async () => {
+      await invalid({
+        output: dedent`
+          export { a } from './a'
+          export { d } from './d'
+          /* eslint-disable rule-to-test/sort-exports */
+          export { c } from './c'
+          export { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          export { e } from './e'
+        `,
+        code: dedent`
+          export { d } from './d'
+          export { e } from './e'
+          /* eslint-disable rule-to-test/sort-exports */
+          export { c } from './c'
+          export { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          export { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
   })
 })

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -3,12 +3,11 @@ import type {
   RuleContext,
 } from '@typescript-eslint/utils/ts-eslint'
 import type { CompilerOptions } from 'typescript'
-import type { Rule } from 'eslint'
 
-import { afterAll, describe, expect, it, vi } from 'vitest'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
 import { createModuleResolutionCache } from 'typescript'
-import { RuleTester as EslintRuleTester } from 'eslint'
+import { describe, expect, it, vi } from 'vitest'
 import dedent from 'dedent'
 
 import type { Options } from '../../rules/sort-imports/types'
@@ -20,8483 +19,11 @@ import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-imports'
 
-let ruleName = 'sort-imports'
-
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
-    let options = {
-      type: 'alphabetical',
-      ignoreCase: true,
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          code: dedent`
-            import { b1 } from 'b'
-            import { a1, a2 } from 'a'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports by groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'e/a',
-                left: 'e/b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                rightGroup: 'type-internal',
-                leftGroup: 'value-internal',
-                right: '~/i',
-                left: '~/b',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: '~/i',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                rightGroup: 'value-builtin',
-                leftGroup: 'type-sibling',
-                left: './d',
-                right: 'fs',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: '~/c',
-                left: 'fs',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                right: '../../h',
-                left: '../f',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                leftGroup: 'value-parent',
-                rightGroup: 'type-index',
-                right: './index.d.ts',
-                left: '../../h',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'type-import',
-                leftGroup: 'value-index',
-                right: 't',
-                left: '.',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: './style.css',
-                left: 't',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-          ],
-          output: dedent`
-            import type { T } from 't'
-
-            import { c1, c2, c3, c4 } from 'c'
-            import { e1 } from 'e/a'
-            import { e2 } from 'e/b'
-            import fs from 'fs'
-            import path from 'path'
-
-            import type { I } from '~/i'
-
-            import { b1, b2 } from '~/b'
-            import { c1 } from '~/c'
-            import { i1, i2, i3 } from '~/i'
-
-            import type { A } from '.'
-            import type { F } from '../f'
-            import type { D } from './d'
-            import type { H } from './index.d.ts'
-
-            import a from '.'
-            import h from '../../h'
-            import './style.css'
-            import { j } from '../j'
-            import { K, L, M } from '../k'
-          `,
-          code: dedent`
-            import { c1, c2, c3, c4 } from 'c'
-            import { e2 } from 'e/b'
-            import { e1 } from 'e/a'
-            import path from 'path'
-
-            import { b1, b2 } from '~/b'
-            import type { I } from '~/i'
-            import type { D } from './d'
-            import fs from 'fs'
-            import { c1 } from '~/c'
-            import { i1, i2, i3 } from '~/i'
-
-            import type { A } from '.'
-            import type { F } from '../f'
-            import h from '../../h'
-            import type { H } from './index.d.ts'
-
-            import a from '.'
-            import type { T } from 't'
-            import './style.css'
-            import { j } from '../j'
-            import { K, L, M } from '../k'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import type { T } from 't'
-
-            import { c1, c2, c3, c4 } from 'c'
-            import { e1 } from 'e/a'
-            import { e2 } from 'e/b'
-            import fs from 'fs'
-            import path from 'path'
-
-            import type { I } from '~/i'
-
-            import { b1, b2 } from '~/b'
-            import { c1 } from '~/c'
-            import { i1, i2, i3 } from '~/i'
-
-            import type { A } from '.'
-            import type { F } from '../f'
-            import type { D } from './d'
-            import type { H } from './index.d.ts'
-
-            import a from '.'
-            import h from '../../h'
-            import { j } from '../j'
-            import { K, L, M } from '../k'
-            import './style.css'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports with no spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'value-external',
-                leftGroup: 'value-index',
-                right: 'a',
-                left: '.',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'value-internal',
-                rightGroup: 'type-import',
-                left: '~/c',
-                right: 't',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'value-internal',
-                leftGroup: 'value-parent',
-                left: '../../e',
-                right: '~/b',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          code: dedent`
-            import d from '.'
-            import { a1, a2, a3 } from 'a'
-            import { c1, c2, c3 } from '~/c'
-
-            import type { T } from 't'
-            import { e1, e2, e3 } from '../../e'
-
-            import { b1, b2 } from '~/b'
-          `,
-          output: dedent`
-            import type { T } from 't'
-            import { a1, a2, a3 } from 'a'
-            import { b1, b2 } from '~/b'
-            import { c1, c2, c3 } from '~/c'
-            import d from '.'
-            import { e1, e2, e3 } from '../../e'
-          `,
-          options: [
-            {
-              ...options,
-              newlinesBetween: 'never',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import type { T } from 't'
-            import { a1, a2, a3 } from 'a'
-            import { b1, b2 } from '~/b'
-            import { c1, c2, c3 } from '~/c'
-            import d from '.'
-            import { e1, e2, e3 } from '../../e'
-          `,
-          options: [
-            {
-              ...options,
-              newlinesBetween: 'never',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): disallow extra spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '~/b',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
-                right: '~/d',
-                left: '~/c',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-          ],
-          code: dedent`
-            import { A } from 'a'
-
-
-            import b from '~/b'
-            import c from '~/c'
-
-            import d from '~/d'
-          `,
-          output: dedent`
-            import { A } from 'a'
-
-            import b from '~/b'
-            import c from '~/c'
-            import d from '~/d'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { A } from 'a'
-
-            import b from '~/b'
-            import c from '~/c'
-            import d from '~/d'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): supports typescript ts import-equals`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '../b',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  leftGroup: 'ts-equals-import',
-                  rightGroup: 'value-external',
-                  left: 'console.log',
-                  right: 'c/c',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import type T = require("T")
-
-              import { A } from 'a'
-              import c = require('c/c')
-
-              import { B } from '../b'
-
-              import log = console.log
-            `,
-            code: dedent`
-              import type T = require("T")
-
-              import { A } from 'a'
-              import { B } from '../b'
-
-              import log = console.log
-              import c = require('c/c')
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import type T = require("T")
-
-              import { A } from 'a'
-              import c = require('c/c')
-
-              import { B } from '../b'
-
-              import log = console.log
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): use type if type of type is not defined`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '../t',
-                  right: '~/u',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '~/u',
-                  right: 'v',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal',
-                  ['parent', 'sibling', 'index'],
-                ],
-              },
-            ],
-            code: dedent`
-              import type { T } from '../t'
-
-              import type { U } from '~/u'
-
-              import type { V } from 'v'
-            `,
-            output: dedent`
-              import type { T } from '../t'
-              import type { U } from '~/u'
-              import type { V } from 'v'
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal',
-                  ['parent', 'sibling', 'index'],
-                ],
-              },
-            ],
-            code: dedent`
-              import type { T } from '../t'
-              import type { U } from '~/u'
-              import type { V } from 'v'
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): ignores inline comments`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import { a } from 'a'
-            import { b1, b2 } from 'b' // Comment
-            import { c } from 'c'
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores comments for counting lines between imports`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import type { T } from 't'
-
-              // @ts-expect-error missing types
-              import { t } from 't'
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): breaks import sorting if there is other nodes between`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import type { V } from 'v'
-
-              export type { U } from 'u'
-
-              import type { T1, T2 } from 't'
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates style imports from the rest`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'style',
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              import { a1, a2 } from 'a'
-
-              import styles from '../s.css'
-              import './t.css'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates side effect imports from the rest`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'side-effect',
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              import { A } from '../a'
-              import { b } from './b'
-
-              import '../c.js'
-              import './d'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates builtin type from the rest types`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: ['builtin-type', 'type'],
-              },
-            ],
-            code: dedent`
-              import type { Server } from 'http'
-
-              import a from 'a'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with imports ending with a semicolon`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'unknown',
-                ],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: './index',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import a from 'a';
-
-              import b from './index';
-            `,
-            code: dedent`
-              import a from 'a';
-              import b from './index';
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): remove unnecessary spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
-                rightGroup: 'value-external',
-                leftGroup: 'value-sibling',
-                left: './b',
-                right: 'c',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          code: dedent`
-            import { a } from 'a'
-
-
-            import { b } from './b'
-
-
-
-            import { c } from 'c'
-          `,
-          output: dedent`
-            import { a } from 'a'
-            import { c } from 'c'
-
-            import { b } from './b'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to define custom groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '@a/a1',
-                  left: 't',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: '@a/a1',
-                  left: 't',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '@b/b1',
-                  left: '@a/a2',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '@b/b3',
-                  right: 'c',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  'primary',
-                  'secondary',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'unknown',
-                ],
-                customGroups: {
-                  value: {
-                    primary: ['t', '@a/.+'],
-                    secondary: '@b/.+',
-                  },
-                  type: {
-                    primary: ['t', '@a/.+'],
-                  },
-                },
-              },
-            ],
-            output: dedent`
-              import a1 from '@a/a1'
-              import a2 from '@a/a2'
-              import type { T } from 't'
-
-              import b1 from '@b/b1'
-              import b2 from '@b/b2'
-              import b3 from '@b/b3'
-
-              import { c } from 'c'
-            `,
-            code: dedent`
-              import type { T } from 't'
-
-              import a1 from '@a/a1'
-              import a2 from '@a/a2'
-              import b1 from '@b/b1'
-              import b2 from '@b/b2'
-              import b3 from '@b/b3'
-              import { c } from 'c'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to define value only custom groups`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  value: {
-                    primary: ['a'],
-                  },
-                },
-                groups: ['type', 'primary'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import type { A } from 'a'
-
-              import { a } from 'a'
-            `,
-            code: dedent`
-              import type { A } from 'a'
-              import { a } from 'a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows hash symbol in internal pattern`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '#c',
-                  left: '#b',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '#b',
-                  left: '#c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-
-              import { b1, b2 } from '#b'
-              import c from '#c'
-
-              import { d } from '../d'
-            `,
-            code: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-              import c from '#c'
-              import { b1, b2 } from '#b'
-
-              import { d } from '../d'
-            `,
-            options: [
-              {
-                ...options,
-                internalPattern: ['#.+'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-
-              import { b1, b2 } from '#b'
-              import c from '#c'
-
-              import { d } from '../d'
-            `,
-            options: [
-              {
-                ...options,
-                internalPattern: ['#.+'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use bun modules`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'external',
-                rightGroup: 'builtin',
-                right: 'bun:test',
-                left: 'a',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['builtin', 'external', 'unknown'],
-              newlinesBetween: 'never',
-              environment: 'bun',
-            },
-          ],
-          output: dedent`
-            import { expect } from 'bun:test'
-            import { a } from 'a'
-          `,
-          code: dedent`
-            import { a } from 'a'
-            import { expect } from 'bun:test'
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: ['builtin', 'external', 'unknown'],
-              newlinesBetween: 'never',
-              environment: 'bun',
-            },
-          ],
-          code: dedent`
-            import { expect } from 'bun:test'
-            import { a } from 'a'
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts require imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            const { a1, a2 } = require('a')
-            const { b1 } = require('b')
-          `,
-          code: dedent`
-            const { b1 } = require('b')
-            const { a1, a2 } = require('a')
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            const { a1, a2 } = require('a')
-            const { b1 } = require('b')
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts require imports by groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'e/a',
-                  left: 'e/b',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'value-internal',
-                  rightGroup: 'value-builtin',
-                  left: '~/b',
-                  right: 'fs',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: '~/c',
-                  left: 'fs',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '../../h',
-                  right: '.',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  left: '../../h',
-                  right: '.',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e1 } = require('e/a')
-              const { e2 } = require('e/b')
-              const fs = require('fs')
-              const path = require('path')
-
-              const { b1, b2 } = require('~/b')
-              const { c1 } = require('~/c')
-              const { i1, i2, i3 } = require('~/i')
-
-              const a = require('.')
-              const h = require('../../h')
-              const { j } = require('../j')
-              const { K, L, M } = require('../k')
-            `,
-            code: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e2 } = require('e/b')
-              const { e1 } = require('e/a')
-              const path = require('path')
-
-              const { b1, b2 } = require('~/b')
-              const fs = require('fs')
-              const { c1 } = require('~/c')
-              const { i1, i2, i3 } = require('~/i')
-
-              const h = require('../../h')
-
-              const a = require('.')
-              const { j } = require('../j')
-              const { K, L, M } = require('../k')
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e1 } = require('e/a')
-              const { e2 } = require('e/b')
-              const fs = require('fs')
-              const path = require('path')
-
-              const { b1, b2 } = require('~/b')
-              const { c1 } = require('~/c')
-              const { i1, i2, i3 } = require('~/i')
-
-              const a = require('.')
-              const h = require('../../h')
-              const { j } = require('../j')
-              const { K, L, M } = require('../k')
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): can enable or disable sorting side effect imports`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'side-effect',
-                  rightGroup: 'external',
-                  left: 'bbb',
-                  right: 'e',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: 'aaaa',
-                  left: 'e',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: '../d',
-                  left: 'aaaa',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            output: dedent`
-              import a from 'aaaa'
-              import e from 'e'
-
-              import './cc'
-              import 'bbb'
-              import '../d'
-            `,
-            code: dedent`
-              import './cc'
-              import 'bbb'
-              import e from 'e'
-              import a from 'aaaa'
-              import '../d'
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: true,
-              },
-            ],
-            output: dedent`
-              import 'aaa'
-              import 'bb'
-              import 'c'
-            `,
-            code: dedent`
-              import 'c'
-              import 'bb'
-              import 'aaa'
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            code: dedent`
-              import a from 'aaaa'
-
-              import 'bbb'
-              import './cc'
-              import '../d'
-            `,
-          },
-          {
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            code: dedent`
-              import 'c'
-              import 'bb'
-              import 'aaa'
-            `,
-          },
-        ],
-      },
-    )
-
-    describe(`${ruleName}(${type}): disabling side-effect sorting`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows 'side-effect' and 'side-effect-style' groups to stay in place`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: './b-side-effect',
-                    left: './b',
-                  },
-                  messageId: 'unexpectedImportsOrder',
-                },
-                {
-                  data: {
-                    left: './a-side-effect',
-                    right: './a',
-                  },
-                  messageId: 'unexpectedImportsOrder',
-                },
-              ],
-              output: dedent`
-                import "./z-side-effect.scss";
-                import a from "./a";
-                import './b-side-effect'
-                import "./g-side-effect.css";
-                import './a-side-effect'
-                import b from "./b";
-              `,
-              code: dedent`
-                import "./z-side-effect.scss";
-                import b from "./b";
-                import './b-side-effect'
-                import "./g-side-effect.css";
-                import './a-side-effect'
-                import a from "./a";
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows 'side-effect' to be grouped together but not sorted`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: './z-side-effect.scss',
-                    right: './b',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-                {
-                  data: {
-                    rightGroup: 'side-effect',
-                    right: './b-side-effect',
-                    leftGroup: 'unknown',
-                    left: './b',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-                {
-                  data: {
-                    left: './a-side-effect',
-                    right: './a',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-              ],
-              output: dedent`
-                import "./z-side-effect.scss";
-                import './b-side-effect'
-                import "./g-side-effect.css";
-                import './a-side-effect'
-
-                import a from "./a";
-                import b from "./b";
-              `,
-              code: dedent`
-                import "./z-side-effect.scss";
-                import b from "./b";
-                import './b-side-effect'
-                import "./g-side-effect.css";
-                import './a-side-effect'
-                import a from "./a";
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['side-effect', 'unknown'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows 'side-effect' and 'side-effect-style' to be grouped together
-         in the same group but not sorted`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: './z-side-effect.scss',
-                    right: './b',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-                {
-                  data: {
-                    rightGroup: 'side-effect',
-                    right: './b-side-effect',
-                    leftGroup: 'unknown',
-                    left: './b',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-                {
-                  data: {
-                    left: './a-side-effect',
-                    right: './a',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-              ],
-              output: dedent`
-                import "./z-side-effect.scss";
-                import './b-side-effect'
-                import "./g-side-effect.css";
-                import './a-side-effect'
-
-                import a from "./a";
-                import b from "./b";
-              `,
-              code: dedent`
-                import "./z-side-effect.scss";
-                import b from "./b";
-                import './b-side-effect'
-                import "./g-side-effect.css";
-                import './a-side-effect'
-                import a from "./a";
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: [['side-effect', 'side-effect-style'], 'unknown'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows 'side-effect' and 'side-effect-style' to be grouped together but not sorted`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: './z-side-effect.scss',
-                    right: './b',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-                {
-                  data: {
-                    rightGroup: 'side-effect',
-                    right: './b-side-effect',
-                    leftGroup: 'unknown',
-                    left: './b',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-                {
-                  data: {
-                    right: './g-side-effect.css',
-                    left: './b-side-effect',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-                {
-                  data: {
-                    leftGroup: 'side-effect-style',
-                    left: './g-side-effect.css',
-                    rightGroup: 'side-effect',
-                    right: './a-side-effect',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-                {
-                  data: {
-                    left: './a-side-effect',
-                    right: './a',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-              ],
-              output: dedent`
-                import './b-side-effect'
-                import './a-side-effect'
-
-                import "./z-side-effect.scss";
-                import "./g-side-effect.css";
-
-                import a from "./a";
-                import b from "./b";
-              `,
-              code: dedent`
-                import "./z-side-effect.scss";
-                import b from "./b";
-                import './b-side-effect'
-                import "./g-side-effect.css";
-                import './a-side-effect'
-                import a from "./a";
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['side-effect', 'side-effect-style', 'unknown'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows 'side-effect-style' to be grouped together but not sorted`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'side-effect-style',
-                    right: './b-side-effect.scss',
-                    leftGroup: 'unknown',
-                    left: './b',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-                {
-                  data: {
-                    left: './b-side-effect.scss',
-                    right: './g-side-effect',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-                {
-                  data: {
-                    rightGroup: 'side-effect-style',
-                    right: './a-side-effect.css',
-                    left: './g-side-effect',
-                    leftGroup: 'unknown',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-                {
-                  data: {
-                    left: './a-side-effect.css',
-                    right: './a',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-              ],
-              output: dedent`
-                import "./z-side-effect";
-                import './b-side-effect.scss'
-                import './a-side-effect.css'
-
-                import "./g-side-effect";
-                import a from "./a";
-                import b from "./b";
-              `,
-              code: dedent`
-                import "./z-side-effect";
-                import b from "./b";
-                import './b-side-effect.scss'
-                import "./g-side-effect";
-                import './a-side-effect.css'
-                import a from "./a";
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['side-effect-style', 'unknown'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): does not sort side-effects and side-effect-style even with fallback sort`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  groups: ['side-effect', 'side-effect-style'],
-                  fallbackSort: { type: 'alphabetical' },
-                },
-              ],
-              code: dedent`
-                import 'b';
-                import 'a';
-
-                import 'b.css';
-                import 'a.css';
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              import '_a'
-              import 'b'
-              import '_c'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              import 'ab'
-              import 'a_c'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import '你好'
-            import '世界'
-            import 'a'
-            import 'A'
-            import 'b'
-            import 'B'
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: '~/y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenImports',
-                  },
-                  {
-                    data: {
-                      right: '~/b',
-                      left: '~/z',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                  {
-                    data: {
-                      right: '~/b',
-                      left: '~/z',
-                    },
-                    messageId: 'extraSpacingBetweenImports',
-                  },
-                ],
-                code: dedent`
-                    import { A } from 'a'
-
-
-                   import y from '~/y'
-                  import z from '~/z'
-
-                      import b from '~/b'
-                `,
-                output: dedent`
-                    import { A } from 'a'
-                   import b from '~/b'
-                  import y from '~/y'
-                      import z from '~/z'
-                `,
-                options: [
-                  {
-                    ...options,
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: '~/a',
-                      left: 'c',
-                    },
-                    messageId: 'missedSpacingBetweenImports',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  import c from 'c';    
-
-                  import a from '~/a'
-                `,
-                code: dedent`
-                  import c from 'c';    import a from '~/a'
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: '~/c',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenImports',
-                  },
-                  {
-                    data: {
-                      right: '~/b',
-                      left: '~/c',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                  {
-                    data: {
-                      right: '~/d',
-                      left: '~/b',
-                    },
-                    messageId: 'extraSpacingBetweenImports',
-                  },
-                ],
-                code: dedent`
-                    import { A } from 'a'
-
-
-                   import c from '~/c'
-                  import b from '~/b'
-
-                      import d from '~/d'
-                `,
-                output: dedent`
-                    import { A } from 'a'
-
-                   import b from '~/b'
-                  import c from '~/c'
-                      import d from '~/d'
-                `,
-                options: [
-                  {
-                    ...options,
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: {
-                      value: {
-                        a: 'a',
-                        b: 'b',
-                        c: 'c',
-                        d: 'd',
-                        e: 'e',
-                      },
-                    },
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenImports',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenImports',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenImports',
-                  },
-                ],
-                output: dedent`
-                  import { A } from 'a'
-
-                  import { B } from 'b'
-
-                  import { C } from 'c'
-                  import { D } from 'd'
-
-
-                  import { E } from 'e'
-                `,
-                code: dedent`
-                  import { A } from 'a'
-                  import { B } from 'b'
-
-
-                  import { C } from 'c'
-
-                  import { D } from 'd'
-
-
-                  import { E } from 'e'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: {
-                          value: {
-                            unusedGroup: 'X',
-                            a: 'a',
-                            b: 'b',
-                          },
-                        },
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenImports',
-                      },
-                    ],
-                    output: dedent`
-                      import { a } from 'a';
-
-
-                      import { b } from 'b';
-                    `,
-                    code: dedent`
-                      import { a } from 'a';
-                      import { b } from 'b';
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: {
-                          value: {
-                            unusedGroup: 'X',
-                            a: 'a',
-                            b: 'b',
-                            c: 'c',
-                          },
-                        },
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenImports',
-                      },
-                    ],
-                    output: dedent`
-                      import { a } from 'a';
-                      import { b } from 'b';
-                    `,
-                    code: dedent`
-                      import { a } from 'a';
-
-                      import { b } from 'b';
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: {
-                          value: {
-                            unusedGroup: 'X',
-                            a: 'a',
-                            b: 'b',
-                          },
-                        },
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      import { a } from 'a';
-
-                      import { b } from 'b';
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: {
-                          value: {
-                            unusedGroup: 'X',
-                            a: 'a',
-                            b: 'b',
-                          },
-                        },
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      import { a } from 'a';
-                      import { b } from 'b';
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  import { a } from './a' // Comment after
-                  import { b } from 'b'
-
-                  import { c } from 'c'
-                `,
-                dedent`
-                  import { a } from './a' // Comment after
-
-                  import { b } from 'b'
-                  import { c } from 'c'
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'external',
-                    right: './a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-              ],
-              code: dedent`
-                import { b } from 'b'
-                import { a } from './a' // Comment after
-
-                import { c } from 'c'
-              `,
-              options: [
-                {
-                  groups: ['unknown', 'external'],
-                  newlinesBetween: 'always',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: './b',
-                      left: './c',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                ],
-                output: dedent`
-                  import a from 'a';
-
-                  // Partition comment
-
-                  import { b } from './b';
-                  import { c } from './c';
-                `,
-                code: dedent`
-                  import a from 'a';
-
-                  // Partition comment
-
-                  import { c } from './c';
-                  import { b } from './b';
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { a } from "a"; import { b } from "b";
-            `,
-            code: dedent`
-              import { b } from "b"; import { a } from "a"
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { a } from "a"; import { b } from "b";
-            `,
-            code: dedent`
-              import { b } from "b"; import { a } from "a";
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: './organisms',
-                  right: './atoms',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  left: './second-folder',
-                  right: './folder',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import * as atoms from "./atoms";
-              import * as organisms from "./organisms";
-              import * as shared from "./shared";
-
-              import { Named } from './folder';
-              import { AnotherNamed } from './second-folder';
-            `,
-            code: dedent`
-              import * as organisms from "./organisms";
-              import * as atoms from "./atoms";
-              import * as shared from "./shared";
-
-              import { AnotherNamed } from './second-folder';
-              import { Named } from './folder';
-            `,
-            options: [
-              {
-                ...options,
-                newlinesBetween: 'ignore',
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): partition comments`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                // Part: A
-                // Not partition comment
-                import bbb from './bbb';
-                import cc from './cc';
-                import d from './d';
-                // Part: B
-                import aaaa from './aaaa';
-                import e from './e';
-                // Part: C
-                // Not partition comment
-                import fff from './fff';
-                import gg from './gg';
-              `,
-              code: dedent`
-                // Part: A
-                import cc from './cc';
-                import d from './d';
-                // Not partition comment
-                import bbb from './bbb';
-                // Part: B
-                import aaaa from './aaaa';
-                import e from './e';
-                // Part: C
-                import gg from './gg';
-                // Not partition comment
-                import fff from './fff';
-              `,
-              errors: [
-                {
-                  data: {
-                    right: './bbb',
-                    left: './d',
-                  },
-                  messageId: 'unexpectedImportsOrder',
-                },
-                {
-                  data: {
-                    right: './fff',
-                    left: './gg',
-                  },
-                  messageId: 'unexpectedImportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                // Comment
-                import bb from './bb';
-                // Other comment
-                import a from './a';
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                /* Partition Comment */
-                // Part: A
-                import d from './d'
-                // Part: B
-                import aaa from './aaa'
-                import bb from './bb'
-                import c from './c'
-                /* Other */
-                import e from './e'
-              `,
-              code: dedent`
-                /* Partition Comment */
-                // Part: A
-                import d from './d'
-                // Part: B
-                import aaa from './aaa'
-                import c from './c'
-                import bb from './bb'
-                /* Other */
-                import e from './e'
-              `,
-              errors: [
-                {
-                  data: {
-                    right: './bb',
-                    left: './c',
-                  },
-                  messageId: 'unexpectedImportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for partition comments`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import e from './e'
-              import f from './f'
-              // I am a partition comment because I don't have f o o
-              import a from './a'
-              import b from './b'
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: './a',
-                  left: './b',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  line: true,
-                },
-              },
-            ],
-            output: dedent`
-              /* Comment */
-              import a from './a'
-              import b from './b'
-            `,
-            code: dedent`
-              import b from './b'
-              /* Comment */
-              import a from './a'
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              code: dedent`
-                import b from './b'
-                // Comment
-                import a from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['a', 'b'],
-                  },
-                },
-              ],
-              code: dedent`
-                import c from './c'
-                // b
-                import b from './b'
-                // a
-                import a from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-              code: dedent`
-                import b from './b'
-                // I am a partition comment because I don't have f o o
-                import a from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: './a',
-                  left: './b',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  block: true,
-                },
-              },
-            ],
-            output: dedent`
-              // Comment
-              import a from './a'
-              import b from './b'
-            `,
-            code: dedent`
-              import b from './b'
-              // Comment
-              import a from './a'
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              code: dedent`
-                import b from './b'
-                /* Comment */
-                import a from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['a', 'b'],
-                  },
-                },
-              ],
-              code: dedent`
-                import c from './c'
-                /* b */
-                import b from './b'
-                /* a */
-                import a from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-              code: dedent`
-                import b from './b'
-                /* I am a partition comment because I don't have f o o */
-                import a from './a'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): supports style imports with optional chaining`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'unknown',
-                  right: './b.css?raw',
-                  rightGroup: 'style',
-                  left: './a.js',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import b from './b.css?raw'
-              import c from './c.css'
-
-              import a from './a.js'
-            `,
-            code: dedent`
-              import a from './a.js'
-              import b from './b.css?raw'
-              import c from './c.css'
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['style', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import b from './b.css?raw'
-              import c from './c.css'
-
-              import a from './a.js'
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['style', 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    describe(`${ruleName}(${type}): handles the new "groups" and "customGroups" API`, () => {
-      describe('selectors priority', () => {
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "index-type" over "sibling-type"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      leftGroup: 'sibling-type',
-                      rightGroup: 'index-type',
-                      right: './index',
-                      left: './a',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['index-type', 'sibling-type'],
-                  },
-                ],
-                output: dedent`
-                  import type b from './index'
-
-                  import type a from './a'
-                `,
-                code: dedent`
-                  import type a from './a'
-
-                  import type b from './index'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes precise "type" selectors over "type"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      [
-                        'index-type',
-                        'internal-type',
-                        'external-type',
-                        'sibling-type',
-                        'builtin-type',
-                      ],
-                      'type',
-                    ],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'sibling-type',
-                      leftGroup: 'type',
-                      right: './b',
-                      left: '../a',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                output: dedent`
-                  import type b from './b'
-                  import type c from './index'
-                  import type d from 'd'
-                  import type e from 'timers'
-
-                  import type a from '../a'
-                `,
-                code: dedent`
-                  import type a from '../a'
-
-                  import type b from './b'
-                  import type c from './index'
-                  import type d from 'd'
-                  import type e from 'timers'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "index" over "sibling"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      leftGroup: 'sibling',
-                      rightGroup: 'index',
-                      right: './index',
-                      left: './a',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['index', 'sibling'],
-                  },
-                ],
-                output: dedent`
-                  import b from './index'
-
-                  import a from './a'
-                `,
-                code: dedent`
-                  import a from './a'
-
-                  import b from './index'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "side-effect-style" over "side-effect"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'side-effect-style',
-                      leftGroup: 'side-effect',
-                      right: 'style.css',
-                      left: 'something',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['side-effect-style', 'side-effect'],
-                  },
-                ],
-                output: dedent`
-                  import 'style.css'
-
-                  import 'something'
-                `,
-                code: dedent`
-                  import 'something'
-
-                  import 'style.css'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "side-effect" over "style"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'side-effect',
-                      right: 'something',
-                      leftGroup: 'style',
-                      left: 'style.css',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['side-effect', 'style'],
-                  },
-                ],
-                output: dedent`
-                  import 'something'
-
-                  import style from 'style.css'
-                `,
-                code: dedent`
-                  import style from 'style.css'
-
-                  import 'something'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "style" over any other non-type "selector"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'style',
-                      [
-                        'index',
-                        'internal',
-                        'subpath',
-                        'external',
-                        'sibling',
-                        'builtin',
-                        'parent',
-                        'tsconfig-path',
-                      ],
-                    ],
-                    tsconfigRootDir: '.',
-                  },
-                ],
-                output: dedent`
-                  import style from 'style.css'
-
-                  import a from '../a'
-                  import b from './b'
-                  import c from './index'
-                  import subpath from '#subpath'
-                  import tsConfigPath from '$path'
-                  import d from 'd'
-                  import e from 'timers'
-                `,
-                code: dedent`
-                  import a from '../a'
-                  import b from './b'
-                  import c from './index'
-                  import subpath from '#subpath'
-                  import tsConfigPath from '$path'
-                  import d from 'd'
-                  import e from 'timers'
-
-                  import style from 'style.css'
-                `,
-                errors: [
-                  {
-                    data: {
-                      leftGroup: 'builtin',
-                      rightGroup: 'style',
-                      right: 'style.css',
-                      left: 'timers',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                before: () => {
-                  mockReadClosestTsConfigByPathWith({
-                    paths: {
-                      $path: ['./path'],
-                    },
-                  })
-                },
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "external" over "import"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'external',
-                      leftGroup: 'import',
-                      left: './a',
-                      right: 'b',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['external', 'import'],
-                  },
-                ],
-                output: dedent`
-                  import b from 'b'
-
-                  import a from './a'
-                `,
-                code: dedent`
-                  import a from './a'
-
-                  import b from 'b'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      })
-
-      describe('modifiers priority', () => {
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "type" over "ts-equals"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'type-import',
-                      leftGroup: 'external',
-                      right: 'z',
-                      left: 'f',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['type-import', 'external', 'ts-equals-import'],
-                  },
-                ],
-                output: dedent`
-                  import type z = z
-
-                  import f from 'f'
-                `,
-                code: dedent`
-                  import f from 'f'
-
-                  import type z = z
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "side-effect" over "value"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'side-effect-import',
-                      leftGroup: 'external',
-                      right: './z',
-                      left: 'f',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['side-effect-import', 'external', 'value-import'],
-                    sortSideEffects: true,
-                  },
-                ],
-                output: dedent`
-                  import "./z"
-
-                  import f from 'f'
-                `,
-                code: dedent`
-                  import f from 'f'
-
-                  import "./z"
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "value" over "ts-equals"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'value-import',
-                      leftGroup: 'external',
-                      right: 'z',
-                      left: 'f',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['value-import', 'external', 'ts-equals-import'],
-                  },
-                ],
-                output: dedent`
-                  import z = z
-
-                  import f from 'f'
-                `,
-                code: dedent`
-                  import f from 'f'
-
-                  import z = z
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "ts-equals" over "require"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'ts-equals-import',
-                      leftGroup: 'external',
-                      right: './z',
-                      left: 'f',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['ts-equals-import', 'external', 'require-import'],
-                  },
-                ],
-                output: dedent`
-                  import z = require('./z')
-
-                  import f from 'f'
-                `,
-                code: dedent`
-                  import f from 'f'
-
-                  import z = require('./z')
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "default" over "named"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'default-import',
-                      leftGroup: 'external',
-                      right: './z',
-                      left: 'f',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['default-import', 'external', 'named-import'],
-                  },
-                ],
-                output: dedent`
-                  import z, { z } from "./z"
-
-                  import f from 'f'
-                `,
-                code: dedent`
-                  import f from 'f'
-
-                  import z, { z } from "./z"
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): prioritizes "wildcard" over "named"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'wildcard-import',
-                      leftGroup: 'external',
-                      right: './z',
-                      left: 'f',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['wildcard-import', 'external', 'named-import'],
-                  },
-                ],
-                output: dedent`
-                  import z, * as z from "./z"
-
-                  import f from 'f'
-                `,
-                code: dedent`
-                  import f from 'f'
-
-                  import z, * as z from "./z"
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      })
-
-      describe(`custom groups`, () => {
-        for (let elementNamePattern of [
-          'hello',
-          ['noMatch', 'hello'],
-          { pattern: 'HELLO', flags: 'i' },
-          ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-        ]) {
-          ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'importsStartingWithHello',
-                      right: 'helloImport',
-                      leftGroup: 'unknown',
-                      left: 'a',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'importsStartingWithHello',
-                        elementNamePattern,
-                      },
-                    ],
-                    groups: ['importsStartingWithHello', 'unknown'],
-                  },
-                ],
-                output: dedent`
-                  import hello from 'helloImport'
-
-                  import a from 'a'
-                `,
-                code: dedent`
-                  import a from 'a'
-
-                  import hello from 'helloImport'
-                `,
-              },
-            ],
-            valid: [],
-          })
-        }
-
-        ruleTester.run(
-          `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'bb',
-                      left: 'a',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'ccc',
-                      left: 'bb',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'dddd',
-                      left: 'ccc',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'reversedExternalImportsByLineLength',
-                      leftGroup: 'unknown',
-                      left: './jjjjj',
-                      right: 'eee',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'reversedExternalImportsByLineLength',
-                        selector: 'external',
-                        type: 'line-length',
-                        order: 'desc',
-                      },
-                    ],
-                    groups: ['reversedExternalImportsByLineLength', 'unknown'],
-                    newlinesBetween: 'ignore',
-                    type: 'alphabetical',
-                    order: 'asc',
-                  },
-                ],
-                output: dedent`
-                  import dddd from 'dddd'
-                  import ccc from 'ccc'
-                  import eee from 'eee'
-                  import bb from 'bb'
-                  import ff from 'ff'
-                  import a from 'a'
-                  import g from 'g'
-                  import h from './h'
-                  import i from './i'
-                  import jjjjj from './jjjjj'
-                `,
-                code: dedent`
-                  import a from 'a'
-                  import bb from 'bb'
-                  import ccc from 'ccc'
-                  import dddd from 'dddd'
-                  import jjjjj from './jjjjj'
-                  import eee from 'eee'
-                  import ff from 'ff'
-                  import g from 'g'
-                  import h from './h'
-                  import i from './i'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        fallbackSort: {
-                          type: 'alphabetical',
-                          order: 'asc',
-                        },
-                        elementNamePattern: '^foo',
-                        type: 'line-length',
-                        groupName: 'foo',
-                        order: 'desc',
-                      },
-                    ],
-                    type: 'alphabetical',
-                    groups: ['foo'],
-                    order: 'asc',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'fooBar',
-                      left: 'fooZar',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                ],
-                output: dedent`
-                  import fooBar from 'fooBar'
-                  import fooZar from 'fooZar'
-                `,
-                code: dedent`
-                  import fooZar from 'fooZar'
-                  import fooBar from 'fooBar'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: does not sort custom groups with 'unsorted' type`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'unsortedExternalImports',
-                        selector: 'external',
-                        type: 'unsorted',
-                      },
-                    ],
-                    groups: ['unsortedExternalImports', 'unknown'],
-                    newlinesBetween: 'ignore',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'unsortedExternalImports',
-                      leftGroup: 'unknown',
-                      left: './something',
-                      right: 'c',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                output: dedent`
-                  import b from 'b'
-                  import a from 'a'
-                  import d from 'd'
-                  import e from 'e'
-                  import c from 'c'
-                  import something from './something'
-                `,
-                code: dedent`
-                  import b from 'b'
-                  import a from 'a'
-                  import d from 'd'
-                  import e from 'e'
-                  import something from './something'
-                  import c from 'c'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      anyOf: [
-                        {
-                          selector: 'external',
-                        },
-                        {
-                          selector: 'sibling',
-                          modifiers: ['type'],
-                        },
-                      ],
-                      groupName: 'externalAndTypeSiblingImports',
-                    },
-                  ],
-                  groups: [
-                    ['externalAndTypeSiblingImports', 'index'],
-                    'unknown',
-                  ],
-                  newlinesBetween: 'ignore',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'externalAndTypeSiblingImports',
-                    leftGroup: 'unknown',
-                    right: './c',
-                    left: './b',
-                  },
-                  messageId: 'unexpectedImportsGroupOrder',
-                },
-                {
-                  data: {
-                    right: './index',
-                    left: 'e',
-                  },
-                  messageId: 'unexpectedImportsOrder',
-                },
-              ],
-              output: dedent`
-                import type c from './c'
-                import type d from './d'
-                import i from './index'
-                import a from 'a'
-                import e from 'e'
-                import b from './b'
-              `,
-              code: dedent`
-                import a from 'a'
-                import b from './b'
-                import type c from './c'
-                import type d from './d'
-                import e from 'e'
-                import i from './index'
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        describe('newlinesInside', () => {
-          for (let newlinesInside of ['always', 1] as const) {
-            ruleTester.run(
-              `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        customGroups: [
-                          {
-                            selector: 'external',
-                            groupName: 'group1',
-                            newlinesInside,
-                          },
-                        ],
-                        groups: ['group1'],
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenImports',
-                      },
-                    ],
-                    output: dedent`
-                      import a from 'a'
-
-                      import b from 'b'
-                    `,
-                    code: dedent`
-                      import a from 'a'
-                      import b from 'b'
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let newlinesInside of ['never', 0] as const) {
-            ruleTester.run(
-              `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        customGroups: [
-                          {
-                            selector: 'external',
-                            groupName: 'group1',
-                            newlinesInside,
-                          },
-                        ],
-                        type: 'alphabetical',
-                        groups: ['group1'],
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenImports',
-                      },
-                    ],
-                    output: dedent`
-                      import a from 'a'
-                      import b from 'b'
-                    `,
-                    code: dedent`
-                      import a from 'a'
-
-                      import b from 'b'
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-        })
-      })
-    })
-
-    describe('detects dependencies', () => {
-      ruleTester.run(
-        `${ruleName}(${type}): detects typescript import-equals dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-              output: dedent`
-                import { aImport } from "b";
-                import a = aImport.a1.a2;
-              `,
-              code: dedent`
-                import a = aImport.a1.a2;
-                import { aImport } from "b";
-              `,
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-              output: dedent`
-                import * as aImport from "b";
-                import a = aImport.a1.a2;
-              `,
-              code: dedent`
-                import a = aImport.a1.a2;
-                import * as aImport from "b";
-              `,
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-              output: dedent`
-                import aImport from "b";
-                import a = aImport.a1.a2;
-              `,
-              code: dedent`
-                import a = aImport.a1.a2;
-                import aImport from "b";
-              `,
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-              output: dedent`
-                import aImport = require("b")
-                import a = aImport.a1.a2;
-              `,
-              code: dedent`
-                import a = aImport.a1.a2;
-                import aImport = require("b")
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over group configuration`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      groupName: 'importsStartingWithA',
-                      elementNamePattern: '^a',
-                    },
-                    {
-                      groupName: 'importsStartingWithB',
-                      elementNamePattern: '^b',
-                    },
-                  ],
-                  groups: ['importsStartingWithA', 'importsStartingWithB'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-                {
-                  data: {
-                    left: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'missedSpacingBetweenImports',
-                },
-              ],
-              output: dedent`
-                import aImport from "b";
-                import a = aImport.a1.a2;
-              `,
-              code: dedent`
-                import a = aImport.a1.a2;
-                import aImport from "b";
-              `,
-            },
-          ],
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      groupName: 'importsStartingWithA',
-                      elementNamePattern: '^a',
-                    },
-                    {
-                      groupName: 'importsStartingWithB',
-                      elementNamePattern: '^b',
-                    },
-                  ],
-                  groups: ['importsStartingWithA', 'importsStartingWithB'],
-                },
-              ],
-              code: dedent`
-                import aImport from "b";
-                import a = aImport.a1.a2;
-              `,
-            },
-          ],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                import aImport from "b";
-
-                // Part: 1
-                import a = aImport.a1.a2;
-              `,
-              code: dedent`
-                import a = aImport.a1.a2;
-
-                // Part: 1
-                import aImport from "b";
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  newlinesBetween: 'ignore',
-                  partitionByNewLine: true,
-                },
-              ],
-              output: dedent`
-                import aImport from "b";
-
-                import a = aImport.a1.a2;
-              `,
-              code: dedent`
-                import a = aImport.a1.a2;
-
-                import aImport from "b";
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes content-separation over dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'yImport.y1.y2',
-                    right: 'z',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'aImport.a1.a2',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedImportsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                import f = fImport.f1.f2;
-
-                import yImport from "z";
-
-                import y = yImport.y1.y2;
-
-                export { something } from "something";
-
-                import aImport from "b";
-
-                import a = aImport.a1.a2;
-
-                import fImport from "g";
-              `,
-              code: dedent`
-                import f = fImport.f1.f2;
-
-                import y = yImport.y1.y2;
-
-                import yImport from "z";
-
-                export { something } from "something";
-
-                import a = aImport.a1.a2;
-
-                import aImport from "b";
-
-                import fImport from "g";
-              `,
-              options: [
-                {
-                  ...options,
-                  newlinesBetween: 'ignore',
-                  partitionByNewLine: true,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(`${ruleName}(${type}): ignores shebang comments`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            #!/usr/bin/node
-            import { a } from 'a'
-            import { b } from 'b'
-          `,
-          code: dedent`
-            #!/usr/bin/node
-            import { b } from 'b'
-            import { a } from 'a'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): use pattern @ as internal import`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '@/a',
-                  left: 'b',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'internal'],
-                newlinesBetween: 'always',
-              },
-            ],
-            output: dedent`
-              import { b } from 'b'
-
-              import { a } from '@/a'
-            `,
-            code: dedent`
-              import { b } from 'b'
-              import { a } from '@/a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): "commentAbove" inside groups`, () => {
-      ruleTester.run(`${ruleName}(${type}): reports missing comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  missedCommentAbove: 'Comment above a',
-                  right: 'a',
-                },
-                messageId: 'missedCommentAboveImport',
-              },
-              {
-                data: {
-                  missedCommentAbove: 'Comment above b',
-                  right: './b',
-                },
-                messageId: 'missedCommentAboveImport',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  { commentAbove: 'Comment above a' },
-                  'external',
-                  { commentAbove: 'Comment above b' },
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              // Comment above a
-              import { a } from "a";
-
-              // Comment above b
-              import { b } from "./b";
-            `,
-            code: dedent`
-              import { a } from "a";
-
-              import { b } from "./b";
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): reports missing comments for single nodes`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    missedCommentAbove: 'Comment above',
-                    right: 'a',
-                  },
-                  messageId: 'missedCommentAboveImport',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [{ commentAbove: 'Comment above' }, 'unknown'],
-                },
-              ],
-              output: dedent`
-                // Comment above
-                import { a } from "a";
-              `,
-              code: dedent`
-                import { a } from "a";
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): ignores shebangs and comments at the top of the file`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    missedCommentAbove: 'Comment above',
-                    right: 'b',
-                  },
-                  messageId: 'missedCommentAboveImport',
-                },
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedImportsOrder',
-                },
-              ],
-              output: [
-                dedent`
-                  #!/usr/bin/node
-                  // Some disclaimer
-
-                  import a from "a";
-                  import b from "b";
-                `,
-                dedent`
-                  #!/usr/bin/node
-                  // Some disclaimer
-
-                  // Comment above
-                  import a from "a";
-                  import b from "b";
-                `,
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: [{ commentAbove: 'Comment above' }, 'external'],
-                },
-              ],
-              code: dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                import b from "b";
-                import a from "a";
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      describe('comment detection', () => {
-        for (let comment of [
-          '//   Comment above  ',
-          '//   comment above  ',
-          `/**
-            * Comment above
-            */`,
-          `/**
-            * Something before
-            * CoMmEnT ABoVe
-            * Something after
-            */`,
-        ]) {
-          ruleTester.run(
-            `${ruleName}(${type}): detects existing comments correctly`,
-            rule,
-            {
-              valid: [
-                {
-                  options: [
-                    {
-                      ...options,
-                      groups: [
-                        'external',
-                        { commentAbove: 'Comment above' },
-                        'unknown',
-                      ],
-                    },
-                  ],
-                  code: dedent`
-                    import a from "a";
-
-                    ${comment}
-                    import b from "./b";
-                  `,
-                },
-              ],
-              invalid: [],
-            },
-          )
-        }
-
-        ruleTester.run(
-          `${ruleName}(${type}): deletes invalid auto-added comments`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      missedCommentAbove: 'internal',
-                      right: '~/d',
-                    },
-                    messageId: 'missedCommentAboveImport',
-                  },
-                  {
-                    data: {
-                      right: '~/c',
-                      left: '~/d',
-                    },
-                    messageId: 'unexpectedImportsOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'sibling',
-                      leftGroup: 'internal',
-                      right: './b',
-                      left: '~/c',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'external',
-                      leftGroup: 'sibling',
-                      left: './b',
-                      right: 'a',
-                    },
-                    messageId: 'unexpectedImportsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      { commentAbove: 'external' },
-                      'external',
-                      { commentAbove: 'sibling' },
-                      'sibling',
-                      { commentAbove: 'internal' },
-                      'internal',
-                    ],
-                  },
-                ],
-                output: dedent`
-                  // external
-                  import a from "a";
-
-                  // sibling
-                  import b from './b';
-
-                  // internal
-                  import c from '~/c';
-                  import d from '~/d';
-                `,
-                code: dedent`
-                  import d from '~/d';
-                  // internal
-                  import c from '~/c';
-
-                  // sibling
-                  import b from './b';
-
-                  // external
-                  import a from "a";
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      })
-
-      ruleTester.run(`${ruleName}(${type}): works with other errors`, rule, {
-        invalid: [
-          {
-            output: [
-              dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                // Comment above a
-                // internal or sibling
-                import a from "a"; // Comment after a
-                // Comment above c
-                // external
-                import c from './c'; // Comment after c
-                // Comment above b
-                // external
-                import b from '~/b'; // Comment after b
-              `,
-              dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                // Comment above a
-                // internal or sibling
-                import a from "a"; // Comment after a
-
-                // Comment above c
-                // external
-                import c from './c'; // Comment after c
-                // Comment above b
-                // external
-                import b from '~/b'; // Comment after b
-              `,
-              dedent`
-                #!/usr/bin/node
-                // Some disclaimer
-
-                // Comment above a
-                // external
-                import a from "a"; // Comment after a
-
-                // internal or sibling
-                // Comment above c
-                import c from './c'; // Comment after c
-                // Comment above b
-                import b from '~/b'; // Comment after b
-              `,
-            ],
-            errors: [
-              {
-                data: {
-                  missedCommentAbove: 'internal or sibling',
-                  right: './c',
-                },
-                messageId: 'missedCommentAboveImport',
-              },
-              {
-                data: {
-                  rightGroup: 'external',
-                  leftGroup: 'sibling',
-                  left: './c',
-                  right: 'a',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: '~/b',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  missedCommentAbove: 'internal or sibling',
-                  right: '~/b',
-                },
-                messageId: 'missedCommentAboveImport',
-              },
-            ],
-            code: dedent`
-              #!/usr/bin/node
-              // Some disclaimer
-
-              // Comment above c
-              // external
-              import c from './c'; // Comment after c
-              // Comment above a
-              // internal or sibling
-              import a from "a"; // Comment after a
-              // Comment above b
-              // external
-              import b from '~/b'; // Comment after b
-            `,
-            options: [
-              {
-                ...options,
-                groups: [
-                  { commentAbove: 'external' },
-                  'external',
-                  {
-                    commentAbove: 'internal or sibling',
-                    newlinesBetween: 'always',
-                  },
-                  ['internal', 'sibling'],
-                ],
-                newlinesBetween: 'never',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      })
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          code: dedent`
-            import { b1 } from 'b'
-            import { a1, a2 } from 'a'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports by groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'e/a',
-                left: 'e/b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                rightGroup: 'type-internal',
-                leftGroup: 'value-internal',
-                right: '~/i',
-                left: '~/b',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: '~/i',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                rightGroup: 'value-builtin',
-                leftGroup: 'type-sibling',
-                left: './d',
-                right: 'fs',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: '~/c',
-                left: 'fs',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                right: '../../h',
-                left: '../f',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                leftGroup: 'value-parent',
-                rightGroup: 'type-index',
-                right: './index.d.ts',
-                left: '../../h',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'type-import',
-                leftGroup: 'value-index',
-                right: 't',
-                left: '.',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: './style.css',
-                left: 't',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-          ],
-          output: dedent`
-            import type { T } from 't'
-
-            import { c1, c2, c3, c4 } from 'c'
-            import { e1 } from 'e/a'
-            import { e2 } from 'e/b'
-            import fs from 'fs'
-            import path from 'path'
-
-            import type { I } from '~/i'
-
-            import { b1, b2 } from '~/b'
-            import { c1 } from '~/c'
-            import { i1, i2, i3 } from '~/i'
-
-            import type { A } from '.'
-            import type { F } from '../f'
-            import type { D } from './d'
-            import type { H } from './index.d.ts'
-
-            import a from '.'
-            import h from '../../h'
-            import './style.css'
-            import { j } from '../j'
-            import { K, L, M } from '../k'
-          `,
-          code: dedent`
-            import { c1, c2, c3, c4 } from 'c'
-            import { e2 } from 'e/b'
-            import { e1 } from 'e/a'
-            import path from 'path'
-
-            import { b1, b2 } from '~/b'
-            import type { I } from '~/i'
-            import type { D } from './d'
-            import fs from 'fs'
-            import { c1 } from '~/c'
-            import { i1, i2, i3 } from '~/i'
-
-            import type { A } from '.'
-            import type { F } from '../f'
-            import h from '../../h'
-            import type { H } from './index.d.ts'
-
-            import a from '.'
-            import type { T } from 't'
-            import './style.css'
-            import { j } from '../j'
-            import { K, L, M } from '../k'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import type { T } from 't'
-
-            import { c1, c2, c3, c4 } from 'c'
-            import { e1 } from 'e/a'
-            import { e2 } from 'e/b'
-            import fs from 'fs'
-            import path from 'path'
-
-            import type { I } from '~/i'
-
-            import { b1, b2 } from '~/b'
-            import { c1 } from '~/c'
-            import { i1, i2, i3 } from '~/i'
-
-            import type { A } from '.'
-            import type { F } from '../f'
-            import type { D } from './d'
-            import type { H } from './index.d.ts'
-
-            import a from '.'
-            import h from '../../h'
-            import { j } from '../j'
-            import { K, L, M } from '../k'
-            import './style.css'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports with no spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'value-external',
-                leftGroup: 'value-index',
-                right: 'a',
-                left: '.',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'value-internal',
-                rightGroup: 'type-import',
-                left: '~/c',
-                right: 't',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'value-internal',
-                leftGroup: 'value-parent',
-                left: '../../e',
-                right: '~/b',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          code: dedent`
-            import d from '.'
-            import { a1, a2, a3 } from 'a'
-            import { c1, c2, c3 } from '~/c'
-
-            import type { T } from 't'
-            import { e1, e2, e3 } from '../../e'
-
-            import { b1, b2 } from '~/b'
-          `,
-          output: dedent`
-            import type { T } from 't'
-            import { a1, a2, a3 } from 'a'
-            import { b1, b2 } from '~/b'
-            import { c1, c2, c3 } from '~/c'
-            import d from '.'
-            import { e1, e2, e3 } from '../../e'
-          `,
-          options: [
-            {
-              ...options,
-              newlinesBetween: 'never',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import type { T } from 't'
-            import { a1, a2, a3 } from 'a'
-            import { b1, b2 } from '~/b'
-            import { c1, c2, c3 } from '~/c'
-            import d from '.'
-            import { e1, e2, e3 } from '../../e'
-          `,
-          options: [
-            {
-              ...options,
-              newlinesBetween: 'never',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): disallow extra spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '~/b',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
-                right: '~/d',
-                left: '~/c',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-          ],
-          code: dedent`
-            import { A } from 'a'
-
-
-            import b from '~/b'
-            import c from '~/c'
-
-            import d from '~/d'
-          `,
-          output: dedent`
-            import { A } from 'a'
-
-            import b from '~/b'
-            import c from '~/c'
-            import d from '~/d'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { A } from 'a'
-
-            import b from '~/b'
-            import c from '~/c'
-            import d from '~/d'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): supports typescript ts import-equals`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '../b',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  leftGroup: 'ts-equals-import',
-                  rightGroup: 'value-external',
-                  left: 'console.log',
-                  right: 'c/c',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import type T = require("T")
-
-              import { A } from 'a'
-              import c = require('c/c')
-
-              import { B } from '../b'
-
-              import log = console.log
-            `,
-            code: dedent`
-              import type T = require("T")
-
-              import { A } from 'a'
-              import { B } from '../b'
-
-              import log = console.log
-              import c = require('c/c')
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import type T = require("T")
-
-              import { A } from 'a'
-              import c = require('c/c')
-
-              import { B } from '../b'
-
-              import log = console.log
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): use type if type of type is not defined`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '../t',
-                  right: 'v',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '~/u',
-                  left: 'v',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal',
-                  ['parent', 'sibling', 'index'],
-                ],
-              },
-            ],
-            code: dedent`
-              import type { T } from '../t'
-
-              import type { V } from 'v'
-
-              import type { U } from '~/u'
-            `,
-            output: dedent`
-              import type { T } from '../t'
-              import type { V } from 'v'
-              import type { U } from '~/u'
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal',
-                  ['parent', 'sibling', 'index'],
-                ],
-              },
-            ],
-            code: dedent`
-              import type { T } from '../t'
-              import type { V } from 'v'
-              import type { U } from '~/u'
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): ignores inline comments`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import { a } from 'a'
-            import { b1, b2 } from 'b' // Comment
-            import { c } from 'c'
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores comments for counting lines between imports`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import type { T } from 't'
-
-              // @ts-expect-error missing types
-              import { t } from 't'
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): breaks import sorting if there is other nodes between`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import type { V } from 'v'
-
-              export type { U } from 'u'
-
-              import type { T1, T2 } from 't'
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates style imports from the rest`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'style',
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              import { a1, a2 } from 'a'
-
-              import styles from '../s.css'
-              import './t.css'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates side effect imports from the rest`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'side-effect',
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              import { A } from '../a'
-              import { b } from './b'
-
-              import '../c.js'
-              import './d'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates builtin type from the rest types`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: ['builtin-type', 'type'],
-              },
-            ],
-            code: dedent`
-              import type { Server } from 'http'
-
-              import a from 'a'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with imports ending with a semicolon`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'unknown',
-                ],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: './index',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import a from 'a';
-
-              import b from './index';
-            `,
-            code: dedent`
-              import a from 'a';
-              import b from './index';
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): remove unnecessary spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
-                rightGroup: 'value-external',
-                leftGroup: 'value-sibling',
-                left: './b',
-                right: 'c',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          code: dedent`
-            import { a } from 'a'
-
-
-            import { b } from './b'
-
-
-
-            import { c } from 'c'
-          `,
-          output: dedent`
-            import { a } from 'a'
-            import { c } from 'c'
-
-            import { b } from './b'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to define custom groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '@a/a1',
-                  left: 't',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: '@a/a1',
-                  left: 't',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '@b/b1',
-                  left: '@a/a2',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '@b/b3',
-                  right: 'c',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  'primary',
-                  'secondary',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'unknown',
-                ],
-                customGroups: {
-                  value: {
-                    primary: ['t', '@a/.+'],
-                    secondary: '@b/.+',
-                  },
-                  type: {
-                    primary: ['t', '@a/.+'],
-                  },
-                },
-              },
-            ],
-            output: dedent`
-              import a1 from '@a/a1'
-              import a2 from '@a/a2'
-              import type { T } from 't'
-
-              import b1 from '@b/b1'
-              import b2 from '@b/b2'
-              import b3 from '@b/b3'
-
-              import { c } from 'c'
-            `,
-            code: dedent`
-              import type { T } from 't'
-
-              import a1 from '@a/a1'
-              import a2 from '@a/a2'
-              import b1 from '@b/b1'
-              import b2 from '@b/b2'
-              import b3 from '@b/b3'
-              import { c } from 'c'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to define value only custom groups`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  value: {
-                    primary: ['a'],
-                  },
-                },
-                groups: ['type', 'primary'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import type { A } from 'a'
-
-              import { a } from 'a'
-            `,
-            code: dedent`
-              import type { A } from 'a'
-              import { a } from 'a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows hash symbol in internal pattern`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '#c',
-                  left: '#b',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '#b',
-                  left: '#c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-
-              import { b1, b2 } from '#b'
-              import c from '#c'
-
-              import { d } from '../d'
-            `,
-            code: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-              import c from '#c'
-              import { b1, b2 } from '#b'
-
-              import { d } from '../d'
-            `,
-            options: [
-              {
-                ...options,
-                internalPattern: ['#.+'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-
-              import { b1, b2 } from '#b'
-              import c from '#c'
-
-              import { d } from '../d'
-            `,
-            options: [
-              {
-                ...options,
-                internalPattern: ['#.+'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use bun modules`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'external',
-                rightGroup: 'builtin',
-                right: 'bun:test',
-                left: 'a',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['builtin', 'external', 'unknown'],
-              newlinesBetween: 'never',
-              environment: 'bun',
-            },
-          ],
-          output: dedent`
-            import { expect } from 'bun:test'
-            import { a } from 'a'
-          `,
-          code: dedent`
-            import { a } from 'a'
-            import { expect } from 'bun:test'
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: ['builtin', 'external', 'unknown'],
-              newlinesBetween: 'never',
-              environment: 'bun',
-            },
-          ],
-          code: dedent`
-            import { expect } from 'bun:test'
-            import { a } from 'a'
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts require imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            const { a1, a2 } = require('a')
-            const { b1 } = require('b')
-          `,
-          code: dedent`
-            const { b1 } = require('b')
-            const { a1, a2 } = require('a')
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            const { a1, a2 } = require('a')
-            const { b1 } = require('b')
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts require imports by groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'e/a',
-                  left: 'e/b',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'value-internal',
-                  rightGroup: 'value-builtin',
-                  left: '~/b',
-                  right: 'fs',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: '~/c',
-                  left: 'fs',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '../../h',
-                  right: '.',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  left: '../../h',
-                  right: '.',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e1 } = require('e/a')
-              const { e2 } = require('e/b')
-              const fs = require('fs')
-              const path = require('path')
-
-              const { b1, b2 } = require('~/b')
-              const { c1 } = require('~/c')
-              const { i1, i2, i3 } = require('~/i')
-
-              const a = require('.')
-              const h = require('../../h')
-              const { j } = require('../j')
-              const { K, L, M } = require('../k')
-            `,
-            code: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e2 } = require('e/b')
-              const { e1 } = require('e/a')
-              const path = require('path')
-
-              const { b1, b2 } = require('~/b')
-              const fs = require('fs')
-              const { c1 } = require('~/c')
-              const { i1, i2, i3 } = require('~/i')
-
-              const h = require('../../h')
-
-              const a = require('.')
-              const { j } = require('../j')
-              const { K, L, M } = require('../k')
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e1 } = require('e/a')
-              const { e2 } = require('e/b')
-              const fs = require('fs')
-              const path = require('path')
-
-              const { b1, b2 } = require('~/b')
-              const { c1 } = require('~/c')
-              const { i1, i2, i3 } = require('~/i')
-
-              const a = require('.')
-              const h = require('../../h')
-              const { j } = require('../j')
-              const { K, L, M } = require('../k')
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): can enable or disable sorting side effect imports`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'side-effect',
-                  rightGroup: 'external',
-                  left: 'bbb',
-                  right: 'e',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: 'aaaa',
-                  left: 'e',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: '../d',
-                  left: 'aaaa',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            output: dedent`
-              import a from 'aaaa'
-              import e from 'e'
-
-              import './cc'
-              import 'bbb'
-              import '../d'
-            `,
-            code: dedent`
-              import './cc'
-              import 'bbb'
-              import e from 'e'
-              import a from 'aaaa'
-              import '../d'
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: true,
-              },
-            ],
-            output: dedent`
-              import 'aaa'
-              import 'bb'
-              import 'c'
-            `,
-            code: dedent`
-              import 'c'
-              import 'bb'
-              import 'aaa'
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            code: dedent`
-              import a from 'aaaa'
-
-              import 'bbb'
-              import './cc'
-              import '../d'
-            `,
-          },
-          {
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            code: dedent`
-              import 'c'
-              import 'bb'
-              import 'aaa'
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): supports style imports with optional chaining`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'unknown',
-                  right: './b.css?raw',
-                  rightGroup: 'style',
-                  left: './a.js',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import b from './b.css?raw'
-              import c from './c.css'
-
-              import a from './a.js'
-            `,
-            code: dedent`
-              import a from './a.js'
-              import b from './b.css?raw'
-              import c from './c.css'
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['style', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import b from './b.css?raw'
-              import c from './c.css'
-
-              import a from './a.js'
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['style', 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): use pattern @ as internal import`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '@/a',
-                  left: 'b',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'internal'],
-                newlinesBetween: 'always',
-              },
-            ],
-            output: dedent`
-              import { b } from 'b'
-
-              import { a } from '@/a'
-            `,
-            code: dedent`
-              import { b } from 'b'
-              import { a } from '@/a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          code: dedent`
-            import { b1 } from 'b'
-            import { a1, a2 } from 'a'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          code: dedent`
-            import { b1 } from 'b'
-            import { a1, a2 } from 'a'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { a1, a2 } from 'a'
-            import { b1 } from 'b'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports by groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'type-internal',
-                leftGroup: 'value-internal',
-                right: '~/i',
-                left: '~/b',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: './d',
-                left: '~/i',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                rightGroup: 'value-builtin',
-                leftGroup: 'type-sibling',
-                left: './d',
-                right: 'fs',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: '~/c',
-                left: 'fs',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                right: '~/i',
-                left: '~/c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                right: '../f',
-                left: '.',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                right: '../../h',
-                left: '../f',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                leftGroup: 'value-parent',
-                rightGroup: 'type-index',
-                right: './index.d.ts',
-                left: '../../h',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'type-import',
-                leftGroup: 'value-index',
-                right: 't',
-                left: '.',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                right: './style.css',
-                left: 't',
-              },
-              messageId: 'missedSpacingBetweenImports',
-            },
-            {
-              data: {
-                left: './style.css',
-                right: '../j',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                right: '../k',
-                left: '../j',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import type { T } from 't'
-
-            import { c1, c2, c3, c4 } from 'c'
-            import { e2 } from 'e/b'
-            import { e1 } from 'e/a'
-            import path from 'path'
-            import fs from 'fs'
-
-            import type { I } from '~/i'
-
-            import { i1, i2, i3 } from '~/i'
-            import { b1, b2 } from '~/b'
-            import { c1 } from '~/c'
-
-            import type { H } from './index.d.ts'
-            import type { F } from '../f'
-            import type { D } from './d'
-            import type { A } from '.'
-
-            import { K, L, M } from '../k'
-            import { j } from '../j'
-            import './style.css'
-            import h from '../../h'
-            import a from '.'
-          `,
-          code: dedent`
-            import { c1, c2, c3, c4 } from 'c'
-            import { e2 } from 'e/b'
-            import { e1 } from 'e/a'
-            import path from 'path'
-
-            import { b1, b2 } from '~/b'
-            import type { I } from '~/i'
-            import type { D } from './d'
-            import fs from 'fs'
-            import { c1 } from '~/c'
-            import { i1, i2, i3 } from '~/i'
-
-            import type { A } from '.'
-            import type { F } from '../f'
-            import h from '../../h'
-            import type { H } from './index.d.ts'
-
-            import a from '.'
-            import type { T } from 't'
-            import './style.css'
-            import { j } from '../j'
-            import { K, L, M } from '../k'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import type { T } from 't'
-
-            import { c1, c2, c3, c4 } from 'c'
-            import { e1 } from 'e/a'
-            import { e2 } from 'e/b'
-            import path from 'path'
-            import fs from 'fs'
-
-            import type { I } from '~/i'
-
-            import { i1, i2, i3 } from '~/i'
-            import { b1, b2 } from '~/b'
-            import { c1 } from '~/c'
-
-            import type { H } from './index.d.ts'
-            import type { F } from '../f'
-            import type { D } from './d'
-            import type { A } from '.'
-
-            import { K, L, M } from '../k'
-            import { j } from '../j'
-            import h from '../../h'
-            import './style.css'
-            import a from '.'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts imports with no spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'value-external',
-                leftGroup: 'value-index',
-                right: 'a',
-                left: '.',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'value-internal',
-                rightGroup: 'type-import',
-                left: '~/c',
-                right: 't',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'value-internal',
-                leftGroup: 'value-parent',
-                left: '../../e',
-                right: '~/b',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          code: dedent`
-            import d from '.'
-            import { a1, a2, a3 } from 'a'
-            import { c1, c2, c3 } from '~/c'
-
-            import type { T } from 't'
-            import { e1, e2, e3 } from '../../e'
-
-            import { b1, b2 } from '~/b'
-          `,
-          output: dedent`
-            import type { T } from 't'
-            import { a1, a2, a3 } from 'a'
-            import { c1, c2, c3 } from '~/c'
-            import { b1, b2 } from '~/b'
-            import { e1, e2, e3 } from '../../e'
-            import d from '.'
-          `,
-          options: [
-            {
-              ...options,
-              newlinesBetween: 'never',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import type { T } from 't'
-            import { a1, a2, a3 } from 'a'
-            import { c1, c2, c3 } from '~/c'
-            import { b1, b2 } from '~/b'
-            import { e1, e2, e3 } from '../../e'
-            import d from '.'
-          `,
-          options: [
-            {
-              ...options,
-              newlinesBetween: 'never',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): disallow extra spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '~/b',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
-                right: '~/d',
-                left: '~/c',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-          ],
-          code: dedent`
-            import { A } from 'a'
-
-
-            import b from '~/b'
-            import c from '~/c'
-
-            import d from '~/d'
-          `,
-          output: dedent`
-            import { A } from 'a'
-
-            import b from '~/b'
-            import c from '~/c'
-            import d from '~/d'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { A } from 'a'
-
-            import b from '~/b'
-            import c from '~/c'
-            import d from '~/d'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): supports typescript ts import-equals`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '../b',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  leftGroup: 'ts-equals-import',
-                  rightGroup: 'value-external',
-                  left: 'console.log',
-                  right: 'c/c',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import type T = require("T")
-
-              import c = require('c/c')
-              import { A } from 'a'
-
-              import { B } from '../b'
-
-              import log = console.log
-            `,
-            code: dedent`
-              import type T = require("T")
-
-              import { A } from 'a'
-              import { B } from '../b'
-
-              import log = console.log
-              import c = require('c/c')
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import type T = require("T")
-
-              import c = require('c/c')
-              import { A } from 'a'
-
-              import { B } from '../b'
-
-              import log = console.log
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): use type if type of type is not defined`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '../t',
-                  right: '~/u',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '~/u',
-                  right: 'v',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal',
-                  ['parent', 'sibling', 'index'],
-                ],
-              },
-            ],
-            code: dedent`
-              import type { T } from '../t'
-
-              import type { U } from '~/u'
-
-              import type { V } from 'v'
-            `,
-            output: dedent`
-              import type { T } from '../t'
-              import type { U } from '~/u'
-              import type { V } from 'v'
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal',
-                  ['parent', 'sibling', 'index'],
-                ],
-              },
-            ],
-            code: dedent`
-              import type { T } from '../t'
-              import type { U } from '~/u'
-              import type { V } from 'v'
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores comments for counting lines between imports`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import type { T } from 't'
-
-              // @ts-expect-error missing types
-              import { t } from 't'
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): breaks import sorting if there is other nodes between`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import type { V } from 'v'
-
-              export type { U } from 'u'
-
-              import type { T1, T2 } from 't'
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates style imports from the rest`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'style',
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              import { a1, a2 } from 'a'
-
-              import styles from '../s.css'
-              import './t.css'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates side effect imports from the rest`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'side-effect',
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              import { A } from '../a'
-              import { b } from './b'
-
-              import '../c.js'
-              import './d'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): separates builtin type from the rest types`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: ['builtin-type', 'type'],
-              },
-            ],
-            code: dedent`
-              import type { Server } from 'http'
-
-              import a from 'a'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with imports ending with a semicolon`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'unknown',
-                ],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: './index',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import a from 'a';
-
-              import b from './index';
-            `,
-            code: dedent`
-              import a from 'a';
-              import b from './index';
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): remove unnecessary spaces`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-            {
-              data: {
-                rightGroup: 'value-external',
-                leftGroup: 'value-sibling',
-                left: './b',
-                right: 'c',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          code: dedent`
-            import { a } from 'a'
-
-
-            import { b } from './b'
-
-
-
-            import { c } from 'c'
-          `,
-          output: dedent`
-            import { a } from 'a'
-            import { c } from 'c'
-
-            import { b } from './b'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to define custom groups`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'type',
-                  'primary',
-                  'secondary',
-                  ['builtin', 'external'],
-                  'internal-type',
-                  'internal',
-                  ['parent-type', 'sibling-type', 'index-type'],
-                  ['parent', 'sibling', 'index'],
-                  'unknown',
-                ],
-                customGroups: {
-                  value: {
-                    primary: ['t', '@a/.+'],
-                    secondary: '@b/.+',
-                  },
-                  type: {
-                    primary: ['t', '@a/.+'],
-                  },
-                },
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: '@a/a1',
-                  left: 't',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '@b/b1',
-                  left: '@a/a2',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '@b/b3',
-                  right: 'c',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import type { T } from 't'
-              import a1 from '@a/a1'
-              import a2 from '@a/a2'
-
-              import b1 from '@b/b1'
-              import b2 from '@b/b2'
-              import b3 from '@b/b3'
-
-              import { c } from 'c'
-            `,
-            code: dedent`
-              import type { T } from 't'
-
-              import a1 from '@a/a1'
-              import a2 from '@a/a2'
-              import b1 from '@b/b1'
-              import b2 from '@b/b2'
-              import b3 from '@b/b3'
-              import { c } from 'c'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to define value only custom groups`,
-      rule,
-      {
-        invalid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  value: {
-                    primary: ['a'],
-                  },
-                },
-                groups: ['type', 'primary'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'a',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import type { A } from 'a'
-
-              import { a } from 'a'
-            `,
-            code: dedent`
-              import type { A } from 'a'
-              import { a } from 'a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows hash symbol in internal pattern`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '#c',
-                  left: '#b',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '#b',
-                  left: '#c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-
-              import { b1, b2 } from '#b'
-              import c from '#c'
-
-              import { d } from '../d'
-            `,
-            code: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-              import c from '#c'
-              import { b1, b2 } from '#b'
-
-              import { d } from '../d'
-            `,
-            options: [
-              {
-                ...options,
-                internalPattern: ['#.+'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import type { T } from 'a'
-
-              import { a } from 'a'
-
-              import type { S } from '#b'
-
-              import { b1, b2 } from '#b'
-              import c from '#c'
-
-              import { d } from '../d'
-            `,
-            options: [
-              {
-                ...options,
-                internalPattern: ['#.+'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): support`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            import {
-              ICantBelieveHowLong,
-              ICantHandleHowLong,
-              KindaLong,
-              Long,
-              ThisIsTheLongestEver,
-              WowSoLong,
-            } from 'app/components/Short';
-            import ThereIsTwoOfMe, {
-              SoWeShouldSplitUpSinceWeAreInDifferentSections
-            } from 'IWillDefinitelyBeSplitUp';
-            import Short from 'app/components/LongName';
-            import { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';
-            import { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';
-            import EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';
-          `,
-          code: dedent`
-            import { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';
-            import { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';
-            import Short from 'app/components/LongName';
-            import {
-              ICantBelieveHowLong,
-              ICantHandleHowLong,
-              KindaLong,
-              Long,
-              ThisIsTheLongestEver,
-              WowSoLong,
-            } from 'app/components/Short';
-            import EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';
-            import ThereIsTwoOfMe, {
-              SoWeShouldSplitUpSinceWeAreInDifferentSections
-            } from 'IWillDefinitelyBeSplitUp';
-          `,
-          errors: [
-            {
-              data: {
-                right: 'app/components/LongName',
-                left: 'IWillNotBeSplitUp',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                left: 'app/components/LongName',
-                right: 'app/components/Short',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                left: 'IWillNotBePutOntoNewLines',
-                right: 'IWillDefinitelyBeSplitUp',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              maxLineLength: 80,
-              order: 'asc',
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows to use bun modules`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'external',
-                rightGroup: 'builtin',
-                right: 'bun:test',
-                left: 'a',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['builtin', 'external', 'unknown'],
-              newlinesBetween: 'never',
-              environment: 'bun',
-            },
-          ],
-          output: dedent`
-            import { expect } from 'bun:test'
-            import { a } from 'a'
-          `,
-          code: dedent`
-            import { a } from 'a'
-            import { expect } from 'bun:test'
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              groups: ['builtin', 'external', 'unknown'],
-              newlinesBetween: 'never',
-              environment: 'bun',
-            },
-          ],
-          code: dedent`
-            import { expect } from 'bun:test'
-            import { a } from 'a'
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts require imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            const { a1, a2 } = require('a')
-            const { b1 } = require('b')
-          `,
-          code: dedent`
-            const { b1 } = require('b')
-            const { a1, a2 } = require('a')
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            const { a1, a2 } = require('a')
-            const { b1 } = require('b')
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts require imports by groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'value-internal',
-                  rightGroup: 'value-builtin',
-                  left: '~/b',
-                  right: 'fs',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: '~/c',
-                  left: 'fs',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '~/i',
-                  left: '~/c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  left: '../../h',
-                  right: '.',
-                },
-                messageId: 'extraSpacingBetweenImports',
-              },
-              {
-                data: {
-                  right: '../j',
-                  left: '.',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: '../k',
-                  left: '../j',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e2 } = require('e/b')
-              const { e1 } = require('e/a')
-              const path = require('path')
-              const fs = require('fs')
-
-              const { i1, i2, i3 } = require('~/i')
-              const { b1, b2 } = require('~/b')
-              const { c1 } = require('~/c')
-
-              const { K, L, M } = require('../k')
-              const { j } = require('../j')
-              const h = require('../../h')
-              const a = require('.')
-            `,
-            code: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e2 } = require('e/b')
-              const { e1 } = require('e/a')
-              const path = require('path')
-
-              const { b1, b2 } = require('~/b')
-              const fs = require('fs')
-              const { c1 } = require('~/c')
-              const { i1, i2, i3 } = require('~/i')
-
-              const h = require('../../h')
-
-              const a = require('.')
-              const { j } = require('../j')
-              const { K, L, M } = require('../k')
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              const { c1, c2, c3, c4 } = require('c')
-              const { e1 } = require('e/a')
-              const { e2 } = require('e/b')
-              const path = require('path')
-              const fs = require('fs')
-
-              const { i1, i2, i3 } = require('~/i')
-              const { b1, b2 } = require('~/b')
-              const { c1 } = require('~/c')
-
-              const { K, L, M } = require('../k')
-              const { j } = require('../j')
-              const h = require('../../h')
-              const a = require('.')
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): can enable or disable sorting side effect imports`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'side-effect',
-                  rightGroup: 'external',
-                  left: 'bbb',
-                  right: 'e',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: 'aaaa',
-                  left: 'e',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: '../d',
-                  left: 'aaaa',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            output: dedent`
-              import a from 'aaaa'
-              import e from 'e'
-
-              import './cc'
-              import 'bbb'
-              import '../d'
-            `,
-            code: dedent`
-              import './cc'
-              import 'bbb'
-              import e from 'e'
-              import a from 'aaaa'
-              import '../d'
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: true,
-              },
-            ],
-            output: dedent`
-              import 'aaa'
-              import 'bb'
-              import 'c'
-            `,
-            code: dedent`
-              import 'c'
-              import 'bb'
-              import 'aaa'
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            code: dedent`
-              import a from 'aaaa'
-
-              import 'bbb'
-              import './cc'
-              import '../d'
-            `,
-          },
-          {
-            options: [
-              {
-                ...options,
-                groups: ['external', 'side-effect', 'unknown'],
-                sortSideEffects: false,
-              },
-            ],
-            code: dedent`
-              import 'c'
-              import 'bb'
-              import 'aaa'
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): supports style imports with optional chaining`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'unknown',
-                  right: './b.css?raw',
-                  rightGroup: 'style',
-                  left: './a.js',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import b from './b.css?raw'
-              import c from './c.css'
-
-              import a from './a.js'
-            `,
-            code: dedent`
-              import a from './a.js'
-              import b from './b.css?raw'
-              import c from './c.css'
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['style', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import b from './b.css?raw'
-              import c from './c.css'
-
-              import a from './a.js'
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['style', 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              import { bb } from 'bb'
-              import { c } from 'c'
-              import { a } from 'a'
-            `,
-            code: dedent`
-              import { a } from 'a'
-              import { bb } from 'bb'
-              import { c } from 'c'
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              import { bb } from 'bb'
-              import { a } from 'a'
-              import { c } from 'c'
-            `,
-            code: dedent`
-              import { c } from 'c'
-              import { bb } from 'bb'
-              import { a } from 'a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): use pattern @ as internal import`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '@/a',
-                  left: 'b',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['external', 'internal'],
-                newlinesBetween: 'always',
-              },
-            ],
-            output: dedent`
-              import { b } from 'b'
-
-              import { a } from '@/a'
-            `,
-            code: dedent`
-              import { b } from 'b'
-              import { a } from '@/a'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: validating group configuration`, () => {
-    ruleTester.run(
-      `${ruleName}: allows predefined groups and defined custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                groups: [
-                  'side-effect-style',
-                  'external-type',
-                  'internal-type',
-                  'builtin-type',
-                  'sibling-type',
-                  'parent-type',
-                  'side-effect',
-                  'index-type',
-                  'internal',
-                  'external',
-                  'sibling',
-                  'unknown',
-                  'builtin',
-                  'parent',
-                  'index',
-                  'style',
-                  'type',
-                  'myCustomGroup1',
-                ],
-                customGroups: {
-                  type: {
-                    myCustomGroup1: 'x',
-                  },
-                },
-              },
-            ],
-            code: dedent`
-              import type { T } from 't'
-
-              // @ts-expect-error missing types
-              import { t } from 't'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import { b } from 'b';
-            import { c } from 'c';
-            import { a } from 'a';
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
-              },
-              messageId: 'unexpectedImportsGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: {
-                value: {
-                  a: '^a',
-                  b: '^b',
-                },
-              },
-              groups: ['b', 'a'],
-            },
-          ],
-          output: dedent`
-            import { ba } from 'ba'
-            import { bb } from 'bb'
-
-            import { ab } from 'ab'
-            import { aa } from 'aa'
-          `,
-          code: dedent`
-            import { ab } from 'ab'
-            import { aa } from 'aa'
-            import { ba } from 'ba'
-            import { bb } from 'bb'
-          `,
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: {
-                value: {
-                  a: '^a',
-                  b: '^b',
-                },
-              },
-              newlinesBetween: 'never',
-              groups: ['b', 'a'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'extraSpacingBetweenImports',
-            },
-          ],
-          output: dedent`
-            import { b } from 'b'
-            import { a } from 'a'
-          `,
-          code: dedent`
-            import { b } from 'b'
-
-            import { a } from 'a'
-          `,
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: misc`, () => {
-    it('validates the JSON schema', async () => {
-      await expect(
-        validateRuleJsonSchema(rule.meta.schema),
-      ).resolves.not.toThrow()
-    })
-
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '~/b',
-                  left: '~/c',
-                },
-                messageId: 'unexpectedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import a from '~/a'
-              import b from '~/b'
-              import c from '~/c'
-              import d from '~/d'
-            `,
-            code: dedent`
-              import a from '~/a'
-              import c from '~/c'
-              import b from '~/b'
-              import d from '~/d'
-            `,
-          },
-        ],
-        valid: [
-          dedent`
-            import a from '~/a'
-            import b from '~/b'
-            import c from '~/c'
-            import d from '~/d'
-          `,
-          {
-            code: dedent`
-              import { log } from './log'
-              import { log10 } from './log10'
-              import { log1p } from './log1p'
-              import { log2 } from './log2'
-            `,
-            options: [{}],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: doesn't sort imports with side effects`,
-      rule,
-      {
-        valid: [
-          dedent`
-            import './index.css'
-            import './animate.css'
-            import './reset.css'
-          `,
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: defines prefix-only builtin modules as core node modules`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'node:fs/promises',
-                  right: 'react',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            output: dedent`
-              import { writeFile } from 'node:fs/promises'
-
-              import { useEffect } from 'react'
-            `,
-            code: dedent`
-              import { writeFile } from 'node:fs/promises'
-              import { useEffect } from 'react'
-            `,
-            options: [
-              {
-                groups: ['builtin', 'external'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import { writeFile } from 'node:fs/promises'
-
-              import { useEffect } from 'react'
-            `,
-            options: [
-              {
-                groups: ['builtin', 'external'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: define side-effect import with internal pattern as side-effect import`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '~/hooks/useClient',
-                  right: '~/data',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  rightGroup: 'side-effect-style',
-                  right: '~/css/globals.css',
-                  leftGroup: 'side-effect',
-                  left: '~/data',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import { useClient } from '~/hooks/useClient'
-
-              import '~/css/globals.css'
-
-              import '~/data'
-            `,
-            code: dedent`
-              import { useClient } from '~/hooks/useClient'
-              import '~/data'
-              import '~/css/globals.css'
-            `,
-            options: [
-              {
-                groups: ['internal', 'side-effect-style', 'side-effect'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import { useClient } from '~/hooks/useClient'
-
-              import '~/css/globals.css'
-
-              import '~/data'
-            `,
-            options: [
-              {
-                groups: ['internal', 'side-effect-style', 'side-effect'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: works with big amount of custom groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: './cart/CartComponentB.vue',
-                  right: '~/utils/ws.ts',
-                  leftGroup: 'sibling',
-                  rightGroup: 'utils',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: '~/services/cartService.ts',
-                  rightGroup: 'services',
-                  left: '~/utils/ws.ts',
-                  leftGroup: 'utils',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  left: '~/services/cartService.ts',
-                  right: '~/stores/userStore.ts',
-                  leftGroup: 'services',
-                  rightGroup: 'stores',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  left: '~/stores/userStore.ts',
-                  right: '~/utils/dateTime.ts',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-              {
-                data: {
-                  left: '~/composable/useFetch.ts',
-                  right: '~/stores/cartStore.ts',
-                  leftGroup: 'composable',
-                  rightGroup: 'stores',
-                },
-                messageId: 'unexpectedImportsGroupOrder',
-              },
-              {
-                data: {
-                  right: '~/composable/useDebounce.ts',
-                  left: '~/stores/cartStore.ts',
-                },
-                messageId: 'missedSpacingBetweenImports',
-              },
-            ],
-            options: [
-              {
-                customGroups: {
-                  value: {
-                    validators: ['~/validators/.+'],
-                    composable: ['~/composable/.+'],
-                    components: ['~/components/.+'],
-                    services: ['~/services/.+'],
-                    widgets: ['~/widgets/.+'],
-                    stores: ['~/stores/.+'],
-                    logics: ['~/logics/.+'],
-                    assets: ['~/assets/.+'],
-                    utils: ['~/utils/.+'],
-                    pages: ['~/pages/.+'],
-                    ui: ['~/ui/.+'],
-                  },
-                },
-                groups: [
-                  ['builtin', 'external'],
-                  'internal',
-                  'stores',
-                  'services',
-                  'validators',
-                  'utils',
-                  'logics',
-                  'composable',
-                  'ui',
-                  'components',
-                  'pages',
-                  'widgets',
-                  'assets',
-                  'parent',
-                  'sibling',
-                  'side-effect',
-                  'index',
-                  'style',
-                  'unknown',
-                ],
-                type: 'line-length',
-              },
-            ],
-            output: dedent`
-              import { useUserStore } from '~/stores/userStore.ts'
-              import { useCartStore } from '~/stores/cartStore.ts'
-
-              import { getCart } from '~/services/cartService.ts'
-
-              import { connect } from '~/utils/ws.ts'
-              import { formattingDate } from '~/utils/dateTime.ts'
-
-              import { useFetch } from '~/composable/useFetch.ts'
-              import { useDebounce } from '~/composable/useDebounce.ts'
-              import { useMouseMove } from '~/composable/useMouseMove.ts'
-
-              import ComponentA from '~/components/ComponentA.vue'
-              import ComponentB from '~/components/ComponentB.vue'
-              import ComponentC from '~/components/ComponentC.vue'
-
-              import CartComponentA from './cart/CartComponentA.vue'
-              import CartComponentB from './cart/CartComponentB.vue'
-            `,
-            code: dedent`
-              import CartComponentA from './cart/CartComponentA.vue'
-              import CartComponentB from './cart/CartComponentB.vue'
-
-              import { connect } from '~/utils/ws.ts'
-              import { getCart } from '~/services/cartService.ts'
-
-              import { useUserStore } from '~/stores/userStore.ts'
-              import { formattingDate } from '~/utils/dateTime.ts'
-
-              import { useFetch } from '~/composable/useFetch.ts'
-              import { useCartStore } from '~/stores/cartStore.ts'
-              import { useDebounce } from '~/composable/useDebounce.ts'
-              import { useMouseMove } from '~/composable/useMouseMove.ts'
-
-              import ComponentA from '~/components/ComponentA.vue'
-              import ComponentB from '~/components/ComponentB.vue'
-              import ComponentC from '~/components/ComponentC.vue'
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                customGroups: {
-                  value: {
-                    validators: ['^~/validators/.+'],
-                    composable: ['^~/composable/.+'],
-                    components: ['^~/components/.+'],
-                    services: ['^~/services/.+'],
-                    widgets: ['^~/widgets/.+'],
-                    stores: ['^~/stores/.+'],
-                    logics: ['^~/logics/.+'],
-                    assets: ['^~/assets/.+'],
-                    utils: ['^~/utils/.+'],
-                    pages: ['^~/pages/.+'],
-                    ui: ['^~/ui/.+'],
-                  },
-                },
-                groups: [
-                  ['builtin', 'external'],
-                  'internal',
-                  'stores',
-                  'services',
-                  'validators',
-                  'utils',
-                  'logics',
-                  'composable',
-                  'ui',
-                  'components',
-                  'pages',
-                  'widgets',
-                  'assets',
-                  'parent',
-                  'sibling',
-                  'side-effect',
-                  'index',
-                  'style',
-                  'unknown',
-                ],
-                type: 'line-length',
-              },
-            ],
-            code: dedent`
-              import { useCartStore } from '~/stores/cartStore.ts'
-              import { useUserStore } from '~/stores/userStore.ts'
-
-              import { getCart } from '~/services/cartService.ts'
-
-              import { connect } from '~/utils/ws.ts'
-              import { formattingDate } from '~/utils/dateTime.ts'
-
-              import { useFetch } from '~/composable/useFetch.ts'
-              import { useDebounce } from '~/composable/useDebounce.ts'
-              import { useMouseMove } from '~/composable/useMouseMove.ts'
-
-              import ComponentA from '~/components/ComponentA.vue'
-              import ComponentB from '~/components/ComponentB.vue'
-              import ComponentC from '~/components/ComponentC.vue'
-
-              import CartComponentA from './cart/CartComponentA.vue'
-              import CartComponentB from './cart/CartComponentB.vue'
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}: does not consider empty named imports to be side-effects`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import {} from 'node:os'
-              import sqlite from 'node:sqlite'
-              import { describe, test } from 'node:test'
-              import { c } from 'c'
-              import 'node:os'
-            `,
-            options: [
-              {
-                groups: ['builtin', 'external', 'side-effect'],
-                newlinesBetween: 'never',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: ignores dynamic requires`, rule, {
-      valid: [
-        {
-          code: dedent`
-            const path = require(path);
-            const myFileName = require('the-filename');
-            const file = require(path.join(myDir, myFileName));
-            const other = require('./other.js');
-          `,
-          options: [
-            {
-              groups: ['builtin', 'external', 'side-effect'],
-              newlinesBetween: 'never',
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: checks compatibility between 'sortSideEffects' and 'groups'`, () => {
-      function createRule(
-        groups: Options[0]['groups'],
-        sortSideEffects: boolean = false,
-      ): RuleListener {
-        return rule.create({
-          options: [
-            {
-              sortSideEffects,
-              groups,
-            },
-          ],
-        } as Readonly<RuleContext<MESSAGE_ID, Options>>)
-      }
-      let expectedThrownError =
-        "Side effect groups cannot be nested with non side effect groups when 'sortSideEffects' is 'false'."
-
-      it(`${ruleName}: throws if 'sideEffects' is in a non side effects only nested group`, () => {
-        expect(() =>
-          createRule(['external', ['side-effect', 'internal']]),
-        ).toThrow(expectedThrownError)
-      })
-
-      it(`${ruleName}: throws if 'sideEffectsStyle' is in a non side effects only nested group`, () => {
-        expect(() =>
-          createRule(['external', ['side-effect-style', 'internal']]),
-        ).toThrow(expectedThrownError)
-      })
-
-      it(`${ruleName}: throws if 'sideEffectsStyle' and 'sideEffectsStyle' are in a non side effects only nested group`, () => {
-        expect(() =>
-          createRule([
-            'external',
-            ['side-effect-style', 'internal', 'side-effect'],
-          ]),
-        ).toThrow(expectedThrownError)
-      })
-
-      it(`${ruleName}: allows 'sideEffects' and 'sideEffectsStyle' in the same group`, () => {
-        expect(() =>
-          createRule(['external', ['side-effect-style', 'side-effect']]),
-        ).not.toThrow(expectedThrownError)
-      })
-
-      it(`${ruleName}: allows 'sideEffects' and 'sideEffectsStyle' anywhere 'sortSideEffects' is true`, () => {
-        expect(() =>
-          createRule(
-            ['external', ['side-effect-style', 'internal', 'side-effect']],
-            true,
-          ),
-        ).not.toThrow(expectedThrownError)
-      })
-    })
-
-    describe(`${ruleName}: handles tsconfig.json`, () => {
-      describe('tsconfigRootDir option', () => {
-        ruleTester.run(
-          `${ruleName}: marks internal imports as 'internal'`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    groups: ['internal', 'unknown'],
-                    tsconfigRootDir: '.',
-                  },
-                ],
-                before: () => {
-                  mockReadClosestTsConfigByPathWith({
-                    baseUrl: './rules/',
-                  })
-                },
-                code: dedent`
-                  import { x } from 'sort-imports'
-
-                  import { a } from './a';
-                `,
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: marks external imports as 'external'`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    groups: ['external', 'unknown'],
-                    tsconfigRootDir: '.',
-                  },
-                ],
-                code: dedent`
-                  import type { ParsedCommandLine } from 'typescript'
-
-                  import { a } from './a';
-                `,
-                before: () => {
-                  mockReadClosestTsConfigByPathWith({
-                    baseUrl: '.',
-                  })
-                },
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: marks non-resolved imports as 'external'`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    groups: ['external', 'unknown'],
-                    tsconfigRootDir: '.',
-                  },
-                ],
-                before: () => {
-                  mockReadClosestTsConfigByPathWith({
-                    baseUrl: '.',
-                  })
-                },
-                code: dedent`
-                  import { b } from 'b'
-
-                  import { a } from './a';
-                `,
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: uses the fallback algorithm if typescript is not present`,
-          rule,
-          {
-            valid: [
-              {
-                before: () => {
-                  vi.spyOn(
-                    getTypescriptImportUtilities,
-                    'getTypescriptImport',
-                  ).mockReturnValue(null)
-                },
-                options: [
-                  {
-                    groups: ['external', 'unknown'],
-                    tsconfigRootDir: '.',
-                  },
-                ],
-                code: dedent`
-                  import { b } from 'b'
-
-                  import { a } from './a';
-                `,
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-
-      describe('tsconfig option', () => {
-        ruleTester.run(
-          `${ruleName}: marks internal imports as 'internal'`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    tsconfig: {
-                      filename: 'tsconfig.json',
-                      rootDir: '.',
-                    },
-                    groups: ['internal', 'unknown'],
-                  },
-                ],
-                before: () => {
-                  mockReadClosestTsConfigByPathWith({
-                    baseUrl: './rules/',
-                  })
-                },
-                code: dedent`
-                  import { x } from 'sort-imports'
-
-                  import { a } from './a';
-                `,
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: marks external imports as 'external'`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    tsconfig: {
-                      filename: 'tsconfig.json',
-                      rootDir: '.',
-                    },
-                    groups: ['external', 'unknown'],
-                  },
-                ],
-                code: dedent`
-                  import type { ParsedCommandLine } from 'typescript'
-
-                  import { a } from './a';
-                `,
-                before: () => {
-                  mockReadClosestTsConfigByPathWith({
-                    baseUrl: '.',
-                  })
-                },
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: marks non-resolved imports as 'external'`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    tsconfig: {
-                      filename: 'tsconfig.json',
-                      rootDir: '.',
-                    },
-                    groups: ['external', 'unknown'],
-                  },
-                ],
-                before: () => {
-                  mockReadClosestTsConfigByPathWith({
-                    baseUrl: '.',
-                  })
-                },
-                code: dedent`
-                  import { b } from 'b'
-
-                  import { a } from './a';
-                `,
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}: uses the fallback algorithm if typescript is not present`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    tsconfig: {
-                      filename: 'tsconfig.json',
-                      rootDir: '.',
-                    },
-                    groups: ['external', 'unknown'],
-                  },
-                ],
-                before: () => {
-                  vi.spyOn(
-                    getTypescriptImportUtilities,
-                    'getTypescriptImport',
-                  ).mockReturnValue(null)
-                },
-                code: dedent`
-                  import { b } from 'b'
-
-                  import { a } from './a';
-                `,
-                after: () => {
-                  vi.resetAllMocks()
-                },
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-    })
-
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            // eslint-disable-next-line
-            import { a } from './a'
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            // eslint-disable-next-line
-            import { a } from './a'
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './c',
-                left: './d',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-            {
-              data: {
-                right: './b',
-                left: './a',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            // eslint-disable-next-line
-            import { a } from './a'
-            import { d } from './d'
-          `,
-          code: dedent`
-            import { d } from './d'
-            import { c } from './c'
-            // eslint-disable-next-line
-            import { a } from './a'
-            import { b } from './b'
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            import { a } from './a' // eslint-disable-line
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            import { a } from './a' // eslint-disable-line
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            /* eslint-disable-next-line */
-            import { a } from './a'
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            /* eslint-disable-next-line */
-            import { a } from './a'
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            import { a } from './a' /* eslint-disable-line */
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            import { a } from './a' /* eslint-disable-line */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import { a } from './a'
-            import { d } from './d'
-            /* eslint-disable */
-            import { c } from './c'
-            import { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            import { e } from './e'
-          `,
-          code: dedent`
-            import { d } from './d'
-            import { e } from './e'
-            /* eslint-disable */
-            import { c } from './c'
-            import { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            import { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-            import { a } from './a'
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-            import { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            import { a } from './a' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            import { a } from './a' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-            import { a } from './a'
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-            import { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import { b } from './b'
-            import { c } from './c'
-            import { a } from './a' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          code: dedent`
-            import { c } from './c'
-            import { b } from './b'
-            import { a } from './a' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          errors: [
-            {
-              data: {
-                right: './b',
-                left: './c',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import { a } from './a'
-            import { d } from './d'
-            /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-            import { c } from './c'
-            import { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            import { e } from './e'
-          `,
-          code: dedent`
-            import { d } from './d'
-            import { e } from './e'
-            /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-            import { c } from './c'
-            import { b } from './b'
-            // Shouldn't move
-            /* eslint-enable */
-            import { a } from './a'
-          `,
-          errors: [
-            {
-              data: {
-                right: './a',
-                left: './b',
-              },
-              messageId: 'unexpectedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { b } from "./b"
-            import { c } from "./c"
-            // eslint-disable-next-line
-            import { a } from "./a"
-          `,
-        },
-      ],
-    })
-
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
-          {
-            code: dedent`
-              import { d } from '~./d.scss'
-              import { a } from 'a'
-              import * as b from 'b'
-              import { c } from 'c'
-            `,
-            options: [{}],
-          },
-        ],
-        invalid: [],
-      },
-    )
+describe('sort-imports', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-imports',
+    rule,
   })
 
   function mockReadClosestTsConfigByPathWith(
@@ -8514,4 +41,12498 @@ describe(ruleName, () => {
       compilerOptions,
     })
   }
+
+  describe('alphabetical', () => {
+    let options = {
+      type: 'alphabetical',
+      order: 'asc',
+    } as const
+
+    it('sorts imports by module name', async () => {
+      await valid({
+        code: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        code: dedent`
+          import { b1 } from 'b'
+          import { a1, a2 } from 'a'
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups and sorts imports by type and source', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+
+          import { c1, c2, c3, c4 } from 'c'
+          import { e1 } from 'e/a'
+          import { e2 } from 'e/b'
+          import fs from 'fs'
+          import path from 'path'
+
+          import type { I } from '~/i'
+
+          import { b1, b2 } from '~/b'
+          import { c1 } from '~/c'
+          import { i1, i2, i3 } from '~/i'
+
+          import type { A } from '.'
+          import type { F } from '../f'
+          import type { D } from './d'
+          import type { H } from './index.d.ts'
+
+          import a from '.'
+          import h from '../../h'
+          import { j } from '../j'
+          import { K, L, M } from '../k'
+          import './style.css'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e/a',
+              left: 'e/b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'type-internal',
+              leftGroup: 'value-internal',
+              right: '~/i',
+              left: '~/b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: '~/i',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'value-builtin',
+              leftGroup: 'type-sibling',
+              left: './d',
+              right: 'fs',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: 'fs',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '../../h',
+              left: '../f',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'value-parent',
+              rightGroup: 'type-index',
+              right: './index.d.ts',
+              left: '../../h',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'type-import',
+              leftGroup: 'value-index',
+              right: 't',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './style.css',
+              left: 't',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import type { T } from 't'
+
+          import { c1, c2, c3, c4 } from 'c'
+          import { e1 } from 'e/a'
+          import { e2 } from 'e/b'
+          import fs from 'fs'
+          import path from 'path'
+
+          import type { I } from '~/i'
+
+          import { b1, b2 } from '~/b'
+          import { c1 } from '~/c'
+          import { i1, i2, i3 } from '~/i'
+
+          import type { A } from '.'
+          import type { F } from '../f'
+          import type { D } from './d'
+          import type { H } from './index.d.ts'
+
+          import a from '.'
+          import h from '../../h'
+          import './style.css'
+          import { j } from '../j'
+          import { K, L, M } from '../k'
+        `,
+        code: dedent`
+          import { c1, c2, c3, c4 } from 'c'
+          import { e2 } from 'e/b'
+          import { e1 } from 'e/a'
+          import path from 'path'
+
+          import { b1, b2 } from '~/b'
+          import type { I } from '~/i'
+          import type { D } from './d'
+          import fs from 'fs'
+          import { c1 } from '~/c'
+          import { i1, i2, i3 } from '~/i'
+
+          import type { A } from '.'
+          import type { F } from '../f'
+          import h from '../../h'
+          import type { H } from './index.d.ts'
+
+          import a from '.'
+          import type { T } from 't'
+          import './style.css'
+          import { j } from '../j'
+          import { K, L, M } from '../k'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts imports without spacing between groups when configured', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+          import { a1, a2, a3 } from 'a'
+          import { b1, b2 } from '~/b'
+          import { c1, c2, c3 } from '~/c'
+          import d from '.'
+          import { e1, e2, e3 } from '../../e'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-external',
+              leftGroup: 'value-index',
+              right: 'a',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'value-internal',
+              rightGroup: 'type-import',
+              left: '~/c',
+              right: 't',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'value-internal',
+              leftGroup: 'value-parent',
+              left: '../../e',
+              right: '~/b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        code: dedent`
+          import d from '.'
+          import { a1, a2, a3 } from 'a'
+          import { c1, c2, c3 } from '~/c'
+
+          import type { T } from 't'
+          import { e1, e2, e3 } from '../../e'
+
+          import { b1, b2 } from '~/b'
+        `,
+        output: dedent`
+          import type { T } from 't'
+          import { a1, a2, a3 } from 'a'
+          import { b1, b2 } from '~/b'
+          import { c1, c2, c3 } from '~/c'
+          import d from '.'
+          import { e1, e2, e3 } from '../../e'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+    })
+
+    it('removes extra spacing between import groups', async () => {
+      await valid({
+        code: dedent`
+          import { A } from 'a'
+
+          import b from '~/b'
+          import c from '~/c'
+          import d from '~/d'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '~/b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/d',
+              left: '~/c',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        code: dedent`
+          import { A } from 'a'
+
+
+          import b from '~/b'
+          import c from '~/c'
+
+          import d from '~/d'
+        `,
+        output: dedent`
+          import { A } from 'a'
+
+          import b from '~/b'
+          import c from '~/c'
+          import d from '~/d'
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles TypeScript import-equals syntax correctly', async () => {
+      await valid({
+        code: dedent`
+          import type T = require("T")
+
+          import { A } from 'a'
+          import c = require('c/c')
+
+          import { B } from '../b'
+
+          import log = console.log
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '../b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'ts-equals-import',
+              rightGroup: 'value-external',
+              left: 'console.log',
+              right: 'c/c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import type T = require("T")
+
+          import { A } from 'a'
+          import c = require('c/c')
+
+          import { B } from '../b'
+
+          import log = console.log
+        `,
+        code: dedent`
+          import type T = require("T")
+
+          import { A } from 'a'
+          import { B } from '../b'
+
+          import log = console.log
+          import c = require('c/c')
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups all type imports together when specific type groups not configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal',
+              ['parent', 'sibling', 'index'],
+            ],
+          },
+        ],
+        code: dedent`
+          import type { T } from '../t'
+          import type { U } from '~/u'
+          import type { V } from 'v'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '../t',
+              right: '~/u',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '~/u',
+              right: 'v',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal',
+              ['parent', 'sibling', 'index'],
+            ],
+          },
+        ],
+        code: dedent`
+          import type { T } from '../t'
+
+          import type { U } from '~/u'
+
+          import type { V } from 'v'
+        `,
+        output: dedent`
+          import type { T } from '../t'
+          import type { U } from '~/u'
+          import type { V } from 'v'
+        `,
+      })
+    })
+
+    it('preserves inline comments during sorting', async () => {
+      await valid({
+        code: dedent`
+          import { a } from 'a'
+          import { b1, b2 } from 'b' // Comment
+          import { c } from 'c'
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores comments when calculating spacing between imports', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+
+          // @ts-expect-error missing types
+          import { t } from 't'
+        `,
+        options: [options],
+      })
+    })
+
+    it('stops grouping imports when other statements appear between them', async () => {
+      await valid({
+        code: dedent`
+          import type { V } from 'v'
+
+          export type { U } from 'u'
+
+          import type { T1, T2 } from 't'
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups style imports separately when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'style',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          import { a1, a2 } from 'a'
+
+          import styles from '../s.css'
+          import './t.css'
+        `,
+      })
+    })
+
+    it('groups side-effect imports separately when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'side-effect',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          import { A } from '../a'
+          import { b } from './b'
+
+          import '../c.js'
+          import './d'
+        `,
+      })
+    })
+
+    it('groups builtin types separately from other type imports', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['builtin-type', 'type'],
+          },
+        ],
+        code: dedent`
+          import type { Server } from 'http'
+
+          import a from 'a'
+        `,
+      })
+    })
+
+    it('handles imports with semicolons correctly', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: './index',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import a from 'a';
+
+          import b from './index';
+        `,
+        code: dedent`
+          import a from 'a';
+          import b from './index';
+        `,
+      })
+    })
+
+    it('removes extra spacing and sorts imports correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'value-external',
+              leftGroup: 'value-sibling',
+              left: './b',
+              right: 'c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        code: dedent`
+          import { a } from 'a'
+
+
+          import { b } from './b'
+
+
+
+          import { c } from 'c'
+        `,
+        output: dedent`
+          import { a } from 'a'
+          import { c } from 'c'
+
+          import { b } from './b'
+        `,
+        options: [options],
+      })
+    })
+
+    it('supports custom import groups with primary and secondary categories', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '@a/a1',
+              left: 't',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '@a/a1',
+              left: 't',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '@b/b1',
+              left: '@a/a2',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '@b/b3',
+              right: 'c',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              'primary',
+              'secondary',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'unknown',
+            ],
+            customGroups: {
+              value: {
+                primary: ['t', '@a/.+'],
+                secondary: '@b/.+',
+              },
+              type: {
+                primary: ['t', '@a/.+'],
+              },
+            },
+          },
+        ],
+        output: dedent`
+          import a1 from '@a/a1'
+          import a2 from '@a/a2'
+          import type { T } from 't'
+
+          import b1 from '@b/b1'
+          import b2 from '@b/b2'
+          import b3 from '@b/b3'
+
+          import { c } from 'c'
+        `,
+        code: dedent`
+          import type { T } from 't'
+
+          import a1 from '@a/a1'
+          import a2 from '@a/a2'
+          import b1 from '@b/b1'
+          import b2 from '@b/b2'
+          import b3 from '@b/b3'
+          import { c } from 'c'
+        `,
+      })
+    })
+
+    it('supports custom groups for value imports only', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              value: {
+                primary: ['a'],
+              },
+            },
+            groups: ['type', 'primary'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import type { A } from 'a'
+
+          import { a } from 'a'
+        `,
+        code: dedent`
+          import type { A } from 'a'
+          import { a } from 'a'
+        `,
+      })
+    })
+
+    it('handles hash symbol in internal patterns correctly', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+
+          import { b1, b2 } from '#b'
+          import c from '#c'
+
+          import { d } from '../d'
+        `,
+        options: [
+          {
+            ...options,
+            internalPattern: ['#.+'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '#c',
+              left: '#b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '#b',
+              left: '#c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+
+          import { b1, b2 } from '#b'
+          import c from '#c'
+
+          import { d } from '../d'
+        `,
+        code: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+          import c from '#c'
+          import { b1, b2 } from '#b'
+
+          import { d } from '../d'
+        `,
+        options: [
+          {
+            ...options,
+            internalPattern: ['#.+'],
+          },
+        ],
+      })
+    })
+
+    it('recognizes Bun built-in modules when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['builtin', 'external', 'unknown'],
+            newlinesBetween: 'never',
+            environment: 'bun',
+          },
+        ],
+        code: dedent`
+          import { expect } from 'bun:test'
+          import { a } from 'a'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'external',
+              rightGroup: 'builtin',
+              right: 'bun:test',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['builtin', 'external', 'unknown'],
+            newlinesBetween: 'never',
+            environment: 'bun',
+          },
+        ],
+        output: dedent`
+          import { expect } from 'bun:test'
+          import { a } from 'a'
+        `,
+        code: dedent`
+          import { a } from 'a'
+          import { expect } from 'bun:test'
+        `,
+      })
+    })
+
+    it('sorts CommonJS require imports by module name', async () => {
+      await valid({
+        code: dedent`
+          const { a1, a2 } = require('a')
+          const { b1 } = require('b')
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          const { a1, a2 } = require('a')
+          const { b1 } = require('b')
+        `,
+        code: dedent`
+          const { b1 } = require('b')
+          const { a1, a2 } = require('a')
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups and sorts CommonJS require imports by type and source', async () => {
+      await valid({
+        code: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e1 } = require('e/a')
+          const { e2 } = require('e/b')
+          const fs = require('fs')
+          const path = require('path')
+
+          const { b1, b2 } = require('~/b')
+          const { c1 } = require('~/c')
+          const { i1, i2, i3 } = require('~/i')
+
+          const a = require('.')
+          const h = require('../../h')
+          const { j } = require('../j')
+          const { K, L, M } = require('../k')
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e/a',
+              left: 'e/b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              leftGroup: 'value-internal',
+              rightGroup: 'value-builtin',
+              left: '~/b',
+              right: 'fs',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: 'fs',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '../../h',
+              right: '.',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: '../../h',
+              right: '.',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e1 } = require('e/a')
+          const { e2 } = require('e/b')
+          const fs = require('fs')
+          const path = require('path')
+
+          const { b1, b2 } = require('~/b')
+          const { c1 } = require('~/c')
+          const { i1, i2, i3 } = require('~/i')
+
+          const a = require('.')
+          const h = require('../../h')
+          const { j } = require('../j')
+          const { K, L, M } = require('../k')
+        `,
+        code: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e2 } = require('e/b')
+          const { e1 } = require('e/a')
+          const path = require('path')
+
+          const { b1, b2 } = require('~/b')
+          const fs = require('fs')
+          const { c1 } = require('~/c')
+          const { i1, i2, i3 } = require('~/i')
+
+          const h = require('../../h')
+
+          const a = require('.')
+          const { j } = require('../j')
+          const { K, L, M } = require('../k')
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves side-effect import order when sorting disabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        code: dedent`
+          import a from 'aaaa'
+
+          import 'bbb'
+          import './cc'
+          import '../d'
+        `,
+      })
+
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        code: dedent`
+          import 'c'
+          import 'bb'
+          import 'aaa'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'side-effect',
+              rightGroup: 'external',
+              left: 'bbb',
+              right: 'e',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: 'aaaa',
+              left: 'e',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '../d',
+              left: 'aaaa',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        output: dedent`
+          import a from 'aaaa'
+          import e from 'e'
+
+          import './cc'
+          import 'bbb'
+          import '../d'
+        `,
+        code: dedent`
+          import './cc'
+          import 'bbb'
+          import e from 'e'
+          import a from 'aaaa'
+          import '../d'
+        `,
+      })
+    })
+
+    it('sorts side-effect imports when sorting enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: true,
+          },
+        ],
+        output: dedent`
+          import 'aaa'
+          import 'bb'
+          import 'c'
+        `,
+        code: dedent`
+          import 'c'
+          import 'bb'
+          import 'aaa'
+        `,
+      })
+    })
+
+    it('preserves original order when side-effect imports are not grouped', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b-side-effect',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import a from "./a";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups side-effect imports together without sorting them', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups side-effect and style imports together in same group without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['side-effect', 'side-effect-style'], 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('separates side-effect and style imports into distinct groups without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './g-side-effect.css',
+              left: './b-side-effect',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'side-effect-style',
+              left: './g-side-effect.css',
+              rightGroup: 'side-effect',
+              right: './a-side-effect',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import './b-side-effect'
+          import './a-side-effect'
+
+          import "./z-side-effect.scss";
+          import "./g-side-effect.css";
+
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'side-effect-style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups style side-effect imports separately without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              right: './b-side-effect.scss',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './b-side-effect.scss',
+              right: './g-side-effect',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              right: './a-side-effect.css',
+              left: './g-side-effect',
+              leftGroup: 'unknown',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect.css',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect";
+          import './b-side-effect.scss'
+          import './a-side-effect.css'
+
+          import "./g-side-effect";
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect";
+          import b from "./b";
+          import './b-side-effect.scss'
+          import "./g-side-effect";
+          import './a-side-effect.css'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores fallback sorting for side-effect imports', async () => {
+      await valid({
+        options: [
+          {
+            groups: ['side-effect', 'side-effect-style'],
+            fallbackSort: { type: 'alphabetical' },
+          },
+        ],
+        code: dedent`
+          import 'b';
+          import 'a';
+
+          import 'b.css';
+          import 'a.css';
+        `,
+      })
+    })
+
+    it('handles special characters with trim option', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          import '_a'
+          import 'b'
+          import '_c'
+        `,
+      })
+    })
+
+    it('handles special characters with remove option', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          import 'ab'
+          import 'a_c'
+        `,
+      })
+    })
+
+    it('supports locale-specific sorting', async () => {
+      await valid({
+        code: dedent`
+          import '你好'
+          import '世界'
+          import 'a'
+          import 'A'
+          import 'b'
+          import 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['removes newlines with never option', 'never'],
+      ['removes newlines with 0 option', 0],
+    ])('%s', async (_description, newlinesBetween) => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '~/y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/b',
+              left: '~/z',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '~/b',
+              left: '~/z',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        code: dedent`
+            import { A } from 'a'
+
+
+           import y from '~/y'
+          import z from '~/z'
+
+              import b from '~/b'
+        `,
+        output: dedent`
+            import { A } from 'a'
+           import b from '~/b'
+          import y from '~/y'
+              import z from '~/z'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween,
+          },
+        ],
+      })
+    })
+
+    it('handles custom spacing rules between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              value: {
+                a: 'a',
+                b: 'b',
+                c: 'c',
+                d: 'd',
+                e: 'e',
+              },
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { A } from 'a'
+
+          import { B } from 'b'
+
+          import { C } from 'c'
+          import { D } from 'd'
+
+
+          import { E } from 'e'
+        `,
+        code: dedent`
+          import { A } from 'a'
+          import { B } from 'b'
+
+
+          import { C } from 'c'
+
+          import { D } from 'd'
+
+
+          import { E } from 'e'
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'enforces spacing when global option is 2 and group option is never',
+        2,
+        'never',
+      ],
+      ['enforces spacing when global option is 2 and group option is 0', 2, 0],
+      [
+        'enforces spacing when global option is 2 and group option is ignore',
+        2,
+        'ignore',
+      ],
+      [
+        'enforces spacing when global option is never and group option is 2',
+        'never',
+        2,
+      ],
+      ['enforces spacing when global option is 0 and group option is 2', 0, 2],
+      [
+        'enforces spacing when global option is ignore and group option is 2',
+        'ignore',
+        2,
+      ],
+    ])(
+      '%s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenImports',
+            },
+          ],
+          output: dedent`
+            import { a } from 'a';
+
+
+            import { b } from 'b';
+          `,
+          code: dedent`
+            import { a } from 'a';
+            import { b } from 'b';
+          `,
+        })
+      },
+    )
+
+    it.each([
+      [
+        'removes spacing when never option exists between groups regardless of global setting always',
+        'always',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting 2',
+        2,
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting ignore',
+        'ignore',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting never',
+        'never',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting 0',
+        0,
+      ],
+    ])('%s', async (_description, globalNewlinesBetween) => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            customGroups: {
+              value: {
+                unusedGroup: 'X',
+                a: 'a',
+                b: 'b',
+                c: 'c',
+              },
+            },
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { a } from 'a';
+          import { b } from 'b';
+        `,
+        code: dedent`
+          import { a } from 'a';
+
+          import { b } from 'b';
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'preserves existing spacing when ignore and never options are combined',
+        'ignore',
+        'never',
+      ],
+      [
+        'preserves existing spacing when ignore and 0 options are combined',
+        'ignore',
+        0,
+      ],
+      [
+        'preserves existing spacing when never and ignore options are combined',
+        'never',
+        'ignore',
+      ],
+      [
+        'preserves existing spacing when 0 and ignore options are combined',
+        0,
+        'ignore',
+      ],
+    ])(
+      '%s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import { a } from 'a';
+
+            import { b } from 'b';
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import { a } from 'a';
+            import { b } from 'b';
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comments after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'external',
+              right: './a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from './a' // Comment after
+
+          import { b } from 'b'
+          import { c } from 'c'
+        `,
+        code: dedent`
+          import { b } from 'b'
+          import { a } from './a' // Comment after
+
+          import { c } from 'c'
+        `,
+        options: [
+          {
+            groups: ['unknown', 'external'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      [
+        'ignores newline fixes between different partitions with never option',
+        'never',
+      ],
+      ['ignores newline fixes between different partitions with 0 option', 0],
+    ])('%s', async (_description, newlinesBetween) => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import a from 'a';
+
+          // Partition comment
+
+          import { b } from './b';
+          import { c } from './c';
+        `,
+        code: dedent`
+          import a from 'a';
+
+          // Partition comment
+
+          import { c } from './c';
+          import { b } from './b';
+        `,
+      })
+    })
+
+    it('sorts inline imports correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from "a"; import { b } from "b";
+        `,
+        code: dedent`
+          import { b } from "b"; import { a } from "a"
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from "a"; import { b } from "b";
+        `,
+        code: dedent`
+          import { b } from "b"; import { a } from "a";
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows partitioning by new lines', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './organisms',
+              right: './atoms',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: './second-folder',
+              right: './folder',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import * as atoms from "./atoms";
+          import * as organisms from "./organisms";
+          import * as shared from "./shared";
+
+          import { Named } from './folder';
+          import { AnotherNamed } from './second-folder';
+        `,
+        code: dedent`
+          import * as organisms from "./organisms";
+          import * as atoms from "./atoms";
+          import * as shared from "./shared";
+
+          import { AnotherNamed } from './second-folder';
+          import { Named } from './folder';
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows partitioning by comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          // Part: A
+          // Not partition comment
+          import bbb from './bbb';
+          import cc from './cc';
+          import d from './d';
+          // Part: B
+          import aaaa from './aaaa';
+          import e from './e';
+          // Part: C
+          // Not partition comment
+          import fff from './fff';
+          import gg from './gg';
+        `,
+        code: dedent`
+          // Part: A
+          import cc from './cc';
+          import d from './d';
+          // Not partition comment
+          import bbb from './bbb';
+          // Part: B
+          import aaaa from './aaaa';
+          import e from './e';
+          // Part: C
+          import gg from './gg';
+          // Not partition comment
+          import fff from './fff';
+        `,
+        errors: [
+          {
+            data: {
+              right: './bbb',
+              left: './d',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: './fff',
+              left: './gg',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition boundaries when enabled', async () => {
+      await valid({
+        code: dedent`
+          // Comment
+          import bb from './bb';
+          // Other comment
+          import a from './a';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          /* Partition Comment */
+          // Part: A
+          import d from './d'
+          // Part: B
+          import aaa from './aaa'
+          import bb from './bb'
+          import c from './c'
+          /* Other */
+          import e from './e'
+        `,
+        code: dedent`
+          /* Partition Comment */
+          // Part: A
+          import d from './d'
+          // Part: B
+          import aaa from './aaa'
+          import c from './c'
+          import bb from './bb'
+          /* Other */
+          import e from './e'
+        `,
+        errors: [
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          import e from './e'
+          import f from './f'
+          // I am a partition comment because I don't have f o o
+          import a from './a'
+          import b from './b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comment partitioning is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          /* Comment */
+          import a from './a'
+          import b from './b'
+        `,
+        code: dedent`
+          import b from './b'
+          /* Comment */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('treats all line comments as partition boundaries when enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          // Comment
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports multiple line comment patterns for partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          import c from './c'
+          // b
+          import b from './b'
+          // a
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comment partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          // I am a partition comment because I don't have f o o
+          import a from './a'
+        `,
+      })
+    })
+
+    it('ignores line comments when block comment partitioning is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          // Comment
+          import a from './a'
+          import b from './b'
+        `,
+        code: dedent`
+          import b from './b'
+          // Comment
+          import a from './a'
+        `,
+      })
+    })
+
+    it('treats all block comments as partition boundaries when enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          /* Comment */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports multiple block comment patterns for partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          import c from './c'
+          /* b */
+          import b from './b'
+          /* a */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comment partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          /* I am a partition comment because I don't have f o o */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports style imports with query parameters', async () => {
+      await valid({
+        code: dedent`
+          import b from './b.css?raw'
+          import c from './c.css'
+
+          import a from './a.js'
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['style', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              right: './b.css?raw',
+              rightGroup: 'style',
+              left: './a.js',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import b from './b.css?raw'
+          import c from './c.css'
+
+          import a from './a.js'
+        `,
+        code: dedent`
+          import a from './a.js'
+          import b from './b.css?raw'
+          import c from './c.css'
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes index types over sibling types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'sibling-type',
+              rightGroup: 'index-type',
+              right: './index',
+              left: './a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['index-type', 'sibling-type'],
+          },
+        ],
+        output: dedent`
+          import type b from './index'
+
+          import type a from './a'
+        `,
+        code: dedent`
+          import type a from './a'
+
+          import type b from './index'
+        `,
+      })
+    })
+
+    it('prioritizes specific type selectors over generic type group', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              [
+                'index-type',
+                'internal-type',
+                'external-type',
+                'sibling-type',
+                'builtin-type',
+              ],
+              'type',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'sibling-type',
+              leftGroup: 'type',
+              right: './b',
+              left: '../a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import type b from './b'
+          import type c from './index'
+          import type d from 'd'
+          import type e from 'timers'
+
+          import type a from '../a'
+        `,
+        code: dedent`
+          import type a from '../a'
+
+          import type b from './b'
+          import type c from './index'
+          import type d from 'd'
+          import type e from 'timers'
+        `,
+      })
+    })
+
+    it('prioritizes index imports over sibling imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'sibling',
+              rightGroup: 'index',
+              right: './index',
+              left: './a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['index', 'sibling'],
+          },
+        ],
+        output: dedent`
+          import b from './index'
+
+          import a from './a'
+        `,
+        code: dedent`
+          import a from './a'
+
+          import b from './index'
+        `,
+      })
+    })
+
+    it('prioritizes style side-effects over generic side-effects', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              leftGroup: 'side-effect',
+              right: 'style.css',
+              left: 'something',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-style', 'side-effect'],
+          },
+        ],
+        output: dedent`
+          import 'style.css'
+
+          import 'something'
+        `,
+        code: dedent`
+          import 'something'
+
+          import 'style.css'
+        `,
+      })
+    })
+
+    it('prioritizes side-effects over style imports with default exports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: 'something',
+              leftGroup: 'style',
+              left: 'style.css',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'style'],
+          },
+        ],
+        output: dedent`
+          import 'something'
+
+          import style from 'style.css'
+        `,
+        code: dedent`
+          import style from 'style.css'
+
+          import 'something'
+        `,
+      })
+    })
+
+    it('prioritizes style imports over other import types', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'style',
+              [
+                'index',
+                'internal',
+                'subpath',
+                'external',
+                'sibling',
+                'builtin',
+                'parent',
+                'tsconfig-path',
+              ],
+            ],
+            tsconfigRootDir: '.',
+          },
+        ],
+        output: dedent`
+          import style from 'style.css'
+
+          import a from '../a'
+          import b from './b'
+          import c from './index'
+          import subpath from '#subpath'
+          import tsConfigPath from '$path'
+          import d from 'd'
+          import e from 'timers'
+        `,
+        code: dedent`
+          import a from '../a'
+          import b from './b'
+          import c from './index'
+          import subpath from '#subpath'
+          import tsConfigPath from '$path'
+          import d from 'd'
+          import e from 'timers'
+
+          import style from 'style.css'
+        `,
+        errors: [
+          {
+            data: {
+              leftGroup: 'builtin',
+              rightGroup: 'style',
+              right: 'style.css',
+              left: 'timers',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            paths: {
+              $path: ['./path'],
+            },
+          })
+        },
+      })
+    })
+
+    it('prioritizes external imports over generic import group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'import',
+              left: './a',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'import'],
+          },
+        ],
+        output: dedent`
+          import b from 'b'
+
+          import a from './a'
+        `,
+        code: dedent`
+          import a from './a'
+
+          import b from 'b'
+        `,
+      })
+    })
+
+    it('prioritizes type imports over TypeScript equals imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'type-import',
+              leftGroup: 'external',
+              right: 'z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['type-import', 'external', 'ts-equals-import'],
+          },
+        ],
+        output: dedent`
+          import type z = z
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import type z = z
+        `,
+      })
+    })
+
+    it('prioritizes side-effect imports over value imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-import', 'external', 'value-import'],
+            sortSideEffects: true,
+          },
+        ],
+        output: dedent`
+          import "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import "./z"
+        `,
+      })
+    })
+
+    it('prioritizes value imports over TypeScript equals imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-import',
+              leftGroup: 'external',
+              right: 'z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['value-import', 'external', 'ts-equals-import'],
+          },
+        ],
+        output: dedent`
+          import z = z
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z = z
+        `,
+      })
+    })
+
+    it('prioritizes TypeScript equals imports over require imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'ts-equals-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['ts-equals-import', 'external', 'require-import'],
+          },
+        ],
+        output: dedent`
+          import z = require('./z')
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z = require('./z')
+        `,
+      })
+    })
+
+    it('prioritizes default imports over named imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-import', 'external', 'named-import'],
+          },
+        ],
+        output: dedent`
+          import z, { z } from "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z, { z } from "./z"
+        `,
+      })
+    })
+
+    it('prioritizes wildcard imports over named imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'wildcard-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['wildcard-import', 'external', 'named-import'],
+          },
+        ],
+        output: dedent`
+          import z, * as z from "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z, * as z from "./z"
+        `,
+      })
+    })
+
+    it.each([
+      ['filters on element name pattern with string', 'hello'],
+      ['filters on element name pattern with array', ['noMatch', 'hello']],
+      [
+        'filters on element name pattern with regex object',
+        { pattern: 'HELLO', flags: 'i' },
+      ],
+      [
+        'filters on element name pattern with array containing regex',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])('%s', async (_description, elementNamePattern) => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'importsStartingWithHello',
+              right: 'helloImport',
+              leftGroup: 'unknown',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'importsStartingWithHello',
+                elementNamePattern,
+              },
+            ],
+            groups: ['importsStartingWithHello', 'unknown'],
+          },
+        ],
+        output: dedent`
+          import hello from 'helloImport'
+
+          import a from 'a'
+        `,
+        code: dedent`
+          import a from 'a'
+
+          import hello from 'helloImport'
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding type and order settings', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedExternalImportsByLineLength',
+              leftGroup: 'unknown',
+              left: './jjjjj',
+              right: 'eee',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedExternalImportsByLineLength',
+                selector: 'external',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedExternalImportsByLineLength', 'unknown'],
+            newlinesBetween: 'ignore',
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          import dddd from 'dddd'
+          import ccc from 'ccc'
+          import eee from 'eee'
+          import bb from 'bb'
+          import ff from 'ff'
+          import a from 'a'
+          import g from 'g'
+          import h from './h'
+          import i from './i'
+          import jjjjj from './jjjjj'
+        `,
+        code: dedent`
+          import a from 'a'
+          import bb from 'bb'
+          import ccc from 'ccc'
+          import dddd from 'dddd'
+          import jjjjj from './jjjjj'
+          import eee from 'eee'
+          import ff from 'ff'
+          import g from 'g'
+          import h from './h'
+          import i from './i'
+        `,
+      })
+    })
+
+    it('sorts custom groups using fallback sort settings', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import fooBar from 'fooBar'
+          import fooZar from 'fooZar'
+        `,
+        code: dedent`
+          import fooZar from 'fooZar'
+          import fooBar from 'fooBar'
+        `,
+      })
+    })
+
+    it('preserves order for custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedExternalImports',
+                selector: 'external',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedExternalImports', 'unknown'],
+            newlinesBetween: 'ignore',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedExternalImports',
+              leftGroup: 'unknown',
+              left: './something',
+              right: 'c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import b from 'b'
+          import a from 'a'
+          import d from 'd'
+          import e from 'e'
+          import c from 'c'
+          import something from './something'
+        `,
+        code: dedent`
+          import b from 'b'
+          import a from 'a'
+          import d from 'd'
+          import e from 'e'
+          import something from './something'
+          import c from 'c'
+        `,
+      })
+    })
+
+    it('sorts custom group blocks with complex selectors', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    selector: 'external',
+                  },
+                  {
+                    selector: 'sibling',
+                    modifiers: ['type'],
+                  },
+                ],
+                groupName: 'externalAndTypeSiblingImports',
+              },
+            ],
+            groups: [['externalAndTypeSiblingImports', 'index'], 'unknown'],
+            newlinesBetween: 'ignore',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'externalAndTypeSiblingImports',
+              leftGroup: 'unknown',
+              right: './c',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './index',
+              left: 'e',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import type c from './c'
+          import type d from './d'
+          import i from './index'
+          import a from 'a'
+          import e from 'e'
+          import b from './b'
+        `,
+        code: dedent`
+          import a from 'a'
+          import b from './b'
+          import type c from './c'
+          import type d from './d'
+          import e from 'e'
+          import i from './index'
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'adds spacing inside custom groups when always option is used',
+        'always',
+      ],
+      ['adds spacing inside custom groups when 1 option is used', 1],
+    ])('%s', async (_description, newlinesInside) => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'external',
+                groupName: 'group1',
+                newlinesInside,
+              },
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import a from 'a'
+
+          import b from 'b'
+        `,
+        code: dedent`
+          import a from 'a'
+          import b from 'b'
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'removes spacing inside custom groups when never option is used',
+        'never',
+      ],
+      ['removes spacing inside custom groups when 0 option is used', 0],
+    ])('%s', async (_description, newlinesInside) => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'external',
+                groupName: 'group1',
+                newlinesInside,
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import a from 'a'
+          import b from 'b'
+        `,
+        code: dedent`
+          import a from 'a'
+
+          import b from 'b'
+        `,
+      })
+    })
+
+    it('detects TypeScript import-equals dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import { aImport } from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import { aImport } from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import * as aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import * as aImport from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import aImport = require("b")
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport = require("b")
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'importsStartingWithA',
+                elementNamePattern: '^a',
+              },
+              {
+                groupName: 'importsStartingWithB',
+                elementNamePattern: '^b',
+              },
+            ],
+            groups: ['importsStartingWithA', 'importsStartingWithB'],
+          },
+        ],
+        code: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'importsStartingWithA',
+                elementNamePattern: '^a',
+              },
+              {
+                groupName: 'importsStartingWithB',
+                elementNamePattern: '^b',
+              },
+            ],
+            groups: ['importsStartingWithA', 'importsStartingWithB'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+          {
+            data: {
+              left: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport from "b";
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over comment-based partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+
+          // Part: 1
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+
+          // Part: 1
+          import aImport from "b";
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over newline-based partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+
+          import aImport from "b";
+        `,
+      })
+    })
+
+    it('prioritizes content separation over dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'yImport.y1.y2',
+              right: 'z',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          import f = fImport.f1.f2;
+
+          import yImport from "z";
+
+          import y = yImport.y1.y2;
+
+          export { something } from "something";
+
+          import aImport from "b";
+
+          import a = aImport.a1.a2;
+
+          import fImport from "g";
+        `,
+        code: dedent`
+          import f = fImport.f1.f2;
+
+          import y = yImport.y1.y2;
+
+          import yImport from "z";
+
+          export { something } from "something";
+
+          import a = aImport.a1.a2;
+
+          import aImport from "b";
+
+          import fImport from "g";
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('ignores shebang comments when sorting imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          import { a } from 'a'
+          import { b } from 'b'
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          import { b } from 'b'
+          import { a } from 'a'
+        `,
+        options: [options],
+      })
+    })
+
+    it('treats @ symbol pattern as internal imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '@/a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'internal'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          import { b } from 'b'
+
+          import { a } from '@/a'
+        `,
+        code: dedent`
+          import { b } from 'b'
+          import { a } from '@/a'
+        `,
+      })
+    })
+
+    it('reports missing comments above import groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above a',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              missedCommentAbove: 'Comment above b',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Comment above a' },
+              'external',
+              { commentAbove: 'Comment above b' },
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          // Comment above a
+          import { a } from "a";
+
+          // Comment above b
+          import { b } from "./b";
+        `,
+        code: dedent`
+          import { a } from "a";
+
+          import { b } from "./b";
+        `,
+      })
+    })
+
+    it('reports missing comments for single import groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        output: dedent`
+          // Comment above
+          import { a } from "a";
+        `,
+        code: dedent`
+          import { a } from "a";
+        `,
+      })
+    })
+
+    it('ignores shebangs and top-level comments when adding group comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above
+          import a from "a";
+          import b from "b";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'external'],
+          },
+        ],
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          import b from "b";
+          import a from "a";
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'detects existing line comment with extra spaces',
+        '//   Comment above  ',
+      ],
+      [
+        'detects existing line comment with different case',
+        '//   comment above  ',
+      ],
+      [
+        'detects existing block comment with standard format',
+        dedent`
+          /**
+           * Comment above
+           */
+        `,
+      ],
+      [
+        'detects existing block comment with surrounding text',
+        dedent`
+          /**
+           * Something before
+           * CoMmEnT ABoVe
+           * Something after
+           */
+        `,
+      ],
+    ])('%s', async (_description, comment) => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', { commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        code: dedent`
+          import a from "a";
+
+          ${comment}
+          import b from "./b";
+        `,
+      })
+    })
+
+    it('removes and repositions invalid auto-added comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'internal',
+              right: '~/d',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: '~/d',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'sibling',
+              leftGroup: 'internal',
+              right: './b',
+              left: '~/c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'sibling',
+              left: './b',
+              right: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              { commentAbove: 'sibling' },
+              'sibling',
+              { commentAbove: 'internal' },
+              'internal',
+            ],
+          },
+        ],
+        output: dedent`
+          // external
+          import a from "a";
+
+          // sibling
+          import b from './b';
+
+          // internal
+          import c from '~/c';
+          import d from '~/d';
+        `,
+        code: dedent`
+          import d from '~/d';
+          // internal
+          import c from '~/c';
+
+          // sibling
+          import b from './b';
+
+          // external
+          import a from "a";
+        `,
+      })
+    })
+
+    it('handles complex scenarios with multiple error types and comment management', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'internal or sibling',
+              right: './c',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'sibling',
+              left: './c',
+              right: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              missedCommentAbove: 'internal or sibling',
+              right: '~/b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above c
+          // external
+          import c from './c'; // Comment after c
+          // Comment above a
+          // internal or sibling
+          import a from "a"; // Comment after a
+          // Comment above b
+          // external
+          import b from '~/b'; // Comment after b
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              {
+                commentAbove: 'internal or sibling',
+                newlinesBetween: 'always',
+              },
+              ['internal', 'sibling'],
+            ],
+            newlinesBetween: 'never',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above a
+          // external
+          import a from "a"; // Comment after a
+
+          // internal or sibling
+          // Comment above c
+          import c from './c'; // Comment after c
+          // Comment above b
+          import b from '~/b'; // Comment after b
+        `,
+      })
+    })
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts imports by module name', async () => {
+      await valid({
+        code: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        code: dedent`
+          import { b1 } from 'b'
+          import { a1, a2 } from 'a'
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups and sorts imports by type and source', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+
+          import { c1, c2, c3, c4 } from 'c'
+          import { e1 } from 'e/a'
+          import { e2 } from 'e/b'
+          import fs from 'fs'
+          import path from 'path'
+
+          import type { I } from '~/i'
+
+          import { b1, b2 } from '~/b'
+          import { c1 } from '~/c'
+          import { i1, i2, i3 } from '~/i'
+
+          import type { A } from '.'
+          import type { F } from '../f'
+          import type { D } from './d'
+          import type { H } from './index.d.ts'
+
+          import a from '.'
+          import h from '../../h'
+          import { j } from '../j'
+          import { K, L, M } from '../k'
+          import './style.css'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e/a',
+              left: 'e/b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'type-internal',
+              leftGroup: 'value-internal',
+              right: '~/i',
+              left: '~/b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: '~/i',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'value-builtin',
+              leftGroup: 'type-sibling',
+              left: './d',
+              right: 'fs',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: 'fs',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '../../h',
+              left: '../f',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'value-parent',
+              rightGroup: 'type-index',
+              right: './index.d.ts',
+              left: '../../h',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'type-import',
+              leftGroup: 'value-index',
+              right: 't',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './style.css',
+              left: 't',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import type { T } from 't'
+
+          import { c1, c2, c3, c4 } from 'c'
+          import { e1 } from 'e/a'
+          import { e2 } from 'e/b'
+          import fs from 'fs'
+          import path from 'path'
+
+          import type { I } from '~/i'
+
+          import { b1, b2 } from '~/b'
+          import { c1 } from '~/c'
+          import { i1, i2, i3 } from '~/i'
+
+          import type { A } from '.'
+          import type { F } from '../f'
+          import type { D } from './d'
+          import type { H } from './index.d.ts'
+
+          import a from '.'
+          import h from '../../h'
+          import './style.css'
+          import { j } from '../j'
+          import { K, L, M } from '../k'
+        `,
+        code: dedent`
+          import { c1, c2, c3, c4 } from 'c'
+          import { e2 } from 'e/b'
+          import { e1 } from 'e/a'
+          import path from 'path'
+
+          import { b1, b2 } from '~/b'
+          import type { I } from '~/i'
+          import type { D } from './d'
+          import fs from 'fs'
+          import { c1 } from '~/c'
+          import { i1, i2, i3 } from '~/i'
+
+          import type { A } from '.'
+          import type { F } from '../f'
+          import h from '../../h'
+          import type { H } from './index.d.ts'
+
+          import a from '.'
+          import type { T } from 't'
+          import './style.css'
+          import { j } from '../j'
+          import { K, L, M } from '../k'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts imports without spacing between groups when configured', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+          import { a1, a2, a3 } from 'a'
+          import { b1, b2 } from '~/b'
+          import { c1, c2, c3 } from '~/c'
+          import d from '.'
+          import { e1, e2, e3 } from '../../e'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-external',
+              leftGroup: 'value-index',
+              right: 'a',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'value-internal',
+              rightGroup: 'type-import',
+              left: '~/c',
+              right: 't',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'value-internal',
+              leftGroup: 'value-parent',
+              left: '../../e',
+              right: '~/b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        code: dedent`
+          import d from '.'
+          import { a1, a2, a3 } from 'a'
+          import { c1, c2, c3 } from '~/c'
+
+          import type { T } from 't'
+          import { e1, e2, e3 } from '../../e'
+
+          import { b1, b2 } from '~/b'
+        `,
+        output: dedent`
+          import type { T } from 't'
+          import { a1, a2, a3 } from 'a'
+          import { b1, b2 } from '~/b'
+          import { c1, c2, c3 } from '~/c'
+          import d from '.'
+          import { e1, e2, e3 } from '../../e'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+    })
+
+    it('removes extra spacing between import groups', async () => {
+      await valid({
+        code: dedent`
+          import { A } from 'a'
+
+          import b from '~/b'
+          import c from '~/c'
+          import d from '~/d'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '~/b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/d',
+              left: '~/c',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        code: dedent`
+          import { A } from 'a'
+
+
+          import b from '~/b'
+          import c from '~/c'
+
+          import d from '~/d'
+        `,
+        output: dedent`
+          import { A } from 'a'
+
+          import b from '~/b'
+          import c from '~/c'
+          import d from '~/d'
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles TypeScript import-equals syntax correctly', async () => {
+      await valid({
+        code: dedent`
+          import type T = require("T")
+
+          import { A } from 'a'
+          import c = require('c/c')
+
+          import { B } from '../b'
+
+          import log = console.log
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '../b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'ts-equals-import',
+              rightGroup: 'value-external',
+              left: 'console.log',
+              right: 'c/c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import type T = require("T")
+
+          import { A } from 'a'
+          import c = require('c/c')
+
+          import { B } from '../b'
+
+          import log = console.log
+        `,
+        code: dedent`
+          import type T = require("T")
+
+          import { A } from 'a'
+          import { B } from '../b'
+
+          import log = console.log
+          import c = require('c/c')
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups all type imports together when specific type groups not configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal',
+              ['parent', 'sibling', 'index'],
+            ],
+          },
+        ],
+        code: dedent`
+          import type { T } from '../t'
+          import type { V } from 'v'
+          import type { U } from '~/u'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '../t',
+              right: '~/u',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '~/u',
+              right: 'v',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: '~/u',
+              right: 'v',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal',
+              ['parent', 'sibling', 'index'],
+            ],
+          },
+        ],
+        code: dedent`
+          import type { T } from '../t'
+
+          import type { U } from '~/u'
+
+          import type { V } from 'v'
+        `,
+        output: dedent`
+          import type { T } from '../t'
+          import type { V } from 'v'
+          import type { U } from '~/u'
+        `,
+      })
+    })
+
+    it('preserves inline comments during sorting', async () => {
+      await valid({
+        code: dedent`
+          import { a } from 'a'
+          import { b1, b2 } from 'b' // Comment
+          import { c } from 'c'
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores comments when calculating spacing between imports', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+
+          // @ts-expect-error missing types
+          import { t } from 't'
+        `,
+        options: [options],
+      })
+    })
+
+    it('stops grouping imports when other statements appear between them', async () => {
+      await valid({
+        code: dedent`
+          import type { V } from 'v'
+
+          export type { U } from 'u'
+
+          import type { T1, T2 } from 't'
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups style imports separately when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'style',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          import { a1, a2 } from 'a'
+
+          import styles from '../s.css'
+          import './t.css'
+        `,
+      })
+    })
+
+    it('groups side-effect imports separately when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'side-effect',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          import { A } from '../a'
+          import { b } from './b'
+
+          import '../c.js'
+          import './d'
+        `,
+      })
+    })
+
+    it('groups builtin types separately from other type imports', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['builtin-type', 'type'],
+          },
+        ],
+        code: dedent`
+          import type { Server } from 'http'
+
+          import a from 'a'
+        `,
+      })
+    })
+
+    it('handles imports with semicolons correctly', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: './index',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import a from 'a';
+
+          import b from './index';
+        `,
+        code: dedent`
+          import a from 'a';
+          import b from './index';
+        `,
+      })
+    })
+
+    it('removes extra spacing and sorts imports correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'value-external',
+              leftGroup: 'value-sibling',
+              left: './b',
+              right: 'c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        code: dedent`
+          import { a } from 'a'
+
+
+          import { b } from './b'
+
+
+
+          import { c } from 'c'
+        `,
+        output: dedent`
+          import { a } from 'a'
+          import { c } from 'c'
+
+          import { b } from './b'
+        `,
+        options: [options],
+      })
+    })
+
+    it('supports custom import groups with primary and secondary categories', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '@a/a1',
+              left: 't',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '@a/a1',
+              left: 't',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '@b/b1',
+              left: '@a/a2',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '@b/b3',
+              right: 'c',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              'primary',
+              'secondary',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'unknown',
+            ],
+            customGroups: {
+              value: {
+                primary: ['t', '@a/.+'],
+                secondary: '@b/.+',
+              },
+              type: {
+                primary: ['t', '@a/.+'],
+              },
+            },
+          },
+        ],
+        output: dedent`
+          import a1 from '@a/a1'
+          import a2 from '@a/a2'
+          import type { T } from 't'
+
+          import b1 from '@b/b1'
+          import b2 from '@b/b2'
+          import b3 from '@b/b3'
+
+          import { c } from 'c'
+        `,
+        code: dedent`
+          import type { T } from 't'
+
+          import a1 from '@a/a1'
+          import a2 from '@a/a2'
+          import b1 from '@b/b1'
+          import b2 from '@b/b2'
+          import b3 from '@b/b3'
+          import { c } from 'c'
+        `,
+      })
+    })
+
+    it('supports custom groups for value imports only', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              value: {
+                primary: ['a'],
+              },
+            },
+            groups: ['type', 'primary'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import type { A } from 'a'
+
+          import { a } from 'a'
+        `,
+        code: dedent`
+          import type { A } from 'a'
+          import { a } from 'a'
+        `,
+      })
+    })
+
+    it('handles hash symbol in internal patterns correctly', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+
+          import { b1, b2 } from '#b'
+          import c from '#c'
+
+          import { d } from '../d'
+        `,
+        options: [
+          {
+            ...options,
+            internalPattern: ['#.+'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '#c',
+              left: '#b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '#b',
+              left: '#c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+
+          import { b1, b2 } from '#b'
+          import c from '#c'
+
+          import { d } from '../d'
+        `,
+        code: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+          import c from '#c'
+          import { b1, b2 } from '#b'
+
+          import { d } from '../d'
+        `,
+        options: [
+          {
+            ...options,
+            internalPattern: ['#.+'],
+          },
+        ],
+      })
+    })
+
+    it('recognizes Bun built-in modules when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['builtin', 'external', 'unknown'],
+            newlinesBetween: 'never',
+            environment: 'bun',
+          },
+        ],
+        code: dedent`
+          import { expect } from 'bun:test'
+          import { a } from 'a'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'external',
+              rightGroup: 'builtin',
+              right: 'bun:test',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['builtin', 'external', 'unknown'],
+            newlinesBetween: 'never',
+            environment: 'bun',
+          },
+        ],
+        output: dedent`
+          import { expect } from 'bun:test'
+          import { a } from 'a'
+        `,
+        code: dedent`
+          import { a } from 'a'
+          import { expect } from 'bun:test'
+        `,
+      })
+    })
+
+    it('sorts CommonJS require imports by module name', async () => {
+      await valid({
+        code: dedent`
+          const { a1, a2 } = require('a')
+          const { b1 } = require('b')
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          const { a1, a2 } = require('a')
+          const { b1 } = require('b')
+        `,
+        code: dedent`
+          const { b1 } = require('b')
+          const { a1, a2 } = require('a')
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups and sorts CommonJS require imports by type and source', async () => {
+      await valid({
+        code: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e1 } = require('e/a')
+          const { e2 } = require('e/b')
+          const fs = require('fs')
+          const path = require('path')
+
+          const { b1, b2 } = require('~/b')
+          const { c1 } = require('~/c')
+          const { i1, i2, i3 } = require('~/i')
+
+          const a = require('.')
+          const h = require('../../h')
+          const { j } = require('../j')
+          const { K, L, M } = require('../k')
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e/a',
+              left: 'e/b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              leftGroup: 'value-internal',
+              rightGroup: 'value-builtin',
+              left: '~/b',
+              right: 'fs',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: 'fs',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '../../h',
+              right: '.',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: '../../h',
+              right: '.',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e1 } = require('e/a')
+          const { e2 } = require('e/b')
+          const fs = require('fs')
+          const path = require('path')
+
+          const { b1, b2 } = require('~/b')
+          const { c1 } = require('~/c')
+          const { i1, i2, i3 } = require('~/i')
+
+          const a = require('.')
+          const h = require('../../h')
+          const { j } = require('../j')
+          const { K, L, M } = require('../k')
+        `,
+        code: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e2 } = require('e/b')
+          const { e1 } = require('e/a')
+          const path = require('path')
+
+          const { b1, b2 } = require('~/b')
+          const fs = require('fs')
+          const { c1 } = require('~/c')
+          const { i1, i2, i3 } = require('~/i')
+
+          const h = require('../../h')
+
+          const a = require('.')
+          const { j } = require('../j')
+          const { K, L, M } = require('../k')
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves side-effect import order when sorting disabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        code: dedent`
+          import a from 'aaaa'
+
+          import 'bbb'
+          import './cc'
+          import '../d'
+        `,
+      })
+
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        code: dedent`
+          import 'c'
+          import 'bb'
+          import 'aaa'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'side-effect',
+              rightGroup: 'external',
+              left: 'bbb',
+              right: 'e',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: 'aaaa',
+              left: 'e',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '../d',
+              left: 'aaaa',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        output: dedent`
+          import a from 'aaaa'
+          import e from 'e'
+
+          import './cc'
+          import 'bbb'
+          import '../d'
+        `,
+        code: dedent`
+          import './cc'
+          import 'bbb'
+          import e from 'e'
+          import a from 'aaaa'
+          import '../d'
+        `,
+      })
+    })
+
+    it('sorts side-effect imports when sorting enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: true,
+          },
+        ],
+        output: dedent`
+          import 'aaa'
+          import 'bb'
+          import 'c'
+        `,
+        code: dedent`
+          import 'c'
+          import 'bb'
+          import 'aaa'
+        `,
+      })
+    })
+
+    it('preserves original order when side-effect imports are not grouped', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b-side-effect',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import a from "./a";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups side-effect imports together without sorting them', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups side-effect and style imports together in same group without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['side-effect', 'side-effect-style'], 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('separates side-effect and style imports into distinct groups without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './g-side-effect.css',
+              left: './b-side-effect',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'side-effect-style',
+              left: './g-side-effect.css',
+              rightGroup: 'side-effect',
+              right: './a-side-effect',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import './b-side-effect'
+          import './a-side-effect'
+
+          import "./z-side-effect.scss";
+          import "./g-side-effect.css";
+
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'side-effect-style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups style side-effect imports separately without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              right: './b-side-effect.scss',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './b-side-effect.scss',
+              right: './g-side-effect',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              right: './a-side-effect.css',
+              left: './g-side-effect',
+              leftGroup: 'unknown',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect.css',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect";
+          import './b-side-effect.scss'
+          import './a-side-effect.css'
+
+          import "./g-side-effect";
+          import a from "./a";
+          import b from "./b";
+        `,
+        code: dedent`
+          import "./z-side-effect";
+          import b from "./b";
+          import './b-side-effect.scss'
+          import "./g-side-effect";
+          import './a-side-effect.css'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores fallback sorting for side-effect imports', async () => {
+      await valid({
+        options: [
+          {
+            groups: ['side-effect', 'side-effect-style'],
+            fallbackSort: { type: 'alphabetical' },
+          },
+        ],
+        code: dedent`
+          import 'b';
+          import 'a';
+
+          import 'b.css';
+          import 'a.css';
+        `,
+      })
+    })
+
+    it('handles special characters with trim option', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          import '_a'
+          import 'b'
+          import '_c'
+        `,
+      })
+    })
+
+    it('handles special characters with remove option', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          import 'ab'
+          import 'a_c'
+        `,
+      })
+    })
+
+    it('supports locale-specific sorting', async () => {
+      await valid({
+        code: dedent`
+          import '你好'
+          import '世界'
+          import 'a'
+          import 'A'
+          import 'b'
+          import 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['removes newlines with never option', 'never'],
+      ['removes newlines with 0 option', 0],
+    ])('%s', async (_description, newlinesBetween) => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '~/y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/b',
+              left: '~/z',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '~/b',
+              left: '~/z',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        code: dedent`
+            import { A } from 'a'
+
+
+           import y from '~/y'
+          import z from '~/z'
+
+              import b from '~/b'
+        `,
+        output: dedent`
+            import { A } from 'a'
+           import b from '~/b'
+          import y from '~/y'
+              import z from '~/z'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween,
+          },
+        ],
+      })
+    })
+
+    it('handles custom spacing rules between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              value: {
+                a: 'a',
+                b: 'b',
+                c: 'c',
+                d: 'd',
+                e: 'e',
+              },
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { A } from 'a'
+
+          import { B } from 'b'
+
+          import { C } from 'c'
+          import { D } from 'd'
+
+
+          import { E } from 'e'
+        `,
+        code: dedent`
+          import { A } from 'a'
+          import { B } from 'b'
+
+
+          import { C } from 'c'
+
+          import { D } from 'd'
+
+
+          import { E } from 'e'
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'enforces spacing when global option is 2 and group option is never',
+        2,
+        'never',
+      ],
+      ['enforces spacing when global option is 2 and group option is 0', 2, 0],
+      [
+        'enforces spacing when global option is 2 and group option is ignore',
+        2,
+        'ignore',
+      ],
+      [
+        'enforces spacing when global option is never and group option is 2',
+        'never',
+        2,
+      ],
+      ['enforces spacing when global option is 0 and group option is 2', 0, 2],
+      [
+        'enforces spacing when global option is ignore and group option is 2',
+        'ignore',
+        2,
+      ],
+    ])(
+      '%s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenImports',
+            },
+          ],
+          output: dedent`
+            import { a } from 'a';
+
+
+            import { b } from 'b';
+          `,
+          code: dedent`
+            import { a } from 'a';
+            import { b } from 'b';
+          `,
+        })
+      },
+    )
+
+    it.each([
+      [
+        'removes spacing when never option exists between groups regardless of global setting always',
+        'always',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting 2',
+        2,
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting ignore',
+        'ignore',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting never',
+        'never',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting 0',
+        0,
+      ],
+    ])('%s', async (_description, globalNewlinesBetween) => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            customGroups: {
+              value: {
+                unusedGroup: 'X',
+                a: 'a',
+                b: 'b',
+                c: 'c',
+              },
+            },
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { a } from 'a';
+          import { b } from 'b';
+        `,
+        code: dedent`
+          import { a } from 'a';
+
+          import { b } from 'b';
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'preserves existing spacing when ignore and never options are combined',
+        'ignore',
+        'never',
+      ],
+      [
+        'preserves existing spacing when ignore and 0 options are combined',
+        'ignore',
+        0,
+      ],
+      [
+        'preserves existing spacing when never and ignore options are combined',
+        'never',
+        'ignore',
+      ],
+      [
+        'preserves existing spacing when 0 and ignore options are combined',
+        0,
+        'ignore',
+      ],
+    ])(
+      '%s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import { a } from 'a';
+
+            import { b } from 'b';
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import { a } from 'a';
+            import { b } from 'b';
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comments after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'external',
+              right: './a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from './a' // Comment after
+
+          import { b } from 'b'
+          import { c } from 'c'
+        `,
+        code: dedent`
+          import { b } from 'b'
+          import { a } from './a' // Comment after
+
+          import { c } from 'c'
+        `,
+        options: [
+          {
+            groups: ['unknown', 'external'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      [
+        'ignores newline fixes between different partitions with never option',
+        'never',
+      ],
+      ['ignores newline fixes between different partitions with 0 option', 0],
+    ])('%s', async (_description, newlinesBetween) => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import a from 'a';
+
+          // Partition comment
+
+          import { b } from './b';
+          import { c } from './c';
+        `,
+        code: dedent`
+          import a from 'a';
+
+          // Partition comment
+
+          import { c } from './c';
+          import { b } from './b';
+        `,
+      })
+    })
+
+    it('sorts inline imports correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from "a"; import { b } from "b";
+        `,
+        code: dedent`
+          import { b } from "b"; import { a } from "a"
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from "a"; import { b } from "b";
+        `,
+        code: dedent`
+          import { b } from "b"; import { a } from "a";
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows partitioning by new lines', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './organisms',
+              right: './atoms',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: './second-folder',
+              right: './folder',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import * as atoms from "./atoms";
+          import * as organisms from "./organisms";
+          import * as shared from "./shared";
+
+          import { Named } from './folder';
+          import { AnotherNamed } from './second-folder';
+        `,
+        code: dedent`
+          import * as organisms from "./organisms";
+          import * as atoms from "./atoms";
+          import * as shared from "./shared";
+
+          import { AnotherNamed } from './second-folder';
+          import { Named } from './folder';
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows partitioning by comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          // Part: A
+          // Not partition comment
+          import bbb from './bbb';
+          import cc from './cc';
+          import d from './d';
+          // Part: B
+          import aaaa from './aaaa';
+          import e from './e';
+          // Part: C
+          // Not partition comment
+          import fff from './fff';
+          import gg from './gg';
+        `,
+        code: dedent`
+          // Part: A
+          import cc from './cc';
+          import d from './d';
+          // Not partition comment
+          import bbb from './bbb';
+          // Part: B
+          import aaaa from './aaaa';
+          import e from './e';
+          // Part: C
+          import gg from './gg';
+          // Not partition comment
+          import fff from './fff';
+        `,
+        errors: [
+          {
+            data: {
+              right: './bbb',
+              left: './d',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: './fff',
+              left: './gg',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition boundaries when enabled', async () => {
+      await valid({
+        code: dedent`
+          // Comment
+          import bb from './bb';
+          // Other comment
+          import a from './a';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          /* Partition Comment */
+          // Part: A
+          import d from './d'
+          // Part: B
+          import aaa from './aaa'
+          import bb from './bb'
+          import c from './c'
+          /* Other */
+          import e from './e'
+        `,
+        code: dedent`
+          /* Partition Comment */
+          // Part: A
+          import d from './d'
+          // Part: B
+          import aaa from './aaa'
+          import c from './c'
+          import bb from './bb'
+          /* Other */
+          import e from './e'
+        `,
+        errors: [
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          import e from './e'
+          import f from './f'
+          // I am a partition comment because I don't have f o o
+          import a from './a'
+          import b from './b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comment partitioning is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          /* Comment */
+          import a from './a'
+          import b from './b'
+        `,
+        code: dedent`
+          import b from './b'
+          /* Comment */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('treats all line comments as partition boundaries when enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          // Comment
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports multiple line comment patterns for partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          import c from './c'
+          // b
+          import b from './b'
+          // a
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comment partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          // I am a partition comment because I don't have f o o
+          import a from './a'
+        `,
+      })
+    })
+
+    it('ignores line comments when block comment partitioning is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          // Comment
+          import a from './a'
+          import b from './b'
+        `,
+        code: dedent`
+          import b from './b'
+          // Comment
+          import a from './a'
+        `,
+      })
+    })
+
+    it('treats all block comments as partition boundaries when enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          /* Comment */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports multiple block comment patterns for partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          import c from './c'
+          /* b */
+          import b from './b'
+          /* a */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comment partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          /* I am a partition comment because I don't have f o o */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports style imports with query parameters', async () => {
+      await valid({
+        code: dedent`
+          import b from './b.css?raw'
+          import c from './c.css'
+
+          import a from './a.js'
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['style', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              right: './b.css?raw',
+              rightGroup: 'style',
+              left: './a.js',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import b from './b.css?raw'
+          import c from './c.css'
+
+          import a from './a.js'
+        `,
+        code: dedent`
+          import a from './a.js'
+          import b from './b.css?raw'
+          import c from './c.css'
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes index types over sibling types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'sibling-type',
+              rightGroup: 'index-type',
+              right: './index',
+              left: './a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['index-type', 'sibling-type'],
+          },
+        ],
+        output: dedent`
+          import type b from './index'
+
+          import type a from './a'
+        `,
+        code: dedent`
+          import type a from './a'
+
+          import type b from './index'
+        `,
+      })
+    })
+
+    it('prioritizes specific type selectors over generic type group', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              [
+                'index-type',
+                'internal-type',
+                'external-type',
+                'sibling-type',
+                'builtin-type',
+              ],
+              'type',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'sibling-type',
+              leftGroup: 'type',
+              right: './b',
+              left: '../a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import type b from './b'
+          import type c from './index'
+          import type d from 'd'
+          import type e from 'timers'
+
+          import type a from '../a'
+        `,
+        code: dedent`
+          import type a from '../a'
+
+          import type b from './b'
+          import type c from './index'
+          import type d from 'd'
+          import type e from 'timers'
+        `,
+      })
+    })
+
+    it('prioritizes index imports over sibling imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'sibling',
+              rightGroup: 'index',
+              right: './index',
+              left: './a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['index', 'sibling'],
+          },
+        ],
+        output: dedent`
+          import b from './index'
+
+          import a from './a'
+        `,
+        code: dedent`
+          import a from './a'
+
+          import b from './index'
+        `,
+      })
+    })
+
+    it('prioritizes style side-effects over generic side-effects', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              leftGroup: 'side-effect',
+              right: 'style.css',
+              left: 'something',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-style', 'side-effect'],
+          },
+        ],
+        output: dedent`
+          import 'style.css'
+
+          import 'something'
+        `,
+        code: dedent`
+          import 'something'
+
+          import 'style.css'
+        `,
+      })
+    })
+
+    it('prioritizes side-effects over style imports with default exports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: 'something',
+              leftGroup: 'style',
+              left: 'style.css',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'style'],
+          },
+        ],
+        output: dedent`
+          import 'something'
+
+          import style from 'style.css'
+        `,
+        code: dedent`
+          import style from 'style.css'
+
+          import 'something'
+        `,
+      })
+    })
+
+    it('prioritizes style imports over other import types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '#subpath',
+              left: './index',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              leftGroup: 'builtin',
+              rightGroup: 'style',
+              right: 'style.css',
+              left: 'timers',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'style',
+              [
+                'index',
+                'internal',
+                'subpath',
+                'external',
+                'sibling',
+                'builtin',
+                'parent',
+                'tsconfig-path',
+              ],
+            ],
+            tsconfigRootDir: '.',
+          },
+        ],
+        output: dedent`
+          import style from 'style.css'
+
+          import subpath from '#subpath'
+          import tsConfigPath from '$path'
+          import a from '../a'
+          import b from './b'
+          import c from './index'
+          import d from 'd'
+          import e from 'timers'
+        `,
+        code: dedent`
+          import a from '../a'
+          import b from './b'
+          import c from './index'
+          import subpath from '#subpath'
+          import tsConfigPath from '$path'
+          import d from 'd'
+          import e from 'timers'
+
+          import style from 'style.css'
+        `,
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            paths: {
+              $path: ['./path'],
+            },
+          })
+        },
+      })
+    })
+
+    it('prioritizes external imports over generic import group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'import',
+              left: './a',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'import'],
+          },
+        ],
+        output: dedent`
+          import b from 'b'
+
+          import a from './a'
+        `,
+        code: dedent`
+          import a from './a'
+
+          import b from 'b'
+        `,
+      })
+    })
+
+    it('prioritizes type imports over TypeScript equals imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'type-import',
+              leftGroup: 'external',
+              right: 'z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['type-import', 'external', 'ts-equals-import'],
+          },
+        ],
+        output: dedent`
+          import type z = z
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import type z = z
+        `,
+      })
+    })
+
+    it('prioritizes side-effect imports over value imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-import', 'external', 'value-import'],
+            sortSideEffects: true,
+          },
+        ],
+        output: dedent`
+          import "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import "./z"
+        `,
+      })
+    })
+
+    it('prioritizes value imports over TypeScript equals imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-import',
+              leftGroup: 'external',
+              right: 'z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['value-import', 'external', 'ts-equals-import'],
+          },
+        ],
+        output: dedent`
+          import z = z
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z = z
+        `,
+      })
+    })
+
+    it('prioritizes TypeScript equals imports over require imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'ts-equals-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['ts-equals-import', 'external', 'require-import'],
+          },
+        ],
+        output: dedent`
+          import z = require('./z')
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z = require('./z')
+        `,
+      })
+    })
+
+    it('prioritizes default imports over named imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-import', 'external', 'named-import'],
+          },
+        ],
+        output: dedent`
+          import z, { z } from "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z, { z } from "./z"
+        `,
+      })
+    })
+
+    it('prioritizes wildcard imports over named imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'wildcard-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['wildcard-import', 'external', 'named-import'],
+          },
+        ],
+        output: dedent`
+          import z, * as z from "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z, * as z from "./z"
+        `,
+      })
+    })
+
+    it.each([
+      ['filters on element name pattern with string', 'hello'],
+      ['filters on element name pattern with array', ['noMatch', 'hello']],
+      [
+        'filters on element name pattern with regex object',
+        { pattern: 'HELLO', flags: 'i' },
+      ],
+      [
+        'filters on element name pattern with array containing regex',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])('%s', async (_description, elementNamePattern) => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'importsStartingWithHello',
+              right: 'helloImport',
+              leftGroup: 'unknown',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'importsStartingWithHello',
+                elementNamePattern,
+              },
+            ],
+            groups: ['importsStartingWithHello', 'unknown'],
+          },
+        ],
+        output: dedent`
+          import hello from 'helloImport'
+
+          import a from 'a'
+        `,
+        code: dedent`
+          import a from 'a'
+
+          import hello from 'helloImport'
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding type and order settings', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedExternalImportsByLineLength',
+              leftGroup: 'unknown',
+              left: './jjjjj',
+              right: 'eee',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedExternalImportsByLineLength',
+                selector: 'external',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedExternalImportsByLineLength', 'unknown'],
+            newlinesBetween: 'ignore',
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          import dddd from 'dddd'
+          import ccc from 'ccc'
+          import eee from 'eee'
+          import bb from 'bb'
+          import ff from 'ff'
+          import a from 'a'
+          import g from 'g'
+          import h from './h'
+          import i from './i'
+          import jjjjj from './jjjjj'
+        `,
+        code: dedent`
+          import a from 'a'
+          import bb from 'bb'
+          import ccc from 'ccc'
+          import dddd from 'dddd'
+          import jjjjj from './jjjjj'
+          import eee from 'eee'
+          import ff from 'ff'
+          import g from 'g'
+          import h from './h'
+          import i from './i'
+        `,
+      })
+    })
+
+    it('sorts custom groups using fallback sort settings', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import fooBar from 'fooBar'
+          import fooZar from 'fooZar'
+        `,
+        code: dedent`
+          import fooZar from 'fooZar'
+          import fooBar from 'fooBar'
+        `,
+      })
+    })
+
+    it('preserves order for custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedExternalImports',
+                selector: 'external',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedExternalImports', 'unknown'],
+            newlinesBetween: 'ignore',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedExternalImports',
+              leftGroup: 'unknown',
+              left: './something',
+              right: 'c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import b from 'b'
+          import a from 'a'
+          import d from 'd'
+          import e from 'e'
+          import c from 'c'
+          import something from './something'
+        `,
+        code: dedent`
+          import b from 'b'
+          import a from 'a'
+          import d from 'd'
+          import e from 'e'
+          import something from './something'
+          import c from 'c'
+        `,
+      })
+    })
+
+    it('sorts custom group blocks with complex selectors', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    selector: 'external',
+                  },
+                  {
+                    selector: 'sibling',
+                    modifiers: ['type'],
+                  },
+                ],
+                groupName: 'externalAndTypeSiblingImports',
+              },
+            ],
+            groups: [['externalAndTypeSiblingImports', 'index'], 'unknown'],
+            newlinesBetween: 'ignore',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'externalAndTypeSiblingImports',
+              leftGroup: 'unknown',
+              right: './c',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './index',
+              left: 'e',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import type c from './c'
+          import type d from './d'
+          import i from './index'
+          import a from 'a'
+          import e from 'e'
+          import b from './b'
+        `,
+        code: dedent`
+          import a from 'a'
+          import b from './b'
+          import type c from './c'
+          import type d from './d'
+          import e from 'e'
+          import i from './index'
+        `,
+      })
+    })
+
+    it('detects TypeScript import-equals dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import { aImport } from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import { aImport } from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import * as aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import * as aImport from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import aImport = require("b")
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport = require("b")
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'importsStartingWithA',
+                elementNamePattern: '^a',
+              },
+              {
+                groupName: 'importsStartingWithB',
+                elementNamePattern: '^b',
+              },
+            ],
+            groups: ['importsStartingWithA', 'importsStartingWithB'],
+          },
+        ],
+        code: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'importsStartingWithA',
+                elementNamePattern: '^a',
+              },
+              {
+                groupName: 'importsStartingWithB',
+                elementNamePattern: '^b',
+              },
+            ],
+            groups: ['importsStartingWithA', 'importsStartingWithB'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+          {
+            data: {
+              left: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport from "b";
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over comment-based partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+
+          // Part: 1
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+
+          // Part: 1
+          import aImport from "b";
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over newline-based partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+
+          import aImport from "b";
+        `,
+      })
+    })
+
+    it('prioritizes content separation over dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'yImport.y1.y2',
+              right: 'z',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          import f = fImport.f1.f2;
+
+          import yImport from "z";
+
+          import y = yImport.y1.y2;
+
+          export { something } from "something";
+
+          import aImport from "b";
+
+          import a = aImport.a1.a2;
+
+          import fImport from "g";
+        `,
+        code: dedent`
+          import f = fImport.f1.f2;
+
+          import y = yImport.y1.y2;
+
+          import yImport from "z";
+
+          export { something } from "something";
+
+          import a = aImport.a1.a2;
+
+          import aImport from "b";
+
+          import fImport from "g";
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('ignores shebang comments when sorting imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          import { a } from 'a'
+          import { b } from 'b'
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          import { b } from 'b'
+          import { a } from 'a'
+        `,
+        options: [options],
+      })
+    })
+
+    it('treats @ symbol pattern as internal imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '@/a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'internal'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          import { b } from 'b'
+
+          import { a } from '@/a'
+        `,
+        code: dedent`
+          import { b } from 'b'
+          import { a } from '@/a'
+        `,
+      })
+    })
+
+    it('reports missing comments above import groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above a',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              missedCommentAbove: 'Comment above b',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Comment above a' },
+              'external',
+              { commentAbove: 'Comment above b' },
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          // Comment above a
+          import { a } from "a";
+
+          // Comment above b
+          import { b } from "./b";
+        `,
+        code: dedent`
+          import { a } from "a";
+
+          import { b } from "./b";
+        `,
+      })
+    })
+
+    it('reports missing comments for single import groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        output: dedent`
+          // Comment above
+          import { a } from "a";
+        `,
+        code: dedent`
+          import { a } from "a";
+        `,
+      })
+    })
+
+    it('ignores shebangs and top-level comments when adding group comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above
+          import a from "a";
+          import b from "b";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'external'],
+          },
+        ],
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          import b from "b";
+          import a from "a";
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'detects existing line comment with extra spaces',
+        '//   Comment above  ',
+      ],
+      [
+        'detects existing line comment with different case',
+        '//   comment above  ',
+      ],
+      [
+        'detects existing block comment with standard format',
+        dedent`
+          /**
+           * Comment above
+           */
+        `,
+      ],
+      [
+        'detects existing block comment with surrounding text',
+        dedent`
+          /**
+           * Something before
+           * CoMmEnT ABoVe
+           * Something after
+           */
+        `,
+      ],
+    ])('%s', async (_description, comment) => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', { commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        code: dedent`
+          import a from "a";
+
+          ${comment}
+          import b from "./b";
+        `,
+      })
+    })
+
+    it('removes and repositions invalid auto-added comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'internal',
+              right: '~/d',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: '~/d',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'sibling',
+              leftGroup: 'internal',
+              right: './b',
+              left: '~/c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'sibling',
+              left: './b',
+              right: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              { commentAbove: 'sibling' },
+              'sibling',
+              { commentAbove: 'internal' },
+              'internal',
+            ],
+          },
+        ],
+        output: dedent`
+          // external
+          import a from "a";
+
+          // sibling
+          import b from './b';
+
+          // internal
+          import c from '~/c';
+          import d from '~/d';
+        `,
+        code: dedent`
+          import d from '~/d';
+          // internal
+          import c from '~/c';
+
+          // sibling
+          import b from './b';
+
+          // external
+          import a from "a";
+        `,
+      })
+    })
+
+    it('handles complex scenarios with multiple error types and comment management', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'internal or sibling',
+              right: './c',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'sibling',
+              left: './c',
+              right: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              missedCommentAbove: 'internal or sibling',
+              right: '~/b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above c
+          // external
+          import c from './c'; // Comment after c
+          // Comment above a
+          // internal or sibling
+          import a from "a"; // Comment after a
+          // Comment above b
+          // external
+          import b from '~/b'; // Comment after b
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              {
+                commentAbove: 'internal or sibling',
+                newlinesBetween: 'always',
+              },
+              ['internal', 'sibling'],
+            ],
+            newlinesBetween: 'never',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above a
+          // external
+          import a from "a"; // Comment after a
+
+          // internal or sibling
+          // Comment above c
+          import c from './c'; // Comment after c
+          // Comment above b
+          import b from '~/b'; // Comment after b
+        `,
+      })
+    })
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts imports by module name', async () => {
+      await valid({
+        code: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        code: dedent`
+          import { b1 } from 'b'
+          import { a1, a2 } from 'a'
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups and sorts imports by type and source', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+
+          import { c1, c2, c3, c4 } from 'c'
+          import { e1 } from 'e/a'
+          import { e2 } from 'e/b'
+          import path from 'path'
+          import fs from 'fs'
+
+          import type { I } from '~/i'
+
+          import { i1, i2, i3 } from '~/i'
+          import { b1, b2 } from '~/b'
+          import { c1 } from '~/c'
+
+          import type { H } from './index.d.ts'
+          import type { F } from '../f'
+          import type { D } from './d'
+          import type { A } from '.'
+
+          import { K, L, M } from '../k'
+          import { j } from '../j'
+          import h from '../../h'
+          import './style.css'
+          import a from '.'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'type-internal',
+              leftGroup: 'value-internal',
+              right: '~/i',
+              left: '~/b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './d',
+              left: '~/i',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'value-builtin',
+              leftGroup: 'type-sibling',
+              left: './d',
+              right: 'fs',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: 'fs',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/i',
+              left: '~/c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '../f',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '../../h',
+              left: '../f',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'value-parent',
+              rightGroup: 'type-index',
+              right: './index.d.ts',
+              left: '../../h',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'type-import',
+              leftGroup: 'value-index',
+              right: 't',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './style.css',
+              left: 't',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: './style.css',
+              right: '../j',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '../k',
+              left: '../j',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import type { T } from 't'
+
+          import { c1, c2, c3, c4 } from 'c'
+          import { e2 } from 'e/b'
+          import { e1 } from 'e/a'
+          import path from 'path'
+          import fs from 'fs'
+
+          import type { I } from '~/i'
+
+          import { i1, i2, i3 } from '~/i'
+          import { b1, b2 } from '~/b'
+          import { c1 } from '~/c'
+
+          import type { H } from './index.d.ts'
+          import type { F } from '../f'
+          import type { D } from './d'
+          import type { A } from '.'
+
+          import { K, L, M } from '../k'
+          import { j } from '../j'
+          import './style.css'
+          import h from '../../h'
+          import a from '.'
+        `,
+        code: dedent`
+          import { c1, c2, c3, c4 } from 'c'
+          import { e2 } from 'e/b'
+          import { e1 } from 'e/a'
+          import path from 'path'
+
+          import { b1, b2 } from '~/b'
+          import type { I } from '~/i'
+          import type { D } from './d'
+          import fs from 'fs'
+          import { c1 } from '~/c'
+          import { i1, i2, i3 } from '~/i'
+
+          import type { A } from '.'
+          import type { F } from '../f'
+          import h from '../../h'
+          import type { H } from './index.d.ts'
+
+          import a from '.'
+          import type { T } from 't'
+          import './style.css'
+          import { j } from '../j'
+          import { K, L, M } from '../k'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts imports without spacing between groups when configured', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+          import { a1, a2, a3 } from 'a'
+          import { c1, c2, c3 } from '~/c'
+          import { b1, b2 } from '~/b'
+          import { e1, e2, e3 } from '../../e'
+          import d from '.'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-external',
+              leftGroup: 'value-index',
+              right: 'a',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'value-internal',
+              rightGroup: 'type-import',
+              left: '~/c',
+              right: 't',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'value-internal',
+              leftGroup: 'value-parent',
+              left: '../../e',
+              right: '~/b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        code: dedent`
+          import d from '.'
+          import { a1, a2, a3 } from 'a'
+          import { c1, c2, c3 } from '~/c'
+
+          import type { T } from 't'
+          import { e1, e2, e3 } from '../../e'
+
+          import { b1, b2 } from '~/b'
+        `,
+        output: dedent`
+          import type { T } from 't'
+          import { a1, a2, a3 } from 'a'
+          import { c1, c2, c3 } from '~/c'
+          import { b1, b2 } from '~/b'
+          import { e1, e2, e3 } from '../../e'
+          import d from '.'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+    })
+
+    it('removes extra spacing between import groups', async () => {
+      await valid({
+        code: dedent`
+          import { A } from 'a'
+
+          import b from '~/b'
+          import c from '~/c'
+          import d from '~/d'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '~/b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/d',
+              left: '~/c',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        code: dedent`
+          import { A } from 'a'
+
+
+          import b from '~/b'
+          import c from '~/c'
+
+          import d from '~/d'
+        `,
+        output: dedent`
+          import { A } from 'a'
+
+          import b from '~/b'
+          import c from '~/c'
+          import d from '~/d'
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles TypeScript import-equals syntax correctly', async () => {
+      await valid({
+        code: dedent`
+          import type T = require("T")
+
+          import c = require('c/c')
+          import { A } from 'a'
+
+          import { B } from '../b'
+
+          import log = console.log
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '../b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'ts-equals-import',
+              rightGroup: 'value-external',
+              left: 'console.log',
+              right: 'c/c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import type T = require("T")
+
+          import c = require('c/c')
+          import { A } from 'a'
+
+          import { B } from '../b'
+
+          import log = console.log
+        `,
+        code: dedent`
+          import type T = require("T")
+
+          import { A } from 'a'
+          import { B } from '../b'
+
+          import log = console.log
+          import c = require('c/c')
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups all type imports together when specific type groups not configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal',
+              ['parent', 'sibling', 'index'],
+            ],
+          },
+        ],
+        code: dedent`
+          import type { T } from '../t'
+          import type { U } from '~/u'
+          import type { V } from 'v'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '../t',
+              right: '~/u',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '~/u',
+              right: 'v',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal',
+              ['parent', 'sibling', 'index'],
+            ],
+          },
+        ],
+        code: dedent`
+          import type { T } from '../t'
+
+          import type { U } from '~/u'
+
+          import type { V } from 'v'
+        `,
+        output: dedent`
+          import type { T } from '../t'
+          import type { U } from '~/u'
+          import type { V } from 'v'
+        `,
+      })
+    })
+
+    it('preserves inline comments during sorting', async () => {
+      await valid({
+        code: dedent`
+          import { b1, b2 } from 'b' // Comment
+          import { a } from 'a'
+          import { c } from 'c'
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores comments when calculating spacing between imports', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 't'
+
+          // @ts-expect-error missing types
+          import { t } from 't'
+        `,
+        options: [options],
+      })
+    })
+
+    it('stops grouping imports when other statements appear between them', async () => {
+      await valid({
+        code: dedent`
+          import type { V } from 'v'
+
+          export type { U } from 'u'
+
+          import type { T1, T2 } from 't'
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups style imports separately when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'style',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          import { a1, a2 } from 'a'
+
+          import styles from '../s.css'
+          import './t.css'
+        `,
+      })
+    })
+
+    it('groups side-effect imports separately when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'side-effect',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          import { A } from '../a'
+          import { b } from './b'
+
+          import '../c.js'
+          import './d'
+        `,
+      })
+    })
+
+    it('groups builtin types separately from other type imports', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['builtin-type', 'type'],
+          },
+        ],
+        code: dedent`
+          import type { Server } from 'http'
+
+          import a from 'a'
+        `,
+      })
+    })
+
+    it('handles imports with semicolons correctly', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: './index',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import a from 'a';
+
+          import b from './index';
+        `,
+        code: dedent`
+          import a from 'a';
+          import b from './index';
+        `,
+      })
+    })
+
+    it('removes extra spacing and sorts imports correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'value-external',
+              leftGroup: 'value-sibling',
+              left: './b',
+              right: 'c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        code: dedent`
+          import { a } from 'a'
+
+
+          import { b } from './b'
+
+
+
+          import { c } from 'c'
+        `,
+        output: dedent`
+          import { a } from 'a'
+          import { c } from 'c'
+
+          import { b } from './b'
+        `,
+        options: [options],
+      })
+    })
+
+    it('supports custom import groups with primary and secondary categories', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'type',
+              'primary',
+              'secondary',
+              ['builtin', 'external'],
+              'internal-type',
+              'internal',
+              ['parent-type', 'sibling-type', 'index-type'],
+              ['parent', 'sibling', 'index'],
+              'unknown',
+            ],
+            customGroups: {
+              value: {
+                primary: ['t', '@a/.+'],
+                secondary: '@b/.+',
+              },
+              type: {
+                primary: ['t', '@a/.+'],
+              },
+            },
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: '@a/a1',
+              left: 't',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '@b/b1',
+              left: '@a/a2',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '@b/b3',
+              right: 'c',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import type { T } from 't'
+          import a1 from '@a/a1'
+          import a2 from '@a/a2'
+
+          import b1 from '@b/b1'
+          import b2 from '@b/b2'
+          import b3 from '@b/b3'
+
+          import { c } from 'c'
+        `,
+        code: dedent`
+          import type { T } from 't'
+
+          import a1 from '@a/a1'
+          import a2 from '@a/a2'
+          import b1 from '@b/b1'
+          import b2 from '@b/b2'
+          import b3 from '@b/b3'
+          import { c } from 'c'
+        `,
+      })
+    })
+
+    it('supports custom groups for value imports only', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              value: {
+                primary: ['a'],
+              },
+            },
+            groups: ['type', 'primary'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import type { A } from 'a'
+
+          import { a } from 'a'
+        `,
+        code: dedent`
+          import type { A } from 'a'
+          import { a } from 'a'
+        `,
+      })
+    })
+
+    it('handles hash symbol in internal patterns correctly', async () => {
+      await valid({
+        code: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+
+          import { b1, b2 } from '#b'
+          import c from '#c'
+
+          import { d } from '../d'
+        `,
+        options: [
+          {
+            ...options,
+            internalPattern: ['#.+'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '#c',
+              left: '#b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '#b',
+              left: '#c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+
+          import { b1, b2 } from '#b'
+          import c from '#c'
+
+          import { d } from '../d'
+        `,
+        code: dedent`
+          import type { T } from 'a'
+
+          import { a } from 'a'
+
+          import type { S } from '#b'
+          import c from '#c'
+          import { b1, b2 } from '#b'
+
+          import { d } from '../d'
+        `,
+        options: [
+          {
+            ...options,
+            internalPattern: ['#.+'],
+          },
+        ],
+      })
+    })
+
+    it('recognizes Bun built-in modules when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['builtin', 'external', 'unknown'],
+            newlinesBetween: 'never',
+            environment: 'bun',
+          },
+        ],
+        code: dedent`
+          import { expect } from 'bun:test'
+          import { a } from 'a'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'external',
+              rightGroup: 'builtin',
+              right: 'bun:test',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['builtin', 'external', 'unknown'],
+            newlinesBetween: 'never',
+            environment: 'bun',
+          },
+        ],
+        output: dedent`
+          import { expect } from 'bun:test'
+          import { a } from 'a'
+        `,
+        code: dedent`
+          import { a } from 'a'
+          import { expect } from 'bun:test'
+        `,
+      })
+    })
+
+    it('sorts CommonJS require imports by module name', async () => {
+      await valid({
+        code: dedent`
+          const { a1, a2 } = require('a')
+          const { b1 } = require('b')
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          const { a1, a2 } = require('a')
+          const { b1 } = require('b')
+        `,
+        code: dedent`
+          const { b1 } = require('b')
+          const { a1, a2 } = require('a')
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups and sorts CommonJS require imports by type and source', async () => {
+      await valid({
+        code: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e1 } = require('e/a')
+          const { e2 } = require('e/b')
+          const path = require('path')
+          const fs = require('fs')
+
+          const { i1, i2, i3 } = require('~/i')
+          const { b1, b2 } = require('~/b')
+          const { c1 } = require('~/c')
+
+          const { K, L, M } = require('../k')
+          const { j } = require('../j')
+          const h = require('../../h')
+          const a = require('.')
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'value-internal',
+              rightGroup: 'value-builtin',
+              left: '~/b',
+              right: 'fs',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/c',
+              left: 'fs',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/i',
+              left: '~/c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: '../../h',
+              right: '.',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '../j',
+              left: '.',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '../k',
+              left: '../j',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e2 } = require('e/b')
+          const { e1 } = require('e/a')
+          const path = require('path')
+          const fs = require('fs')
+
+          const { i1, i2, i3 } = require('~/i')
+          const { b1, b2 } = require('~/b')
+          const { c1 } = require('~/c')
+
+          const { K, L, M } = require('../k')
+          const { j } = require('../j')
+          const h = require('../../h')
+          const a = require('.')
+        `,
+        code: dedent`
+          const { c1, c2, c3, c4 } = require('c')
+          const { e2 } = require('e/b')
+          const { e1 } = require('e/a')
+          const path = require('path')
+
+          const { b1, b2 } = require('~/b')
+          const fs = require('fs')
+          const { c1 } = require('~/c')
+          const { i1, i2, i3 } = require('~/i')
+
+          const h = require('../../h')
+
+          const a = require('.')
+          const { j } = require('../j')
+          const { K, L, M } = require('../k')
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves side-effect import order when sorting disabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        code: dedent`
+          import a from 'aaaa'
+
+          import 'bbb'
+          import './cc'
+          import '../d'
+        `,
+      })
+
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        code: dedent`
+          import 'c'
+          import 'bb'
+          import 'aaa'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'side-effect',
+              rightGroup: 'external',
+              left: 'bbb',
+              right: 'e',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: 'aaaa',
+              left: 'e',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '../d',
+              left: 'aaaa',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: false,
+          },
+        ],
+        output: dedent`
+          import a from 'aaaa'
+          import e from 'e'
+
+          import './cc'
+          import 'bbb'
+          import '../d'
+        `,
+        code: dedent`
+          import './cc'
+          import 'bbb'
+          import e from 'e'
+          import a from 'aaaa'
+          import '../d'
+        `,
+      })
+    })
+
+    it('sorts side-effect imports when sorting enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'side-effect', 'unknown'],
+            sortSideEffects: true,
+          },
+        ],
+        output: dedent`
+          import 'aaa'
+          import 'bb'
+          import 'c'
+        `,
+        code: dedent`
+          import 'c'
+          import 'bb'
+          import 'aaa'
+        `,
+      })
+    })
+
+    it('preserves original order when side-effect imports are not grouped', async () => {
+      await invalid({
+        output: dedent`
+          import "./z-side-effect.scss";
+          import a from "./aa";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import a from "./aa";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+        `,
+        errors: [
+          {
+            data: {
+              right: './aa',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups side-effect imports together without sorting them', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+
+          import b from "./b";
+          import a from "./a";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups side-effect and style imports together in same group without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect.scss";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+
+          import b from "./b";
+          import a from "./a";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [['side-effect', 'side-effect-style'], 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('separates side-effect and style imports into distinct groups without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './z-side-effect.scss',
+              right: './b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: './b-side-effect',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './g-side-effect.css',
+              left: './b-side-effect',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              leftGroup: 'side-effect-style',
+              left: './g-side-effect.css',
+              rightGroup: 'side-effect',
+              right: './a-side-effect',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import './b-side-effect'
+          import './a-side-effect'
+
+          import "./z-side-effect.scss";
+          import "./g-side-effect.css";
+
+          import b from "./b";
+          import a from "./a";
+        `,
+        code: dedent`
+          import "./z-side-effect.scss";
+          import b from "./b";
+          import './b-side-effect'
+          import "./g-side-effect.css";
+          import './a-side-effect'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'side-effect-style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('groups style side-effect imports separately without sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              right: './b-side-effect.scss',
+              leftGroup: 'unknown',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './b-side-effect.scss',
+              right: './g-side-effect',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              right: './a-side-effect.css',
+              left: './g-side-effect',
+              leftGroup: 'unknown',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: './a-side-effect.css',
+              right: './a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import "./z-side-effect";
+          import './b-side-effect.scss'
+          import './a-side-effect.css'
+
+          import "./g-side-effect";
+          import b from "./b";
+          import a from "./a";
+        `,
+        code: dedent`
+          import "./z-side-effect";
+          import b from "./b";
+          import './b-side-effect.scss'
+          import "./g-side-effect";
+          import './a-side-effect.css'
+          import a from "./a";
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores fallback sorting for side-effect imports', async () => {
+      await valid({
+        options: [
+          {
+            groups: ['side-effect', 'side-effect-style'],
+            fallbackSort: { type: 'alphabetical' },
+          },
+        ],
+        code: dedent`
+          import 'b';
+          import 'a';
+
+          import 'b.css';
+          import 'a.css';
+        `,
+      })
+    })
+
+    it('handles special characters with trim option', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          import '_a'
+          import 'b'
+          import '_c'
+        `,
+      })
+    })
+
+    it('handles special characters with remove option', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          import 'ab'
+          import 'a_c'
+        `,
+      })
+    })
+
+    it('supports locale-specific sorting', async () => {
+      await valid({
+        code: dedent`
+          import '你好'
+          import '世界'
+          import 'a'
+          import 'A'
+          import 'b'
+          import 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['removes newlines with never option', 'never'],
+      ['removes newlines with 0 option', 0],
+    ])('%s', async (_description, newlinesBetween) => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '~/y',
+              left: 'aaaa',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: '~/bb',
+              left: '~/z',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '~/bb',
+              left: '~/z',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        code: dedent`
+            import { A } from 'aaaa'
+
+
+           import y from '~/y'
+          import z from '~/z'
+
+              import b from '~/bb'
+        `,
+        output: dedent`
+            import { A } from 'aaaa'
+           import b from '~/bb'
+          import y from '~/y'
+              import z from '~/z'
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween,
+          },
+        ],
+      })
+    })
+
+    it('handles custom spacing rules between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              value: {
+                a: 'a',
+                b: 'b',
+                c: 'c',
+                d: 'd',
+                e: 'e',
+              },
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { A } from 'a'
+
+          import { B } from 'b'
+
+          import { C } from 'c'
+          import { D } from 'd'
+
+
+          import { E } from 'e'
+        `,
+        code: dedent`
+          import { A } from 'a'
+          import { B } from 'b'
+
+
+          import { C } from 'c'
+
+          import { D } from 'd'
+
+
+          import { E } from 'e'
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'enforces spacing when global option is 2 and group option is never',
+        2,
+        'never',
+      ],
+      ['enforces spacing when global option is 2 and group option is 0', 2, 0],
+      [
+        'enforces spacing when global option is 2 and group option is ignore',
+        2,
+        'ignore',
+      ],
+      [
+        'enforces spacing when global option is never and group option is 2',
+        'never',
+        2,
+      ],
+      ['enforces spacing when global option is 0 and group option is 2', 0, 2],
+      [
+        'enforces spacing when global option is ignore and group option is 2',
+        'ignore',
+        2,
+      ],
+    ])(
+      '%s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenImports',
+            },
+          ],
+          output: dedent`
+            import { a } from 'a';
+
+
+            import { b } from 'b';
+          `,
+          code: dedent`
+            import { a } from 'a';
+            import { b } from 'b';
+          `,
+        })
+      },
+    )
+
+    it.each([
+      [
+        'removes spacing when never option exists between groups regardless of global setting always',
+        'always',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting 2',
+        2,
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting ignore',
+        'ignore',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting never',
+        'never',
+      ],
+      [
+        'removes spacing when never option exists between groups regardless of global setting 0',
+        0,
+      ],
+    ])('%s', async (_description, globalNewlinesBetween) => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            customGroups: {
+              value: {
+                unusedGroup: 'X',
+                a: 'a',
+                b: 'b',
+                c: 'c',
+              },
+            },
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { a } from 'a';
+          import { b } from 'b';
+        `,
+        code: dedent`
+          import { a } from 'a';
+
+          import { b } from 'b';
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'preserves existing spacing when ignore and never options are combined',
+        'ignore',
+        'never',
+      ],
+      [
+        'preserves existing spacing when ignore and 0 options are combined',
+        'ignore',
+        0,
+      ],
+      [
+        'preserves existing spacing when never and ignore options are combined',
+        'never',
+        'ignore',
+      ],
+      [
+        'preserves existing spacing when 0 and ignore options are combined',
+        0,
+        'ignore',
+      ],
+    ])(
+      '%s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import { a } from 'a';
+
+            import { b } from 'b';
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: {
+                value: {
+                  unusedGroup: 'X',
+                  a: 'a',
+                  b: 'b',
+                },
+              },
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import { a } from 'a';
+            import { b } from 'b';
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comments after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'external',
+              right: './a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from './a' // Comment after
+
+          import { b } from 'b'
+          import { c } from 'c'
+        `,
+        code: dedent`
+          import { b } from 'b'
+          import { a } from './a' // Comment after
+
+          import { c } from 'c'
+        `,
+        options: [
+          {
+            groups: ['unknown', 'external'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      [
+        'ignores newline fixes between different partitions with never option',
+        'never',
+      ],
+      ['ignores newline fixes between different partitions with 0 option', 0],
+    ])('%s', async (_description, newlinesBetween) => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import a from 'a';
+
+          // Partition comment
+
+          import { b } from './bb';
+          import { c } from './c';
+        `,
+        code: dedent`
+          import a from 'a';
+
+          // Partition comment
+
+          import { c } from './c';
+          import { b } from './bb';
+        `,
+      })
+    })
+
+    it('sorts inline imports correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from "aa"; import { b } from "b";
+        `,
+        code: dedent`
+          import { b } from "b"; import { a } from "aa"
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a } from "aa"; import { b } from "b";
+        `,
+        code: dedent`
+          import { b } from "b"; import { a } from "aa";
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows partitioning by new lines', async () => {
+      await invalid({
+        output: dedent`
+          import * as organisms from "./organisms";
+          import * as shared from "./shared";
+          import * as atoms from "./atoms";
+
+          import { AnotherNamed } from './second-folder';
+          import { Named } from './folder';
+        `,
+        code: dedent`
+          import * as organisms from "./organisms";
+          import * as atoms from "./atoms";
+          import * as shared from "./shared";
+
+          import { AnotherNamed } from './second-folder';
+          import { Named } from './folder';
+        `,
+        errors: [
+          {
+            data: {
+              right: './shared',
+              left: './atoms',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows partitioning by comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          // Part: A
+          // Not partition comment
+          import bbb from './bbb';
+          import cc from './cc';
+          import d from './d';
+          // Part: B
+          import aaaa from './aaaa';
+          import e from './e';
+          // Part: C
+          // Not partition comment
+          import fff from './fff';
+          import gg from './gg';
+        `,
+        code: dedent`
+          // Part: A
+          import cc from './cc';
+          import d from './d';
+          // Not partition comment
+          import bbb from './bbb';
+          // Part: B
+          import aaaa from './aaaa';
+          import e from './e';
+          // Part: C
+          import gg from './gg';
+          // Not partition comment
+          import fff from './fff';
+        `,
+        errors: [
+          {
+            data: {
+              right: './bbb',
+              left: './d',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: './fff',
+              left: './gg',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition boundaries when enabled', async () => {
+      await valid({
+        code: dedent`
+          // Comment
+          import bb from './bb';
+          // Other comment
+          import a from './a';
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          /* Partition Comment */
+          // Part: A
+          import d from './d'
+          // Part: B
+          import aaa from './aaa'
+          import bb from './bb'
+          import c from './c'
+          /* Other */
+          import e from './e'
+        `,
+        code: dedent`
+          /* Partition Comment */
+          // Part: A
+          import d from './d'
+          // Part: B
+          import aaa from './aaa'
+          import c from './c'
+          import bb from './bb'
+          /* Other */
+          import e from './e'
+        `,
+        errors: [
+          {
+            data: {
+              right: './bb',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          import e from './e'
+          import f from './f'
+          // I am a partition comment because I don't have f o o
+          import a from './a'
+          import b from './b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comment partitioning is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './aa',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          /* Comment */
+          import a from './aa'
+          import b from './b'
+        `,
+        code: dedent`
+          import b from './b'
+          /* Comment */
+          import a from './aa'
+        `,
+      })
+    })
+
+    it('treats all line comments as partition boundaries when enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          // Comment
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports multiple line comment patterns for partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          import c from './c'
+          // b
+          import b from './b'
+          // a
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comment partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          // I am a partition comment because I don't have f o o
+          import a from './a'
+        `,
+      })
+    })
+
+    it('ignores line comments when block comment partitioning is enabled', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './aa',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          // Comment
+          import a from './aa'
+          import b from './b'
+        `,
+        code: dedent`
+          import b from './b'
+          // Comment
+          import a from './aa'
+        `,
+      })
+    })
+
+    it('treats all block comments as partition boundaries when enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          import b from './b'
+          /* Comment */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports multiple block comment patterns for partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          import c from './c'
+          /* b */
+          import b from './b'
+          /* a */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comment partitioning', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          import b from './bb'
+          /* I am a partition comment because I don't have f o o */
+          import a from './a'
+        `,
+      })
+    })
+
+    it('supports style imports with query parameters', async () => {
+      await valid({
+        code: dedent`
+          import b from './b.css?raw'
+          import c from './c.css'
+
+          import a from './a.js'
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['style', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              right: './b.css?raw',
+              rightGroup: 'style',
+              left: './a.js',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import b from './b.css?raw'
+          import c from './c.css'
+
+          import a from './a.js'
+        `,
+        code: dedent`
+          import a from './a.js'
+          import b from './b.css?raw'
+          import c from './c.css'
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['style', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes index types over sibling types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'sibling-type',
+              rightGroup: 'index-type',
+              right: './index',
+              left: './a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['index-type', 'sibling-type'],
+          },
+        ],
+        output: dedent`
+          import type b from './index'
+
+          import type a from './a'
+        `,
+        code: dedent`
+          import type a from './a'
+
+          import type b from './index'
+        `,
+      })
+    })
+
+    it('prioritizes specific type selectors over generic type group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'sibling-type',
+              leftGroup: 'type',
+              right: './b',
+              left: '../a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './index',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'timers',
+              left: 'd',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              [
+                'index-type',
+                'internal-type',
+                'external-type',
+                'sibling-type',
+                'builtin-type',
+              ],
+              'type',
+            ],
+          },
+        ],
+        output: dedent`
+          import type c from './index'
+          import type e from 'timers'
+          import type b from './b'
+          import type d from 'd'
+
+          import type a from '../a'
+        `,
+        code: dedent`
+          import type a from '../a'
+
+          import type b from './b'
+          import type c from './index'
+          import type d from 'd'
+          import type e from 'timers'
+        `,
+      })
+    })
+
+    it('prioritizes index imports over sibling imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'sibling',
+              rightGroup: 'index',
+              right: './index',
+              left: './a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['index', 'sibling'],
+          },
+        ],
+        output: dedent`
+          import b from './index'
+
+          import a from './a'
+        `,
+        code: dedent`
+          import a from './a'
+
+          import b from './index'
+        `,
+      })
+    })
+
+    it('prioritizes style side-effects over generic side-effects', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              leftGroup: 'side-effect',
+              right: 'style.css',
+              left: 'something',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-style', 'side-effect'],
+          },
+        ],
+        output: dedent`
+          import 'style.css'
+
+          import 'something'
+        `,
+        code: dedent`
+          import 'something'
+
+          import 'style.css'
+        `,
+      })
+    })
+
+    it('prioritizes side-effects over style imports with default exports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect',
+              right: 'something',
+              leftGroup: 'style',
+              left: 'style.css',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect', 'style'],
+          },
+        ],
+        output: dedent`
+          import 'something'
+
+          import style from 'style.css'
+        `,
+        code: dedent`
+          import style from 'style.css'
+
+          import 'something'
+        `,
+      })
+    })
+
+    it('prioritizes style imports over other import types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './index',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: '#subpath',
+              left: './index',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: '#subpath',
+              right: '$path',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'timers',
+              left: 'd',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              leftGroup: 'builtin',
+              rightGroup: 'style',
+              right: 'style.css',
+              left: 'timers',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'style',
+              [
+                'index',
+                'internal',
+                'subpath',
+                'external',
+                'sibling',
+                'builtin',
+                'parent',
+                'tsconfig-path',
+              ],
+            ],
+            tsconfigRootDir: '.',
+          },
+        ],
+        output: dedent`
+          import style from 'style.css'
+
+          import tsConfigPath from '$path'
+          import subpath from '#subpath'
+          import c from './index'
+          import e from 'timers'
+          import a from '../a'
+          import b from './b'
+          import d from 'd'
+        `,
+        code: dedent`
+          import a from '../a'
+          import b from './b'
+          import c from './index'
+          import subpath from '#subpath'
+          import tsConfigPath from '$path'
+          import d from 'd'
+          import e from 'timers'
+
+          import style from 'style.css'
+        `,
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            paths: {
+              $path: ['./path'],
+            },
+          })
+        },
+      })
+    })
+
+    it('prioritizes external imports over generic import group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'import',
+              left: './aa',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'import'],
+          },
+        ],
+        output: dedent`
+          import b from 'b'
+
+          import a from './aa'
+        `,
+        code: dedent`
+          import a from './aa'
+
+          import b from 'b'
+        `,
+      })
+    })
+
+    it('prioritizes type imports over TypeScript equals imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'type-import',
+              leftGroup: 'external',
+              right: 'z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['type-import', 'external', 'ts-equals-import'],
+          },
+        ],
+        output: dedent`
+          import type z = z
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import type z = z
+        `,
+      })
+    })
+
+    it('prioritizes side-effect imports over value imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'side-effect-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['side-effect-import', 'external', 'value-import'],
+            sortSideEffects: true,
+          },
+        ],
+        output: dedent`
+          import "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import "./z"
+        `,
+      })
+    })
+
+    it('prioritizes value imports over TypeScript equals imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'value-import',
+              leftGroup: 'external',
+              right: 'z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['value-import', 'external', 'ts-equals-import'],
+          },
+        ],
+        output: dedent`
+          import z = z
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z = z
+        `,
+      })
+    })
+
+    it('prioritizes TypeScript equals imports over require imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'ts-equals-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['ts-equals-import', 'external', 'require-import'],
+          },
+        ],
+        output: dedent`
+          import z = require('./z')
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z = require('./z')
+        `,
+      })
+    })
+
+    it('prioritizes default imports over named imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-import', 'external', 'named-import'],
+          },
+        ],
+        output: dedent`
+          import z, { z } from "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z, { z } from "./z"
+        `,
+      })
+    })
+
+    it('prioritizes wildcard imports over named imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'wildcard-import',
+              leftGroup: 'external',
+              right: './z',
+              left: 'f',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['wildcard-import', 'external', 'named-import'],
+          },
+        ],
+        output: dedent`
+          import z, * as z from "./z"
+
+          import f from 'f'
+        `,
+        code: dedent`
+          import f from 'f'
+
+          import z, * as z from "./z"
+        `,
+      })
+    })
+
+    it.each([
+      ['filters on element name pattern with string', 'hello'],
+      ['filters on element name pattern with array', ['noMatch', 'hello']],
+      [
+        'filters on element name pattern with regex object',
+        { pattern: 'HELLO', flags: 'i' },
+      ],
+      [
+        'filters on element name pattern with array containing regex',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])('%s', async (_description, elementNamePattern) => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'importsStartingWithHello',
+              right: 'helloImport',
+              leftGroup: 'unknown',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'importsStartingWithHello',
+                elementNamePattern,
+              },
+            ],
+            groups: ['importsStartingWithHello', 'unknown'],
+          },
+        ],
+        output: dedent`
+          import hello from 'helloImport'
+
+          import a from 'a'
+        `,
+        code: dedent`
+          import a from 'a'
+
+          import hello from 'helloImport'
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding type and order settings', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedExternalImportsByLineLength',
+              leftGroup: 'unknown',
+              left: './jjjjj',
+              right: 'eee',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedExternalImportsByLineLength',
+                selector: 'external',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedExternalImportsByLineLength', 'unknown'],
+            newlinesBetween: 'ignore',
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          import dddd from 'dddd'
+          import ccc from 'ccc'
+          import eee from 'eee'
+          import bb from 'bb'
+          import ff from 'ff'
+          import a from 'a'
+          import g from 'g'
+          import h from './h'
+          import i from './i'
+          import jjjjj from './jjjjj'
+        `,
+        code: dedent`
+          import a from 'a'
+          import bb from 'bb'
+          import ccc from 'ccc'
+          import dddd from 'dddd'
+          import jjjjj from './jjjjj'
+          import eee from 'eee'
+          import ff from 'ff'
+          import g from 'g'
+          import h from './h'
+          import i from './i'
+        `,
+      })
+    })
+
+    it('sorts custom groups using fallback sort settings', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import fooBar from 'fooBar'
+          import fooZar from 'fooZar'
+        `,
+        code: dedent`
+          import fooZar from 'fooZar'
+          import fooBar from 'fooBar'
+        `,
+      })
+    })
+
+    it('preserves order for custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedExternalImports',
+                selector: 'external',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedExternalImports', 'unknown'],
+            newlinesBetween: 'ignore',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedExternalImports',
+              leftGroup: 'unknown',
+              left: './something',
+              right: 'c',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import b from 'b'
+          import a from 'a'
+          import d from 'd'
+          import e from 'e'
+          import c from 'c'
+          import something from './something'
+        `,
+        code: dedent`
+          import b from 'b'
+          import a from 'a'
+          import d from 'd'
+          import e from 'e'
+          import something from './something'
+          import c from 'c'
+        `,
+      })
+    })
+
+    it('sorts custom group blocks with complex selectors', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    selector: 'external',
+                  },
+                  {
+                    selector: 'sibling',
+                    modifiers: ['type'],
+                  },
+                ],
+                groupName: 'externalAndTypeSiblingImports',
+              },
+            ],
+            groups: [['externalAndTypeSiblingImports', 'index'], 'unknown'],
+            newlinesBetween: 'ignore',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'externalAndTypeSiblingImports',
+              leftGroup: 'unknown',
+              right: './c',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: './index',
+              left: 'e',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import type c from './c'
+          import type d from './d'
+          import i from './index'
+          import a from 'a'
+          import e from 'e'
+          import b from './b'
+        `,
+        code: dedent`
+          import a from 'a'
+          import b from './b'
+          import type c from './c'
+          import type d from './d'
+          import e from 'e'
+          import i from './index'
+        `,
+      })
+    })
+
+    it('detects TypeScript import-equals dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import { aImport } from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import { aImport } from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import * as aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import * as aImport from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport from "b";
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        output: dedent`
+          import aImport = require("b")
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport = require("b")
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'importsStartingWithA',
+                elementNamePattern: '^a',
+              },
+              {
+                groupName: 'importsStartingWithB',
+                elementNamePattern: '^b',
+              },
+            ],
+            groups: ['importsStartingWithA', 'importsStartingWithB'],
+          },
+        ],
+        code: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'importsStartingWithA',
+                elementNamePattern: '^a',
+              },
+              {
+                groupName: 'importsStartingWithB',
+                elementNamePattern: '^b',
+              },
+            ],
+            groups: ['importsStartingWithA', 'importsStartingWithB'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+          {
+            data: {
+              left: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+          import aImport from "b";
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over comment-based partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+
+          // Part: 1
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+
+          // Part: 1
+          import aImport from "b";
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over newline-based partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          import aImport from "b";
+
+          import a = aImport.a1.a2;
+        `,
+        code: dedent`
+          import a = aImport.a1.a2;
+
+          import aImport from "b";
+        `,
+      })
+    })
+
+    it('prioritizes content separation over dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'yImport.y1.y2',
+              right: 'z',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'aImport.a1.a2',
+              right: 'b',
+            },
+            messageId: 'unexpectedImportsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          import f = fImport.f1.f2;
+
+          import yImport from "z";
+
+          import y = yImport.y1.y2;
+
+          export { something } from "something";
+
+          import aImport from "b";
+
+          import a = aImport.a1.a2;
+
+          import fImport from "g";
+        `,
+        code: dedent`
+          import f = fImport.f1.f2;
+
+          import y = yImport.y1.y2;
+
+          import yImport from "z";
+
+          export { something } from "something";
+
+          import a = aImport.a1.a2;
+
+          import aImport from "b";
+
+          import fImport from "g";
+        `,
+        options: [
+          {
+            ...options,
+            newlinesBetween: 'ignore',
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('ignores shebang comments when sorting imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          import { a } from 'aa'
+          import { b } from 'b'
+        `,
+        code: dedent`
+          #!/usr/bin/node
+          import { b } from 'b'
+          import { a } from 'aa'
+        `,
+        options: [options],
+      })
+    })
+
+    it('treats @ symbol pattern as internal imports', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '@/a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['external', 'internal'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          import { b } from 'b'
+
+          import { a } from '@/a'
+        `,
+        code: dedent`
+          import { b } from 'b'
+          import { a } from '@/a'
+        `,
+      })
+    })
+
+    it('reports missing comments above import groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above a',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              missedCommentAbove: 'Comment above b',
+              right: './b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'Comment above a' },
+              'external',
+              { commentAbove: 'Comment above b' },
+              'unknown',
+            ],
+          },
+        ],
+        output: dedent`
+          // Comment above a
+          import { a } from "a";
+
+          // Comment above b
+          import { b } from "./b";
+        `,
+        code: dedent`
+          import { a } from "a";
+
+          import { b } from "./b";
+        `,
+      })
+    })
+
+    it('reports missing comments for single import groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'a',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        output: dedent`
+          // Comment above
+          import { a } from "a";
+        `,
+        code: dedent`
+          import { a } from "a";
+        `,
+      })
+    })
+
+    it('ignores shebangs and top-level comments when adding group comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'Comment above',
+              right: 'b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above
+          import a from "aa";
+          import b from "b";
+        `,
+        options: [
+          {
+            ...options,
+            groups: [{ commentAbove: 'Comment above' }, 'external'],
+          },
+        ],
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          import b from "b";
+          import a from "aa";
+        `,
+      })
+    })
+
+    it.each([
+      [
+        'detects existing line comment with extra spaces',
+        '//   Comment above  ',
+      ],
+      [
+        'detects existing line comment with different case',
+        '//   comment above  ',
+      ],
+      [
+        'detects existing block comment with standard format',
+        dedent`
+          /**
+           * Comment above
+           */
+        `,
+      ],
+      [
+        'detects existing block comment with surrounding text',
+        dedent`
+          /**
+           * Something before
+           * CoMmEnT ABoVe
+           * Something after
+           */
+        `,
+      ],
+    ])('%s', async (_description, comment) => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['external', { commentAbove: 'Comment above' }, 'unknown'],
+          },
+        ],
+        code: dedent`
+          import a from "a";
+
+          ${comment}
+          import b from "./b";
+        `,
+      })
+    })
+
+    it('removes and repositions invalid auto-added comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'internal',
+              right: '~/d',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              right: '~/cc',
+              left: '~/d',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'sibling',
+              leftGroup: 'internal',
+              right: './bbb',
+              left: '~/cc',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'sibling',
+              left: './bbb',
+              right: 'aaaa',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              { commentAbove: 'sibling' },
+              'sibling',
+              { commentAbove: 'internal' },
+              'internal',
+            ],
+          },
+        ],
+        output: dedent`
+          // external
+          import a from "aaaa";
+
+          // sibling
+          import b from './bbb';
+
+          // internal
+          import c from '~/cc';
+          import d from '~/d';
+        `,
+        code: dedent`
+          import d from '~/d';
+          // internal
+          import c from '~/cc';
+
+          // sibling
+          import b from './bbb';
+
+          // external
+          import a from "aaaa";
+        `,
+      })
+    })
+
+    it('handles complex scenarios with multiple error types and comment management', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              missedCommentAbove: 'internal or sibling',
+              right: './c',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+          {
+            data: {
+              rightGroup: 'external',
+              leftGroup: 'sibling',
+              left: './c',
+              right: 'a',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              missedCommentAbove: 'internal or sibling',
+              right: '~/b',
+            },
+            messageId: 'missedCommentAboveImport',
+          },
+        ],
+        code: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above c
+          // external
+          import c from './c'; // Comment after c
+          // Comment above a
+          // internal or sibling
+          import a from "a"; // Comment after a
+          // Comment above b
+          // external
+          import b from '~/b'; // Comment after b
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              {
+                commentAbove: 'internal or sibling',
+                newlinesBetween: 'always',
+              },
+              ['internal', 'sibling'],
+            ],
+            newlinesBetween: 'never',
+          },
+        ],
+        output: dedent`
+          #!/usr/bin/node
+          // Some disclaimer
+
+          // Comment above a
+          // external
+          import a from "a"; // Comment after a
+
+          // internal or sibling
+          // Comment above c
+          import c from './c'; // Comment after c
+          // Comment above b
+          import b from '~/b'; // Comment after b
+        `,
+      })
+    })
+
+    it('handles complex import formatting with line length constraints', async () => {
+      await invalid({
+        output: dedent`
+          import {
+            ICantBelieveHowLong,
+            ICantHandleHowLong,
+            KindaLong,
+            Long,
+            ThisIsTheLongestEver,
+            WowSoLong,
+          } from 'app/components/Short';
+          import ThereIsTwoOfMe, {
+            SoWeShouldSplitUpSinceWeAreInDifferentSections
+          } from 'IWillDefinitelyBeSplitUp';
+          import Short from 'app/components/LongName';
+          import { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';
+          import { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';
+          import EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';
+        `,
+        code: dedent`
+          import { ThisIsApprox, SeventyNine } from '~CharactersLongAndShouldNotBeSplit';
+          import { EvenThoughThisIsLongItShouldNotGetSplitUpAsItThereIsOnlyOne } from 'IWillNotBeSplitUp';
+          import Short from 'app/components/LongName';
+          import {
+            ICantBelieveHowLong,
+            ICantHandleHowLong,
+            KindaLong,
+            Long,
+            ThisIsTheLongestEver,
+            WowSoLong,
+          } from 'app/components/Short';
+          import EvenThoughThisIsLongItShouldNotBePutOntoAnyNewLinesAsThereIsOnlyOne from 'IWillNotBePutOntoNewLines';
+          import ThereIsTwoOfMe, {
+            SoWeShouldSplitUpSinceWeAreInDifferentSections
+          } from 'IWillDefinitelyBeSplitUp';
+        `,
+        errors: [
+          {
+            data: {
+              right: 'app/components/LongName',
+              left: 'IWillNotBeSplitUp',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: 'app/components/LongName',
+              right: 'app/components/Short',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              left: 'IWillNotBePutOntoNewLines',
+              right: 'IWillDefinitelyBeSplitUp',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            maxLineLength: 80,
+            order: 'asc',
+          },
+        ],
+      })
+    })
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts imports by module name', async () => {
+      await valid({
+        code: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { a1, a2 } from 'a'
+          import { b1 } from 'b'
+        `,
+        code: dedent`
+          import { b1 } from 'b'
+          import { a1, a2 } from 'a'
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('preserves original order when sorting is disabled', async () => {
+      await valid({
+        code: dedent`
+          import { b } from 'b';
+          import { c } from 'c';
+          import { a } from 'a';
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces group order regardless of sorting settings', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: {
+              value: {
+                a: '^a',
+                b: '^b',
+              },
+            },
+            groups: ['b', 'a'],
+          },
+        ],
+        output: dedent`
+          import { ba } from 'ba'
+          import { bb } from 'bb'
+
+          import { ab } from 'ab'
+          import { aa } from 'aa'
+        `,
+        code: dedent`
+          import { ab } from 'ab'
+          import { aa } from 'aa'
+          import { ba } from 'ba'
+          import { bb } from 'bb'
+        `,
+      })
+    })
+
+    it('enforces spacing rules between import groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              value: {
+                a: '^a',
+                b: '^b',
+              },
+            },
+            newlinesBetween: 'never',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { b } from 'b'
+          import { a } from 'a'
+        `,
+        code: dedent`
+          import { b } from 'b'
+
+          import { a } from 'a'
+        `,
+      })
+    })
+  })
+
+  describe('misc', () => {
+    it('validates the JSON schema', async () => {
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
+    })
+
+    it('supports combination of predefined and custom groups', async () => {
+      await valid({
+        options: [
+          {
+            groups: [
+              'side-effect-style',
+              'external-type',
+              'internal-type',
+              'builtin-type',
+              'sibling-type',
+              'parent-type',
+              'side-effect',
+              'index-type',
+              'internal',
+              'external',
+              'sibling',
+              'unknown',
+              'builtin',
+              'parent',
+              'index',
+              'style',
+              'type',
+              'myCustomGroup1',
+            ],
+            customGroups: {
+              type: {
+                myCustomGroup1: 'x',
+              },
+            },
+          },
+        ],
+        code: dedent`
+          import type { T } from 't'
+
+          // @ts-expect-error missing types
+          import { t } from 't'
+        `,
+      })
+    })
+
+    it('uses alphabetical ascending sorting by default', async () => {
+      await valid(dedent`
+        import a from '~/a'
+        import b from '~/b'
+        import c from '~/c'
+        import d from '~/d'
+      `)
+
+      await valid({
+        code: dedent`
+          import { log } from './log'
+          import { log10 } from './log10'
+          import { log1p } from './log1p'
+          import { log2 } from './log2'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '~/b',
+              left: '~/c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import a from '~/a'
+          import b from '~/b'
+          import c from '~/c'
+          import d from '~/d'
+        `,
+        code: dedent`
+          import a from '~/a'
+          import c from '~/c'
+          import b from '~/b'
+          import d from '~/d'
+        `,
+      })
+    })
+
+    it('preserves order of side-effect imports', async () => {
+      await valid(dedent`
+        import './index.css'
+        import './animate.css'
+        import './reset.css'
+      `)
+    })
+
+    it('recognizes Node.js built-in modules with node: prefix', async () => {
+      await valid({
+        code: dedent`
+          import { writeFile } from 'node:fs/promises'
+
+          import { useEffect } from 'react'
+        `,
+        options: [
+          {
+            groups: ['builtin', 'external'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'node:fs/promises',
+              right: 'react',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        output: dedent`
+          import { writeFile } from 'node:fs/promises'
+
+          import { useEffect } from 'react'
+        `,
+        code: dedent`
+          import { writeFile } from 'node:fs/promises'
+          import { useEffect } from 'react'
+        `,
+        options: [
+          {
+            groups: ['builtin', 'external'],
+          },
+        ],
+      })
+    })
+
+    it('classifies internal pattern side-effects correctly by group priority', async () => {
+      await valid({
+        code: dedent`
+          import { useClient } from '~/hooks/useClient'
+
+          import '~/css/globals.css'
+
+          import '~/data'
+        `,
+        options: [
+          {
+            groups: ['internal', 'side-effect-style', 'side-effect'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '~/hooks/useClient',
+              right: '~/data',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              rightGroup: 'side-effect-style',
+              right: '~/css/globals.css',
+              leftGroup: 'side-effect',
+              left: '~/data',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import { useClient } from '~/hooks/useClient'
+
+          import '~/css/globals.css'
+
+          import '~/data'
+        `,
+        code: dedent`
+          import { useClient } from '~/hooks/useClient'
+          import '~/data'
+          import '~/css/globals.css'
+        `,
+        options: [
+          {
+            groups: ['internal', 'side-effect-style', 'side-effect'],
+          },
+        ],
+      })
+    })
+
+    it('handles complex projects with many custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: {
+              value: {
+                validators: ['^~/validators/.+'],
+                composable: ['^~/composable/.+'],
+                components: ['^~/components/.+'],
+                services: ['^~/services/.+'],
+                widgets: ['^~/widgets/.+'],
+                stores: ['^~/stores/.+'],
+                logics: ['^~/logics/.+'],
+                assets: ['^~/assets/.+'],
+                utils: ['^~/utils/.+'],
+                pages: ['^~/pages/.+'],
+                ui: ['^~/ui/.+'],
+              },
+            },
+            groups: [
+              ['builtin', 'external'],
+              'internal',
+              'stores',
+              'services',
+              'validators',
+              'utils',
+              'logics',
+              'composable',
+              'ui',
+              'components',
+              'pages',
+              'widgets',
+              'assets',
+              'parent',
+              'sibling',
+              'side-effect',
+              'index',
+              'style',
+              'unknown',
+            ],
+            type: 'line-length',
+          },
+        ],
+        code: dedent`
+          import { useCartStore } from '~/stores/cartStore.ts'
+          import { useUserStore } from '~/stores/userStore.ts'
+
+          import { getCart } from '~/services/cartService.ts'
+
+          import { connect } from '~/utils/ws.ts'
+          import { formattingDate } from '~/utils/dateTime.ts'
+
+          import { useFetch } from '~/composable/useFetch.ts'
+          import { useDebounce } from '~/composable/useDebounce.ts'
+          import { useMouseMove } from '~/composable/useMouseMove.ts'
+
+          import ComponentA from '~/components/ComponentA.vue'
+          import ComponentB from '~/components/ComponentB.vue'
+          import ComponentC from '~/components/ComponentC.vue'
+
+          import CartComponentA from './cart/CartComponentA.vue'
+          import CartComponentB from './cart/CartComponentB.vue'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: './cart/CartComponentB.vue',
+              right: '~/utils/ws.ts',
+              leftGroup: 'sibling',
+              rightGroup: 'utils',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/services/cartService.ts',
+              rightGroup: 'services',
+              left: '~/utils/ws.ts',
+              leftGroup: 'utils',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: '~/services/cartService.ts',
+              right: '~/stores/userStore.ts',
+              leftGroup: 'services',
+              rightGroup: 'stores',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              left: '~/stores/userStore.ts',
+              right: '~/utils/dateTime.ts',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+          {
+            data: {
+              left: '~/composable/useFetch.ts',
+              right: '~/stores/cartStore.ts',
+              leftGroup: 'composable',
+              rightGroup: 'stores',
+            },
+            messageId: 'unexpectedImportsGroupOrder',
+          },
+          {
+            data: {
+              right: '~/composable/useDebounce.ts',
+              left: '~/stores/cartStore.ts',
+            },
+            messageId: 'missedSpacingBetweenImports',
+          },
+        ],
+        options: [
+          {
+            customGroups: {
+              value: {
+                validators: ['~/validators/.+'],
+                composable: ['~/composable/.+'],
+                components: ['~/components/.+'],
+                services: ['~/services/.+'],
+                widgets: ['~/widgets/.+'],
+                stores: ['~/stores/.+'],
+                logics: ['~/logics/.+'],
+                assets: ['~/assets/.+'],
+                utils: ['~/utils/.+'],
+                pages: ['~/pages/.+'],
+                ui: ['~/ui/.+'],
+              },
+            },
+            groups: [
+              ['builtin', 'external'],
+              'internal',
+              'stores',
+              'services',
+              'validators',
+              'utils',
+              'logics',
+              'composable',
+              'ui',
+              'components',
+              'pages',
+              'widgets',
+              'assets',
+              'parent',
+              'sibling',
+              'side-effect',
+              'index',
+              'style',
+              'unknown',
+            ],
+            type: 'line-length',
+          },
+        ],
+        output: dedent`
+          import { useUserStore } from '~/stores/userStore.ts'
+          import { useCartStore } from '~/stores/cartStore.ts'
+
+          import { getCart } from '~/services/cartService.ts'
+
+          import { connect } from '~/utils/ws.ts'
+          import { formattingDate } from '~/utils/dateTime.ts'
+
+          import { useFetch } from '~/composable/useFetch.ts'
+          import { useDebounce } from '~/composable/useDebounce.ts'
+          import { useMouseMove } from '~/composable/useMouseMove.ts'
+
+          import ComponentA from '~/components/ComponentA.vue'
+          import ComponentB from '~/components/ComponentB.vue'
+          import ComponentC from '~/components/ComponentC.vue'
+
+          import CartComponentA from './cart/CartComponentA.vue'
+          import CartComponentB from './cart/CartComponentB.vue'
+        `,
+        code: dedent`
+          import CartComponentA from './cart/CartComponentA.vue'
+          import CartComponentB from './cart/CartComponentB.vue'
+
+          import { connect } from '~/utils/ws.ts'
+          import { getCart } from '~/services/cartService.ts'
+
+          import { useUserStore } from '~/stores/userStore.ts'
+          import { formattingDate } from '~/utils/dateTime.ts'
+
+          import { useFetch } from '~/composable/useFetch.ts'
+          import { useCartStore } from '~/stores/cartStore.ts'
+          import { useDebounce } from '~/composable/useDebounce.ts'
+          import { useMouseMove } from '~/composable/useMouseMove.ts'
+
+          import ComponentA from '~/components/ComponentA.vue'
+          import ComponentB from '~/components/ComponentB.vue'
+          import ComponentC from '~/components/ComponentC.vue'
+        `,
+      })
+    })
+
+    it('treats empty named imports as regular imports not side-effects', async () => {
+      await valid({
+        code: dedent`
+          import {} from 'node:os'
+          import sqlite from 'node:sqlite'
+          import { describe, test } from 'node:test'
+          import { c } from 'c'
+          import 'node:os'
+        `,
+        options: [
+          {
+            groups: ['builtin', 'external', 'side-effect'],
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+    })
+
+    it('ignores dynamic require statements', async () => {
+      await valid({
+        code: dedent`
+          const path = require(path);
+          const myFileName = require('the-filename');
+          const file = require(path.join(myDir, myFileName));
+          const other = require('./other.js');
+        `,
+        options: [
+          {
+            groups: ['builtin', 'external', 'side-effect'],
+            newlinesBetween: 'never',
+          },
+        ],
+      })
+    })
+
+    describe('validates compatibility between sortSideEffects and groups configuration', () => {
+      function createRule(
+        groups: Options[0]['groups'],
+        sortSideEffects: boolean = false,
+      ): RuleListener {
+        return rule.create({
+          options: [
+            {
+              sortSideEffects,
+              groups,
+            },
+          ],
+        } as Readonly<RuleContext<MESSAGE_ID, Options>>)
+      }
+
+      let expectedThrownError =
+        "Side effect groups cannot be nested with non side effect groups when 'sortSideEffects' is 'false'."
+
+      it('throws error when side-effect group is nested with non-side-effect groups', () => {
+        expect(() =>
+          createRule(['external', ['side-effect', 'internal']]),
+        ).toThrow(expectedThrownError)
+      })
+
+      it('throws error when side-effect-style group is nested with non-side-effect groups', () => {
+        expect(() =>
+          createRule(['external', ['side-effect-style', 'internal']]),
+        ).toThrow(expectedThrownError)
+      })
+
+      it('throws error when mixed side-effect groups are nested with non-side-effect groups', () => {
+        expect(() =>
+          createRule([
+            'external',
+            ['side-effect-style', 'internal', 'side-effect'],
+          ]),
+        ).toThrow(expectedThrownError)
+      })
+
+      it('allows side-effect groups to be nested together', () => {
+        expect(() =>
+          createRule(['external', ['side-effect-style', 'side-effect']]),
+        ).not.toThrow(expectedThrownError)
+      })
+
+      it('allows any group nesting when sortSideEffects is enabled', () => {
+        expect(() =>
+          createRule(
+            ['external', ['side-effect-style', 'internal', 'side-effect']],
+            true,
+          ),
+        ).not.toThrow(expectedThrownError)
+      })
+    })
+
+    it('classifies TypeScript configured imports as internal', async () => {
+      await valid({
+        options: [
+          {
+            groups: ['internal', 'unknown'],
+            tsconfigRootDir: '.',
+          },
+        ],
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            baseUrl: './rules/',
+          })
+        },
+        code: dedent`
+          import { x } from 'sort-imports'
+
+          import { a } from './a';
+        `,
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('classifies package imports as external', async () => {
+      await valid({
+        options: [
+          {
+            groups: ['external', 'unknown'],
+            tsconfigRootDir: '.',
+          },
+        ],
+        code: dedent`
+          import type { ParsedCommandLine } from 'typescript'
+
+          import { a } from './a';
+        `,
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            baseUrl: '.',
+          })
+        },
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('treats unresolved imports as external by default', async () => {
+      await valid({
+        options: [
+          {
+            groups: ['external', 'unknown'],
+            tsconfigRootDir: '.',
+          },
+        ],
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            baseUrl: '.',
+          })
+        },
+        code: dedent`
+          import { b } from 'b'
+
+          import { a } from './a';
+        `,
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('falls back to basic classification when TypeScript is unavailable', async () => {
+      await valid({
+        before: () => {
+          vi.spyOn(
+            getTypescriptImportUtilities,
+            'getTypescriptImport',
+          ).mockReturnValue(null)
+        },
+        options: [
+          {
+            groups: ['external', 'unknown'],
+            tsconfigRootDir: '.',
+          },
+        ],
+        code: dedent`
+          import { b } from 'b'
+
+          import { a } from './a';
+        `,
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('classifies TypeScript configured imports as internal with tsconfig option', async () => {
+      await valid({
+        options: [
+          {
+            tsconfig: {
+              filename: 'tsconfig.json',
+              rootDir: '.',
+            },
+            groups: ['internal', 'unknown'],
+          },
+        ],
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            baseUrl: './rules/',
+          })
+        },
+        code: dedent`
+          import { x } from 'sort-imports'
+
+          import { a } from './a';
+        `,
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('classifies package imports as external with tsconfig option', async () => {
+      await valid({
+        options: [
+          {
+            tsconfig: {
+              filename: 'tsconfig.json',
+              rootDir: '.',
+            },
+            groups: ['external', 'unknown'],
+          },
+        ],
+        code: dedent`
+          import type { ParsedCommandLine } from 'typescript'
+
+          import { a } from './a';
+        `,
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            baseUrl: '.',
+          })
+        },
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('treats unresolved imports as external by default with tsconfig option', async () => {
+      await valid({
+        options: [
+          {
+            tsconfig: {
+              filename: 'tsconfig.json',
+              rootDir: '.',
+            },
+            groups: ['external', 'unknown'],
+          },
+        ],
+        before: () => {
+          mockReadClosestTsConfigByPathWith({
+            baseUrl: '.',
+          })
+        },
+        code: dedent`
+          import { b } from 'b'
+
+          import { a } from './a';
+        `,
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('falls back to basic classification when TypeScript is unavailable with tsconfig option', async () => {
+      await valid({
+        options: [
+          {
+            tsconfig: {
+              filename: 'tsconfig.json',
+              rootDir: '.',
+            },
+            groups: ['external', 'unknown'],
+          },
+        ],
+        before: () => {
+          vi.spyOn(
+            getTypescriptImportUtilities,
+            'getTypescriptImport',
+          ).mockReturnValue(null)
+        },
+        code: dedent`
+          import { b } from 'b'
+
+          import { a } from './a';
+        `,
+        after: () => {
+          vi.resetAllMocks()
+        },
+      })
+    })
+
+    it('respects ESLint disable comments when sorting imports', async () => {
+      await valid({
+        code: dedent`
+          import { b } from "./b"
+          import { c } from "./c"
+          // eslint-disable-next-line
+          import { a } from "./a"
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          // eslint-disable-next-line
+          import { a } from './a'
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          // eslint-disable-next-line
+          import { a } from './a'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './c',
+              left: './d',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+          {
+            data: {
+              right: './b',
+              left: './a',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          // eslint-disable-next-line
+          import { a } from './a'
+          import { d } from './d'
+        `,
+        code: dedent`
+          import { d } from './d'
+          import { c } from './c'
+          // eslint-disable-next-line
+          import { a } from './a'
+          import { b } from './b'
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          import { a } from './a' // eslint-disable-line
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          import { a } from './a' // eslint-disable-line
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          /* eslint-disable-next-line */
+          import { a } from './a'
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          /* eslint-disable-next-line */
+          import { a } from './a'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          import { a } from './a' /* eslint-disable-line */
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          import { a } from './a' /* eslint-disable-line */
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import { a } from './a'
+          import { d } from './d'
+          /* eslint-disable */
+          import { c } from './c'
+          import { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          import { e } from './e'
+        `,
+        code: dedent`
+          import { d } from './d'
+          import { e } from './e'
+          /* eslint-disable */
+          import { c } from './c'
+          import { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          import { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          // eslint-disable-next-line rule-to-test/sort-imports
+          import { a } from './a'
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          // eslint-disable-next-line rule-to-test/sort-imports
+          import { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          import { a } from './a' // eslint-disable-line rule-to-test/sort-imports
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          import { a } from './a' // eslint-disable-line rule-to-test/sort-imports
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          /* eslint-disable-next-line rule-to-test/sort-imports */
+          import { a } from './a'
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          /* eslint-disable-next-line rule-to-test/sort-imports */
+          import { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: './b',
+              left: './c',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { b } from './b'
+          import { c } from './c'
+          import { a } from './a' /* eslint-disable-line rule-to-test/sort-imports */
+        `,
+        code: dedent`
+          import { c } from './c'
+          import { b } from './b'
+          import { a } from './a' /* eslint-disable-line rule-to-test/sort-imports */
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import { a } from './a'
+          import { d } from './d'
+          /* eslint-disable rule-to-test/sort-imports */
+          import { c } from './c'
+          import { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          import { e } from './e'
+        `,
+        code: dedent`
+          import { d } from './d'
+          import { e } from './e'
+          /* eslint-disable rule-to-test/sort-imports */
+          import { c } from './c'
+          import { b } from './b'
+          // Shouldn't move
+          /* eslint-enable */
+          import { a } from './a'
+        `,
+        errors: [
+          {
+            data: {
+              right: './a',
+              left: './b',
+            },
+            messageId: 'unexpectedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+  })
 })

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1,5386 +1,2447 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
-
-import type { Options } from '../../rules/sort-interfaces'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-interfaces'
 
-let ruleName = 'sort-interfaces'
+describe('sort-interfaces', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-interfaces',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
-    let options: Options[0] = {
+  describe('alphabetical', () => {
+    let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface Interface {
-              a: string
-              b: 'b1' | 'b2',
-              c: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a: string
-              c: string
-              b: 'b1' | 'b2',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              a: string
-            }
-          `,
-          options: [options],
-        },
-        {
-          code: dedent`
-            interface Interface {
-              a: string
-              b: 'b1' | 'b2',
-              c: string
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with ts index signature`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key in Object]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [key in Object]: string
-                a: 'a'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: 'a'
-                [key in Object]: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                [key in Object]: string
-                a: 'a'
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts multi-word keys by value`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'b-b',
-                  right: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  left: 'd-d',
-                  right: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: Value
-                'b-b': string
-                c: string
-                'd-d': string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                'b-b': string
-                a: Value
-                'd-d': string
-                c: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                a: Value
-                'b-b': string
-                c: string
-                'd-d': string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with typescript index signature`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key: string]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [key: string]: string
-                a: string
-                b: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string
-                [key: string]: string
-                b: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                [key: string]: string
-                a: string
-                b: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with method and construct signatures`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: number
-                b: () => void
-                c(): number
-                d: string
-                e()
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                c(): number
-                a: number
-                b: () => void
-                e()
-                d: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                a: number
-                b: () => void
-                c(): number
-                d: string
-                e()
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with empty properties with empty values`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[...other]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: '[v in V]',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [...other]
-                [d in D]
-                [v in V]?
-                a: 10 | 20 | 30
-                b: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                [d in D]
-                a: 10 | 20 | 30
-                [...other]
-                b: string
-                [v in V]?
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                [...other]
-                [d in D]
-                [v in V]?
-                a: 10 | 20 | 30
-                b: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break interface docs`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                /**
-                 * Comment A
-                 */
-                a: string
-                /**
-                 * Comment B
-                 */
-                b: Array
-                /* Comment C */
-                c: string | number
-                // Comment D
-                d: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                /**
-                 * Comment B
-                 */
-                b: Array
-                /**
-                 * Comment A
-                 */
-                a: string
-                // Comment D
-                d: string
-                /* Comment C */
-                c: string | number
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts interfaces with comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: string | number // Comment A
-                b: string // Comment B
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string // Comment B
-                a: string | number // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts interfaces with semi and comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: 'aaa'; // Comment A
-                b: 'b'; // Comment B
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: 'b'; // Comment B
-                a: 'aaa'; // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort call signature declarations`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                <Parameters extends Record<string, number | string>>(
-                  input: AFunction<[Parameters], string>
-                ): Alternatives<Parameters>
-                <A extends CountA>(input: Input): AFunction<
-                  [number],
-                  A[keyof A]
-                >
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort constructor declarations`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                new (value: number | string): number;
-                new (value: number): unknown;
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              interface Interface {
-                new (value: number): unknown;
-                new (value: number | string): number;
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts complex predefined groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'required-property',
-                  rightGroup: 'index-signature',
-                  right: '[key: string]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'optional-multiline',
-                  leftGroup: 'index-signature',
-                  left: '[key: string]',
-                  right: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'optional-multiline',
-                  rightGroup: 'required-method',
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'unknown',
-                  'required-method',
-                  'optional-multiline',
-                  'index-signature',
-                  'required-property',
-                ],
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                c(): void
-                b?: {
-                  property: string;
-                }
-                [key: string]: string;
-                a: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string
-                [key: string]: string;
-                b?: {
-                  property: string;
-                }
-                c(): void
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): prioritize selectors over modifiers quantity`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'required-property',
-                  rightGroup: 'method',
-                  left: 'property',
-                  right: 'method',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                method(): void
-                property: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                property: string
-                method(): void
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['method', 'required-property'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): selectors priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize index-signature over multiline`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'index-signature',
-                    left: 'multilineProperty',
-                    right: '[key: string]',
-                    leftGroup: 'multiline',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  [key: string]: string;
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  multilineProperty: {
-                    a: string
-                  }
-                  [key: string]: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['index-signature', 'multiline'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize method over multiline`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: 'multilineProperty',
-                    leftGroup: 'multiline',
-                    rightGroup: 'method',
-                    right: 'method',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  method(): string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  multilineProperty: {
-                    a: string
-                  }
-                  method(): string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['method', 'multiline'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize multiline over property`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'multilineProperty',
-                    rightGroup: 'multiline',
-                    leftGroup: 'property',
-                    left: 'property',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  multilineProperty: {
-                    a: string
-                  }
-                  property: string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  property: string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['multiline', 'property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize property over member`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'property',
-                    leftGroup: 'member',
-                    right: 'property',
-                    left: 'method',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  property: string
-                  method(): string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  method(): string
-                  property: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property', 'member'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize multiline over optional`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'multiline-property',
-                    leftGroup: 'optional-property',
-                    right: 'multilineProperty',
-                    left: 'optionalProperty',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  multilineProperty: {
-                    a: string
-                  }
-                  optionalProperty?: string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  optionalProperty?: string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['multiline-property', 'optional-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize multiline over required`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'multiline-property',
-                    leftGroup: 'required-property',
-                    right: 'multilineProperty',
-                    left: 'requiredProperty',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  multilineProperty: {
-                    a: string
-                  }
-                  requiredProperty: string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  requiredProperty: string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['multiline-property', 'required-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'multiline',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'multiline',
-                  rightGroup: 'g',
-                  right: 'g',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                g: 'g'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                g: 'g'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  g: 'g',
-                },
-                groups: ['g', 'multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                g: 'g'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  g: 'g',
-                },
-                groups: ['g', 'multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector and modifiers`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'unusedCustomGroup',
-                    modifiers: ['optional'],
-                    selector: 'method',
-                  },
-                  {
-                    groupName: 'optionalPropertyGroup',
-                    modifiers: ['optional'],
-                    selector: 'property',
-                  },
-                  {
-                    groupName: 'propertyGroup',
-                    selector: 'property',
-                  },
-                ],
-                groups: ['propertyGroup', 'optionalPropertyGroup'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  leftGroup: 'optionalPropertyGroup',
-                  rightGroup: 'propertyGroup',
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                c: string
-                a?: string
-                b?: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a?: string
-                b?: string
-                c: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'propertiesStartingWithHello',
-                      selector: 'property',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['propertiesStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'propertiesStartingWithHello',
-                    right: 'helloProperty',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  helloProperty: string
-                  a: string
-                  b: string
-                  method(): void
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  a: string
-                  b: string
-                  method(): void
-                  helloProperty: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      for (let dateElementValuePattern of [
-        'Date',
-        ['noMatch', 'Date'],
-        { pattern: 'DATE', flags: 'i' },
-        ['noMatch', { pattern: 'DATE', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementValuePattern: dateElementValuePattern,
-                      groupName: 'date',
-                    },
-                    {
-                      elementValuePattern: 'number',
-                      groupName: 'number',
-                    },
-                  ],
-                  groups: ['number', 'date', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'number',
-                    leftGroup: 'date',
-                    right: 'z',
-                    left: 'y',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  a: number
-                  z: number
-                  b: Date
-                  y: Date
-                  c(): string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  a: number
-                  b: Date
-                  y: Date
-                  z: number
-                  c(): string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedPropertiesByLineLength',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                    right: 'eee',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedPropertiesByLineLength',
-                      selector: 'property',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedPropertiesByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  dddd: string
-                  ccc: string
-                  eee: string
-                  bb: string
-                  ff: string
-                  a: string
-                  g: string
-                  anotherMethod(): void
-                  method(): void
-                  yetAnotherMethod(): void
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  a: string
-                  bb: string
-                  ccc: string
-                  dddd: string
-                  method(): void
-                  eee: string
-                  ff: string
-                  g: string
-                  anotherMethod(): void
-                  yetAnotherMethod(): void
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  fooBar: string
-                  fooZar: string
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  fooZar: string
-                  fooBar: string
-                }
-              `,
-            },
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        sortBy: 'value',
-                      },
-                      elementValuePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  b: fooBar
-                  a: fooZar
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  a: fooZar
-                  b: fooBar
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'sortBy'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'fooElementsSortedByValue',
-                    leftGroup: 'unknown',
-                    right: 'fooC',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-                {
-                  data: {
-                    right: 'fooA',
-                    left: 'fooB',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'fooElementsSortedByValue',
-                    leftGroup: 'unknown',
-                    right: 'fooMethod',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'fooElementsSortedByValue',
-                      elementNamePattern: '^foo',
-                      sortBy: 'value',
-                    },
-                  ],
-                  groups: ['fooElementsSortedByValue', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  fooA: Date
-                  fooC: number
-                  fooB: string
-                  fooMethod(): void
-                  a: string
-                  z: boolean
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  z: boolean
-                  fooC: number
-                  fooB: string
-                  fooA: Date
-                  a: string
-                  fooMethod(): void
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedProperties',
-                      selector: 'property',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedProperties', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedProperties',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  b
-                  a
-                  d
-                  e
-                  c
-                  method(): void
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  b
-                  a
-                  d
-                  e
-                  method(): void
-                  c
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        modifiers: ['required'],
-                        selector: 'property',
-                      },
-                      {
-                        modifiers: ['optional'],
-                        selector: 'method',
-                      },
-                    ],
-                    groupName: 'requiredPropertiesAndOptionalMethods',
-                  },
-                ],
-                groups: [
-                  ['requiredPropertiesAndOptionalMethods', 'index-signature'],
-                  'unknown',
-                ],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'requiredPropertiesAndOptionalMethods',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-              {
-                data: {
-                  right: '[key: string]',
-                  left: 'e',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [key: string]: string
-                a: string
-                d?: () => void
-                e: string
-                b(): void
-                c?: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string
-                b(): void
-                c?: string
-                d?: () => void
-                e: string
-                [key: string]: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                interface Interface {
-                  iHaveFooInMyName: string
-                  meTooIHaveFoo: string
-                  a: string
-                  b: string
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe('newlinesInside', () => {
-        for (let newlinesInside of ['always', 1] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          selector: 'property',
-                          groupName: 'group1',
-                          newlinesInside,
-                        },
-                      ],
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'b',
-                        left: 'a',
-                      },
-                      messageId: 'missedSpacingBetweenInterfaceMembers',
-                    },
-                  ],
-                  output: dedent`
-                    interface Interface {
-                      a
-
-                      b
-                    }
-                  `,
-                  code: dedent`
-                    interface Interface {
-                      a
-                      b
-                    }
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-
-        for (let newlinesInside of ['never', 0] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          selector: 'property',
-                          groupName: 'group1',
-                          newlinesInside,
-                        },
-                      ],
-                      type: 'alphabetical',
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'b',
-                        left: 'a',
-                      },
-                      messageId: 'extraSpacingBetweenInterfaceMembers',
-                    },
-                  ],
-                  output: dedent`
-                    interface Interface {
-                      a
-                      b
-                    }
-                  `,
-                  code: dedent`
-                    interface Interface {
-                      a
-
-                      b
-                    }
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-      })
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  elementsWithoutFoo: '^(?!.*Foo).*$',
-                },
-                groups: ['unknown', 'elementsWithoutFoo'],
-              },
-            ],
-            code: dedent`
-              interface Interface {
-                  iHaveFooInMyName: string
-                  meTooIHaveFoo: string
-                  a: string
-                  b: string
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'e',
-                  left: 'f',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                e: 'eee'
-                f: 'ff'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                c: 'cc'
-                d: 'd'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                f: 'ff'
-                e: 'eee'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                d: 'd'
-                c: 'cc'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                e: 'eee'
-                f: 'ff'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                c: 'cc'
-                d: 'd'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface Interface {
-              a?: string
-              c?: string
-              d?: string
-              e?(): void
-              b: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a?: string
-              b: string
-              c?: string
-              d?: string
-              e?(): void
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'optional-first',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              a?: string
-              [index: number]: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'optional-first',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'unknown',
-                  leftGroup: 'last',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  last: 'a',
-                },
-                groups: ['unknown', 'last'],
-                groupKind: 'optional-first',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                c?: string
-                d?: string
-                b: string
-                e: string
-                a: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string
-                b: string
-                c?: string
-                d?: string
-                e: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              interface MyInterface {
-                // Part: A
-                // Not partition comment
-                bbb: string;
-                cc: string;
-                d: string;
-                // Part: B
-                aaaa: string;
-                e: string;
-                // Part: C
-                // Not partition comment
-                fff: string;
-                'gg': string;
-              }
-            `,
-            code: dedent`
-              interface MyInterface {
-                // Part: A
-                cc: string;
-                d: string;
-                // Not partition comment
-                bbb: string;
-                // Part: B
-                aaaa: string;
-                e: string;
-                // Part: C
-                'gg': string;
-                // Not partition comment
-                fff: string;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bbb',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'fff',
-                  left: 'gg',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface MyInterface {
-                // Comment
-                bb: string;
-                // Other comment
-                a: string;
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              interface MyInterface {
-                /* Partition Comment */
-                // Part: A
-                d: string;
-                // Part: B
-                aaa: string;
-                bb: string;
-                c: string;
-                /* Other */
-                e: string;
-              }
-            `,
-            code: dedent`
-              interface MyInterface {
-                /* Partition Comment */
-                // Part: A
-                d: string;
-                // Part: B
-                aaa: string;
-                c: string;
-                bb: string;
-                /* Other */
-                e: string;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for partition comments`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface MyInterface {
-                e: string,
-                f: string,
-                // I am a partition comment because I don't have f o o
-                a: string,
-                b: string,
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface MyInterface {
-                _a: string
-                b: string
-                _c: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  line: true,
-                },
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                /* Comment */
-                a: string
-                b: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string
-                /* Comment */
-                a: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              code: dedent`
-                interface Interface {
-                  b: string
-                  // Comment
-                  a: string
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                interface Interface {
-                  c: string
-                  // b
-                  b: string
-                  // a
-                  a: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['a', 'b'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                interface Interface {
-                  b: string
-                  // I am a partition comment because I don't have f o o
-                  a: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  block: true,
-                },
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                // Comment
-                a: string
-                b: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string
-                // Comment
-                a: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              code: dedent`
-                interface Interface {
-                  b: string
-                  /* Comment */
-                  a: string
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                interface Interface {
-                  c: string
-                  /* b */
-                  b: string
-                  /* a */
-                  a: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['a', 'b'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                interface Interface {
-                  b: string
-                  /* I am a partition comment because I don't have f o o */
-                  a: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface MyInterface {
-                ab: string
-                a_c: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            interface MyInterface {
-              你好: string
-              世界: string
-              a: string
-              A: string
-              b: string
-              B: string
-            }
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              b(): void
-              c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
-              a: string
-              d: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenInterfaceMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedInterfacePropertiesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenInterfaceMembers',
-                  },
-                ],
-                code: dedent`
-                  interface Interface {
-                    a: () => null,
-
-
-                   y: "y",
-                  z: "z",
-
-                      b: "b",
-                  }
-                `,
-                output: dedent`
-                  interface Interface {
-                    a: () => null,
-                   b: "b",
-                  y: "y",
-                      z: "z",
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    groups: ['method', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenInterfaceMembers',
-                  },
-                ],
-                output: dedent`
-                  interface Interface {
-                    a; 
-
-                  b;
-                  }
-                `,
-                code: dedent`
-                  interface Interface {
-                    a; b;
-                  }
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenInterfaceMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedInterfacePropertiesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenInterfaceMembers',
-                  },
-                ],
-                output: dedent`
-                  interface Interface {
-                    a: () => null,
-
-                   y: "y",
-                  z: "z",
-
-                      b: {
-                        // Newline stuff
-                      },
-                  }
-                `,
-                code: dedent`
-                  interface Interface {
-                    a: () => null,
-
-
-                   z: "z",
-                  y: "y",
-                      b: {
-                        // Newline stuff
-                      },
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    groups: ['method', 'unknown', 'multiline'],
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenInterfaceMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenInterfaceMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenInterfaceMembers',
-                  },
-                ],
-                output: dedent`
-                  interface Interface {
-                    a: string
-
-                    b: string
-
-                    c: string
-                    d: string
-
-
-                    e: string
-                  }
-                `,
-                code: dedent`
-                  interface Interface {
-                    a: string
-                    b: string
-
-
-                    c: string
-
-                    d: string
-
-
-                    e: string
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenInterfaceMembers',
-                      },
-                    ],
-                    output: dedent`
-                      interface Interface {
-                        a: string
-
-
-                        b: string
-                      }
-                    `,
-                    code: dedent`
-                      interface Interface {
-                        a: string
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
+    it('sorts interface properties', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: string
           }
+        `,
+        options: [options],
+      })
 
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenInterfaceMembers',
-                      },
-                    ],
-                    output: dedent`
-                      interface Interface {
-                        a: string
-                        b: string
-                      }
-                    `,
-                    code: dedent`
-                      interface Interface {
-                        a: string
-
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: string
+            b: 'b1' | 'b2',
+            c: string
           }
+        `,
+        options: [options],
+      })
 
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      interface Interface {
-                        a: string
-
-                        b: string
-                      }
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      interface Interface {
-                        a: string
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+            b: 'b1' | 'b2',
+            c: string
           }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  interface Interface {
-                    a: string // Comment after
-                    b: () => void
-
-                    c: () => void
-                  };
-                `,
-                dedent`
-                  interface Interface {
-                    a: string // Comment after
-
-                    b: () => void
-                    c: () => void
-                  };
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'property',
-                    leftGroup: 'method',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              code: dedent`
-                interface Interface {
-                  b: () => void
-                  a: string // Comment after
-
-                  c: () => void
-                };
-              `,
-              options: [
-                {
-                  groups: ['property', 'method'],
-                  newlinesBetween: 'always',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedInterfacePropertiesOrder',
-                  },
-                ],
-                output: dedent`
-                  interface Interface {
-                    a
-
-                    // Partition comment
-
-                    b
-                    c
-                  }
-                `,
-                code: dedent`
-                  interface Interface {
-                    a
-
-                    // Partition comment
-
-                    c
-                    b
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: string; b: string,
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string, a: string
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: string; b: string,
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string, a: string;
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: string, b: string,
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string, a: string,
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      for (let rgbAllNamesMatchPattern of [
-        '^r|g|b$',
-        ['noMatch', '^r|g|b$'],
-        { pattern: '^R|G|B$', flags: 'i' },
-        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'g',
-                      leftGroup: 'b',
-                      right: 'g',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'r',
-                      leftGroup: 'g',
-                      right: 'r',
-                      left: 'g',
-                    },
-                    messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    useConfigurationIf: {
-                      allNamesMatchPattern: 'foo',
-                    },
-                  },
-                  {
-                    ...options,
-                    customGroups: {
-                      r: 'r',
-                      g: 'g',
-                      b: 'b',
-                    },
-                    useConfigurationIf: {
-                      allNamesMatchPattern: rgbAllNamesMatchPattern,
-                    },
-                    groups: ['r', 'g', 'b'],
-                  },
-                ],
-                output: dedent`
-                  interface Interface {
-                    r: string
-                    g: string
-                    b: string
-                  }
-                `,
-                code: dedent`
-                  interface Interface {
-                    b: string
-                    g: string
-                    r: string
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): allows to use 'declarationMatchesPattern'`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): detects declaration name by pattern`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    useConfigurationIf: {
-                      declarationMatchesPattern: '^Interface$',
-                    },
-                    type: 'unsorted',
-                  },
-                  options,
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'a',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedInterfacePropertiesOrder',
-                  },
-                ],
-                output: dedent`
-                  interface OtherInterface {
-                    a: string
-                    b: string
-                  }
-                `,
-                code: dedent`
-                  interface OtherInterface {
-                    b: string
-                    a: string
-                  }
-                `,
-              },
-            ],
-            valid: [
-              {
-                options: [
-                  {
-                    useConfigurationIf: {
-                      declarationMatchesPattern: '^Interface$',
-                    },
-                    type: 'unsorted',
-                  },
-                  options,
-                ],
-                code: dedent`
-                  interface Interface {
-                    b: string
-                    c: string
-                    a: string
-                  }
-                `,
-              },
-            ],
-          },
-        )
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            c: string
+            b: 'b1' | 'b2',
+          }
+        `,
+        options: [options],
       })
     })
 
-    describe(`${ruleName}(${type}): sorting by value`, () => {
-      ruleTester.run(`${ruleName}(${type}): allows sorting by value`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                b: 'a'
-                a: 'b'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: 'b'
-                b: 'a'
-              }
-            `,
-            options: [
-              {
-                sortBy: 'value',
-                ...options,
-              },
-            ],
-          },
-        ],
-        valid: [],
+    it('works with ts index signature', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [key in Object]: string
+            a: 'a'
+          }
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}): does not enforce sorting of non-properties in the same group`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-                {
-                  data: {
-                    right: 'y',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  y: 'y'
-                  a(): void
-                  z: 'z'
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  z: 'z'
-                  a(): void
-                  y: 'y'
-                }
-              `,
-              options: [
-                {
-                  sortBy: 'value',
-                  ...options,
-                },
-              ],
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key in Object]',
+              left: 'a',
             },
-            {
-              errors: [
-                {
-                  data: {
-                    right: '[key: string]',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-                {
-                  data: {
-                    left: '[key: string]',
-                    right: 'y',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesOrder',
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  y: 'y'
-                  [key: string]
-                  z: 'z'
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  z: 'z'
-                  [key: string]
-                  y: 'y'
-                }
-              `,
-              options: [
-                {
-                  sortBy: 'value',
-                  ...options,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): enforces grouping but does not enforce sorting of non-properties`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'method',
-                    leftGroup: 'unknown',
-                    right: 'a',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedInterfacePropertiesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  sortBy: 'value',
-                  ...options,
-                  groups: ['method', 'unknown'],
-                },
-              ],
-              output: dedent`
-                interface Interface {
-                  b(): void
-                  a(): void
-                  z: 'z'
-                }
-              `,
-              code: dedent`
-                interface Interface {
-                  b(): void
-                  z: 'z'
-                  a(): void
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface Interface {
-              a: string
-              b: 'b1' | 'b2',
-              c: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a: string
-              c: string
-              b: 'b1' | 'b2',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              a: string
-              b: 'b1' | 'b2',
-              c: string
-            }
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key in Object]: string
+            a: 'a'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'a'
+            [key in Object]: string
+          }
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): works with ts index signature`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key in Object]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [key in Object]: string
-                a: 'a'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: 'a'
-                [key in Object]: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                [key in Object]: string
-                a: 'a'
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
+    it('sorts multi-word keys by value', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: Value
+            'b-b': string
+            c: string
+            'd-d': string
+          }
+        `,
+        options: [options],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts multi-word keys by value`,
-      rule,
-      {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  left: 'b-b',
-                  right: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  left: 'd-d',
-                  right: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: Value
-                'b-b': string
-                c: string
-                'd-d': string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                'b-b': string
-                a: Value
-                'd-d': string
-                c: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                a: Value
-                'b-b': string
-                c: string
-                'd-d': string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with typescript index signature`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key: string]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [key: string]: string
-                a: string
-                b: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string
-                [key: string]: string
-                b: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                [key: string]: string
-                a: string
-                b: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with method and construct signatures`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: number
-                b: () => void
-                c(): number
-                d: string
-                e()
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                c(): number
-                a: number
-                b: () => void
-                e()
-                d: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                a: number
-                b: () => void
-                c(): number
-                d: string
-                e()
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with empty properties with empty values`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[...other]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: '[v in V]',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [...other]
-                [d in D]
-                [v in V]?
-                a: 10 | 20 | 30
-                b: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                [d in D]
-                a: 10 | 20 | 30
-                [...other]
-                b: string
-                [v in V]?
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                [...other]
-                [d in D]
-                [v in V]?
-                a: 10 | 20 | 30
-                b: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break interface docs`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                /**
-                 * Comment A
-                 */
-                a: string
-                /**
-                 * Comment B
-                 */
-                b: Array
-                /* Comment C */
-                c: string | number
-                // Comment D
-                d: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                /**
-                 * Comment B
-                 */
-                b: Array
-                /**
-                 * Comment A
-                 */
-                a: string
-                // Comment D
-                d: string
-                /* Comment C */
-                c: string | number
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts interfaces with comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: string | number // Comment A
-                b: string // Comment B
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string // Comment B
-                a: string | number // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts interfaces with semi and comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: 'aaa'; // Comment A
-                b: 'b'; // Comment B
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: 'b'; // Comment B
-                a: 'aaa'; // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort call signature declarations`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                <Parameters extends Record<string, number | string>>(
-                  input: AFunction<[Parameters], string>
-                ): Alternatives<Parameters>
-                <A extends CountA>(input: Input): AFunction<
-                  [number],
-                  A[keyof A]
-                >
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'e',
-                  left: 'f',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                e: 'eee'
-                f: 'ff'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                c: 'cc'
-                d: 'd'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                f: 'ff'
-                e: 'eee'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                d: 'd'
-                c: 'cc'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                e: 'eee'
-                f: 'ff'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                c: 'cc'
-                d: 'd'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            data: {
+              left: 'b-b',
+              right: 'a',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a?: string
-              c?: string
-              d?: string
-              e?(): void
-              b: string
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              left: 'd-d',
+              right: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: Value
+            'b-b': string
+            c: string
+            'd-d': string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            'b-b': string
+            a: Value
+            'd-d': string
+            c: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with typescript index signature', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            b: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            [key: string]: string
+            b: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with method and construct signatures', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: number
+            b: () => void
+            c(): number
+            d: string
+            e()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: number
+            b: () => void
+            c(): number
+            d: string
+            e()
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c(): number
+            a: number
+            b: () => void
+            e()
+            d: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with empty properties with empty values', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [...other]
+            [d in D]
+            [v in V]?
+            a: 10 | 20 | 30
+            b: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[...other]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: '[v in V]',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [...other]
+            [d in D]
+            [v in V]?
+            a: 10 | 20 | 30
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            [d in D]
+            a: 10 | 20 | 30
+            [...other]
+            b: string
+            [v in V]?
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not break interface docs', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            /**
+             * Comment A
+             */
+            a: string
+            /**
+             * Comment B
+             */
+            b: Array
+            /* Comment C */
+            c: string | number
+            // Comment D
+            d: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            /**
+             * Comment B
+             */
+            b: Array
+            /**
+             * Comment A
+             */
+            a: string
+            // Comment D
+            d: string
+            /* Comment C */
+            c: string | number
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts interfaces with comments on the same line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string | number // Comment A
+            b: string // Comment B
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string // Comment B
+            a: string | number // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts interfaces with semi and comments on the same line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: 'aaa'; // Comment A
+            b: 'b'; // Comment B
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: 'b'; // Comment B
+            a: 'aaa'; // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort call signature declarations', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            <Parameters extends Record<string, number | string>>(
+              input: AFunction<[Parameters], string>
+            ): Alternatives<Parameters>
+            <A extends CountA>(input: Input): AFunction<
+              [number],
+              A[keyof A]
+            >
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort constructor declarations', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            new (value: number | string): number;
+            new (value: number): unknown;
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          interface Interface {
+            new (value: number): unknown;
+            new (value: number | string): number;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts complex predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'index-signature',
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'optional-multiline',
+              leftGroup: 'index-signature',
+              left: '[key: string]',
+              right: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'optional-multiline',
+              rightGroup: 'required-method',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'required-method',
+              'optional-multiline',
+              'index-signature',
+              'required-property',
+            ],
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c(): void
+            b?: {
+              property: string;
             }
-          `,
-          code: dedent`
-            interface Interface {
-              a?: string
-              b: string
-              c?: string
-              d?: string
-              e?(): void
+            [key: string]: string;
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            [key: string]: string;
+            b?: {
+              property: string;
             }
-          `,
+            c(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritize selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'method',
+              left: 'property',
+              right: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            method(): void
+            property: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            property: string
+            method(): void
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes index-signature over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'index-signature',
+              left: 'multilineProperty',
+              right: '[key: string]',
+              leftGroup: 'multiline',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string;
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            [key: string]: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['index-signature', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes method over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            method(): string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            method(): string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'multilineProperty',
+              rightGroup: 'multiline',
+              leftGroup: 'property',
+              left: 'property',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            property: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            property: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes property over member', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            property: string
+            method(): string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            method(): string
+            property: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over optional', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'optional-property',
+              right: 'multilineProperty',
+              left: 'optionalProperty',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            optionalProperty?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            optionalProperty?: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'optional-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over required', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'required-property',
+              right: 'multilineProperty',
+              left: 'requiredProperty',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            requiredProperty: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            requiredProperty: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'multiline',
+              rightGroup: 'g',
+              right: 'g',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            g: 'g'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('filters on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['optional'],
+                selector: 'method',
+              },
+              {
+                groupName: 'optionalPropertyGroup',
+                modifiers: ['optional'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'optionalPropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'optionalPropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c: string
+            a?: string
+            b?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a?: string
+            b?: string
+            c: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['array with regex', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'filters on elementNamePattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
           options: [
             {
-              ...options,
-              groupKind: 'optional-first',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              a?: string
-              [index: number]: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'optional-first',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              interface MyInterface {
-                // Part: A
-                // Not partition comment
-                bbb: boolean;
-                cc: string;
-                d: string;
-                // Part: B
-                aaaa: string;
-                e: string;
-                // Part: C
-                // Not partition comment
-                fff: string;
-                'gg': string;
-              }
-            `,
-            code: dedent`
-              interface MyInterface {
-                // Part: A
-                cc: string;
-                d: string;
-                // Not partition comment
-                bbb: boolean;
-                // Part: B
-                aaaa: string;
-                e: string;
-                // Part: C
-                'gg': string;
-                // Not partition comment
-                fff: string;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bbb',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'fff',
-                  left: 'gg',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface MyInterface {
-                // Comment
-                bb: string;
-                // Other comment
-                a: string;
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              interface MyInterface {
-                /* Partition Comment */
-                // Part: A
-                d: string;
-                // Part: B
-                aaa: string;
-                bb: string;
-                c: string;
-                /* Other */
-                e: string;
-              }
-            `,
-            code: dedent`
-              interface MyInterface {
-                /* Partition Comment */
-                // Part: A
-                d: string;
-                // Part: B
-                aaa: string;
-                c: string;
-                bb: string;
-                /* Other */
-                e: string;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              b(): void
-              c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
-              a: string
-              d: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface Interface {
-              a: string
-              b: 'b1' | 'b2',
-              c: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a: string
-              c: string
-              b: 'b1' | 'b2',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              a: string
-            }
-          `,
-          options: [options],
-        },
-        {
-          code: dedent`
-            interface Interface {
-              a: string
-              b: 'b1' | 'b2',
-              c: string
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface Interface {
-              b: 'b1' | 'b2',
-              a: string
-              c: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a: string
-              c: string
-              b: 'b1' | 'b2',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              b: 'b1' | 'b2',
-              a: string
-              c: string
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): takes into account the presence of an optional operator`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                b?: string
-                a: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string
-                b?: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                a: string
-                b: string
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              interface Interface {
-                b: string
-                a: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with ts index signature`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key in Object]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                [key in Object]: string
-                a: 'a'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: 'a'
-                [key in Object]: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                [key in Object]: string
-                a: 'a'
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with method and construct signatures`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'c',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                b: () => void
-                c(): number
-                d: string
-                a: number
-                e()
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: () => void
-                d: string
-                a: number
-                c(): number
-                e()
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                b: () => void
-                c(): number
-                a: number
-                d: string
-                e()
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with empty properties with empty values`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '[d in D]',
-                  right: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: 10 | 20 | 30
-                [...other]
-                b: string
-                [v in V]?
-                [d in D]
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                [d in D]
-                a: 10 | 20 | 30
-                [...other]
-                b: string
-                [v in V]?
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                a: 10 | 20 | 30
-                [...other]
-                [v in V]?
-                b: string
-                [d in D]
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break interface docs`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                /* Comment C */
-                c: string | number
-                /**
-                 * Comment A
-                 */
-                a: string
-                // Comment D
-                d: string
-                /**
-                 * Comment B
-                 */
-                b: Array
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                /**
-                 * Comment B
-                 */
-                b: Array
-                /**
-                 * Comment A
-                 */
-                a: string
-                // Comment D
-                d: string
-                /* Comment C */
-                c: string | number
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts interfaces with comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: string | number // Comment A
-                b: string // Comment B
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string // Comment B
-                a: string | number // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts interfaces with semi and comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: 'aaa'; // Comment A
-                b: 'b'; // Comment B
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: 'b'; // Comment B
-                a: 'aaa'; // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort call signature declarations`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                <Parameters extends Record<string, number | string>>(
-                  input: AFunction<[Parameters], string>
-                ): Alternatives<Parameters>
-                <A extends CountA>(input: Input): AFunction<
-                  [number],
-                  A[keyof A]
-                >
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'multiline',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'multiline',
-                  rightGroup: 'g',
-                  right: 'g',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesGroupOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                g: 'g'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                g: 'g'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  g: 'g',
-                },
-                groups: ['g', 'multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                g: 'g'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  g: 'g',
-                },
-                groups: ['g', 'multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'e',
-                  left: 'f',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                e: 'eee'
-                f: 'ff'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                c: 'cc'
-                d: 'd'
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                f: 'ff'
-                e: 'eee'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                d: 'd'
-                c: 'cc'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              interface Interface {
-                e: 'eee'
-                f: 'ff'
-                g: 'g'
-
-                a: 'aaa'
-
-                b?: 'bbb'
-                c: 'cc'
-                d: 'd'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface Interface {
-              a?: string
-              c?: string
-              d?: string
-              e?(): void
-              b: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a?: string
-              b: string
-              c?: string
-              d?: string
-              e?(): void
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'optional-first',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              a?: string
-              [index: number]: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'optional-first',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: 'backgroundColor',
-                right: 'label',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-            {
-              data: {
-                left: 'primary',
-                right: 'size',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface ButtonProps {
-              label: string
-              size?: 'large' | 'medium' | 'small'
-              backgroundColor?: string
-              primary?: boolean
-              onClick?(): void
-            }
-          `,
-          code: dedent`
-            interface ButtonProps {
-              backgroundColor?: string
-              label: string
-              primary?: boolean
-              size?: 'large' | 'medium' | 'small'
-              onClick?(): void
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'required-first',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            interface X {
-              [index: number]: string
-              a?: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'required-first',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'backgroundColor',
-                  right: 'label',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  left: 'primary',
-                  right: 'size',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface ButtonProps {
-                label: string
-                size?: 'large' | 'medium' | 'small'
-                backgroundColor?: string
-                primary?: boolean
-                onClick?(): void
-              }
-            `,
-            code: dedent`
-              interface ButtonProps {
-                backgroundColor?: string
-                label: string
-                primary?: boolean
-                size?: 'large' | 'medium' | 'small'
-                onClick?(): void
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  callback: '^on.+',
-                },
-                groups: ['unknown', 'callback'],
-                groupKind: 'required-first',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'firstName',
-                  right: 'id',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'password',
-                  left: 'lastName',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-              {
-                data: {
-                  right: 'createdAt',
-                  left: 'avatarUrl',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface User {
-                password: string
-                username: string
-                email: string
-                id: number
-                firstName?: string
-                lastName?: string
-
-                createdAt: Date
-                updatedAt: Date
-                biography?: string
-                avatarUrl?: string
-              }
-            `,
-            code: dedent`
-              interface User {
-                email: string
-                firstName?: string
-                id: number
-                lastName?: string
-                password: string
-                username: string
-
-                biography?: string
-                avatarUrl?: string
-                createdAt: Date
-                updatedAt: Date
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'required-first',
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              interface MyInterface {
-                // Part: A
-                // Not partition comment
-                bbb: string;
-                cc: string;
-                d: string;
-                // Part: B
-                aaaa: string;
-                e: string;
-                // Part: C
-                'gg': string;
-                // Not partition comment
-                fff: string;
-              }
-            `,
-            code: dedent`
-              interface MyInterface {
-                // Part: A
-                cc: string;
-                d: string;
-                // Not partition comment
-                bbb: string;
-                // Part: B
-                aaaa: string;
-                e: string;
-                // Part: C
-                'gg': string;
-                // Not partition comment
-                fff: string;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bbb',
-                  left: 'd',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface MyInterface {
-                // Comment
-                bb: string;
-                // Other comment
-                a: string;
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              interface MyInterface {
-                /* Partition Comment */
-                // Part: A
-                d: string;
-                // Part: B
-                aaa: string;
-                bb: string;
-                c: string;
-                /* Other */
-                e: string;
-              }
-            `,
-            code: dedent`
-              interface MyInterface {
-                /* Partition Comment */
-                // Part: A
-                d: string;
-                // Part: B
-                aaa: string;
-                c: string;
-                bb: string;
-                /* Other */
-                e: string;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
-              b(): void
-              a: string
-              d: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                bb: string;
-                c: string;
-                a: string;
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                a: string;
-                bb: string;
-                c: string;
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                bb: string;
-                a: string;
-                c: string;
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                c: string;
-                bb: string;
-                a: string;
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  sortBy: 'value',
-                },
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                bb: string;
-                c: boolean;
-                a: number;
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                c: boolean;
-                bb: string;
-                a: number;
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            interface Interface {
-              b: string;
-              c: string;
-              a: string;
-            }
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
               customGroups: [
                 {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
                 },
               ],
-              groups: ['b', 'a'],
+              groups: ['propertiesStartingWithHello', 'unknown'],
             },
           ],
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
               },
               messageId: 'unexpectedInterfacePropertiesGroupOrder',
             },
           ],
           output: dedent`
             interface Interface {
-              ba: string
-              bb: string
-              ab: string
-              aa: string
+              helloProperty: string
+              a: string
+              b: string
+              method(): void
             }
           `,
           code: dedent`
             interface Interface {
-              ab: string
-              aa: string
-              ba: string
-              bb: string
+              a: string
+              b: string
+              method(): void
+              helloProperty: string
             }
           `,
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Date'],
+      ['array with string pattern', ['noMatch', 'Date']],
+      ['case-insensitive regex', { pattern: 'DATE', flags: 'i' }],
+      ['array with regex', ['noMatch', { pattern: 'DATE', flags: 'i' }]],
+    ])(
+      'filters on elementValuePattern - %s',
+      async (_description, dateElementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: dateElementValuePattern,
+                  groupName: 'date',
+                },
+                {
+                  elementValuePattern: 'number',
+                  groupName: 'number',
+                },
+              ],
+              groups: ['number', 'date', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'number',
+                leftGroup: 'date',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: number
+              z: number
+              b: Date
+              y: Date
+              c(): string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: number
+              b: Date
+              y: Date
+              z: number
+              c(): string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            dddd: string
+            ccc: string
+            eee: string
+            bb: string
+            ff: string
+            a: string
+            g: string
+            anotherMethod(): void
+            method(): void
+            yetAnotherMethod(): void
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            bb: string
+            ccc: string
+            dddd: string
+            method(): void
+            eee: string
+            ff: string
+            g: string
+            anotherMethod(): void
+            yetAnotherMethod(): void
+          }
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                elementValuePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: fooBar
+            a: fooZar
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: fooZar
+            b: fooBar
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding sortBy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooC',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: 'fooA',
+              left: 'fooB',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooMethod',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'fooElementsSortedByValue',
+                elementNamePattern: '^foo',
+                sortBy: 'value',
+              },
+            ],
+            groups: ['fooElementsSortedByValue', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            fooA: Date
+            fooC: number
+            fooB: string
+            fooMethod(): void
+            a: string
+            z: boolean
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: boolean
+            fooC: number
+            fooB: string
+            fooA: Date
+            a: string
+            fooMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b
+            a
+            d
+            e
+            c
+            method(): void
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b
+            a
+            d
+            e
+            method(): void
+            c
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['required'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['optional'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'requiredPropertiesAndOptionalMethods',
+              },
+            ],
+            groups: [
+              ['requiredPropertiesAndOptionalMethods', 'index-signature'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'requiredPropertiesAndOptionalMethods',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: '[key: string]',
+              left: 'e',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            d?: () => void
+            e: string
+            b(): void
+            c?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b(): void
+            c?: string
+            d?: () => void
+            e: string
+            [key: string]: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always'],
+      ['1', 1],
+    ] as const)(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a
+
+              b
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows to use regex for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          interface Interface {
+              iHaveFooInMyName: string
+              meTooIHaveFoo: string
+              a: string
+              b: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            e: 'eee'
+            f: 'ff'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            c: 'cc'
+            d: 'd'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e',
+              left: 'f',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            e: 'eee'
+            f: 'ff'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            c: 'cc'
+            d: 'd'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            f: 'ff'
+            e: 'eee'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            d: 'd'
+            c: 'cc'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('sorts interface properties with group kind', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a?: string
+            [index: number]: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a?: string
+            c?: string
+            d?: string
+            e?(): void
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a?: string
+            b: string
+            c?: string
+            d?: string
+            e?(): void
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting with group kind', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'last',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: {
+              last: 'a',
+            },
+            groups: ['unknown', 'last'],
+            groupKind: 'optional-first',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c?: string
+            d?: string
+            b: string
+            e: string
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b: string
+            c?: string
+            d?: string
+            e: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          interface MyInterface {
+            // Part: A
+            // Not partition comment
+            bbb: string;
+            cc: string;
+            d: string;
+            // Part: B
+            aaaa: string;
+            e: string;
+            // Part: C
+            // Not partition comment
+            fff: string;
+            'gg': string;
+          }
+        `,
+        code: dedent`
+          interface MyInterface {
+            // Part: A
+            cc: string;
+            d: string;
+            // Not partition comment
+            bbb: string;
+            // Part: B
+            aaaa: string;
+            e: string;
+            // Part: C
+            'gg': string;
+            // Not partition comment
+            fff: string;
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            // Comment
+            bb: string;
+            // Other comment
+            a: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          interface MyInterface {
+            /* Partition Comment */
+            // Part: A
+            d: string;
+            // Part: B
+            aaa: string;
+            bb: string;
+            c: string;
+            /* Other */
+            e: string;
+          }
+        `,
+        code: dedent`
+          interface MyInterface {
+            /* Partition Comment */
+            // Part: A
+            d: string;
+            // Part: B
+            aaa: string;
+            c: string;
+            bb: string;
+            /* Other */
+            e: string;
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            e: string,
+            f: string,
+            // I am a partition comment because I don't have f o o
+            a: string,
+            b: string,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            _a: string
+            b: string
+            _c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when using line partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            /* Comment */
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all line comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple line partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            c: string
+            // b
+            b: string
+            // a
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for line partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string
+            // I am a partition comment because I don't have f o o
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            // Comment
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all block comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple block partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            c: string
+            /* b */
+            b: string
+            /* a */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for block partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string
+            /* I am a partition comment because I don't have f o o */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            ab: string
+            a_c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            你好: string
+            世界: string
+            a: string
+            A: string
+            b: string
+            B: string
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('allows to use method group', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b(): void
+            c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
+            a: string
+            d: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedInterfacePropertiesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: () => null,
+
+
+             y: "y",
+            z: "z",
+
+                b: "b",
+            }
+          `,
+          output: dedent`
+            interface Interface {
+              a: () => null,
+             b: "b",
+            y: "y",
+                z: "z",
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines when global option is %s and group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: string
+
+
+              b: string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'],
+      ['ignore', 0],
+      ['never', 'ignore'],
+      [0, 'ignore'],
+    ] as const)(
+      'does not enforce newline when global option is %s and group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string // Comment after
+
+            b: () => void
+            c: () => void
+          };
+        `,
+        code: dedent`
+          interface Interface {
+            b: () => void
+            a: string // Comment after
+
+            c: () => void
+          };
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
@@ -5389,223 +2450,2832 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedInterfacePropertiesOrder',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a
+
+              // Partition comment
+
+              b
+              c
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a
+
+              // Partition comment
+
+              c
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, a: string;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string, b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, a: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['^r|g|b$', '^r|g|b$'],
+      ['array with ^r|g|b$', ['noMatch', '^r|g|b$']],
+      ['pattern with flags', { pattern: '^R|G|B$', flags: 'i' }],
+      [
+        'array with pattern and flags',
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ],
+    ])(
+      'allows to use allNamesMatchPattern with %s',
+      async (_description, rgbAllNamesMatchPattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
                 left: 'b',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              r: string
+              g: string
+              b: string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              b: string
+              g: string
+              r: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('detects declaration name by pattern', async () => {
+      await valid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Interface$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            c: string
+            a: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Interface$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface OtherInterface {
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface OtherInterface {
+            b: string
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows sorting by value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: 'a'
+            a: 'b'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'b'
+            b: 'a'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('does not enforce sorting of non-properties in the same group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            y: 'y'
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: 'z'
+            a(): void
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              left: '[key: string]',
+              right: 'y',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            y: 'y'
+            [key: string]
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: 'z'
+            [key: string]
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('enforces grouping but does not enforce sorting of non-properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'method',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b(): void
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b(): void
+            z: 'z'
+            a(): void
+          }
+        `,
+      })
+    })
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts interface properties', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: string
+            b: 'b1' | 'b2',
+            c: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+            b: 'b1' | 'b2',
+            c: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            c: string
+            b: 'b1' | 'b2',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with ts index signature', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [key in Object]: string
+            a: 'a'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key in Object]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key in Object]: string
+            a: 'a'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'a'
+            [key in Object]: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts multi-word keys by value', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: Value
+            'b-b': string
+            c: string
+            'd-d': string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'b-b',
+              right: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              left: 'd-d',
+              right: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: Value
+            'b-b': string
+            c: string
+            'd-d': string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            'b-b': string
+            a: Value
+            'd-d': string
+            c: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with typescript index signature', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            b: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            [key: string]: string
+            b: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with method and construct signatures', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: number
+            b: () => void
+            c(): number
+            d: string
+            e()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: number
+            b: () => void
+            c(): number
+            d: string
+            e()
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c(): number
+            a: number
+            b: () => void
+            e()
+            d: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with empty properties with empty values', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [...other]
+            [d in D]
+            [v in V]?
+            a: 10 | 20 | 30
+            b: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[...other]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: '[v in V]',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [...other]
+            [d in D]
+            [v in V]?
+            a: 10 | 20 | 30
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            [d in D]
+            a: 10 | 20 | 30
+            [...other]
+            b: string
+            [v in V]?
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not break interface docs', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            /**
+             * Comment A
+             */
+            a: string
+            /**
+             * Comment B
+             */
+            b: Array
+            /* Comment C */
+            c: string | number
+            // Comment D
+            d: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            /**
+             * Comment B
+             */
+            b: Array
+            /**
+             * Comment A
+             */
+            a: string
+            // Comment D
+            d: string
+            /* Comment C */
+            c: string | number
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts interfaces with comments on the same line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string | number // Comment A
+            b: string // Comment B
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string // Comment B
+            a: string | number // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts interfaces with semi and comments on the same line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: 'aaa'; // Comment A
+            b: 'b'; // Comment B
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: 'b'; // Comment B
+            a: 'aaa'; // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort call signature declarations', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            <Parameters extends Record<string, number | string>>(
+              input: AFunction<[Parameters], string>
+            ): Alternatives<Parameters>
+            <A extends CountA>(input: Input): AFunction<
+              [number],
+              A[keyof A]
+            >
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort constructor declarations', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            new (value: number | string): number;
+            new (value: number): unknown;
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          interface Interface {
+            new (value: number): unknown;
+            new (value: number | string): number;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts complex predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'index-signature',
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'optional-multiline',
+              leftGroup: 'index-signature',
+              left: '[key: string]',
+              right: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'optional-multiline',
+              rightGroup: 'required-method',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'required-method',
+              'optional-multiline',
+              'index-signature',
+              'required-property',
+            ],
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c(): void
+            b?: {
+              property: string;
+            }
+            [key: string]: string;
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            [key: string]: string;
+            b?: {
+              property: string;
+            }
+            c(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritize selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'method',
+              left: 'property',
+              right: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            method(): void
+            property: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            property: string
+            method(): void
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes index-signature over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'index-signature',
+              left: 'multilineProperty',
+              right: '[key: string]',
+              leftGroup: 'multiline',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string;
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            [key: string]: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['index-signature', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes method over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            method(): string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            method(): string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'multilineProperty',
+              rightGroup: 'multiline',
+              leftGroup: 'property',
+              left: 'property',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            property: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            property: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes property over member', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            property: string
+            method(): string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            method(): string
+            property: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over optional', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'optional-property',
+              right: 'multilineProperty',
+              left: 'optionalProperty',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            optionalProperty?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            optionalProperty?: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'optional-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over required', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'required-property',
+              right: 'multilineProperty',
+              left: 'requiredProperty',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            requiredProperty: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            requiredProperty: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'multiline',
+              rightGroup: 'g',
+              right: 'g',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            g: 'g'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('filters on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['optional'],
+                selector: 'method',
+              },
+              {
+                groupName: 'optionalPropertyGroup',
+                modifiers: ['optional'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'optionalPropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'optionalPropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c: string
+            a?: string
+            b?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a?: string
+            b?: string
+            c: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['array with regex', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'filters on elementNamePattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              helloProperty: string
+              a: string
+              b: string
+              method(): void
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+              method(): void
+              helloProperty: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Date'],
+      ['array with string pattern', ['noMatch', 'Date']],
+      ['case-insensitive regex', { pattern: 'DATE', flags: 'i' }],
+      ['array with regex', ['noMatch', { pattern: 'DATE', flags: 'i' }]],
+    ])(
+      'filters on elementValuePattern - %s',
+      async (_description, dateElementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: dateElementValuePattern,
+                  groupName: 'date',
+                },
+                {
+                  elementValuePattern: 'number',
+                  groupName: 'number',
+                },
+              ],
+              groups: ['number', 'date', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'number',
+                leftGroup: 'date',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: number
+              z: number
+              b: Date
+              y: Date
+              c(): string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: number
+              b: Date
+              y: Date
+              z: number
+              c(): string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            dddd: string
+            ccc: string
+            eee: string
+            bb: string
+            ff: string
+            a: string
+            g: string
+            anotherMethod(): void
+            method(): void
+            yetAnotherMethod(): void
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            bb: string
+            ccc: string
+            dddd: string
+            method(): void
+            eee: string
+            ff: string
+            g: string
+            anotherMethod(): void
+            yetAnotherMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                elementValuePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: fooBar
+            a: fooZar
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: fooZar
+            b: fooBar
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding sortBy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooC',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: 'fooA',
+              left: 'fooB',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooMethod',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'fooElementsSortedByValue',
+                elementNamePattern: '^foo',
+                sortBy: 'value',
+              },
+            ],
+            groups: ['fooElementsSortedByValue', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            fooA: Date
+            fooC: number
+            fooB: string
+            fooMethod(): void
+            a: string
+            z: boolean
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: boolean
+            fooC: number
+            fooB: string
+            fooA: Date
+            a: string
+            fooMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b
+            a
+            d
+            e
+            c
+            method(): void
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b
+            a
+            d
+            e
+            method(): void
+            c
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['required'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['optional'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'requiredPropertiesAndOptionalMethods',
+              },
+            ],
+            groups: [
+              ['requiredPropertiesAndOptionalMethods', 'index-signature'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'requiredPropertiesAndOptionalMethods',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: '[key: string]',
+              left: 'e',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            d?: () => void
+            e: string
+            b(): void
+            c?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b(): void
+            c?: string
+            d?: () => void
+            e: string
+            [key: string]: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always'],
+      ['1', 1],
+    ] as const)(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenInterfaceMembers',
             },
           ],
           output: dedent`
             interface Interface {
-              b: string
+              a
 
-              a: string
+              b
             }
           `,
           code: dedent`
             interface Interface {
-              b: string
-              a: string
+              a
+              b
             }
           `,
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: validating group configuration`, () => {
-    ruleTester.run(
-      `${ruleName}: allows predefined groups and defined custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                customGroups: {
-                  myCustomGroup: 'x',
-                },
-                groups: ['multiline', 'unknown', 'myCustomGroup'],
-              },
-            ],
-            code: dedent`
-              interface Interface {
-                a: string
-                b: 'b1' | 'b2',
-                c: string
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: misc`, () => {
-    it('validates the JSON schema', async () => {
-      await expect(
-        validateRuleJsonSchema(rule.meta.schema),
-      ).resolves.not.toThrow()
-    })
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedInterfacePropertiesOrder',
-              },
-            ],
-            output: dedent`
-              interface Interface {
-                a: string
-                b: string
-              }
-            `,
-            code: dedent`
-              interface Interface {
-                b: string
-                a: string
-              }
-            `,
-          },
-        ],
-        valid: [
-          dedent`
-            interface Interface {
-              a: string
-              b: string
-            }
-          `,
-          {
-            code: dedent`
-              interface Calculator {
-                log: (x: number) => number,
-                log10: (x: number) => number,
-                log1p: (x: number) => number,
-                log2: (x: number) => number,
-              }
-            `,
-            options: [{}],
-          },
-        ],
+        })
       },
     )
 
-    ruleTester.run(`${ruleName}: allows to ignore interfaces`, rule, {
-      valid: [
-        {
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
           options: [
             {
-              ignorePattern: ['Ignore'],
-              type: 'line-length',
-              order: 'desc',
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
             },
           ],
-          code: dedent`
-            interface IgnoreInterface {
-              b: 'b'
-              a: 'aaa'
-            }
-          `,
-        },
-      ],
-      invalid: [],
-    })
-
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
           errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
-          ],
-          output: dedent`
-            interface Interface {
-              b: string
-              c: string
-              // eslint-disable-next-line
-              a: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              c: string
-              b: string
-              // eslint-disable-next-line
-              a: string
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
-            },
             {
               data: {
                 right: 'b',
                 left: 'a',
               },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+              messageId: 'extraSpacingBetweenInterfaceMembers',
             },
           ],
           output: dedent`
             interface Interface {
-              b: string
-              c: string
-              // eslint-disable-next-line
-              a: string
-              d: string
+              a
+              b
             }
           `,
           code: dedent`
             interface Interface {
-              d: string
-              c: string
-              // eslint-disable-next-line
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows to use regex for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          interface Interface {
+              iHaveFooInMyName: string
+              meTooIHaveFoo: string
               a: string
               b: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            e: 'eee'
+            f: 'ff'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            c: 'cc'
+            d: 'd'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e',
+              left: 'f',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            e: 'eee'
+            f: 'ff'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            c: 'cc'
+            d: 'd'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            f: 'ff'
+            e: 'eee'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            d: 'd'
+            c: 'cc'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('sorts interface properties with group kind', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a?: string
+            [index: number]: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a?: string
+            c?: string
+            d?: string
+            e?(): void
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a?: string
+            b: string
+            c?: string
+            d?: string
+            e?(): void
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting with group kind', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'last',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: {
+              last: 'a',
+            },
+            groups: ['unknown', 'last'],
+            groupKind: 'optional-first',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c?: string
+            d?: string
+            b: string
+            e: string
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b: string
+            c?: string
+            d?: string
+            e: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          interface MyInterface {
+            // Part: A
+            // Not partition comment
+            bbb: string;
+            cc: string;
+            d: string;
+            // Part: B
+            aaaa: string;
+            e: string;
+            // Part: C
+            // Not partition comment
+            fff: string;
+            'gg': string;
+          }
+        `,
+        code: dedent`
+          interface MyInterface {
+            // Part: A
+            cc: string;
+            d: string;
+            // Not partition comment
+            bbb: string;
+            // Part: B
+            aaaa: string;
+            e: string;
+            // Part: C
+            'gg': string;
+            // Not partition comment
+            fff: string;
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            // Comment
+            bb: string;
+            // Other comment
+            a: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          interface MyInterface {
+            /* Partition Comment */
+            // Part: A
+            d: string;
+            // Part: B
+            aaa: string;
+            bb: string;
+            c: string;
+            /* Other */
+            e: string;
+          }
+        `,
+        code: dedent`
+          interface MyInterface {
+            /* Partition Comment */
+            // Part: A
+            d: string;
+            // Part: B
+            aaa: string;
+            c: string;
+            bb: string;
+            /* Other */
+            e: string;
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            e: string,
+            f: string,
+            // I am a partition comment because I don't have f o o
+            a: string,
+            b: string,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            _a: string
+            b: string
+            _c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when using line partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            /* Comment */
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all line comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple line partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            c: string
+            // b
+            b: string
+            // a
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for line partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string
+            // I am a partition comment because I don't have f o o
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            // Comment
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all block comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple block partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            c: string
+            /* b */
+            b: string
+            /* a */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for block partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string
+            /* I am a partition comment because I don't have f o o */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            ab: string
+            a_c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            你好: string
+            世界: string
+            a: string
+            A: string
+            b: string
+            B: string
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('allows to use method group', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b(): void
+            c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
+            a: string
+            d: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedInterfacePropertiesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: () => null,
+
+
+             y: "y",
+            z: "z",
+
+                b: "b",
+            }
+          `,
+          output: dedent`
+            interface Interface {
+              a: () => null,
+             b: "b",
+            y: "y",
+                z: "z",
             }
           `,
           options: [
             {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines when global option is %s and group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: string
+
+
+              b: string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'],
+      ['ignore', 0],
+      ['never', 'ignore'],
+      [0, 'ignore'],
+    ] as const)(
+      'does not enforce newline when global option is %s and group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string // Comment after
+
+            b: () => void
+            c: () => void
+          };
+        `,
+        code: dedent`
+          interface Interface {
+            b: () => void
+            a: string // Comment after
+
+            c: () => void
+          };
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
               partitionByComment: true,
+              newlinesBetween,
             },
           ],
-        },
-        {
           errors: [
             {
               data: {
@@ -5617,267 +5287,3727 @@ describe(ruleName, () => {
           ],
           output: dedent`
             interface Interface {
-              b: string
-              c: string
-              a: string // eslint-disable-line
+              a
+
+              // Partition comment
+
+              b
+              c
             }
           `,
           code: dedent`
             interface Interface {
-              c: string
-              b: string
-              a: string // eslint-disable-line
+              a
+
+              // Partition comment
+
+              c
+              b
             }
           `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              b: string
-              c: string
-              /* eslint-disable-next-line */
-              a: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              c: string
-              b: string
-              /* eslint-disable-next-line */
-              a: string
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              b: string
-              c: string
-              a: string /* eslint-disable-line */
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              c: string
-              b: string
-              a: string /* eslint-disable-line */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            interface Interface {
-              a: string
-              d: string
-              /* eslint-disable */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              e: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              d: string
-              e: string
-              /* eslint-disable */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              a: string
-            }
-          `,
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, a: string;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string, b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, a: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['^r|g|b$', '^r|g|b$'],
+      ['array with ^r|g|b$', ['noMatch', '^r|g|b$']],
+      ['pattern with flags', { pattern: '^R|G|B$', flags: 'i' }],
+      [
+        'array with pattern and flags',
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ],
+    ])(
+      'allows to use allNamesMatchPattern with %s',
+      async (_description, rgbAllNamesMatchPattern) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'a',
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
                 left: 'b',
               },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
             },
           ],
-          options: [{}],
-        },
-        {
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
           output: dedent`
             interface Interface {
+              r: string
+              g: string
               b: string
-              c: string
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a: string
             }
           `,
           code: dedent`
             interface Interface {
-              c: string
               b: string
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a: string
+              g: string
+              r: string
             }
           `,
+        })
+      },
+    )
+
+    it('detects declaration name by pattern', async () => {
+      await valid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Interface$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            c: string
+            a: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Interface$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface OtherInterface {
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface OtherInterface {
+            b: string
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows sorting by value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: 'a'
+            a: 'b'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'b'
+            b: 'a'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('does not enforce sorting of non-properties in the same group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            y: 'y'
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: 'z'
+            a(): void
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              left: '[key: string]',
+              right: 'y',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            y: 'y'
+            [key: string]
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: 'z'
+            [key: string]
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('enforces grouping but does not enforce sorting of non-properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'method',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b(): void
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b(): void
+            z: 'z'
+            a(): void
+          }
+        `,
+      })
+    })
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts interface properties', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: 'b1' | 'b2',
+            a: string
+            c: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: 'b1' | 'b2',
+            a: string
+            c: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            c: string
+            b: 'b1' | 'b2',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with ts index signature', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [key in Object]: string
+            a: 'a'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key in Object]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key in Object]: string
+            a: 'a'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'a'
+            [key in Object]: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts multi-word keys by value', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            'b-b': string
+            'd-d': string
+            c: string
+            a: Value
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd-d',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            'b-b': string
+            'd-d': string
+            c: string
+            a: Value
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            'b-b': string
+            a: Value
+            'd-d': string
+            c: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with typescript index signature', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            b: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            [key: string]: string
+            b: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with method and construct signatures', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: () => void
+            c(): number
+            d: string
+            a: number
+            e()
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: () => void
+            c(): number
+            a: number
+            d: string
+            e()
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c(): number
+            a: number
+            b: () => void
+            e()
+            d: string
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with empty properties with empty values', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: 10 | 20 | 30
+            [...other]
+            b: string
+            [v in V]?
+            [d in D]
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '[d in D]',
+              right: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: 10 | 20 | 30
+            [...other]
+            b: string
+            [v in V]?
+            [d in D]
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            [d in D]
+            a: 10 | 20 | 30
+            [...other]
+            b: string
+            [v in V]?
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not break interface docs', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            /* Comment C */
+            c: string | number
+            /**
+             * Comment A
+             */
+            a: string
+            // Comment D
+            d: string
+            /**
+             * Comment B
+             */
+            b: Array
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            /**
+             * Comment B
+             */
+            b: Array
+            /**
+             * Comment A
+             */
+            a: string
+            // Comment D
+            d: string
+            /* Comment C */
+            c: string | number
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts interfaces with comments on the same line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string | number // Comment A
+            b: string // Comment B
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string // Comment B
+            a: string | number // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts interfaces with semi and comments on the same line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: 'aaa'; // Comment A
+            b: 'b'; // Comment B
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: 'b'; // Comment B
+            a: 'aaa'; // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort call signature declarations', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            <Parameters extends Record<string, number | string>>(
+              input: AFunction<[Parameters], string>
+            ): Alternatives<Parameters>
+            <A extends CountA>(input: Input): AFunction<
+              [number],
+              A[keyof A]
+            >
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort constructor declarations', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            new (value: number | string): number;
+            new (value: number): unknown;
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          interface Interface {
+            new (value: number): unknown;
+            new (value: number | string): number;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts complex predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'index-signature',
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'optional-multiline',
+              leftGroup: 'index-signature',
+              left: '[key: string]',
+              right: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'optional-multiline',
+              rightGroup: 'required-method',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'required-method',
+              'optional-multiline',
+              'index-signature',
+              'required-property',
+            ],
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c(): void
+            b?: {
+              property: string;
+            }
+            [key: string]: string;
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            [key: string]: string;
+            b?: {
+              property: string;
+            }
+            c(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritize selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'method',
+              left: 'property',
+              right: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            method(): void
+            property: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            property: string
+            method(): void
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes index-signature over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'index-signature',
+              left: 'multilineProperty',
+              right: '[key: string]',
+              leftGroup: 'multiline',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string;
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            [key: string]: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['index-signature', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes method over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            method(): string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            method(): string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'multilineProperty',
+              rightGroup: 'multiline',
+              leftGroup: 'property',
+              left: 'property',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            property: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            property: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes property over member', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            property: string
+            method(): string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            method(): string
+            property: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over optional', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'optional-property',
+              right: 'multilineProperty',
+              left: 'optionalProperty',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            optionalProperty?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            optionalProperty?: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'optional-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over required', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'required-property',
+              right: 'multilineProperty',
+              left: 'requiredProperty',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            multilineProperty: {
+              a: string
+            }
+            requiredProperty: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            requiredProperty: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'multiline',
+              rightGroup: 'g',
+              right: 'g',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            g: 'g'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('filters on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['optional'],
+                selector: 'method',
+              },
+              {
+                groupName: 'optionalPropertyGroup',
+                modifiers: ['optional'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'optionalPropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'optionalPropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c: string
+            a?: string
+            b?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a?: string
+            b?: string
+            c: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['array with regex', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'filters on elementNamePattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              helloProperty: string
+              a: string
+              b: string
+              method(): void
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+              method(): void
+              helloProperty: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Date'],
+      ['array with string pattern', ['noMatch', 'Date']],
+      ['case-insensitive regex', { pattern: 'DATE', flags: 'i' }],
+      ['array with regex', ['noMatch', { pattern: 'DATE', flags: 'i' }]],
+    ])(
+      'filters on elementValuePattern - %s',
+      async (_description, dateElementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: dateElementValuePattern,
+                  groupName: 'date',
+                },
+                {
+                  elementValuePattern: 'number',
+                  groupName: 'number',
+                },
+              ],
+              groups: ['number', 'date', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'number',
+                leftGroup: 'date',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: number
+              z: number
+              b: Date
+              y: Date
+              c(): string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: number
+              b: Date
+              y: Date
+              z: number
+              c(): string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            dddd: string
+            ccc: string
+            eee: string
+            bb: string
+            ff: string
+            a: string
+            g: string
+            anotherMethod(): void
+            method(): void
+            yetAnotherMethod(): void
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            bb: string
+            ccc: string
+            dddd: string
+            method(): void
+            eee: string
+            ff: string
+            g: string
+            anotherMethod(): void
+            yetAnotherMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                elementValuePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: fooBar
+            a: fooZar
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: fooZar
+            b: fooBar
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding sortBy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooC',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: 'fooA',
+              left: 'fooB',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooMethod',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'fooElementsSortedByValue',
+                elementNamePattern: '^foo',
+                sortBy: 'value',
+              },
+            ],
+            groups: ['fooElementsSortedByValue', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            fooA: Date
+            fooC: number
+            fooB: string
+            fooMethod(): void
+            a: string
+            z: boolean
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: boolean
+            fooC: number
+            fooB: string
+            fooA: Date
+            a: string
+            fooMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b
+            a
+            d
+            e
+            c
+            method(): void
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b
+            a
+            d
+            e
+            method(): void
+            c
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['required'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['optional'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'requiredPropertiesAndOptionalMethods',
+              },
+            ],
+            groups: [
+              ['requiredPropertiesAndOptionalMethods', 'index-signature'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'requiredPropertiesAndOptionalMethods',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: '[key: string]',
+              left: 'e',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            [key: string]: string
+            a: string
+            d?: () => void
+            e: string
+            b(): void
+            c?: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b(): void
+            c?: string
+            d?: () => void
+            e: string
+            [key: string]: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always'],
+      ['1', 1],
+    ] as const)(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
           errors: [
             {
               data: {
                 right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a
+
+              b
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows to use regex for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          interface Interface {
+              iHaveFooInMyName: string
+              meTooIHaveFoo: string
+              a: string
+              b: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            e: 'eee'
+            f: 'ff'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            c: 'cc'
+            d: 'd'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'e',
+              left: 'f',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            e: 'eee'
+            f: 'ff'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            c: 'cc'
+            d: 'd'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            f: 'ff'
+            e: 'eee'
+            g: 'g'
+
+            a: 'aaa'
+
+            b?: 'bbb'
+            d: 'd'
+            c: 'cc'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('sorts interface properties with group kind', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a?: string
+            [index: number]: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a?: string
+            c?: string
+            d?: string
+            e?(): void
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a?: string
+            b: string
+            c?: string
+            d?: string
+            e?(): void
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting with group kind', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'last',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: {
+              last: 'a',
+            },
+            groups: ['unknown', 'last'],
+            groupKind: 'optional-first',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            c?: string
+            d?: string
+            b: string
+            e: string
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b: string
+            c?: string
+            d?: string
+            e: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          interface MyInterface {
+            // Part: A
+            // Not partition comment
+            bbb: string;
+            cc: string;
+            d: string;
+            // Part: B
+            aaaa: string;
+            e: string;
+            // Part: C
+            'gg': string;
+            // Not partition comment
+            fff: string;
+          }
+        `,
+        code: dedent`
+          interface MyInterface {
+            // Part: A
+            cc: string;
+            d: string;
+            // Not partition comment
+            bbb: string;
+            // Part: B
+            aaaa: string;
+            e: string;
+            // Part: C
+            'gg': string;
+            // Not partition comment
+            fff: string;
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            // Comment
+            bb: string;
+            // Other comment
+            a: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          interface MyInterface {
+            /* Partition Comment */
+            // Part: A
+            d: string;
+            // Part: B
+            aaa: string;
+            bb: string;
+            c: string;
+            /* Other */
+            e: string;
+          }
+        `,
+        code: dedent`
+          interface MyInterface {
+            /* Partition Comment */
+            // Part: A
+            d: string;
+            // Part: B
+            aaa: string;
+            c: string;
+            bb: string;
+            /* Other */
+            e: string;
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            e: string,
+            f: string,
+            // I am a partition comment because I don't have f o o
+            a: string,
+            b: string,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            _aaa: string
+            bb: string
+            _c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when using line partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            /* Comment */
+            aa: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            /* Comment */
+            aa: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all line comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple line partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            c: string
+            // b
+            b: string
+            // a
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for line partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string
+            // I am a partition comment because I don't have f o o
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            // Comment
+            aa: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            // Comment
+            aa: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all block comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple block partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            c: string
+            /* b */
+            b: string
+            /* a */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for block partition comments', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string
+            /* I am a partition comment because I don't have f o o */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            abc: string
+            a_c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          interface MyInterface {
+            你好: string
+            世界: string
+            a: string
+            A: string
+            b: string
+            B: string
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('allows to use method group', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
+            b(): void
+            a: string
+            d: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedInterfacePropertiesOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              aaaa: () => null,
+
+
+             yy: "y",
+            z: "z",
+
+                bbb: "b",
+            }
+          `,
+          output: dedent`
+            interface Interface {
+              aaaa: () => null,
+             bbb: "b",
+            yy: "y",
+                z: "z",
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines when global option is %s and group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: string
+
+
+              b: string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenInterfaceMembers',
+            },
+          ],
+          output: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+          code: dedent`
+            interface Interface {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'],
+      ['ignore', 0],
+      ['never', 'ignore'],
+      [0, 'ignore'],
+    ] as const)(
+      'does not enforce newline when global option is %s and group option is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            interface Interface {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string // Comment after
+
+            b: () => void
+            c: () => void
+          };
+        `,
+        code: dedent`
+          interface Interface {
+            b: () => void
+            a: string // Comment after
+
+            c: () => void
+          };
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ] as const)(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
                 left: 'c',
               },
               messageId: 'unexpectedInterfacePropertiesOrder',
             },
           ],
-          options: [{}],
-        },
-        {
           output: dedent`
             interface Interface {
-              b: string
-              c: string
-              a: string // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
+              aaa
+
+              // Partition comment
+
+              bb
+              c
             }
           `,
           code: dedent`
             interface Interface {
-              c: string
-              b: string
-              a: string // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
+              aaa
+
+              // Partition comment
+
+              c
+              bb
             }
           `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            interface Interface {
-              b: string
-              c: string
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              c: string
-              b: string
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            aa: string; b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, aa: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            interface Interface {
-              b: string
-              c: string
-              a: string /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              c: string
-              b: string
-              a: string /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            aa: string; b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, aa: string;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            interface Interface {
-              a: string
-              d: string
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              e: string
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              d: string
-              e: string
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              a: string
-            }
-          `,
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            aa: string, b: string,
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string, aa: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['^r|g|b$', '^r|g|b$'],
+      ['array with ^r|g|b$', ['noMatch', '^r|g|b$']],
+      ['pattern with flags', { pattern: '^R|G|B$', flags: 'i' }],
+      [
+        'array with pattern and flags',
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ],
+    ])(
+      'allows to use allNamesMatchPattern with %s',
+      async (_description, rgbAllNamesMatchPattern) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'a',
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
                 left: 'b',
               },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedInterfacePropertiesGroupOrder',
             },
           ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
             interface Interface {
-              b: string;
-              c: string;
-              // eslint-disable-next-line
-              a: string;
+              r: string
+              g: string
+              b: string
             }
           `,
-        },
-      ],
+          code: dedent`
+            interface Interface {
+              b: string
+              g: string
+              r: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('detects declaration name by pattern', async () => {
+      await valid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Interface$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        code: dedent`
+          interface Interface {
+            b: string
+            c: string
+            a: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Interface$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface OtherInterface {
+            aa: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface OtherInterface {
+            b: string
+            aa: string
+          }
+        `,
+      })
+    })
+
+    it('allows sorting by value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            bb: 'a'
+            a: 'b'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: 'b'
+            bb: 'a'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('does not enforce sorting of non-properties in the same group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            y: 'yy'
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            z: 'z'
+            a(): void
+            y: 'yy'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('enforces grouping but does not enforce sorting of non-properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'method',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b(): void
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b(): void
+            z: 'z'
+            a(): void
+          }
+        `,
+      })
+    })
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts interface properties', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          interface Interface {
+            a: string
+            b: 'b1' | 'b2',
+            c: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+            b: 'b1' | 'b2',
+            c: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a: string
+            c: string
+            b: 'b1' | 'b2',
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string;
+            c: string;
+            a: string;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces grouping', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: '^b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedInterfacePropertiesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            ba: string
+            bb: string
+            ab: string
+            aa: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            ab: string
+            aa: string
+            ba: string
+            bb: string
+          }
+        `,
+      })
+    })
+
+    it('enforces newlines between groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            a: string
+          }
+        `,
+      })
+    })
+  })
+
+  describe('misc', () => {
+    it('validates the JSON schema', async () => {
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
+    })
+
+    it('sets alphabetical asc sorting as default', async () => {
+      await valid(dedent`
+        interface Interface {
+          a: string
+          b: string
+        }
+      `)
+
+      await valid({
+        code: dedent`
+          interface Calculator {
+            log: (x: number) => number,
+            log10: (x: number) => number,
+            log1p: (x: number) => number,
+            log2: (x: number) => number,
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to ignore interfaces', async () => {
+      await valid({
+        options: [
+          {
+            ignorePattern: ['Ignore'],
+            type: 'line-length',
+            order: 'desc',
+          },
+        ],
+        code: dedent`
+          interface IgnoreInterface {
+            b: 'b'
+            a: 'aaa'
+          }
+        `,
+      })
+    })
+
+    it('supports eslint-disable for individual nodes', async () => {
+      await valid({
+        code: dedent`
+          interface Interface {
+            b: string;
+            c: string;
+            // eslint-disable-next-line
+            a: string;
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            // eslint-disable-next-line
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            // eslint-disable-next-line
+            a: string
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            // eslint-disable-next-line
+            a: string
+            d: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            d: string
+            c: string
+            // eslint-disable-next-line
+            a: string
+            b: string
+          }
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            a: string // eslint-disable-line
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            a: string // eslint-disable-line
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            /* eslint-disable-next-line */
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            /* eslint-disable-next-line */
+            a: string
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            a: string /* eslint-disable-line */
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            a: string /* eslint-disable-line */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          interface Interface {
+            a: string
+            d: string
+            /* eslint-disable */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            e: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            d: string
+            e: string
+            /* eslint-disable */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            // eslint-disable-next-line rule-to-test/sort-interfaces
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            // eslint-disable-next-line rule-to-test/sort-interfaces
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            a: string // eslint-disable-line rule-to-test/sort-interfaces
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            a: string // eslint-disable-line rule-to-test/sort-interfaces
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            /* eslint-disable-next-line rule-to-test/sort-interfaces */
+            a: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            /* eslint-disable-next-line rule-to-test/sort-interfaces */
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            b: string
+            c: string
+            a: string /* eslint-disable-line rule-to-test/sort-interfaces */
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            c: string
+            b: string
+            a: string /* eslint-disable-line rule-to-test/sort-interfaces */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          interface Interface {
+            a: string
+            d: string
+            /* eslint-disable rule-to-test/sort-interfaces */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            e: string
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            d: string
+            e: string
+            /* eslint-disable rule-to-test/sort-interfaces */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        options: [{}],
+      })
     })
   })
 })

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -1,3416 +1,5538 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-intersection-types'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-intersection-types'
+describe('sort-intersection-types', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-intersection-types',
+    parser: typescriptParser,
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}: sorts intersection types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ label: 'bb' }",
-                left: "{ label: 'c' }",
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+    it(`sorts intersection types`, async () => {
+      await valid({
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ label: 'bb' }",
+              left: "{ label: 'c' }",
             },
-          ],
-          output: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts keyword intersection types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: '{ stringValue: string }',
-                right: '{ anyValue: any }',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+    it('sorts keyword intersection types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '{ stringValue: string }',
+              right: '{ anyValue: any }',
             },
-            {
-              data: {
-                left: '{ unknownValue: unknown }',
-                right: '{ nullValue: null }',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              left: '{ unknownValue: unknown }',
+              right: '{ nullValue: null }',
             },
-            {
-              data: {
-                left: '{ undefinedValue: undefined }',
-                right: '{ neverValue: never }',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              left: '{ undefinedValue: undefined }',
+              right: '{ neverValue: never }',
             },
-            {
-              data: {
-                right: '{ bigintValue: bigint }',
-                left: '{ voidValue: void }',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: '{ bigintValue: bigint }',
+              left: '{ voidValue: void }',
             },
-          ],
-          output: dedent`
-            type Value =
-              & { anyValue: any }
-              & { bigintValue: bigint }
-              & { booleanValue: boolean }
-              & { neverValue: never }
-              & { nullValue: null }
-              & { numberValue: number }
-              & { stringValue: string }
-              & { undefinedValue: undefined }
-              & { unknownValue: unknown }
-              & { voidValue: void }
-          `,
-          code: dedent`
-            type Value =
-              & { booleanValue: boolean }
-              & { numberValue: number }
-              & { stringValue: string }
-              & { anyValue: any }
-              & { unknownValue: unknown }
-              & { nullValue: null }
-              & { undefinedValue: undefined }
-              & { neverValue: never }
-              & { voidValue: void }
-              & { bigintValue: bigint }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Value =
+            & { anyValue: any }
+            & { bigintValue: bigint }
+            & { booleanValue: boolean }
+            & { neverValue: never }
+            & { nullValue: null }
+            & { numberValue: number }
+            & { stringValue: string }
+            & { undefinedValue: undefined }
+            & { unknownValue: unknown }
+            & { voidValue: void }
+        `,
+        code: dedent`
+          type Value =
+            & { booleanValue: boolean }
+            & { numberValue: number }
+            & { stringValue: string }
+            & { anyValue: any }
+            & { unknownValue: unknown }
+            & { nullValue: null }
+            & { undefinedValue: undefined }
+            & { neverValue: never }
+            & { voidValue: void }
+            & { bigintValue: bigint }
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: works with generics`, rule, {
-      invalid: [
-        {
+    it('works with generics', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: 'Omit<T, AA & B>',
+        code: 'Omit<T, B & AA>',
+        options: [options],
+      })
+    })
+
+    it('works with type references', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: 'type Type = A & B & C',
+        code: 'type Type = A & C & B',
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with named properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ name: A, status: 'aa' }",
+              left: "{ name: B, status: 'b' }",
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & { name: A, status: 'aa' }
+            & { name: B, status: 'b' }
+        `,
+        code: dedent`
+          type Type =
+            & { name: B, status: 'b' }
+            & { name: A, status: 'aa' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with parentheses', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '( A: () => void, ) => B & C',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            t:
+              & ((
+                  A: () => void,
+                ) => B & C)
+              & B
+              & C
+          }
+        `,
+        code: dedent`
+          type Type = {
+            t:
+              & B
+              & ((
+                  A: () => void,
+                ) => B & C)
+              & C
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with comment at the end', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ value3: 3 }',
+              left: '{ value4: 4 }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: '{ value100: 100 }',
+              left: '{ value5: 5 }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Step =  { value1: 1 } & { value100: 100 } & { value2: 2 } & { value3: 3 } & { value4: 4 } & { value5: 5 }; // Comment
+        `,
+        code: dedent`
+          type Step =  { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 } & { value100: 100 }; // Comment
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections using groups', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            & A
+            & intrinsic
+            & SomeClass['name']
+            & string[]
+            & any
+            & bigint
+            & boolean
+            & number
+            & this
+            & unknown
+            & keyof { a: string; b: number }
+            & keyof A
+            & typeof B
+            & 'aaa'
+            & \`\${A}\`
+            & 1
+            & (new () => SomeClass)
+            & (import('path'))
+            & (A extends B ? C : D)
+            & { [P in keyof T]: T[P] }
+            & { name: 'a' }
+            & [A, B, C]
+            & (A & B)
+            & (A | B)
+            & null
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: "{ name: 'a' }",
+              rightGroup: 'keyword',
+              leftGroup: 'object',
+              right: 'boolean',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'keyword',
+              rightGroup: 'named',
+              left: 'boolean',
+              right: 'A',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'operator',
+              rightGroup: 'keyword',
+              left: 'keyof A',
+              right: 'bigint',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'nullish',
+              left: 'null',
+              right: '1',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'intersection',
+              leftGroup: 'union',
+              right: 'A & B',
+              left: 'A | B',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type =
+            & A
+            & any
+            & bigint
+            & boolean
+            & keyof A
+            & typeof B
+            & 'aaa'
+            & 1
+            & (import('path'))
+            & (A extends B ? C : D)
+            & { name: 'a' }
+            & [A, B, C]
+            & (A & B)
+            & (A | B)
+            & null
+        `,
+        code: dedent`
+          type Type =
+            & any
+            & { name: 'a' }
+            & boolean
+            & A
+            & keyof A
+            & bigint
+            & typeof B
+            & 'aaa'
+            & (import('path'))
+            & null
+            & 1
+            & (A extends B ? C : D)
+            & [A, B, C]
+            & (A | B)
+            & (A & B)
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            A &
+            D &
+
+            C &
+
+            B &
+            E
+        `,
+        code: dedent`
+          type Type =
+            D &
+            A &
+
+            C &
+
+            E &
+            B
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            // Not partition comment
+            BBB &
+            CC &
+            D &
+            // Part: B
+            AAA &
+            E &
+            // Part: C
+            // Not partition comment
+            FFF &
+            GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            CC &
+            D &
+            // Not partition comment
+            BBB &
+            // Part: B
+            AAA &
+            E &
+            // Part: C
+            GG &
+            // Not partition comment
+            FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            & BBB
+            & CC
+            // Not partition comment
+            & D
+            // Part: B
+            & AAA
+            & E
+            // Part: C
+            & FFF
+            // Not partition comment
+            & GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            & CC
+            & D
+            // Not partition comment
+            & BBB
+            // Part: B
+            & AAA
+            & E
+            // Part: C
+            & GG
+            // Not partition comment
+            & FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            // Comment
+            BB &
+            // Other comment
+            A
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D &
+            // Part: B
+            AAA &
+            BB &
+            C &
+            /* Other */
+            E
+        `,
+        code: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D &
+            // Part: B
+            AAA &
+            C &
+            BB &
+            /* Other */
+            E
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            E &
+            F &
+            // I am a partition comment because I don't have f o o
+            A &
+            B
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            /* Comment */
+            A &
+            B
+        `,
+        code: dedent`
+          type Type =
+            B &
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C &
+            // B
+            B &
+            // A
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            // I am a partition comment because I don't have f o o
+            A
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            // Comment
+            A &
+            B
+        `,
+        code: dedent`
+          type Type =
+            B &
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C &
+            /* B */
+            B &
+            /* A */
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            /* I am a partition comment because I don't have f o o */
+            A
+        `,
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          type T =
+            _A &
+            B &
+            _C
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type T =
+            AB &
+            A_C
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            你好 &
+            世界 &
+            a &
+            A &
+            b &
+            B
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'AA',
-                left: 'B',
+                left: '() => null',
+                right: 'Y',
               },
-              messageId: 'unexpectedIntersectionTypesOrder',
+              messageId: 'extraSpacingBetweenIntersectionTypes',
             },
-          ],
-          output: 'Omit<T, AA & B>',
-          code: 'Omit<T, B & AA>',
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
             {
               data: {
                 right: 'B',
-                left: 'C',
+                left: 'Z',
               },
               messageId: 'unexpectedIntersectionTypesOrder',
             },
-          ],
-          output: 'type Type = A & B & C',
-          code: 'type Type = A & C & B',
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
             {
               data: {
-                right: "{ name: A, status: 'aa' }",
-                left: "{ name: B, status: 'b' }",
+                right: 'B',
+                left: 'Z',
               },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type =
-              & { name: A, status: 'aa' }
-              & { name: B, status: 'b' }
-          `,
-          code: dedent`
-            type Type =
-              & { name: B, status: 'b' }
-              & { name: A, status: 'aa' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts intersections with parentheses`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '( A: () => void, ) => B & C',
-                left: 'B',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              t:
-                & ((
-                    A: () => void,
-                  ) => B & C)
-                & B
-                & C
-            }
-          `,
-          code: dedent`
-            type Type = {
-              t:
-                & B
-                & ((
-                    A: () => void,
-                  ) => B & C)
-                & C
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts intersections with comment at the end`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '{ value3: 3 }',
-                  left: '{ value4: 4 }',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-              {
-                data: {
-                  right: '{ value100: 100 }',
-                  left: '{ value5: 5 }',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Step =  { value1: 1 } & { value100: 100 } & { value2: 2 } & { value3: 3 } & { value4: 4 } & { value5: 5 }; // Comment
-            `,
-            code: dedent`
-              type Step =  { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 } & { value100: 100 }; // Comment
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: sorts intersections using groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: "{ name: 'a' }",
-                rightGroup: 'keyword',
-                leftGroup: 'object',
-                right: 'boolean',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'keyword',
-                rightGroup: 'named',
-                left: 'boolean',
-                right: 'A',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'operator',
-                rightGroup: 'keyword',
-                left: 'keyof A',
-                right: 'bigint',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'literal',
-                leftGroup: 'nullish',
-                left: 'null',
-                right: '1',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'intersection',
-                leftGroup: 'union',
-                right: 'A & B',
-                left: 'A | B',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
+              messageId: 'extraSpacingBetweenIntersectionTypes',
             },
           ],
           options: [
             {
               ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
-              ],
+              groups: ['function', 'unknown'],
+              newlinesBetween,
             },
           ],
-          output: dedent`
-            type Type =
-              & A
-              & any
-              & bigint
-              & boolean
-              & keyof A
-              & typeof B
-              & 'aaa'
-              & 1
-              & (import('path'))
-              & (A extends B ? C : D)
-              & { name: 'a' }
-              & [A, B, C]
-              & (A & B)
-              & (A | B)
-              & null
-          `,
-          code: dedent`
-            type Type =
-              & any
-              & { name: 'a' }
-              & boolean
-              & A
-              & keyof A
-              & bigint
-              & typeof B
-              & 'aaa'
-              & (import('path'))
-              & null
-              & 1
-              & (A extends B ? C : D)
-              & [A, B, C]
-              & (A | B)
-              & (A & B)
-          `,
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              & A
-              & intrinsic
-              & SomeClass['name']
-              & string[]
-              & any
-              & bigint
-              & boolean
-              & number
-              & this
-              & unknown
-              & keyof { a: string; b: number }
-              & keyof A
-              & typeof B
-              & 'aaa'
-              & \`\${A}\`
-              & 1
-              & (new () => SomeClass)
-              & (import('path'))
-              & (A extends B ? C : D)
-              & { [P in keyof T]: T[P] }
-              & { name: 'a' }
-              & [A, B, C]
-              & (A & B)
-              & (A | B)
-              & null
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
-              ],
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'D',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-              {
-                data: {
-                  right: 'B',
-                  left: 'E',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type =
-                A &
-                D &
-
-                C &
-
-                B &
-                E
-            `,
-            code: dedent`
-              type Type =
-                D &
-                A &
-
-                C &
-
-                E &
-                B
-            `,
-            options: [
-              {
-                partitionByNewLine: true,
-                type: 'alphabetical',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe('partition comments', () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'BBB',
-                    left: 'D',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'FFF',
-                    left: 'GG',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  // Part: A
-                  // Not partition comment
-                  BBB &
-                  CC &
-                  D &
-                  // Part: B
-                  AAA &
-                  E &
-                  // Part: C
-                  // Not partition comment
-                  FFF &
-                  GG
-              `,
-              code: dedent`
-                type T =
-                  // Part: A
-                  CC &
-                  D &
-                  // Not partition comment
-                  BBB &
-                  // Part: B
-                  AAA &
-                  E &
-                  // Part: C
-                  GG &
-                  // Not partition comment
-                  FFF
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'BBB',
-                    left: 'D',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'FFF',
-                    left: 'GG',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  // Part: A
-                  & BBB
-                  & CC
-                  // Not partition comment
-                  & D
-                  // Part: B
-                  & AAA
-                  & E
-                  // Part: C
-                  & FFF
-                  // Not partition comment
-                  & GG
-              `,
-              code: dedent`
-                type T =
-                  // Part: A
-                  & CC
-                  & D
-                  // Not partition comment
-                  & BBB
-                  // Part: B
-                  & AAA
-                  & E
-                  // Part: C
-                  & GG
-                  // Not partition comment
-                  & FFF
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                type T =
-                  // Comment
-                  BB &
-                  // Other comment
-                  A
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                type T =
-                  /* Partition Comment */
-                  // Part: A
-                  D &
-                  // Part: B
-                  AAA &
-                  BB &
-                  C &
-                  /* Other */
-                  E
-              `,
-              code: dedent`
-                type T =
-                  /* Partition Comment */
-                  // Part: A
-                  D &
-                  // Part: B
-                  AAA &
-                  C &
-                  BB &
-                  /* Other */
-                  E
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'BB',
-                    left: 'C',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                type T =
-                  E &
-                  F &
-                  // I am a partition comment because I don't have f o o
-                  A &
-                  B
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['^(?!.*foo).*$'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                type Type =
-                  /* Comment */
-                  A &
-                  B
-              `,
-              code: dedent`
-                type Type =
-                  B &
-                  /* Comment */
-                  A
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B &
-                    // Comment
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['A', 'B'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    C &
-                    // B
-                    B &
-                    // A
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B &
-                    // I am a partition comment because I don't have f o o
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                type Type =
-                  // Comment
-                  A &
-                  B
-              `,
-              code: dedent`
-                type Type =
-                  B &
-                  // Comment
-                  A
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B &
-                    /* Comment */
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['A', 'B'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    C &
-                    /* B */
-                    B &
-                    /* A */
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B &
-                    /* I am a partition comment because I don't have f o o */
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              type T =
-                _A &
-                B &
-                _C
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              type T =
-                AB &
-                A_C
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
           code: dedent`
             type T =
-              你好 &
-              世界 &
-              a &
-              A &
-              b &
-              B
+              (() => null)
+
+
+             & Y
+            & Z
+
+                & B
           `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      left: '() => null',
-                      right: 'Y',
-                    },
-                    messageId: 'extraSpacingBetweenIntersectionTypes',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'Z',
-                    },
-                    messageId: 'unexpectedIntersectionTypesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'Z',
-                    },
-                    messageId: 'extraSpacingBetweenIntersectionTypes',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['function', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  type T =
-                    (() => null)
-
-
-                   & Y
-                  & Z
-
-                      & B
-                `,
-                output: dedent`
-                  type T =
-                    (() => null)
-                   & B
-                  & Y
-                      & Z
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenIntersectionTypes',
-                  },
-                ],
-                output: dedent`
-                  type Type =
-                    & a & 
-
-                  b
-                `,
-                code: dedent`
-                  type Type =
-                    & a & b
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      left: '() => null',
-                      right: 'Z',
-                    },
-                    messageId: 'extraSpacingBetweenIntersectionTypes',
-                  },
-                  {
-                    data: {
-                      right: 'Y',
-                      left: 'Z',
-                    },
-                    messageId: 'unexpectedIntersectionTypesOrder',
-                  },
-                  {
-                    data: {
-                      right: '"A"',
-                      left: 'Y',
-                    },
-                    messageId: 'missedSpacingBetweenIntersectionTypes',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['function', 'unknown', 'literal'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  type T =
-                    (() => null)
-
-                   & Y
-                  & Z
-
-                      & "A"
-                `,
-                code: dedent`
-                  type T =
-                    (() => null)
-
-
-                   & Z
-                  & Y
-                      & "A"
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: '{ a: string }',
-                      left: '() => void',
-                    },
-                    messageId: 'missedSpacingBetweenIntersectionTypes',
-                  },
-                  {
-                    data: {
-                      left: '{ a: string }',
-                      right: 'A',
-                    },
-                    messageId: 'extraSpacingBetweenIntersectionTypes',
-                  },
-                  {
-                    data: {
-                      right: '[A]',
-                      left: 'A',
-                    },
-                    messageId: 'extraSpacingBetweenIntersectionTypes',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'function',
-                      { newlinesBetween: 'always' },
-                      'object',
-                      { newlinesBetween: 'always' },
-                      'named',
-                      { newlinesBetween: 'never' },
-                      'tuple',
-                      { newlinesBetween: 'ignore' },
-                      'nullish',
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                output: dedent`
-                  type Type =
-                    (() => void) &
-
-                    { a: string } &
-
-                    A &
-                    [A] &
-
-
-                    null
-                `,
-                code: dedent`
-                  type Type =
-                    (() => void) &
-                    { a: string } &
-
-
-                    A &
-
-                    [A] &
-
-
-                    null
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          'tuple',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'null',
-                          left: 'A',
-                        },
-                        messageId: 'missedSpacingBetweenIntersectionTypes',
-                      },
-                    ],
-                    output: dedent`
-                      type T =
-                        A &
-
-
-                        null
-                    `,
-                    code: dedent`
-                      type T =
-                        A &
-                        null
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          { newlinesBetween: 'never' },
-                          'tuple',
-                          { newlinesBetween: 'never' },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'null',
-                          left: 'A',
-                        },
-                        messageId: 'extraSpacingBetweenIntersectionTypes',
-                      },
-                    ],
-                    output: dedent`
-                      type T =
-                        A &
-                        null
-                    `,
-                    code: dedent`
-                      type T =
-                        A &
-
-                        null
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          'tuple',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      type T =
-                        A &
-
-                        null
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          'tuple',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      type T =
-                        A &
-                        null
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
+          output: dedent`
+            type T =
+              (() => null)
+             & B
+            & Y
+                & Z
+          `,
         })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  type T =
-                    & 'a' // Comment after
-                    & B
-
-                    & C
-                `,
-                dedent`
-                  type T =
-                    & 'a' // Comment after
-
-                    & B
-                    & C
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'literal',
-                    leftGroup: 'named',
-                    right: "'a'",
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedIntersectionTypesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  groups: ['literal', 'named'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              code: dedent`
-                type T =
-                  & B
-                  & 'a' // Comment after
-
-                  & C
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedIntersectionTypesOrder',
-                  },
-                ],
-                output: dedent`
-                  type Type =
-                    & a
-
-                    // Partition comment
-
-                    & b
-                    & c
-                `,
-                code: dedent`
-                  type Type =
-                    & a
-
-                    // Partition comment
-
-                    & c
-                    & b
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type T =
-                & A & B
-            `,
-            code: dedent`
-              type T =
-                & B & A
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type T =
-                A & B
-            `,
-            code: dedent`
-              type T =
-                B & A
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
       },
     )
 
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector`, rule, {
-        invalid: [
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'namedElements',
-                  leftGroup: 'unknown',
-                  left: 'null',
-                  right: 'a',
+            data: {
+              right: '{ a: string }',
+              left: '() => void',
+            },
+            messageId: 'missedSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              left: '{ a: string }',
+              right: 'A',
+            },
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              right: '[A]',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'function',
+              { newlinesBetween: 'always' },
+              'object',
+              { newlinesBetween: 'always' },
+              'named',
+              { newlinesBetween: 'never' },
+              'tuple',
+              { newlinesBetween: 'ignore' },
+              'nullish',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            (() => void) &
+
+            { a: string } &
+
+            A &
+            [A] &
+
+
+            null
+        `,
+        code: dedent`
+          type Type =
+            (() => void) &
+            { a: string } &
+
+
+            A &
+
+            [A] &
+
+
+            null
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A &
+
+
+              null
+          `,
+          code: dedent`
+            type T =
+              A &
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                { newlinesBetween: 'never' },
+                'tuple',
+                { newlinesBetween: 'never' },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A &
+              null
+          `,
+          code: dedent`
+            type T =
+              A &
+
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A &
+
+              null
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A &
+              null
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'named',
+              right: "'a'",
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['literal', 'named'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type T =
+            & 'a' // Comment after
+
+            & B
+            & C
+        `,
+        code: dedent`
+          type T =
+            & B
+            & 'a' // Comment after
+
+            & C
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
                 },
-                messageId: 'unexpectedIntersectionTypesGroupOrder',
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedIntersectionTypesOrder',
+            },
+          ],
+          output: dedent`
+            type Type =
+              & a
+
+              // Partition comment
+
+              & b
+              & c
+          `,
+          code: dedent`
+            type Type =
+              & a
+
+              // Partition comment
+
+              & c
+              & b
+          `,
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & A & B
+        `,
+        code: dedent`
+          type T =
+            & B & A
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            A & B
+        `,
+        code: dedent`
+          type T =
+            B & A
+        `,
+        options: [options],
+      })
+    })
+
+    it('filters on selector', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'namedElements',
+              leftGroup: 'unknown',
+              left: 'null',
+              right: 'a',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'namedElements',
+                selector: 'named',
               },
             ],
-            options: [
+            groups: ['namedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
+            & null
+        `,
+        code: dedent`
+          type T =
+            & null
+            & a
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'namedStartingWithHello',
+                  elementNamePattern,
+                  selector: 'named',
+                },
+              ],
+              groups: ['namedStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'namedStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloNamed',
+                left: 'undefined',
+              },
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type =
+              & helloNamed
+              & null
+              & undefined
+          `,
+          code: dedent`
+            type Type =
+              & null
+              & undefined
+              & helloNamed
+          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedNamedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: "'m'",
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
               {
-                customGroups: [
+                groupName: 'reversedNamedByLineLength',
+                type: 'line-length',
+                selector: 'named',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedNamedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type T =
+            & dddd
+            & ccc
+            & eee
+            & bb
+            & ff
+            & a
+            & g
+            & 'm'
+            & 'o'
+            & 'p'
+        `,
+        code: dedent`
+          type T =
+            & a
+            & bb
+            & ccc
+            & dddd
+            & 'm'
+            & eee
+            & ff
+            & g
+            & 'o'
+            & 'p'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & fooBar
+            & fooZar
+        `,
+        code: dedent`
+          type T =
+            & fooZar
+            & fooBar
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedNamed',
+                selector: 'named',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedNamed', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedNamed',
+              leftGroup: 'unknown',
+              left: "'m'",
+              right: 'c',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & b
+            & a
+            & d
+            & e
+            & c
+            & 'm'
+        `,
+        code: dedent`
+          type T =
+            & b
+            & a
+            & d
+            & e
+            & 'm'
+            & c
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
                   {
-                    groupName: 'namedElements',
+                    elementNamePattern: 'foo|Foo',
                     selector: 'named',
                   },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'literal',
+                  },
                 ],
-                groups: ['namedElements', 'unknown'],
+                groupName: 'elementsIncludingFoo',
               },
             ],
-            output: dedent`
-              type T =
-                & a
-                & null
-            `,
-            code: dedent`
-              type T =
-                & null
-                & a
-            `,
+            groups: ['elementsIncludingFoo', 'unknown'],
+            newlinesBetween: 'always',
           },
         ],
-        valid: [],
-      })
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'foo'",
+              left: 'null',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & 'foo'
+            & cFoo
 
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
+            & null
+        `,
+        code: dedent`
+          type T =
+            & null
+            & 'foo'
+            & cFoo
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type T =
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines within groups when newlinesInside is %s',
+      async (_, newlinesInside) => {
+        await invalid({
+          options: [
             {
-              options: [
+              customGroups: [
                 {
-                  customGroups: [
-                    {
-                      groupName: 'namedStartingWithHello',
-                      elementNamePattern,
-                      selector: 'named',
-                    },
-                  ],
-                  groups: ['namedStartingWithHello', 'unknown'],
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
                 },
               ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'namedStartingWithHello',
-                    leftGroup: 'unknown',
-                    right: 'helloNamed',
-                    left: 'undefined',
-                  },
-                  messageId: 'unexpectedIntersectionTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type =
-                  & helloNamed
-                  & null
-                  & undefined
-              `,
-              code: dedent`
-                type Type =
-                  & null
-                  & undefined
-                  & helloNamed
-              `,
+              groups: ['group1'],
             },
           ],
-          valid: [],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              & a
+
+              & b
+          `,
+          code: dedent`
+            type T =
+              & a
+              & b
+          `,
         })
-      }
+      },
+    )
 
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within groups when newlinesInside is %s',
+      async (_, newlinesInside) => {
+        await invalid({
+          options: [
             {
-              errors: [
+              customGroups: [
                 {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedNamedByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'eee',
-                    left: "'m'",
-                  },
-                  messageId: 'unexpectedIntersectionTypesGroupOrder',
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
                 },
               ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedNamedByLineLength',
-                      type: 'line-length',
-                      selector: 'named',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedNamedByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                type T =
-                  & dddd
-                  & ccc
-                  & eee
-                  & bb
-                  & ff
-                  & a
-                  & g
-                  & 'm'
-                  & 'o'
-                  & 'p'
-              `,
-              code: dedent`
-                type T =
-                  & a
-                  & bb
-                  & ccc
-                  & dddd
-                  & 'm'
-                  & eee
-                  & ff
-                  & g
-                  & 'o'
-                  & 'p'
-              `,
+              type: 'alphabetical',
+              groups: ['group1'],
             },
           ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
+          errors: [
             {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedIntersectionTypesOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  & fooBar
-                  & fooZar
-              `,
-              code: dedent`
-                type T =
-                  & fooZar
-                  & fooBar
-              `,
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
             },
           ],
-          valid: [],
-        },
-      )
+          output: dedent`
+            type T =
+              & a
+              & b
+          `,
+          code: dedent`
+            type T =
+              & a
 
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedNamed',
-                      selector: 'named',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedNamed', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedNamed',
-                    leftGroup: 'unknown',
-                    left: "'m'",
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedIntersectionTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  & b
-                  & a
-                  & d
-                  & e
-                  & c
-                  & 'm'
-              `,
-              code: dedent`
-                type T =
-                  & b
-                  & a
-                  & d
-                  & e
-                  & 'm'
-                  & c
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'named',
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'literal',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-                newlinesBetween: 'always',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: "'foo'",
-                  left: 'null',
-                },
-                messageId: 'unexpectedIntersectionTypesGroupOrder',
-              },
-            ],
-            output: dedent`
-              type T =
-                & 'foo'
-                & cFoo
-
-                & null
-            `,
-            code: dedent`
-              type T =
-                & null
-                & 'foo'
-                & cFoo
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                type T =
-                  iHaveFooInMyName
-                  meTooIHaveFoo
-                  a
-                  b
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe('newlinesInside', () => {
-      for (let newlinesInside of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'group1',
-                        selector: 'named',
-                        newlinesInside,
-                      },
-                    ],
-                    groups: ['group1'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenIntersectionTypes',
-                  },
-                ],
-                output: dedent`
-                  type T =
-                    & a
-
-                    & b
-                `,
-                code: dedent`
-                  type T =
-                    & a
-                    & b
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesInside of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'group1',
-                        selector: 'named',
-                        newlinesInside,
-                      },
-                    ],
-                    type: 'alphabetical',
-                    groups: ['group1'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenIntersectionTypes',
-                  },
-                ],
-                output: dedent`
-                  type T =
-                    & a
-                    & b
-                `,
-                code: dedent`
-                  type T =
-                    & a
-
-                    & b
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
+              & b
+          `,
+        })
+      },
+    )
   })
 
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
+  describe('natural', () => {
     let options = {
-      type: 'alphabetical',
-      ignoreCase: true,
+      type: 'natural',
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}: sorts intersection types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ label: 'bb' }",
-                left: "{ label: 'c' }",
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          options: [options],
-        },
-      ],
-    })
+    it(`sorts intersection types`, async () => {
+      await valid({
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        options: [options],
+      })
 
-    ruleTester.run(`${ruleName}: sorts keyword intersection types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: 'string',
-                right: 'any',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-            {
-              data: {
-                left: 'unknown',
-                right: 'null',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-            {
-              data: {
-                left: 'undefined',
-                right: 'never',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-            {
-              data: {
-                right: 'bigint',
-                left: 'void',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Value =
-              & any
-              & bigint
-              & boolean
-              & never
-              & null
-              & number
-              & string
-              & undefined
-              & unknown
-              & void
-          `,
-          code: dedent`
-            type Value =
-              & boolean
-              & number
-              & string
-              & any
-              & unknown
-              & null
-              & undefined
-              & never
-              & void
-              & bigint
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with generics`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'AA',
-                left: 'B',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: 'Omit<T, AA & B>',
-          code: 'Omit<T, B & AA>',
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ name: A, status: 'aa' }",
-                left: "{ name: B, status: 'b' }",
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type =
-              & { name: A, status: 'aa' }
-              & { name: B, status: 'b' }
-          `,
-          code: dedent`
-            type Type =
-              & { name: B, status: 'b' }
-              & { name: A, status: 'aa' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts intersections with parentheses`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '( A: () => void, ) => B & C',
-                left: 'B',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              t:
-                & ((
-                    A: () => void,
-                  ) => B & C)
-                & B
-                & C
-            }
-          `,
-          code: dedent`
-            type Type = {
-              t:
-                & B
-                & ((
-                    A: () => void,
-                  ) => B & C)
-                & C
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts intersections with comment at the end`,
-      rule,
-      {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: '{ value3: 3 }',
-                  left: '{ value4: 4 }',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-              {
-                data: {
-                  right: '{ value100: 100 }',
-                  left: '{ value5: 5 }',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Step = { value1: 1 } & { value100: 100 } & { value2: 2 } & { value3: 3 } & { value4: 4 } & { value5: 5 }; // Comment
-            `,
-            code: dedent`
-              type Step = { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 } & { value100: 100 }; // Comment
-            `,
-            options: [options],
+            data: {
+              right: "{ label: 'bb' }",
+              left: "{ label: 'c' }",
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
           },
         ],
-        valid: [],
+        output: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts keyword intersection types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '{ stringValue: string }',
+              right: '{ anyValue: any }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              left: '{ unknownValue: unknown }',
+              right: '{ nullValue: null }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              left: '{ undefinedValue: undefined }',
+              right: '{ neverValue: never }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: '{ bigintValue: bigint }',
+              left: '{ voidValue: void }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Value =
+            & { anyValue: any }
+            & { bigintValue: bigint }
+            & { booleanValue: boolean }
+            & { neverValue: never }
+            & { nullValue: null }
+            & { numberValue: number }
+            & { stringValue: string }
+            & { undefinedValue: undefined }
+            & { unknownValue: unknown }
+            & { voidValue: void }
+        `,
+        code: dedent`
+          type Value =
+            & { booleanValue: boolean }
+            & { numberValue: number }
+            & { stringValue: string }
+            & { anyValue: any }
+            & { unknownValue: unknown }
+            & { nullValue: null }
+            & { undefinedValue: undefined }
+            & { neverValue: never }
+            & { voidValue: void }
+            & { bigintValue: bigint }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with generics', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: 'Omit<T, AA & B>',
+        code: 'Omit<T, B & AA>',
+        options: [options],
+      })
+    })
+
+    it('works with type references', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: 'type Type = A & B & C',
+        code: 'type Type = A & C & B',
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with named properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ name: A, status: 'aa' }",
+              left: "{ name: B, status: 'b' }",
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & { name: A, status: 'aa' }
+            & { name: B, status: 'b' }
+        `,
+        code: dedent`
+          type Type =
+            & { name: B, status: 'b' }
+            & { name: A, status: 'aa' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with parentheses', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '( A: () => void, ) => B & C',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            t:
+              & ((
+                  A: () => void,
+                ) => B & C)
+              & B
+              & C
+          }
+        `,
+        code: dedent`
+          type Type = {
+            t:
+              & B
+              & ((
+                  A: () => void,
+                ) => B & C)
+              & C
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with comment at the end', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ value3: 3 }',
+              left: '{ value4: 4 }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Step =  { value1: 1 } & { value2: 2 } & { value3: 3 } & { value4: 4 } & { value5: 5 } & { value100: 100 }; // Comment
+        `,
+        code: dedent`
+          type Step =  { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 } & { value100: 100 }; // Comment
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections using groups', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            & A
+            & intrinsic
+            & SomeClass['name']
+            & string[]
+            & any
+            & bigint
+            & boolean
+            & number
+            & this
+            & unknown
+            & keyof A
+            & keyof { a: string; b: number }
+            & typeof B
+            & 1
+            & 'aaa'
+            & \`\${A}\`
+            & (new () => SomeClass)
+            & (import('path'))
+            & (A extends B ? C : D)
+            & { [P in keyof T]: T[P] }
+            & { name: 'a' }
+            & [A, B, C]
+            & (A & B)
+            & (A | B)
+            & null
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: "{ name: 'a' }",
+              rightGroup: 'keyword',
+              leftGroup: 'object',
+              right: 'boolean',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'keyword',
+              rightGroup: 'named',
+              left: 'boolean',
+              right: 'A',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'operator',
+              rightGroup: 'keyword',
+              left: 'keyof A',
+              right: 'bigint',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'nullish',
+              left: 'null',
+              right: '1',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'intersection',
+              leftGroup: 'union',
+              right: 'A & B',
+              left: 'A | B',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type =
+            & A
+            & any
+            & bigint
+            & boolean
+            & keyof A
+            & typeof B
+            & 1
+            & 'aaa'
+            & (import('path'))
+            & (A extends B ? C : D)
+            & { name: 'a' }
+            & [A, B, C]
+            & (A & B)
+            & (A | B)
+            & null
+        `,
+        code: dedent`
+          type Type =
+            & any
+            & { name: 'a' }
+            & boolean
+            & A
+            & keyof A
+            & bigint
+            & typeof B
+            & 'aaa'
+            & (import('path'))
+            & null
+            & 1
+            & (A extends B ? C : D)
+            & [A, B, C]
+            & (A | B)
+            & (A & B)
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            A &
+            D &
+
+            C &
+
+            B &
+            E
+        `,
+        code: dedent`
+          type Type =
+            D &
+            A &
+
+            C &
+
+            E &
+            B
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            // Not partition comment
+            BBB &
+            CC &
+            D &
+            // Part: B
+            AAA &
+            E &
+            // Part: C
+            // Not partition comment
+            FFF &
+            GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            CC &
+            D &
+            // Not partition comment
+            BBB &
+            // Part: B
+            AAA &
+            E &
+            // Part: C
+            GG &
+            // Not partition comment
+            FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            & BBB
+            & CC
+            // Not partition comment
+            & D
+            // Part: B
+            & AAA
+            & E
+            // Part: C
+            & FFF
+            // Not partition comment
+            & GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            & CC
+            & D
+            // Not partition comment
+            & BBB
+            // Part: B
+            & AAA
+            & E
+            // Part: C
+            & GG
+            // Not partition comment
+            & FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            // Comment
+            BB &
+            // Other comment
+            A
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D &
+            // Part: B
+            AAA &
+            BB &
+            C &
+            /* Other */
+            E
+        `,
+        code: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D &
+            // Part: B
+            AAA &
+            C &
+            BB &
+            /* Other */
+            E
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            E &
+            F &
+            // I am a partition comment because I don't have f o o
+            A &
+            B
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            /* Comment */
+            A &
+            B
+        `,
+        code: dedent`
+          type Type =
+            B &
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C &
+            // B
+            B &
+            // A
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            // I am a partition comment because I don't have f o o
+            A
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            // Comment
+            A &
+            B
+        `,
+        code: dedent`
+          type Type =
+            B &
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C &
+            /* B */
+            B &
+            /* A */
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            /* I am a partition comment because I don't have f o o */
+            A
+        `,
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          type T =
+            _A &
+            B &
+            _C
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type T =
+            AB &
+            A_C
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            你好 &
+            世界 &
+            a &
+            A &
+            b &
+            B
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: '() => null',
+                right: 'Y',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'unexpectedIntersectionTypesOrder',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['function', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              (() => null)
+
+
+             & Y
+            & Z
+
+                & B
+          `,
+          output: dedent`
+            type T =
+              (() => null)
+             & B
+            & Y
+                & Z
+          `,
+        })
       },
     )
 
-    ruleTester.run(`${ruleName}: sorts intersections using groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: "{ name: 'a' }",
-                rightGroup: 'keyword',
-                leftGroup: 'object',
-                right: 'boolean',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ a: string }',
+              left: '() => void',
             },
-            {
-              data: {
-                leftGroup: 'keyword',
-                rightGroup: 'named',
-                left: 'boolean',
-                right: 'A',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
+            messageId: 'missedSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              left: '{ a: string }',
+              right: 'A',
             },
-            {
-              data: {
-                leftGroup: 'operator',
-                rightGroup: 'keyword',
-                left: 'keyof A',
-                right: 'bigint',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              right: '[A]',
+              left: 'A',
             },
-            {
-              data: {
-                rightGroup: 'literal',
-                leftGroup: 'nullish',
-                left: 'null',
-                right: '1',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'intersection',
-                leftGroup: 'union',
-                right: 'A & B',
-                left: 'A | B',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-          ],
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'function',
+              { newlinesBetween: 'always' },
+              'object',
+              { newlinesBetween: 'always' },
+              'named',
+              { newlinesBetween: 'never' },
+              'tuple',
+              { newlinesBetween: 'ignore' },
+              'nullish',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            (() => void) &
+
+            { a: string } &
+
+            A &
+            [A] &
+
+
+            null
+        `,
+        code: dedent`
+          type Type =
+            (() => void) &
+            { a: string } &
+
+
+            A &
+
+            [A] &
+
+
+            null
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
               groups: [
                 'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
                 'tuple',
-                'intersection',
-                'union',
+                { newlinesBetween: groupNewlinesBetween },
                 'nullish',
               ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A &
+
+
+              null
+          `,
+          code: dedent`
+            type T =
+              A &
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                { newlinesBetween: 'never' },
+                'tuple',
+                { newlinesBetween: 'never' },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A &
+              null
+          `,
+          code: dedent`
+            type T =
+              A &
+
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A &
+
+              null
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A &
+              null
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'named',
+              right: "'a'",
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['literal', 'named'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type T =
+            & 'a' // Comment after
+
+            & B
+            & C
+        `,
+        code: dedent`
+          type T =
+            & B
+            & 'a' // Comment after
+
+            & C
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedIntersectionTypesOrder',
             },
           ],
           output: dedent`
             type Type =
-              & A
-              & any
-              & bigint
-              & boolean
-              & keyof A
-              & typeof B
-              & 'aaa'
-              & 1
-              & (import('path'))
-              & (A extends B ? C : D)
-              & { name: 'a' }
-              & [A, B, C]
-              & (A & B)
-              & (A | B)
-              & null
+              & a
+
+              // Partition comment
+
+              & b
+              & c
           `,
           code: dedent`
             type Type =
-              & any
-              & { name: 'a' }
-              & boolean
-              & A
-              & keyof A
-              & bigint
-              & typeof B
-              & 'aaa'
-              & (import('path'))
-              & null
-              & 1
-              & (A extends B ? C : D)
-              & [A, B, C]
-              & (A | B)
-              & (A & B)
+              & a
+
+              // Partition comment
+
+              & c
+              & b
           `,
-        },
-      ],
-      valid: [
-        {
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & A & B
+        `,
+        code: dedent`
+          type T =
+            & B & A
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            A & B
+        `,
+        code: dedent`
+          type T =
+            B & A
+        `,
+        options: [options],
+      })
+    })
+
+    it('filters on selector', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'namedElements',
+              leftGroup: 'unknown',
+              left: 'null',
+              right: 'a',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'namedElements',
+                selector: 'named',
+              },
+            ],
+            groups: ['namedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
+            & null
+        `,
+        code: dedent`
+          type T =
+            & null
+            & a
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'namedStartingWithHello',
+                  elementNamePattern,
+                  selector: 'named',
+                },
+              ],
+              groups: ['namedStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'namedStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloNamed',
+                left: 'undefined',
+              },
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type =
+              & helloNamed
+              & null
+              & undefined
+          `,
           code: dedent`
             type Type =
-              & A
-              & SomeClass['name']
-              & string[]
-              & any
-              & bigint
-              & boolean
-              & keyof A
-              & typeof B
-              & 'aaa'
-              & 1
-              & (new () => SomeClass)
-              & (import('path'))
-              & (A extends B ? C : D)
-              & { [P in keyof T]: T[P] }
-              & { name: 'a' }
-              & [A, B, C]
-              & (A & B)
-              & (A | B)
               & null
+              & undefined
+              & helloNamed
           `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedNamedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: "'m'",
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedNamedByLineLength',
+                type: 'line-length',
+                selector: 'named',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedNamedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type T =
+            & dddd
+            & ccc
+            & eee
+            & bb
+            & ff
+            & a
+            & g
+            & 'm'
+            & 'o'
+            & 'p'
+        `,
+        code: dedent`
+          type T =
+            & a
+            & bb
+            & ccc
+            & dddd
+            & 'm'
+            & eee
+            & ff
+            & g
+            & 'o'
+            & 'p'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & fooBar
+            & fooZar
+        `,
+        code: dedent`
+          type T =
+            & fooZar
+            & fooBar
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedNamed',
+                selector: 'named',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedNamed', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedNamed',
+              leftGroup: 'unknown',
+              left: "'m'",
+              right: 'c',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & b
+            & a
+            & d
+            & e
+            & c
+            & 'm'
+        `,
+        code: dedent`
+          type T =
+            & b
+            & a
+            & d
+            & e
+            & 'm'
+            & c
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'named',
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'literal',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'foo'",
+              left: 'null',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & 'foo'
+            & cFoo
+
+            & null
+        `,
+        code: dedent`
+          type T =
+            & null
+            & 'foo'
+            & cFoo
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type T =
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines within groups when newlinesInside is %s',
+      async (_, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              & a
+
+              & b
+          `,
+          code: dedent`
+            type T =
+              & a
+              & b
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within groups when newlinesInside is %s',
+      async (_, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              & a
+              & b
+          `,
+          code: dedent`
+            type T =
+              & a
+
+              & b
+          `,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it(`sorts intersection types`, async () => {
+      await valid({
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ label: 'bb' }",
+              left: "{ label: 'c' }",
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts keyword intersection types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ unknownValue: unknown }',
+              left: '{ anyValue: any }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: '{ undefinedValue: undefined }',
+              left: '{ nullValue: null }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: '{ bigintValue: bigint }',
+              left: '{ voidValue: void }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Value =
+            & { undefinedValue: undefined }
+            & { booleanValue: boolean }
+            & { unknownValue: unknown }
+            & { numberValue: number }
+            & { stringValue: string }
+            & { bigintValue: bigint }
+            & { neverValue: never }
+            & { nullValue: null }
+            & { voidValue: void }
+            & { anyValue: any }
+        `,
+        code: dedent`
+          type Value =
+            & { booleanValue: boolean }
+            & { numberValue: number }
+            & { stringValue: string }
+            & { anyValue: any }
+            & { unknownValue: unknown }
+            & { nullValue: null }
+            & { undefinedValue: undefined }
+            & { neverValue: never }
+            & { voidValue: void }
+            & { bigintValue: bigint }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with generics', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: 'Omit<T, AA & B>',
+        code: 'Omit<T, B & AA>',
+        options: [options],
+      })
+    })
+
+    it('works with type references', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: 'type Type = AAA & BB & C',
+        code: 'type Type = AAA & C & BB',
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with named properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ name: A, status: 'aa' }",
+              left: "{ name: B, status: 'b' }",
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & { name: A, status: 'aa' }
+            & { name: B, status: 'b' }
+        `,
+        code: dedent`
+          type Type =
+            & { name: B, status: 'b' }
+            & { name: A, status: 'aa' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with parentheses', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '( A: () => void, ) => B & C',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            t:
+              & ((
+                  A: () => void,
+                ) => B & C)
+              & B
+              & C
+          }
+        `,
+        code: dedent`
+          type Type = {
+            t:
+              & B
+              & ((
+                  A: () => void,
+                ) => B & C)
+              & C
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections with comment at the end', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ value100: 100 }',
+              left: '{ value5: 5 }',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Step =  { value100: 100 } & { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 }; // Comment
+        `,
+        code: dedent`
+          type Step =  { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 } & { value100: 100 }; // Comment
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts intersections using groups', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            & SomeClass['name']
+            & intrinsic
+            & string[]
+            & A
+            & boolean
+            & unknown
+            & bigint
+            & number
+            & this
+            & any
+            & keyof { a: string; b: number }
+            & typeof B
+            & keyof A
+            & \`\${A}\`
+            & 'aaa'
+            & 1
+            & (new () => SomeClass)
+            & (import('path'))
+            & (A extends B ? C : D)
+            & { [P in keyof T]: T[P] }
+            & { name: 'a' }
+            & [A, B, C]
+            & (A & B)
+            & (A | B)
+            & null
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: "{ name: 'a' }",
+              rightGroup: 'keyword',
+              leftGroup: 'object',
+              right: 'boolean',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'keyword',
+              rightGroup: 'named',
+              left: 'boolean',
+              right: 'A',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'operator',
+              rightGroup: 'keyword',
+              left: 'keyof A',
+              right: 'bigint',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'nullish',
+              left: 'null',
+              right: '1',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'intersection',
+              leftGroup: 'union',
+              right: 'A & B',
+              left: 'A | B',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type =
+            & A
+            & boolean
+            & bigint
+            & any
+            & typeof B
+            & keyof A
+            & 'aaa'
+            & 1
+            & (import('path'))
+            & (A extends B ? C : D)
+            & { name: 'a' }
+            & [A, B, C]
+            & (A & B)
+            & (A | B)
+            & null
+        `,
+        code: dedent`
+          type Type =
+            & any
+            & { name: 'a' }
+            & boolean
+            & A
+            & keyof A
+            & bigint
+            & typeof B
+            & 'aaa'
+            & (import('path'))
+            & null
+            & 1
+            & (A extends B ? C : D)
+            & [A, B, C]
+            & (A | B)
+            & (A & B)
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            A &
+            D &
+
+            C &
+
+            B &
+            E
+        `,
+        code: dedent`
+          type Type =
+            D &
+            A &
+
+            C &
+
+            E &
+            B
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            // Not partition comment
+            BBB &
+            CC &
+            D &
+            // Part: B
+            AAA &
+            E &
+            // Part: C
+            // Not partition comment
+            FFF &
+            GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            CC &
+            D &
+            // Not partition comment
+            BBB &
+            // Part: B
+            AAA &
+            E &
+            // Part: C
+            GG &
+            // Not partition comment
+            FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            & BBB
+            & CC
+            // Not partition comment
+            & D
+            // Part: B
+            & AAA
+            & E
+            // Part: C
+            & FFF
+            // Not partition comment
+            & GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            & CC
+            & D
+            // Not partition comment
+            & BBB
+            // Part: B
+            & AAA
+            & E
+            // Part: C
+            & GG
+            // Not partition comment
+            & FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            // Comment
+            BB &
+            // Other comment
+            A
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D &
+            // Part: B
+            AAA &
+            BB &
+            C &
+            /* Other */
+            E
+        `,
+        code: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D &
+            // Part: B
+            AAA &
+            C &
+            BB &
+            /* Other */
+            E
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            E &
+            F &
+            // I am a partition comment because I don't have f o o
+            AAA &
+            BB
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            /* Comment */
+            AA &
+            B
+        `,
+        code: dedent`
+          type Type =
+            B &
+            /* Comment */
+            AA
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C &
+            // B
+            B &
+            // A
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            // I am a partition comment because I don't have f o o
+            A
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            // Comment
+            AA &
+            B
+        `,
+        code: dedent`
+          type Type =
+            B &
+            // Comment
+            AA
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C &
+            /* B */
+            B &
+            /* A */
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B &
+            /* I am a partition comment because I don't have f o o */
+            A
+        `,
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          type T =
+            _AA &
+            BB &
+            _C
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type T =
+            ABC &
+            A_C
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            你好 &
+            世界 &
+            a &
+            A &
+            b &
+            B
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: '() => null',
+                right: 'YY',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+            {
+              data: {
+                right: 'BBB',
+                left: 'Z',
+              },
+              messageId: 'unexpectedIntersectionTypesOrder',
+            },
+            {
+              data: {
+                right: 'BBB',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['function', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              (() => null)
+
+
+             & YY
+            & Z
+
+                & BBB
+          `,
+          output: dedent`
+            type T =
+              (() => null)
+             & BBB
+            & YY
+                & Z
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ a: string }',
+              left: '() => void',
+            },
+            messageId: 'missedSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              left: '{ a: string }',
+              right: 'A',
+            },
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              right: '[A]',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'function',
+              { newlinesBetween: 'always' },
+              'object',
+              { newlinesBetween: 'always' },
+              'named',
+              { newlinesBetween: 'never' },
+              'tuple',
+              { newlinesBetween: 'ignore' },
+              'nullish',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            (() => void) &
+
+            { a: string } &
+
+            A &
+            [A] &
+
+
+            null
+        `,
+        code: dedent`
+          type Type =
+            (() => void) &
+            { a: string } &
+
+
+            A &
+
+            [A] &
+
+
+            null
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
               groups: [
                 'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
                 'tuple',
-                'intersection',
-                'union',
+                { newlinesBetween: groupNewlinesBetween },
                 'nullish',
               ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
-        },
-      ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A &
+
+
+              null
+          `,
+          code: dedent`
+            type T =
+              A &
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                { newlinesBetween: 'never' },
+                'tuple',
+                { newlinesBetween: 'never' },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A &
+              null
+          `,
+          code: dedent`
+            type T =
+              A &
+
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A &
+
+              null
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A &
+              null
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'named',
+              right: "'a'",
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['literal', 'named'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type T =
+            & 'a' // Comment after
+
+            & B
+            & C
+        `,
+        code: dedent`
+          type T =
+            & B
+            & 'a' // Comment after
+
+            & C
+        `,
+      })
     })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedIntersectionTypesOrder',
+            },
+          ],
+          output: dedent`
+            type Type =
+              & aaa
+
+              // Partition comment
+
+              & bb
+              & c
+          `,
+          code: dedent`
+            type Type =
+              & aaa
+
+              // Partition comment
+
+              & c
+              & bb
+          `,
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & AA & B
+        `,
+        code: dedent`
+          type T =
+            & B & AA
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            AA & B
+        `,
+        code: dedent`
+          type T =
+            B & AA
+        `,
+        options: [options],
+      })
+    })
+
+    it('filters on selector', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'namedElements',
+              leftGroup: 'unknown',
+              left: 'null',
+              right: 'a',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'namedElements',
+                selector: 'named',
+              },
+            ],
+            groups: ['namedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
+            & null
+        `,
+        code: dedent`
+          type T =
+            & null
+            & a
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'namedStartingWithHello',
+                  elementNamePattern,
+                  selector: 'named',
+                },
+              ],
+              groups: ['namedStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'namedStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloNamed',
+                left: 'undefined',
+              },
+              messageId: 'unexpectedIntersectionTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type =
+              & helloNamed
+              & null
+              & undefined
+          `,
+          code: dedent`
+            type Type =
+              & null
+              & undefined
+              & helloNamed
+          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedNamedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: "'m'",
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedNamedByLineLength',
+                type: 'line-length',
+                selector: 'named',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedNamedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type T =
+            & dddd
+            & ccc
+            & eee
+            & bb
+            & ff
+            & a
+            & g
+            & 'm'
+            & 'o'
+            & 'p'
+        `,
+        code: dedent`
+          type T =
+            & a
+            & bb
+            & ccc
+            & dddd
+            & 'm'
+            & eee
+            & ff
+            & g
+            & 'o'
+            & 'p'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & fooBar
+            & fooZar
+        `,
+        code: dedent`
+          type T =
+            & fooZar
+            & fooBar
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedNamed',
+                selector: 'named',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedNamed', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedNamed',
+              leftGroup: 'unknown',
+              left: "'m'",
+              right: 'c',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & b
+            & a
+            & d
+            & e
+            & c
+            & 'm'
+        `,
+        code: dedent`
+          type T =
+            & b
+            & a
+            & d
+            & e
+            & 'm'
+            & c
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'named',
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'literal',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'foo'",
+              left: 'null',
+            },
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            & 'foo'
+            & cFoo
+
+            & null
+        `,
+        code: dedent`
+          type T =
+            & null
+            & 'foo'
+            & cFoo
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type T =
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines within groups when newlinesInside is %s',
+      async (_, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              & a
+
+              & b
+          `,
+          code: dedent`
+            type T =
+              & a
+              & b
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within groups when newlinesInside is %s',
+      async (_, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenIntersectionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              & a
+              & b
+          `,
+          code: dedent`
+            type T =
+              & a
+
+              & b
+          `,
+        })
+      },
+    )
   })
 
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
+  describe('custom', () => {
     let alphabet = Alphabet.generateRecommendedAlphabet()
       .sortByLocaleCompare('en-US')
       .getCharacters()
+
     let options = {
       type: 'custom',
       order: 'asc',
       alphabet,
     } as const
 
-    ruleTester.run(`${ruleName}(${type}: sorts intersection types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ label: 'bb' }",
-                left: "{ label: 'c' }",
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
+    it('sorts intersection types', async () => {
+      await valid({
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        options: [options],
+      })
 
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}: sorts intersection types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ label: 'bb' }",
-                left: "{ label: 'c' }",
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: sorts keyword intersection types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'unknown',
-                left: 'any',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-            {
-              data: {
-                right: 'undefined',
-                left: 'null',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-            {
-              data: {
-                right: 'bigint',
-                left: 'void',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Value =
-              & undefined
-              & boolean
-              & unknown
-              & number
-              & string
-              & bigint
-              & never
-              & null
-              & void
-              & any
-          `,
-          code: dedent`
-            type Value =
-              & boolean
-              & number
-              & string
-              & any
-              & unknown
-              & null
-              & undefined
-              & never
-              & void
-              & bigint
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with generics`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'AA',
-                left: 'B',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: 'Omit<T, AA & B>',
-          code: 'Omit<T, B & AA>',
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      valid: [
-        {
-          code: 'type DemonSlayer = A & B & C',
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ name: A, status: 'aa' }",
-                left: "{ name: B, status: 'b' }",
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type =
-              & { name: A, status: 'aa' }
-              & { name: B, status: 'b' }
-          `,
-          code: dedent`
-            type Type =
-              & { name: B, status: 'b' }
-              & { name: A, status: 'aa' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts intersections with parentheses`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '( A: () => void, ) => B & C',
-                left: 'B',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              t:
-                & ((
-                    A: () => void,
-                  ) => B & C)
-                & B
-                & C
-            }
-          `,
-          code: dedent`
-            type Type = {
-              t:
-                & B
-                & ((
-                    A: () => void,
-                  ) => B & C)
-                & C
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts intersections with comment at the end`,
-      rule,
-      {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: '{ value100: 100 }',
-                  left: '{ value5: 5 }',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Step = { value100: 100 } & { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 }; // Comment
-            `,
-            code: dedent`
-              type Step = { value1: 1 } & { value2: 2 } & { value4: 4 } & { value3: 3 } & { value5: 5 } & { value100: 100 }; // Comment
-            `,
-            options: [options],
+            data: {
+              right: "{ label: 'bb' }",
+              left: "{ label: 'c' }",
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
           },
         ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: sorts intersections using groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: "{ name: 'a' }",
-                rightGroup: 'keyword',
-                leftGroup: 'object',
-                right: 'boolean',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'keyword',
-                rightGroup: 'named',
-                left: 'boolean',
-                right: 'A',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'operator',
-                rightGroup: 'keyword',
-                left: 'keyof A',
-                right: 'bigint',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'literal',
-                leftGroup: 'nullish',
-                left: 'null',
-                right: '1',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'intersection',
-                leftGroup: 'union',
-                right: 'A & B',
-                left: 'A | B',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
-              ],
-            },
-          ],
-          output: dedent`
-            type Type =
-              & A
-              & boolean
-              & bigint
-              & any
-              & typeof B
-              & keyof A
-              & 'aaa'
-              & 1
-              & (import('path'))
-              & (A extends B ? C : D)
-              & { name: 'a' }
-              & [A, B, C]
-              & (A & B)
-              & (A | B)
-              & null
-          `,
-          code: dedent`
-            type Type =
-              & any
-              & { name: 'a' }
-              & boolean
-              & A
-              & keyof A
-              & bigint
-              & typeof B
-              & 'aaa'
-              & (import('path'))
-              & null
-              & 1
-              & (A extends B ? C : D)
-              & [A, B, C]
-              & (A | B)
-              & (A & B)
-          `,
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              & SomeClass['name']
-              & string[]
-              & A
-              & boolean
-              & bigint
-              & any
-              & typeof B
-              & keyof A
-              & 'aaa'
-              & 1
-              & (new () => SomeClass)
-              & (import('path'))
-              & (A extends B ? C : D)
-              & { [P in keyof T]: T[P] }
-              & { name: 'a' }
-              & [A, B, C]
-              & (A & B)
-              & (A | B)
-              & null
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
-              ],
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'A',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              type T =
-                & BB
-                & C
-                & A
-            `,
-            code: dedent`
-              type T =
-                & A
-                & BB
-                & C
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              type T =
-                & BB
-                & A
-                & C
-
-            `,
-            code: dedent`
-              type T =
-                & C
-                & BB
-                & A
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: validating group configuration`, () => {
-    ruleTester.run(`${ruleName}: allows predefined groups`, rule, {
-      valid: [
-        {
-          options: [
-            {
-              groups: [
-                'intersection',
-                'conditional',
-                'function',
-                'operator',
-                'keyword',
-                'literal',
-                'nullish',
-                'unknown',
-                'import',
-                'object',
-                'named',
-                'tuple',
-                'union',
-              ],
-            },
-          ],
-          code: dedent`
-            type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
-          `,
-        },
-      ],
-      invalid: [],
+        output: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'c' } & { label: 'bb' }
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
+  describe('unsorted', () => {
     let options = {
       type: 'unsorted',
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              & B
-              & C
-              & A
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            & B
+            & C
+            & A
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'literal',
-                rightGroup: 'named',
-                left: "'aa'",
-                right: 'ba',
-              },
-              messageId: 'unexpectedIntersectionTypesGroupOrder',
+    it('enforces grouping', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'literal',
+              rightGroup: 'named',
+              left: "'aa'",
+              right: 'ba',
             },
-          ],
-          output: dedent`
-            type Type =
-              & ba
-              & bb
-              & 'ab'
-              & 'aa'
-          `,
-          code: dedent`
-            type Type =
-              & 'ab'
-              & 'aa'
-              & ba
-              & bb
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['named', 'literal'],
-            },
-          ],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedIntersectionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & ba
+            & bb
+            & 'ab'
+            & 'aa'
+        `,
+        code: dedent`
+          type Type =
+            & 'ab'
+            & 'aa'
+            & ba
+            & bb
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['named', 'literal'],
+          },
+        ],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "'a'",
-                left: 'b',
-              },
-              messageId: 'missedSpacingBetweenIntersectionTypes',
+    it('enforces newlines between groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: 'b',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['named', 'literal'],
-              newlinesBetween: 'always',
-            },
-          ],
-          output: dedent`
-            type Type =
-              & b
+            messageId: 'missedSpacingBetweenIntersectionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['named', 'literal'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & b
 
-              & 'a'
-          `,
-          code: dedent`
-            type Type =
-              & b
-              & 'a'
-          `,
-        },
-      ],
-      valid: [],
+            & 'a'
+        `,
+        code: dedent`
+          type Type =
+            & b
+            & 'a'
+        `,
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'NumberBase.BASE_10',
-                  left: 'NumberBase.BASE_2',
-                },
-                messageId: 'unexpectedIntersectionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type SupportedNumberBase = NumberBase.BASE_10 & NumberBase.BASE_16 & NumberBase.BASE_2
-            `,
-            code: dedent`
-              type SupportedNumberBase = NumberBase.BASE_2 & NumberBase.BASE_10 & NumberBase.BASE_16
-            `,
-          },
-        ],
-        valid: [
-          dedent`
-            type SupportedNumberBase = NumberBase.BASE_10 & NumberBase.BASE_16 & NumberBase.BASE_2
-          `,
-          {
-            code: dedent`
-              type SupportedNumberBase = NumberBase.BASE_10 & NumberBase.BASE_16 & NumberBase.BASE_2
-            `,
-            options: [{}],
-          },
-        ],
-      },
-    )
 
-    ruleTester.run(`${ruleName}: should ignore whitespaces`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type T =
-            { a: string } &
-            {  b: string }
-          `,
-          options: [{}],
-        },
-      ],
-      invalid: [],
+    it('allows predefined groups', async () => {
+      await valid({
+        options: [
+          {
+            groups: [
+              'intersection',
+              'conditional',
+              'function',
+              'operator',
+              'keyword',
+              'literal',
+              'nullish',
+              'unknown',
+              'import',
+              'object',
+              'named',
+              'tuple',
+              'union',
+            ],
+          },
+        ],
+        code: dedent`
+          type Type = { label: 'aaa' } & { label: 'bb' } & { label: 'c' }
+        `,
+      })
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+    it('sets alphabetical asc sorting as default', async () => {
+      await valid(
+        dedent`
+          type SupportedNumberBase = NumberBase.BASE_10 & NumberBase.BASE_16 & NumberBase.BASE_2
+        `,
+      )
+
+      await valid({
+        code: dedent`
+          type SupportedNumberBase = NumberBase.BASE_10 & NumberBase.BASE_16 & NumberBase.BASE_2
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'NumberBase.BASE_10',
+              left: 'NumberBase.BASE_2',
             },
-          ],
-          output: dedent`
-            type T =
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type SupportedNumberBase = NumberBase.BASE_10 & NumberBase.BASE_16 & NumberBase.BASE_2
+        `,
+        code: dedent`
+          type SupportedNumberBase = NumberBase.BASE_2 & NumberBase.BASE_10 & NumberBase.BASE_16
+        `,
+      })
+    })
+
+    it('ignores whitespaces', async () => {
+      await valid({
+        code: dedent`
+          type T =
+          { a: string } &
+          {  b: string }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable comments', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            & B
+            & C
+            // eslint-disable-next-line
+            & A
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            // eslint-disable-next-line
+            & A
+        `,
+        code: dedent`
+          type T =
+            C
+            & B
+            // eslint-disable-next-line
+            & A
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'C',
+              left: 'D',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'A',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            // eslint-disable-next-line
+            & A
+            & D
+        `,
+        code: dedent`
+          type T =
+            D
+            & C
+            // eslint-disable-next-line
+            & A
+            & B
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            & A // eslint-disable-line
+        `,
+        code: dedent`
+          type T =
+            C
+            & B
+            & A // eslint-disable-line
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            /* eslint-disable-next-line */
+            & A
+        `,
+        code: dedent`
+          type T =
+            C
+            & B
+            /* eslint-disable-next-line */
+            & A
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            & A /* eslint-disable-line */
+        `,
+        code: dedent`
+          type T =
+            C
+            & B
+            & A /* eslint-disable-line */
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type =
+            A
+            & D
+            /* eslint-disable */
+            & C
+            & B
+            // Shouldn't move
+            /* eslint-enable */
+            & E
+        `,
+        code: dedent`
+          type Type =
+            D
+            & E
+            /* eslint-disable */
+            & C
+            & B
+            // Shouldn't move
+            /* eslint-enable */
+            & A
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            // eslint-disable-next-line rule-to-test/sort-intersection-types
+            & A
+        `,
+        code: dedent`
+          type T =
+            C
+            & B
+            // eslint-disable-next-line rule-to-test/sort-intersection-types
+            & A
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            & A // eslint-disable-line rule-to-test/sort-intersection-types
+        `,
+        code: dedent`
+          type T =
+            C
+            & B
+            & A // eslint-disable-line rule-to-test/sort-intersection-types
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
               B
               & C
-              // eslint-disable-next-line
+              /* eslint-disable-next-line rule-to-test/sort-intersection-types */
               & A
-          `,
-          code: dedent`
-            type T =
+        `,
+        code: dedent`
+          type T =
               C
               & B
-              // eslint-disable-next-line
+              /* eslint-disable-next-line rule-to-test/sort-intersection-types */
               & A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'C',
-                left: 'D',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'A',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            & C
+            & A /* eslint-disable-line rule-to-test/sort-intersection-types */
+        `,
+        code: dedent`
+          type T =
+            C
+            & B
+            & A /* eslint-disable-line rule-to-test/sort-intersection-types */
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type =
+            A
+            & D
+            /* eslint-disable rule-to-test/sort-intersection-types */
+            & C
+            & B
+            // Shouldn't move
+            /* eslint-enable */
+            & E
+        `,
+        code: dedent`
+          type Type =
+            D
+            & E
+            /* eslint-disable rule-to-test/sort-intersection-types */
+            & C
+            & B
+            // Shouldn't move
+            /* eslint-enable */
+            & A
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              & C
-              // eslint-disable-next-line
-              & A
-              & D
-          `,
-          code: dedent`
-            type T =
-              D
-              & C
-              // eslint-disable-next-line
-              & A
-              & B
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type T =
-              B
-              & C
-              & A // eslint-disable-line
-          `,
-          code: dedent`
-            type T =
-              C
-              & B
-              & A // eslint-disable-line
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type T =
-              B
-              & C
-              /* eslint-disable-next-line */
-              & A
-          `,
-          code: dedent`
-            type T =
-              C
-              & B
-              /* eslint-disable-next-line */
-              & A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type T =
-              B
-              & C
-              & A /* eslint-disable-line */
-          `,
-          code: dedent`
-            type T =
-              C
-              & B
-              & A /* eslint-disable-line */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type =
-              A
-              & D
-              /* eslint-disable */
-              & C
-              & B
-              // Shouldn't move
-              /* eslint-enable */
-              & E
-          `,
-          code: dedent`
-            type Type =
-              D
-              & E
-              /* eslint-disable */
-              & C
-              & B
-              // Shouldn't move
-              /* eslint-enable */
-              & A
-          `,
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type T =
-              B
-              & C
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              & A
-          `,
-          code: dedent`
-            type T =
-              C
-              & B
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              & A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type T =
-              B
-              & C
-              & A // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          code: dedent`
-            type T =
-              C
-              & B
-              & A // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type T =
-                B
-                & C
-                /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-                & A
-          `,
-          code: dedent`
-            type T =
-                C
-                & B
-                /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-                & A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type T =
-              B
-              & C
-              & A /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          code: dedent`
-            type T =
-              C
-              & B
-              & A /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type =
-              A
-              & D
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              & C
-              & B
-              // Shouldn't move
-              /* eslint-enable */
-              & E
-          `,
-          code: dedent`
-            type Type =
-              D
-              & E
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              & C
-              & B
-              // Shouldn't move
-              /* eslint-enable */
-              & A
-          `,
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              & B
-              & C
-              // eslint-disable-next-line
-              & A
-          `,
-        },
-      ],
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
     })
   })
 })

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1,6 +1,6 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
 import typescriptParser from '@typescript-eslint/parser'
-import { afterAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import path from 'node:path'
 import dedent from 'dedent'
 
@@ -8,20 +8,11 @@ import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-jsx-props'
 
-let ruleName = 'sort-jsx-props'
-
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester({
+describe('sort-jsx-props', () => {
+  let { invalid, valid } = createRuleTester({
     languageOptions: {
       parserOptions: {
-        tsconfigRootDir: path.join(__dirname, '../fixtures'),
+        tsconfigRootDir: path.join(import.meta.dirname, '../fixtures'),
         extraFileExtensions: ['.svelte', '.astro', '.vue'],
         ecmaFeatures: {
           jsx: true,
@@ -30,2838 +21,1398 @@ describe(ruleName, () => {
         parser: typescriptParser,
       },
     },
+    name: 'sort-jsx-props',
+    rule,
   })
 
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts jsx props`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
-          `,
-          code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                c="c"
-                b="bb"
-              >
-                Value
-              </Element>
-            )
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
+    it('sorts jsx props', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              c="c"
+              b="bb"
+            >
+              Value
+            </Element>
+          )
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [options],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts jsx props with namespaced names`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  b="bb"
-                  c="c"
-                  d:e="d"
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  d:e="d"
-                  b="bb"
-                  c="c"
-                />
-              )
-            `,
-            errors: [
-              {
-                data: {
-                  left: 'd:e',
-                  right: 'b',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  b="bb"
-                  c="c"
-                  d:e="d"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
+    it('sorts jsx props with namespaced names', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+              d:e="d"
+            />
+          )
+        `,
+        options: [options],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+              d:e="d"
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              d:e="d"
+              b="bb"
+              c="c"
+            />
+          )
+        `,
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            output: dedent`
-              let Component = () => (
-                <Element
-                  d
-                  e="e"
-                  f="f"
-                  {...data}
-                  a="a"
-                  b="b"
-                  c="c"
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  e="e"
-                  d
-                  f="f"
-                  {...data}
-                  b="b"
-                  a="a"
-                  c="c"
-                />
-              )
-            `,
-            options: [options],
+            data: {
+              left: 'd:e',
+              right: 'b',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
           },
         ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  d
-                  e="e"
-                  f="f"
-                  {...data}
-                  a="a"
-                  b="b"
-                  c="c"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
+        options: [options],
+      })
+    })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set shorthand props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'shorthand',
-                  rightGroup: 'unknown',
-                  left: 'aaaaaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let Component = () => (
-                <Element
-                  b="b"
-                  c="c"
-                  d="d"
-                  aaaaaa
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  aaaaaa
-                  b="b"
-                  c="c"
-                  d="d"
-                />
-              )
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown', 'shorthand'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  b="b"
-                  c="c"
-                  d="d"
-                  aaaaaa
-                />
-              )
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown', 'shorthand'],
-              },
-            ],
-          },
-        ],
-      },
-    )
+    it('preserves spread elements between jsx props groups', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              d
+              e="e"
+              f="f"
+              {...data}
+              a="a"
+              b="b"
+              c="c"
+            />
+          )
+        `,
+        options: [options],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set callback props position`,
-      rule,
-      {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'callback',
-                  rightGroup: 'unknown',
-                  left: 'onChange',
-                  right: 'a',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                customGroups: { callback: 'on' },
-                groups: ['unknown', 'callback'],
-              },
-            ],
-            output: dedent`
-              <Element
-                a="a"
-                b="b"
-                onChange={handleChange}
-              />
-            `,
-            code: dedent`
-              <Element
-                onChange={handleChange}
-                a="a"
-                b="b"
-              />
-            `,
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
           },
         ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: { callback: 'on' },
-                groups: ['unknown', 'callback'],
-              },
-            ],
-            code: dedent`
-              <Element
-                a="a"
-                b="b"
-                onChange={handleChange}
-              />
-            `,
-          },
-        ],
-      },
-    )
+        output: dedent`
+          let Component = () => (
+            <Element
+              d
+              e="e"
+              f="f"
+              {...data}
+              a="a"
+              b="b"
+              c="c"
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              e="e"
+              d
+              f="f"
+              {...data}
+              b="b"
+              a="a"
+              c="c"
+            />
+          )
+        `,
+        options: [options],
+      })
+    })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set multiline props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'multiline',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            output: dedent`
-              <Element
-                d={() => {
-                  fn()
-                }}
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-                a="aaa"
-                b="bb"
-                c="c"
-              />
-            `,
-            code: dedent`
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-                d={() => {
-                  fn()
-                }}
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-              />
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              <Element
-                d={() => {
-                  fn()
-                }}
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-                a="aaa"
-                b="bb"
-                c="c"
-              />
-            `,
-            options: [
-              {
-                ...options,
-                groups: [['multiline'], 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
+    it('positions shorthand props according to group configuration', async () => {
+      let shorthandOptions = {
+        ...options,
+        groups: ['unknown', 'shorthand'],
+      }
 
-    ruleTester.run(`${ruleName}(${type}): allows to set priority props`, rule, {
-      invalid: [
-        {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              b="b"
+              c="c"
+              d="d"
+              aaaaaa
+            />
+          )
+        `,
+        options: [shorthandOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'shorthand',
+              rightGroup: 'unknown',
+              left: 'aaaaaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let Component = () => (
+            <Element
+              b="b"
+              c="c"
+              d="d"
+              aaaaaa
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              aaaaaa
+              b="b"
+              c="c"
+              d="d"
+            />
+          )
+        `,
+        options: [shorthandOptions],
+      })
+    })
+
+    it('positions callback props according to custom group pattern', async () => {
+      let callbackOptions = {
+        ...options,
+        customGroups: { callback: 'on' },
+        groups: ['unknown', 'callback'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            a="a"
+            b="b"
+            onChange={handleChange}
+          />
+        `,
+        options: [callbackOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'callback',
+              rightGroup: 'unknown',
+              left: 'onChange',
+              right: 'a',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            a="a"
+            b="b"
+            onChange={handleChange}
+          />
+        `,
+        code: dedent`
+          <Element
+            onChange={handleChange}
+            a="a"
+            b="b"
+          />
+        `,
+        options: [callbackOptions],
+      })
+    })
+
+    it('positions multiline props according to group configuration', async () => {
+      let multilineOptions = {
+        ...options,
+        groups: ['multiline', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            d={() => {
+              fn()
+            }}
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+            a="aaa"
+            b="bb"
+            c="c"
+          />
+        `,
+        options: [multilineOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            d={() => {
+              fn()
+            }}
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+            a="aaa"
+            b="bb"
+            c="c"
+          />
+        `,
+        code: dedent`
+          <Element
+            a="aaa"
+            b="bb"
+            c="c"
+            d={() => {
+              fn()
+            }}
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+          />
+        `,
+        options: [multilineOptions],
+      })
+    })
+
+    it('prioritizes props in custom top group', async () => {
+      let topGroupOptions = {
+        ...options,
+        customGroups: { top: ['d', 'e'] },
+        groups: ['top', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            d="ddd"
+            e="ee"
+            a="aaaa"
+            b="bbb"
+            c="cc"
+          />
+        `,
+        options: [topGroupOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'top',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            d="ddd"
+            e="ee"
+            a="aaaa"
+            b="bbb"
+            c="cc"
+          />
+        `,
+        code: dedent`
+          <Element
+            a="aaaa"
+            b="bbb"
+            c="cc"
+            d="ddd"
+            e="ee"
+          />
+        `,
+        options: [topGroupOptions],
+      })
+    })
+
+    it('matches props using regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          <Element
+            iHaveFooInMyName="iHaveFooInMyName"
+            meTooIHaveFoo="meTooIHaveFoo"
+            a="a"
+            b="b"
+          />
+        `,
+      })
+    })
+
+    it('ignores special characters when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          <Element
+            $a
+            b="b"
+            $c
+          />
+        `,
+      })
+    })
+
+    it('groups props by shorthand selector', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'shorthandElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'shorthandElements',
+                selector: 'shorthand',
+              },
+            ],
+            groups: ['shorthandElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          <Element
+            a
+            b="b"
+          />
+        `,
+        code: dedent`
+          <Element
+            b="b"
+            a
+          />
+        `,
+      })
+    })
+
+    it('groups props by shorthand modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'shorthandElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'shorthandElements',
+                modifiers: ['shorthand'],
+              },
+            ],
+            groups: ['shorthandElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          <Element
+            a
+            b="b"
+          />
+        `,
+        code: dedent`
+          <Element
+            b="b"
+            a
+          />
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups props by element name pattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'shorthandsStartingWithHello',
+                  modifiers: ['shorthand'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['shorthandsStartingWithHello', 'unknown'],
+            },
+          ],
           errors: [
             {
               data: {
+                rightGroup: 'shorthandsStartingWithHello',
+                right: 'helloShorthand',
                 leftGroup: 'unknown',
-                rightGroup: 'top',
-                right: 'd',
-                left: 'c',
+                left: 'b',
               },
               messageId: 'unexpectedJSXPropsGroupOrder',
             },
           ],
           output: dedent`
             <Element
-              d="ddd"
-              e="ee"
-              a="aaaa"
-              b="bbb"
-              c="cc"
+              helloShorthand
+              a="a"
+              b="b"
             />
           `,
           code: dedent`
             <Element
-              a="aaaa"
-              b="bbb"
-              c="cc"
-              d="ddd"
-              e="ee"
+              a="a"
+              b="b"
+              helloShorthand
             />
           `,
-          options: [
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array of patterns', ['noMatch', 'HELLO']],
+      ['case-insensitive regex', { pattern: 'hello', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'hello', flags: 'i' }]],
+    ])(
+      'groups props by element value pattern - %s',
+      async (_description, elementValuePattern) => {
+        await invalid({
+          errors: [
             {
-              ...options,
-              customGroups: { top: ['d', 'e'] },
-              groups: ['top', 'unknown'],
+              data: {
+                rightGroup: 'valuesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'z',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsGroupOrder',
             },
           ],
-        },
-      ],
-      valid: [
-        {
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  elementValuePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            <Element
+              z="HELLO_VALUE"
+              a="a"
+              b
+            />
+          `,
           code: dedent`
             <Element
-              d="ddd"
-              e="ee"
-              a="aaaa"
-              b="bbb"
-              c="cc"
+              a="a"
+              b
+              z="HELLO_VALUE"
             />
           `,
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['d', 'e'] },
-              groups: ['top', 'unknown'],
+        })
+      },
+    )
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
             },
-          ],
-        },
-      ],
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedShorthandsByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedShorthandsByLineLength',
+                modifiers: ['shorthand'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedShorthandsByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          <Element
+            dddd
+            ccc
+            eee
+            bb
+            ff
+            a
+            g
+            m="m"
+            o="o"
+            p="p"
+          />
+        `,
+        code: dedent`
+          <Element
+            a
+            bb
+            ccc
+            dddd
+            m="m"
+            eee
+            ff
+            g
+            o="o"
+            p="p"
+          />
+        `,
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for custom groups`,
-      rule,
-      {
-        valid: [
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
           {
-            options: [
+            customGroups: [
               {
-                ...options,
-                customGroups: {
-                  elementsWithoutFoo: '^(?!.*Foo).*$',
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
                 },
-                groups: ['unknown', 'elementsWithoutFoo'],
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
               },
             ],
-            code: dedent`
-              <Element
-                iHaveFooInMyName="iHaveFooInMyName"
-                meTooIHaveFoo="meTooIHaveFoo"
-                a="a"
-                b="b"
-              />
-            `,
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
+        errors: [
           {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              <Element
-                $a
-                b="b"
-                $c
-              />
-            `,
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'shorthandElements',
-                  leftGroup: 'unknown',
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'shorthandElements',
-                    selector: 'shorthand',
-                  },
-                ],
-                groups: ['shorthandElements', 'unknown'],
-              },
-            ],
-            output: dedent`
-              <Element
-                a
-                b="b"
-              />
-            `,
-            code: dedent`
-              <Element
-                b="b"
-                a
-              />
-            `,
-          },
-        ],
-        valid: [],
+        output: dedent`
+          <Element
+            fooBar
+            fooZar
+          />
+        `,
+        code: dedent`
+          <Element
+            fooZar
+            fooBar
+          />
+        `,
       })
+    })
 
-      ruleTester.run(`${ruleName}: filters on modifier`, rule, {
-        invalid: [
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
           {
-            errors: [
+            customGroups: [
               {
-                data: {
-                  rightGroup: 'shorthandElements',
-                  leftGroup: 'unknown',
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
+                groupName: 'unsortedShorthands',
+                modifiers: ['shorthand'],
+                type: 'unsorted',
               },
             ],
-            options: [
+            groups: ['unsortedShorthands', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedShorthands',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b
+            a
+            d
+            e
+            c
+            m="m"
+          />
+        `,
+        code: dedent`
+          <Element
+            b
+            a
+            d
+            e
+            m="m"
+            c
+          />
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
               {
-                customGroups: [
+                anyOf: [
                   {
-                    groupName: 'shorthandElements',
+                    elementNamePattern: 'foo|Foo',
                     modifiers: ['shorthand'],
                   },
-                ],
-                groups: ['shorthandElements', 'unknown'],
-              },
-            ],
-            output: dedent`
-              <Element
-                a
-                b="b"
-              />
-            `,
-            code: dedent`
-              <Element
-                b="b"
-                a
-              />
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'shorthandsStartingWithHello',
-                      modifiers: ['shorthand'],
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['shorthandsStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'shorthandsStartingWithHello',
-                    right: 'helloShorthand',
-                    leftGroup: 'unknown',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedJSXPropsGroupOrder',
-                },
-              ],
-              output: dedent`
-                <Element
-                  helloShorthand
-                  a="a"
-                  b="b"
-                />
-              `,
-              code: dedent`
-                <Element
-                  a="a"
-                  b="b"
-                  helloShorthand
-                />
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      for (let elementValuePattern of [
-        'HELLO',
-        ['noMatch', 'HELLO'],
-        { pattern: 'hello', flags: 'i' },
-        ['noMatch', { pattern: 'hello', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'valuesStartingWithHello',
-                    leftGroup: 'unknown',
-                    right: 'z',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedJSXPropsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'valuesStartingWithHello',
-                      elementValuePattern,
-                    },
-                  ],
-                  groups: ['valuesStartingWithHello', 'unknown'],
-                },
-              ],
-              output: dedent`
-                <Element
-                  z="HELLO_VALUE"
-                  a="a"
-                  b
-                />
-              `,
-              code: dedent`
-                <Element
-                  a="a"
-                  b
-                  z="HELLO_VALUE"
-                />
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedJSXPropsOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedJSXPropsOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedJSXPropsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedShorthandsByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'eee',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedJSXPropsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedShorthandsByLineLength',
-                      modifiers: ['shorthand'],
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedShorthandsByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                <Element
-                  dddd
-                  ccc
-                  eee
-                  bb
-                  ff
-                  a
-                  g
-                  m="m"
-                  o="o"
-                  p="p"
-                />
-              `,
-              code: dedent`
-                <Element
-                  a
-                  bb
-                  ccc
-                  dddd
-                  m="m"
-                  eee
-                  ff
-                  g
-                  o="o"
-                  p="p"
-                />
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedJSXPropsOrder',
-                },
-              ],
-              output: dedent`
-                <Element
-                  fooBar
-                  fooZar
-                />
-              `,
-              code: dedent`
-                <Element
-                  fooZar
-                  fooBar
-                />
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedShorthands',
-                      modifiers: ['shorthand'],
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedShorthands', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedShorthands',
-                    leftGroup: 'unknown',
-                    right: 'c',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedJSXPropsGroupOrder',
-                },
-              ],
-              output: dedent`
-                <Element
-                  b
-                  a
-                  d
-                  e
-                  c
-                  m="m"
-                />
-              `,
-              code: dedent`
-                <Element
-                  b
-                  a
-                  d
-                  e
-                  m="m"
-                  c
-                />
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
                   {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        modifiers: ['shorthand'],
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
+                    elementNamePattern: 'foo|Foo',
                   },
                 ],
-                groups: ['elementsIncludingFoo', 'unknown'],
+                groupName: 'elementsIncludingFoo',
               },
             ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: 'cFoo',
-                  left: 'a',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            output: dedent`
-              <Element
-                cFoo
-                foo="foo"
-                a
-              />
-            `,
-            code: dedent`
-              <Element
-                a
-                cFoo
-                foo="foo"
-              />
-            `,
+            groups: ['elementsIncludingFoo', 'unknown'],
           },
         ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                <Element
-                  iHaveFooInMyName
-                  meTooIHaveFoo
-                  a
-                  b
-                />
-              `,
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
             },
-          ],
-          invalid: [],
-        },
-      )
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            cFoo
+            foo="foo"
+            a
+          />
+        `,
+        code: dedent`
+          <Element
+            a
+            cFoo
+            foo="foo"
+          />
+        `,
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
           {
-            options: [
+            customGroups: [
               {
-                ...options,
-                specialCharacters: 'remove',
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
               },
             ],
-            code: dedent`
-              <Component
-                ab
-                a$c
-              />
-            `,
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
           },
         ],
-        invalid: [],
-      },
-    )
+        code: dedent`
+          <Element
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+          />
+        `,
+      })
+    })
 
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          <Component
+            ab
+            a$c
+          />
+        `,
+      })
+    })
+
+    it('sorts props according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          <Component
+            你好
+            世界
+            a
+            A
+            b
+            B
+          />
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts props within newline-separated groups independently', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+            d
+
+            c
+
+            b
+            e
+          />
+        `,
+        code: dedent`
+          <Component
+            d
+            a
+
+            c
+
+            e
+            b
+          />
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: { a: 'a' },
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
           code: dedent`
             <Component
-              你好
-              世界
               a
-              A
-              b
-              B
+
+
+             y
+            z
+
+                b
             />
           `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'd',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-              {
-                data: {
-                  right: 'b',
-                  left: 'e',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            output: dedent`
-              <Component
-                a
-                d
-
-                c
-
-                b
-                e
-              />
-            `,
-            code: dedent`
-              <Component
-                d
-                a
-
-                c
-
-                e
-                b
-              />
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenJSXPropsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedJSXPropsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenJSXPropsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: { a: 'a' },
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  <Component
-                    a
-
-
-                   y
-                  z
-
-                      b
-                  />
-                `,
-                output: dedent`
-                  <Component
-                    a
-                   b
-                  y
-                      z
-                  />
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenJSXPropsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedJSXPropsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenJSXPropsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: {
-                      a: 'a',
-                      b: 'b',
-                    },
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  <Component
-                    a
-
-                   y
-                  z
-
-                      b
-                  />
-                `,
-                code: dedent`
-                  <Component
-                    a
-
-
-                   z
-                  y
-                      b
-                  />
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: {
-                      a: 'a',
-                      b: 'b',
-                      c: 'c',
-                      d: 'd',
-                      e: 'e',
-                    },
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenJSXPropsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenJSXPropsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenJSXPropsMembers',
-                  },
-                ],
-                output: dedent`
-                  <Component
-                    a
-
-                    b
-
-                    c
-                    d
-
-
-                    e
-                  />
-                `,
-                code: dedent`
-                  <Component
-                    a
-                    b
-
-
-                    c
-
-                    d
-
-
-                    e
-                  />
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        customGroups: {
-                          unusedGroup: 'X',
-                          a: 'a',
-                          b: 'b',
-                        },
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenJSXPropsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      <Component
-                        a
-
-
-                        b
-                      />
-                    `,
-                    code: dedent`
-                      <Component
-                        a
-                        b
-                      />
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenJSXPropsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      <Component
-                        a
-                        b
-                      />
-                    `,
-                    code: dedent`
-                      <Component
-                        a
-
-                        b
-                      />
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        customGroups: {
-                          unusedGroup: 'X',
-                          a: 'a',
-                          b: 'b',
-                        },
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      <Component
-                        a
-
-                        b
-                      />
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        customGroups: {
-                          unusedGroup: 'X',
-                          a: 'a',
-                          b: 'b',
-                        },
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      <Component
-                        a
-                        b
-                      />
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
+          output: dedent`
+            <Component
+              a
+             b
+            y
+                z
+            />
+          `,
         })
-      })
+      },
+    )
 
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
             {
-              output: [
-                dedent`
-                  <Component
-                    a // Comment after
-                    b
-
-                    c
-                  />
-                `,
-                dedent`
-                  <Component
-                    a // Comment after
-
-                    b
-                    c
-                  />
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedJSXPropsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: {
-                    'b|c': 'b|c',
-                  },
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              code: dedent`
-                <Component
-                  b
-                  a // Comment after
-
-                  c
-                />
-              `,
+              data: {
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+            {
+              data: {
+                right: 'y',
+                left: 'z',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'y',
+              },
+              messageId: 'missedSpacingBetweenJSXPropsMembers',
             },
           ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      for (let rgbAllNamesMatchPattern of [
-        '^r|g|b$',
-        ['noMatch', '^r|g|b$'],
-        { pattern: '^R|G|B$', flags: 'i' },
-        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'g',
-                      leftGroup: 'b',
-                      right: 'g',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedJSXPropsGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'r',
-                      leftGroup: 'g',
-                      right: 'r',
-                      left: 'g',
-                    },
-                    messageId: 'unexpectedJSXPropsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    useConfigurationIf: {
-                      allNamesMatchPattern: 'foo',
-                    },
-                  },
-                  {
-                    ...options,
-                    customGroups: {
-                      r: 'r',
-                      g: 'g',
-                      b: 'b',
-                    },
-                    useConfigurationIf: {
-                      allNamesMatchPattern: rgbAllNamesMatchPattern,
-                    },
-                    groups: ['r', 'g', 'b'],
-                  },
-                ],
-                output: dedent`
-                  <Component
-                    r
-                    g
-                    b
-                  />
-                `,
-                code: dedent`
-                  <Component
-                    b
-                    g
-                    r
-                  />
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): allows to use 'tagMatchesPattern'`, () => {
-        for (let tagMatchesPattern of [
-          '^Component$',
-          ['noMatch', '^Component'],
-          { pattern: '^COMPONENT$', flags: 'i' },
-          ['noMatch', { pattern: '^COMPONENT', flags: 'i' }],
-        ]) {
-          ruleTester.run(
-            `${ruleName}(${type}): detects tag name by pattern`,
-            rule,
+          options: [
             {
-              invalid: [
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedJSXPropsOrder',
-                    },
-                  ],
-                  options: [
-                    {
-                      useConfigurationIf: {
-                        tagMatchesPattern,
-                      },
-                      type: 'unsorted',
-                    },
-                    options,
-                  ],
-                  output: dedent`
-                    <OtherComponent
-                      a
-                      b
-                    />
-                  `,
-                  code: dedent`
-                    <OtherComponent
-                      b
-                      a
-                    />
-                  `,
-                },
-              ],
-              valid: [
-                {
-                  options: [
-                    {
-                      useConfigurationIf: {
-                        tagMatchesPattern,
-                      },
-                      type: 'unsorted',
-                    },
-                    options,
-                  ],
-                  code: dedent`
-                    <Component
-                      b
-                      c
-                      a
-                    />
-                  `,
-                },
-              ],
+              ...options,
+              customGroups: {
+                a: 'a',
+                b: 'b',
+              },
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
             },
-          )
-        }
-      })
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts jsx props`, rule, {
-      invalid: [
-        {
+          ],
           output: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
+            <Component
+              a
+
+             y
+            z
+
+                b
+            />
           `,
           code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                c="c"
-                b="bb"
-              >
-                Value
-              </Element>
-            )
+            <Component
+              a
+
+
+             z
+            y
+                b
+            />
           `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              a: 'a',
+              b: 'b',
+              c: 'c',
+              d: 'd',
+              e: 'e',
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+
+            b
+
+            c
+            d
+
+
+            e
+          />
+        `,
+        code: dedent`
+          <Component
+            a
+            b
+
+
+            c
+
+            d
+
+
+            e
+          />
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              customGroups: {
+                unusedGroup: 'X',
+                a: 'a',
+                b: 'b',
+              },
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
           errors: [
             {
               data: {
                 right: 'b',
-                left: 'c',
+                left: 'a',
               },
-              messageId: 'unexpectedJSXPropsOrder',
+              messageId: 'missedSpacingBetweenJSXPropsMembers',
             },
           ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
+          output: dedent`
+            <Component
+              a
+
+
+              b
+            />
           `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts jsx props with namespaced names`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  b="bb"
-                  c="c"
-                  d:e="d"
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  d:e="d"
-                  b="bb"
-                  c="c"
-                />
-              )
-            `,
-            errors: [
-              {
-                data: {
-                  left: 'd:e',
-                  right: 'b',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  b="bb"
-                  c="c"
-                  d:e="d"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
+          code: dedent`
+            <Component
+              a
+              b
+            />
+          `,
+        })
       },
     )
 
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            output: dedent`
-              let Component = () => (
-                <Element
-                  d
-                  e="e"
-                  f="f"
-                  {...data}
-                  a="a"
-                  b="b"
-                  c="c"
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  e="e"
-                  d
-                  f="f"
-                  {...data}
-                  b="b"
-                  a="a"
-                  c="c"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  d
-                  e="e"
-                  f="f"
-                  {...data}
-                  a="a"
-                  b="b"
-                  c="c"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set shorthand props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'shorthand',
-                  rightGroup: 'unknown',
-                  left: 'aaaaaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let Component = () => (
-                <Element
-                  b="b"
-                  c="c"
-                  d="d"
-                  aaaaaa
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  aaaaaa
-                  b="b"
-                  c="c"
-                  d="d"
-                />
-              )
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown', 'shorthand'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  b="b"
-                  c="c"
-                  d="d"
-                  aaaaaa
-                />
-              )
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown', 'shorthand'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set callback props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'callback',
-                  rightGroup: 'unknown',
-                  left: 'onChange',
-                  right: 'a',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                customGroups: { callback: 'on' },
-                groups: ['unknown', 'callback'],
-              },
-            ],
-            output: dedent`
-              <Element
-                a="a"
-                b="b"
-                onChange={handleChange}
-              />
-            `,
-            code: dedent`
-              <Element
-                onChange={handleChange}
-                a="a"
-                b="b"
-              />
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: { callback: 'on' },
-                groups: ['unknown', 'callback'],
-              },
-            ],
-            code: dedent`
-              <Element
-                a="a"
-                b="b"
-                onChange={handleChange}
-              />
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set multiline props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'multiline',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            output: dedent`
-              <Element
-                d={() => {
-                  fn()
-                }}
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-                a="aaa"
-                b="bb"
-                c="c"
-              />
-            `,
-            code: dedent`
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-                d={() => {
-                  fn()
-                }}
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-              />
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              <Element
-                d={() => {
-                  fn()
-                }}
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-                a="aaa"
-                b="bb"
-                c="c"
-              />
-            `,
-            options: [
-              {
-                ...options,
-                groups: [['multiline'], 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to set priority props`, rule, {
-      invalid: [
-        {
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
           errors: [
             {
               data: {
-                leftGroup: 'unknown',
-                rightGroup: 'top',
-                right: 'd',
-                left: 'c',
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          output: dedent`
+            <Component
+              a
+              b
+            />
+          `,
+          code: dedent`
+            <Component
+              a
+
+              b
+            />
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering props', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: {
+              'b|c': 'b|c',
+            },
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          <Component
+            a // Comment after
+
+            b
+            c
+          />
+        `,
+        code: dedent`
+          <Component
+            b
+            a // Comment after
+
+            c
+          />
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', '^r|g|b$'],
+      ['array of patterns', ['noMatch', '^r|g|b$']],
+      ['case-insensitive regex', { pattern: '^R|G|B$', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: '^R|G|B$', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_description, allNamesMatchPattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
               },
               messageId: 'unexpectedJSXPropsGroupOrder',
             },
           ],
-          output: dedent`
-            <Element
-              d="ddd"
-              e="ee"
-              a="aaaa"
-              b="bbb"
-              c="cc"
-            />
-          `,
-          code: dedent`
-            <Element
-              a="aaaa"
-              b="bbb"
-              c="cc"
-              d="ddd"
-              e="ee"
-            />
-          `,
           options: [
             {
               ...options,
-              customGroups: { top: ['d', 'e'] },
-              groups: ['top', 'unknown'],
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
             },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            <Element
-              d="ddd"
-              e="ee"
-              a="aaaa"
-              b="bbb"
-              c="cc"
-            />
-          `,
-          options: [
             {
               ...options,
-              customGroups: { top: ['d', 'e'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts jsx props`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
-          `,
-          code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                c="c"
-                b="bb"
-              >
-                Value
-              </Element>
-            )
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
               },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-          ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts jsx props`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
-          `,
-          code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                c="c"
-                b="bb"
-              >
-                Value
-              </Element>
-            )
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+              useConfigurationIf: {
+                allNamesMatchPattern,
               },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-          ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Component = () => (
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-              >
-                Value
-              </Element>
-            )
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts jsx props with namespaced names`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  d:e="d"
-                  b="bb"
-                  c="c"
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  b="bb"
-                  d:e="d"
-                  c="c"
-                />
-              )
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'd:e',
-                  left: 'b',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  d:e="d"
-                  b="bb"
-                  c="c"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'f',
-                  left: 'd',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            output: dedent`
-              let Component = () => (
-                <Element
-                  e="ee"
-                  f="f"
-                  d
-                  {...data}
-                  a="aaa"
-                  b="bb"
-                  c="c"
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  e="ee"
-                  d
-                  f="f"
-                  {...data}
-                  b="bb"
-                  a="aaa"
-                  c="c"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  e="ee"
-                  f="f"
-                  d
-                  {...data}
-                  a="aaa"
-                  b="bb"
-                  c="c"
-                />
-              )
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set shorthand props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'shorthand',
-                  rightGroup: 'unknown',
-                  left: 'aaaaaa',
-                  right: 'b',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let Component = () => (
-                <Element
-                  b="b"
-                  c="c"
-                  d="d"
-                  aaaaaa
-                />
-              )
-            `,
-            code: dedent`
-              let Component = () => (
-                <Element
-                  aaaaaa
-                  b="b"
-                  c="c"
-                  d="d"
-                />
-              )
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown', 'shorthand'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  b="b"
-                  c="c"
-                  d="d"
-                  aaaaaa
-                />
-              )
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown', 'shorthand'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set callback props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'callback',
-                  rightGroup: 'unknown',
-                  left: 'onChange',
-                  right: 'a',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                customGroups: { callback: 'on' },
-                groups: ['unknown', 'callback'],
-              },
-            ],
-            output: dedent`
-              <Element
-                a="a"
-                b="b"
-                onChange={handleChange}
-              />
-            `,
-            code: dedent`
-              <Element
-                onChange={handleChange}
-                a="a"
-                b="b"
-              />
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: { callback: 'on' },
-                groups: ['unknown', 'callback'],
-              },
-            ],
-            code: dedent`
-              <Element
-                a="a"
-                b="b"
-                onChange={handleChange}
-              />
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set multiline props position`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'multiline',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedJSXPropsGroupOrder',
-              },
-              {
-                data: {
-                  right: 'e',
-                  left: 'd',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            output: dedent`
-              <Element
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-                d={() => {
-                  fn()
-                }}
-                a="aaa"
-                b="bb"
-                c="c"
-              />
-            `,
-            code: dedent`
-              <Element
-                a="aaa"
-                b="bb"
-                c="c"
-                d={() => {
-                  fn()
-                }}
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-              />
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              <Element
-                e={{
-                  f: 'f',
-                  g: 'g',
-                }}
-                d={() => {
-                  fn()
-                }}
-                a="aaa"
-                b="bb"
-                c="c"
-              />
-            `,
-            options: [
-              {
-                ...options,
-                groups: [['multiline'], 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to set priority props`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'unknown',
-                rightGroup: 'top',
-                right: 'd',
-                left: 'c',
-              },
-              messageId: 'unexpectedJSXPropsGroupOrder',
+              groups: ['r', 'g', 'b'],
             },
           ],
           output: dedent`
-            <Element
-              d="ddd"
-              e="ee"
-              a="aaaa"
-              b="bbb"
-              c="cc"
+            <Component
+              r
+              g
+              b
             />
           `,
           code: dedent`
-            <Element
-              a="aaaa"
-              b="bbb"
-              c="cc"
-              d="ddd"
-              e="ee"
+            <Component
+              b
+              g
+              r
             />
           `,
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['d', 'e'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['d', 'e'] },
-              groups: ['top', 'unknown'],
-              ignoreCase: true,
-            },
-          ],
-          code: dedent`
-            <Element
-              d="ddd"
-              e="ee"
-              a="aaaa"
-              b="bbb"
-              c="cc"
-            />
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              <Element
-                bb="bb"
-                c="c"
-                a="a"
-              />
-            `,
-            code: dedent`
-              <Element
-                a="a"
-                bb="bb"
-                c="c"
-              />
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedJSXPropsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              <Element
-                bb="bb"
-                a="a"
-                c="c"
-              />
-            `,
-            code: dedent`
-              <Element
-                c="c"
-                bb="bb"
-                a="a"
-              />
-            `,
-          },
-        ],
-        valid: [],
+        })
       },
     )
-  })
 
-  describe(`${ruleName}: validating group configuration`, () => {
-    ruleTester.run(
-      `${ruleName}: allows predefined groups and defined custom groups`,
-      rule,
-      {
-        valid: [
+    it.each([
+      ['string pattern', '^Component$'],
+      ['array of patterns', ['noMatch', '^Component']],
+      ['case-insensitive regex', { pattern: '^COMPONENT$', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: '^COMPONENT', flags: 'i' }]],
+    ])(
+      'applies different configuration based on tag name pattern - %s',
+      async (_description, tagMatchesPattern) => {
+        let conditionalOptions = [
           {
-            code: dedent`
-              let Component = () => (
-                <Element
-                  a="aaa"
-                  b="bb"
-                  c="c"
-                >
-                  Value
-                </Element>
-              )
-            `,
-            options: [
-              {
-                customGroups: {
-                  myCustomGroup: 'x',
-                },
-                groups: ['multiline', 'shorthand', 'unknown', 'myCustomGroup'],
-              },
-            ],
+            useConfigurationIf: {
+              tagMatchesPattern,
+            },
+            type: 'unsorted',
           },
-        ],
-        invalid: [],
-      },
-    )
-  })
+          options,
+        ]
 
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
+        await valid({
           code: dedent`
             <Component
               b
@@ -2869,22 +1420,1364 @@ describe(ruleName, () => {
               a
             />
           `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
+          options: conditionalOptions,
+        })
 
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
+        await invalid({
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+          ],
+          output: dedent`
+            <OtherComponent
+              a
+              b
+            />
+          `,
+          code: dedent`
+            <OtherComponent
+              b
+              a
+            />
+          `,
+          options: conditionalOptions,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts jsx props', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              c="c"
+              b="bb"
+            >
+              Value
+            </Element>
+          )
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('sorts jsx props with namespaced names', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+              d:e="d"
+            />
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+              d:e="d"
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              d:e="d"
+              b="bb"
+              c="c"
+            />
+          )
+        `,
+        errors: [
+          {
+            data: {
+              left: 'd:e',
+              right: 'b',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('preserves spread elements between jsx props groups', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              d
+              e="e"
+              f="f"
+              {...data}
+              a="a"
+              b="b"
+              c="c"
+            />
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          let Component = () => (
+            <Element
+              d
+              e="e"
+              f="f"
+              {...data}
+              a="a"
+              b="b"
+              c="c"
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              e="e"
+              d
+              f="f"
+              {...data}
+              b="b"
+              a="a"
+              c="c"
+            />
+          )
+        `,
+        options: [options],
+      })
+    })
+
+    it('positions shorthand props according to group configuration', async () => {
+      let shorthandOptions = {
+        ...options,
+        groups: ['unknown', 'shorthand'],
+      }
+
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              b="b"
+              c="c"
+              d="d"
+              aaaaaa
+            />
+          )
+        `,
+        options: [shorthandOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'shorthand',
+              rightGroup: 'unknown',
+              left: 'aaaaaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let Component = () => (
+            <Element
+              b="b"
+              c="c"
+              d="d"
+              aaaaaa
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              aaaaaa
+              b="b"
+              c="c"
+              d="d"
+            />
+          )
+        `,
+        options: [shorthandOptions],
+      })
+    })
+
+    it('positions callback props according to custom group pattern', async () => {
+      let callbackOptions = {
+        ...options,
+        customGroups: { callback: 'on' },
+        groups: ['unknown', 'callback'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            a="a"
+            b="b"
+            onChange={handleChange}
+          />
+        `,
+        options: [callbackOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'callback',
+              rightGroup: 'unknown',
+              left: 'onChange',
+              right: 'a',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            a="a"
+            b="b"
+            onChange={handleChange}
+          />
+        `,
+        code: dedent`
+          <Element
+            onChange={handleChange}
+            a="a"
+            b="b"
+          />
+        `,
+        options: [callbackOptions],
+      })
+    })
+
+    it('positions multiline props according to group configuration', async () => {
+      let multilineOptions = {
+        ...options,
+        groups: ['multiline', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            d={() => {
+              fn()
+            }}
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+            a="aaa"
+            b="bb"
+            c="c"
+          />
+        `,
+        options: [multilineOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            d={() => {
+              fn()
+            }}
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+            a="aaa"
+            b="bb"
+            c="c"
+          />
+        `,
+        code: dedent`
+          <Element
+            a="aaa"
+            b="bb"
+            c="c"
+            d={() => {
+              fn()
+            }}
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+          />
+        `,
+        options: [multilineOptions],
+      })
+    })
+
+    it('prioritizes props in custom top group', async () => {
+      let topGroupOptions = {
+        ...options,
+        customGroups: { top: ['d', 'e'] },
+        groups: ['top', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            d="ddd"
+            e="ee"
+            a="aaaa"
+            b="bbb"
+            c="cc"
+          />
+        `,
+        options: [topGroupOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'top',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            d="ddd"
+            e="ee"
+            a="aaaa"
+            b="bbb"
+            c="cc"
+          />
+        `,
+        code: dedent`
+          <Element
+            a="aaaa"
+            b="bbb"
+            c="cc"
+            d="ddd"
+            e="ee"
+          />
+        `,
+        options: [topGroupOptions],
+      })
+    })
+
+    it('matches props using regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          <Element
+            iHaveFooInMyName="iHaveFooInMyName"
+            meTooIHaveFoo="meTooIHaveFoo"
+            a="a"
+            b="b"
+          />
+        `,
+      })
+    })
+
+    it('ignores special characters when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          <Element
+            $a
+            b="b"
+            $c
+          />
+        `,
+      })
+    })
+
+    it('groups props by shorthand selector', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'shorthandElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'shorthandElements',
+                selector: 'shorthand',
+              },
+            ],
+            groups: ['shorthandElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          <Element
+            a
+            b="b"
+          />
+        `,
+        code: dedent`
+          <Element
+            b="b"
+            a
+          />
+        `,
+      })
+    })
+
+    it('groups props by shorthand modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'shorthandElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'shorthandElements',
+                modifiers: ['shorthand'],
+              },
+            ],
+            groups: ['shorthandElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          <Element
+            a
+            b="b"
+          />
+        `,
+        code: dedent`
+          <Element
+            b="b"
+            a
+          />
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups props by element name pattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'shorthandsStartingWithHello',
+                  modifiers: ['shorthand'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['shorthandsStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'shorthandsStartingWithHello',
+                right: 'helloShorthand',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsGroupOrder',
+            },
+          ],
+          output: dedent`
+            <Element
+              helloShorthand
+              a="a"
+              b="b"
+            />
+          `,
+          code: dedent`
+            <Element
+              a="a"
+              b="b"
+              helloShorthand
+            />
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array of patterns', ['noMatch', 'HELLO']],
+      ['case-insensitive regex', { pattern: 'hello', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'hello', flags: 'i' }]],
+    ])(
+      'groups props by element value pattern - %s',
+      async (_description, elementValuePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'valuesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'z',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  elementValuePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            <Element
+              z="HELLO_VALUE"
+              a="a"
+              b
+            />
+          `,
+          code: dedent`
+            <Element
+              a="a"
+              b
+              z="HELLO_VALUE"
+            />
+          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedShorthandsByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedShorthandsByLineLength',
+                modifiers: ['shorthand'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedShorthandsByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          <Element
+            dddd
+            ccc
+            eee
+            bb
+            ff
+            a
+            g
+            m="m"
+            o="o"
+            p="p"
+          />
+        `,
+        code: dedent`
+          <Element
+            a
+            bb
+            ccc
+            dddd
+            m="m"
+            eee
+            ff
+            g
+            o="o"
+            p="p"
+          />
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            fooBar
+            fooZar
+          />
+        `,
+        code: dedent`
+          <Element
+            fooZar
+            fooBar
+          />
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedShorthands',
+                modifiers: ['shorthand'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedShorthands', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedShorthands',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b
+            a
+            d
+            e
+            c
+            m="m"
+          />
+        `,
+        code: dedent`
+          <Element
+            b
+            a
+            d
+            e
+            m="m"
+            c
+          />
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['shorthand'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            cFoo
+            foo="foo"
+            a
+          />
+        `,
+        code: dedent`
+          <Element
+            a
+            cFoo
+            foo="foo"
+          />
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          <Element
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+          />
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          <Component
+            ab
+            a$c
+          />
+        `,
+      })
+    })
+
+    it('sorts props according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          <Component
+            你好
+            世界
+            a
+            A
+            b
+            B
+          />
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts props within newline-separated groups independently', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+            d
+
+            c
+
+            b
+            e
+          />
+        `,
+        code: dedent`
+          <Component
+            d
+            a
+
+            c
+
+            e
+            b
+          />
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: { a: 'a' },
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            <Component
+              a
+
+
+             y
+            z
+
+                b
+            />
+          `,
+          output: dedent`
+            <Component
+              a
+             b
+            y
+                z
+            />
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+            {
+              data: {
+                right: 'y',
+                left: 'z',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'y',
+              },
+              messageId: 'missedSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: {
+                a: 'a',
+                b: 'b',
+              },
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            <Component
+              a
+
+             y
+            z
+
+                b
+            />
+          `,
+          code: dedent`
+            <Component
+              a
+
+
+             z
+            y
+                b
+            />
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              a: 'a',
+              b: 'b',
+              c: 'c',
+              d: 'd',
+              e: 'e',
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+
+            b
+
+            c
+            d
+
+
+            e
+          />
+        `,
+        code: dedent`
+          <Component
+            a
+            b
+
+
+            c
+
+            d
+
+
+            e
+          />
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              customGroups: {
+                unusedGroup: 'X',
+                a: 'a',
+                b: 'b',
+              },
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          output: dedent`
+            <Component
+              a
+
+
+              b
+            />
+          `,
+          code: dedent`
+            <Component
+              a
+              b
+            />
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          output: dedent`
+            <Component
+              a
+              b
+            />
+          `,
+          code: dedent`
+            <Component
+              a
+
+              b
+            />
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering props', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: {
+              'b|c': 'b|c',
+            },
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          <Component
+            a // Comment after
+
+            b
+            c
+          />
+        `,
+        code: dedent`
+          <Component
+            b
+            a // Comment after
+
+            c
+          />
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', '^r|g|b$'],
+      ['array of patterns', ['noMatch', '^r|g|b$']],
+      ['case-insensitive regex', { pattern: '^R|G|B$', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: '^R|G|B$', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_description, allNamesMatchPattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
               },
               messageId: 'unexpectedJSXPropsGroupOrder',
             },
@@ -2892,481 +2785,2131 @@ describe(ruleName, () => {
           options: [
             {
               ...options,
-              customGroups: {
-                a: '^a',
-                b: '^b',
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
               },
-              groups: ['b', 'a'],
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
             },
           ],
           output: dedent`
             <Component
-              ba
-              bb
-              ab
-              aa
+              r
+              g
+              b
             />
           `,
           code: dedent`
             <Component
-              ab
-              aa
-              ba
-              bb
+              b
+              g
+              r
             />
           `,
-        },
-      ],
-      valid: [],
-    })
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: {
-                a: '^a',
-                b: '^b',
-              },
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+    it.each([
+      ['string pattern', '^Component$'],
+      ['array of patterns', ['noMatch', '^Component']],
+      ['case-insensitive regex', { pattern: '^COMPONENT$', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: '^COMPONENT', flags: 'i' }]],
+    ])(
+      'applies different configuration based on tag name pattern - %s',
+      async (_description, tagMatchesPattern) => {
+        let conditionalOptions = [
+          {
+            useConfigurationIf: {
+              tagMatchesPattern,
             },
-          ],
+            type: 'unsorted',
+          },
+          options,
+        ]
+
+        await valid({
+          code: dedent`
+            <Component
+              b
+              c
+              a
+            />
+          `,
+          options: conditionalOptions,
+        })
+
+        await invalid({
           errors: [
             {
               data: {
                 right: 'a',
                 left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+          ],
+          output: dedent`
+            <OtherComponent
+              a
+              b
+            />
+          `,
+          code: dedent`
+            <OtherComponent
+              b
+              a
+            />
+          `,
+          options: conditionalOptions,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts jsx props', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              c="c"
+              b="bb"
+            >
+              Value
+            </Element>
+          )
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('sorts jsx props with namespaced names', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              d:e="d"
+              b="bb"
+              c="c"
+            />
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              d:e="d"
+              b="bb"
+              c="c"
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              d:e="d"
+              c="c"
+            />
+          )
+        `,
+        errors: [
+          {
+            data: {
+              right: 'd:e',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('preserves spread elements between jsx props groups', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              e="e"
+              f="f"
+              d
+              {...data}
+              a="a"
+              b="b"
+              c="c"
+            />
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              e="e"
+              f="f"
+              d
+              {...data}
+              b="b"
+              a="a"
+              c="c"
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              e="e"
+              d
+              f="f"
+              {...data}
+              b="b"
+              a="a"
+              c="c"
+            />
+          )
+        `,
+        errors: [
+          {
+            data: {
+              right: 'f',
+              left: 'd',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('positions shorthand props according to group configuration', async () => {
+      let shorthandOptions = {
+        ...options,
+        groups: ['unknown', 'shorthand'],
+      }
+
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              b="b"
+              c="c"
+              d="d"
+              aaaaaa
+            />
+          )
+        `,
+        options: [shorthandOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'shorthand',
+              rightGroup: 'unknown',
+              left: 'aaaaaa',
+              right: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let Component = () => (
+            <Element
+              b="b"
+              c="c"
+              d="d"
+              aaaaaa
+            />
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              aaaaaa
+              b="b"
+              c="c"
+              d="d"
+            />
+          )
+        `,
+        options: [shorthandOptions],
+      })
+    })
+
+    it('positions callback props according to custom group pattern', async () => {
+      let callbackOptions = {
+        ...options,
+        customGroups: { callback: 'on' },
+        groups: ['unknown', 'callback'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            a="a"
+            b="b"
+            onChange={handleChange}
+          />
+        `,
+        options: [callbackOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'callback',
+              rightGroup: 'unknown',
+              left: 'onChange',
+              right: 'a',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            a="a"
+            b="b"
+            onChange={handleChange}
+          />
+        `,
+        code: dedent`
+          <Element
+            onChange={handleChange}
+            a="a"
+            b="b"
+          />
+        `,
+        options: [callbackOptions],
+      })
+    })
+
+    it('positions multiline props according to group configuration', async () => {
+      let multilineOptions = {
+        ...options,
+        groups: ['multiline', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+            d={() => {
+              fn()
+            }}
+            a="aaa"
+            b="bb"
+            c="c"
+          />
+        `,
+        options: [multilineOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+          {
+            data: {
+              right: 'e',
+              left: 'd',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+            d={() => {
+              fn()
+            }}
+            a="aaa"
+            b="bb"
+            c="c"
+          />
+        `,
+        code: dedent`
+          <Element
+            a="aaa"
+            b="bb"
+            c="c"
+            d={() => {
+              fn()
+            }}
+            e={{
+              f: 'f',
+              g: 'g',
+            }}
+          />
+        `,
+        options: [multilineOptions],
+      })
+    })
+
+    it('prioritizes props in custom top group', async () => {
+      let topGroupOptions = {
+        ...options,
+        customGroups: { top: ['d', 'e'] },
+        groups: ['top', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          <Element
+            d="ddd"
+            e="ee"
+            a="aaaa"
+            b="bbb"
+            c="cc"
+          />
+        `,
+        options: [topGroupOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'top',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            d="ddd"
+            e="ee"
+            a="aaaa"
+            b="bbb"
+            c="cc"
+          />
+        `,
+        code: dedent`
+          <Element
+            a="aaaa"
+            b="bbb"
+            c="cc"
+            d="ddd"
+            e="ee"
+          />
+        `,
+        options: [topGroupOptions],
+      })
+    })
+
+    it('matches props using regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          <Element
+            iHaveFooInMyName="iHaveFooInMyName"
+            meTooIHaveFoo="meTooIHaveFoo"
+            a="a"
+            b="b"
+          />
+        `,
+      })
+    })
+
+    it('ignores special characters when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          <Element
+            b="b"
+            $a
+            $c
+          />
+        `,
+      })
+    })
+
+    it('groups props by shorthand selector', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'shorthandElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'shorthandElements',
+                selector: 'shorthand',
+              },
+            ],
+            groups: ['shorthandElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          <Element
+            a
+            b="b"
+          />
+        `,
+        code: dedent`
+          <Element
+            b="b"
+            a
+          />
+        `,
+      })
+    })
+
+    it('groups props by shorthand modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'shorthandElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'shorthandElements',
+                modifiers: ['shorthand'],
+              },
+            ],
+            groups: ['shorthandElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          <Element
+            a
+            b="b"
+          />
+        `,
+        code: dedent`
+          <Element
+            b="b"
+            a
+          />
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups props by element name pattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'shorthandsStartingWithHello',
+                  modifiers: ['shorthand'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['shorthandsStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'shorthandsStartingWithHello',
+                right: 'helloShorthand',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsGroupOrder',
+            },
+          ],
+          output: dedent`
+            <Element
+              helloShorthand
+              a="a"
+              b="b"
+            />
+          `,
+          code: dedent`
+            <Element
+              a="a"
+              b="b"
+              helloShorthand
+            />
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'HELLO'],
+      ['array of patterns', ['noMatch', 'HELLO']],
+      ['case-insensitive regex', { pattern: 'hello', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'hello', flags: 'i' }]],
+    ])(
+      'groups props by element value pattern - %s',
+      async (_description, elementValuePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'valuesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'z',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'valuesStartingWithHello',
+                  elementValuePattern,
+                },
+              ],
+              groups: ['valuesStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            <Element
+              z="HELLO_VALUE"
+              a="a"
+              b
+            />
+          `,
+          code: dedent`
+            <Element
+              a="a"
+              b
+              z="HELLO_VALUE"
+            />
+          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedShorthandsByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedShorthandsByLineLength',
+                modifiers: ['shorthand'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedShorthandsByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          <Element
+            dddd
+            ccc
+            eee
+            bb
+            ff
+            a
+            g
+            m="m"
+            o="o"
+            p="p"
+          />
+        `,
+        code: dedent`
+          <Element
+            a
+            bb
+            ccc
+            dddd
+            m="m"
+            eee
+            ff
+            g
+            o="o"
+            p="p"
+          />
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            fooBar
+            fooZar
+          />
+        `,
+        code: dedent`
+          <Element
+            fooZar
+            fooBar
+          />
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedShorthands',
+                modifiers: ['shorthand'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedShorthands', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedShorthands',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b
+            a
+            d
+            e
+            c
+            m="m"
+          />
+        `,
+        code: dedent`
+          <Element
+            b
+            a
+            d
+            e
+            m="m"
+            c
+          />
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['shorthand'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            cFoo
+            foo="foo"
+            a
+          />
+        `,
+        code: dedent`
+          <Element
+            a
+            cFoo
+            foo="foo"
+          />
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          <Element
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+          />
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          <Component
+            abcd
+            a$c
+          />
+        `,
+      })
+    })
+
+    it('sorts props according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          <Component
+            你好
+            世界
+            a
+            A
+            b
+            B
+          />
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts props within newline-separated groups independently', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaaaa',
+              left: 'dd',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'bbbb',
+              left: 'e',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Component
+            aaaaa
+            dd
+
+            ccc
+
+            bbbb
+            e
+          />
+        `,
+        code: dedent`
+          <Component
+            dd
+            aaaaa
+
+            ccc
+
+            e
+            bbbb
+          />
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: { a: 'aaaa' },
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            <Component
+              aaaa
+
+
+             yy
+            z
+
+                bbb
+            />
+          `,
+          output: dedent`
+            <Component
+              aaaa
+             bbb
+            yy
+                z
+            />
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'z',
+              },
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            },
+            {
+              data: {
+                right: 'yy',
+                left: 'z',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'yy',
+              },
+              messageId: 'missedSpacingBetweenJSXPropsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: {
+                a: 'aaaa',
+                b: 'bbb',
+              },
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            <Component
+              aaaa
+
+             yy
+            z
+
+                bbb
+            />
+          `,
+          code: dedent`
+            <Component
+              aaaa
+
+
+             z
+            yy
+                bbb
+            />
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              a: 'a',
+              b: 'b',
+              c: 'c',
+              d: 'd',
+              e: 'e',
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+
+            b
+
+            c
+            d
+
+
+            e
+          />
+        `,
+        code: dedent`
+          <Component
+            a
+            b
+
+
+            c
+
+            d
+
+
+            e
+          />
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              customGroups: {
+                unusedGroup: 'X',
+                a: 'a',
+                b: 'b',
+              },
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenJSXPropsMembers',
             },
           ],
           output: dedent`
             <Component
-              b
-
               a
+
+
+              b
             />
           `,
           code: dedent`
             <Component
-              b
               a
+              b
             />
           `,
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: misc`, () => {
-    it('validates the JSON schema', async () => {
-      await expect(
-        validateRuleJsonSchema(rule.meta.schema),
-      ).resolves.not.toThrow()
-    })
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        valid: [
-          dedent`
-            let Component = () => (
-              <Element
-                a="a"
-                b="b"
-                c="c"
-              />
-            )
-          `,
-          {
-            code: dedent`
-              const Component = (
-                <Element
-                  link1="value"
-                  link10="value"
-                  link2="value"
-                />
-              )
-            `,
-            options: [{}],
-          },
-        ],
-        invalid: [],
+        })
       },
     )
 
-    ruleTester.run(`${ruleName}: does not work with empty props`, rule, {
-      valid: [
-        dedent`
-          let Component = () => (
-            <Element />
-          )
-        `,
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}: does not work with single prop`, rule, {
-      valid: [
-        dedent`
-          let Component = () => (
-            <Element a="a" />
-          )
-        `,
-      ],
-      invalid: [],
-    })
-
-    for (let ignorePattern of [
-      'Element',
-      ['noMatch', 'Element'],
-      { pattern: 'ELEMENT', flags: 'i' },
-      ['noMatch', { pattern: 'ELEMENT', flags: 'i' }],
-    ]) {
-      ruleTester.run(
-        `${ruleName}: allow to disable rule for some JSX elements`,
-        rule,
-        {
-          valid: [
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
             {
-              code: dedent`
-                let Component = () => (
-                  <Element
-                    c="c"
-                    b="bb"
-                    a="aaa"
-                  />
-                )
-              `,
-              options: [
-                {
-                  ignorePattern,
-                },
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
               ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
-          invalid: [],
-        },
-      )
-    }
-
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
           errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-          ],
-          output: dedent`
-            <Element
-              b="b"
-              c="c"
-              a="a" // eslint-disable-line
-            />
-          `,
-          code: dedent`
-            <Element
-              c="c"
-              b="b"
-              a="a" // eslint-disable-line
-            />
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
             {
               data: {
                 right: 'b',
                 left: 'a',
               },
-              messageId: 'unexpectedJSXPropsOrder',
+              messageId: 'extraSpacingBetweenJSXPropsMembers',
             },
           ],
           output: dedent`
-            <Element
-              b="b"
-              c="c"
-              // eslint-disable-next-line
-              a="a"
-              d="d"
+            <Component
+              a
+              b
             />
           `,
           code: dedent`
-            <Element
-              d="d"
-              c="c"
-              // eslint-disable-next-line
-              a="a"
-              b="b"
+            <Component
+              a
+
+              b
             />
           `,
-          options: [{}],
-        },
-        {
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering props', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: {
+              'b|c': 'b|c',
+            },
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          <Component
+            a // Comment after
+
+            b
+            c
+          />
+        `,
+        code: dedent`
+          <Component
+            b
+            a // Comment after
+
+            c
+          />
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', '^r|g|b$'],
+      ['array of patterns', ['noMatch', '^r|g|b$']],
+      ['case-insensitive regex', { pattern: '^R|G|B$', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: '^R|G|B$', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_description, allNamesMatchPattern) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'b',
-                left: 'c',
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
               },
-              messageId: 'unexpectedJSXPropsOrder',
+              messageId: 'unexpectedJSXPropsGroupOrder',
             },
-          ],
-          output: dedent`
-            <Element
-              b="b"
-              c="c"
-              /* eslint-disable-next-line */
-              a="a"
-            />
-          `,
-          code: dedent`
-            <Element
-              c="c"
-              b="b"
-              /* eslint-disable-next-line */
-              a="a"
-            />
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
             {
               data: {
-                right: 'b',
-                left: 'c',
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
               },
-              messageId: 'unexpectedJSXPropsOrder',
+              messageId: 'unexpectedJSXPropsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
             },
           ],
           output: dedent`
-            <Element
-              b="b"
-              c="c"
-              a="a" /* eslint-disable-line */
+            <Component
+              r
+              g
+              b
             />
           `,
           code: dedent`
-            <Element
-              c="c"
-              b="b"
-              a="a" /* eslint-disable-line */
+            <Component
+              b
+              g
+              r
             />
           `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            <Element
-              a="a"
-              d="d"
-              /* eslint-disable */
-              c="c"
-              b="b"
-              // Shouldn't move
-              /* eslint-enable */
-              e="e"
-            />
-          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', '^Component$'],
+      ['array of patterns', ['noMatch', '^Component']],
+      ['case-insensitive regex', { pattern: '^COMPONENT$', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: '^COMPONENT', flags: 'i' }]],
+    ])(
+      'applies different configuration based on tag name pattern - %s',
+      async (_description, tagMatchesPattern) => {
+        let conditionalOptions = [
+          {
+            useConfigurationIf: {
+              tagMatchesPattern,
+            },
+            type: 'unsorted',
+          },
+          options,
+        ]
+
+        await valid({
           code: dedent`
-            <Element
-              d="d"
-              e="e"
-              /* eslint-disable */
-              c="c"
-              b="b"
-              // Shouldn't move
-              /* eslint-enable */
-              a="a"
+            <Component
+              b
+              c
+              a
             />
           `,
+          options: conditionalOptions,
+        })
+
+        await invalid({
           errors: [
             {
               data: {
-                right: 'a',
+                right: 'aa',
                 left: 'b',
               },
               messageId: 'unexpectedJSXPropsOrder',
             },
           ],
-          options: [{}],
-        },
-        {
           output: dedent`
-            <Element
-              b="b"
-              c="c"
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a="a"
+            <OtherComponent
+              aa
+              b
             />
           `,
           code: dedent`
-            <Element
-              c="c"
-              b="b"
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a="a"
+            <OtherComponent
+              b
+              aa
             />
           `,
-          errors: [
+          options: conditionalOptions,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts jsx props', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              c="c"
+              b="bb"
+            >
+              Value
+            </Element>
+          )
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('allows mixed prop order when type is unsorted', async () => {
+      await valid({
+        code: dedent`
+          <Component
+            b
+            c
+            a
+          />
+        `,
+        options: [options],
+      })
+    })
+
+    it('groups props by pattern while preserving order within groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedJSXPropsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: {
+              a: '^a',
+              b: '^b',
+            },
+            groups: ['b', 'a'],
+          },
+        ],
+        output: dedent`
+          <Component
+            ba
+            bb
+            ab
+            aa
+          />
+        `,
+        code: dedent`
+          <Component
+            ab
+            aa
+            ba
+            bb
+          />
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is always', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              a: '^a',
+              b: '^b',
+            },
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        output: dedent`
+          <Component
+            b
+
+            a
+          />
+        `,
+        code: dedent`
+          <Component
+            b
+            a
+          />
+        `,
+      })
+    })
+  })
+
+  describe('misc', () => {
+    it('validates the JSON schema', async () => {
+      await expect(
+        validateRuleJsonSchema(rule.meta.schema),
+      ).resolves.not.toThrow()
+    })
+
+    it('supports mixing predefined and custom groups', async () => {
+      await valid({
+        code: dedent`
+          let Component = () => (
+            <Element
+              a="aaa"
+              b="bb"
+              c="c"
+            >
+              Value
+            </Element>
+          )
+        `,
+        options: [
+          {
+            customGroups: {
+              myCustomGroup: 'x',
+            },
+            groups: ['multiline', 'shorthand', 'unknown', 'myCustomGroup'],
+          },
+        ],
+      })
+    })
+
+    it('uses alphabetical ascending order by default', async () => {
+      await valid(
+        dedent`
+          let Component = () => (
+            <Element
+              a="a"
+              b="b"
+              c="c"
+            />
+          )
+        `,
+      )
+
+      await valid({
+        code: dedent`
+          const Component = (
+            <Element
+              link1="value"
+              link10="value"
+              link2="value"
+            />
+          )
+        `,
+        options: [{}],
+      })
+    })
+
+    it('ignores elements without props', async () => {
+      await valid(
+        dedent`
+          let Component = () => (
+            <Element />
+          )
+        `,
+      )
+    })
+
+    it('ignores elements with single prop', async () => {
+      await valid(
+        dedent`
+          let Component = () => (
+            <Element a="a" />
+          )
+        `,
+      )
+    })
+
+    it.each([
+      ['string pattern', 'Element'],
+      ['array of patterns', ['noMatch', 'Element']],
+      ['case-insensitive regex', { pattern: 'ELEMENT', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'ELEMENT', flags: 'i' }]],
+    ])(
+      'ignores jsx elements matching ignore pattern - %s',
+      async (_description, ignorePattern) => {
+        await valid({
+          code: dedent`
+            let Component = () => (
+              <Element
+                c="c"
+                b="bb"
+                a="aaa"
+              />
+            )
+          `,
+          options: [
             {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
+              ignorePattern,
             },
           ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
+        })
+      },
+    )
+
+    it('ignores props disabled with eslint-disable-next-line', async () => {
+      await valid({
+        code: dedent`
+          <Element
+            b="b"
+            c="c"
+            // eslint-disable-next-line
+            a="a"
+          />
+        `,
+      })
+    })
+
+    it('sorts props with eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            <Element
-              b="b"
-              c="c"
-              a="a" // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            />
-          `,
-          code: dedent`
-            <Element
-              c="c"
-              b="b"
-              a="a" // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            />
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            <Element
-              b="b"
-              c="c"
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a="a"
-            />
-          `,
-          code: dedent`
-            <Element
-              c="c"
-              b="b"
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a="a"
-            />
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            a="a" // eslint-disable-line
+          />
+        `,
+        code: dedent`
+          <Element
+            c="c"
+            b="b"
+            a="a" // eslint-disable-line
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles multiple eslint-disable-next-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
             },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            <Element
-              b="b"
-              c="c"
-              a="a" /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            />
-          `,
-          code: dedent`
-            <Element
-              c="c"
-              b="b"
-              a="a" /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            />
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            <Element
-              a="a"
-              d="d"
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c="c"
-              b="b"
-              // Shouldn't move
-              /* eslint-enable */
-              e="e"
-            />
-          `,
-          code: dedent`
-            <Element
-              d="d"
-              e="e"
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c="c"
-              b="b"
-              // Shouldn't move
-              /* eslint-enable */
-              a="a"
-            />
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            // eslint-disable-next-line
+            a="a"
+            d="d"
+          />
+        `,
+        code: dedent`
+          <Element
+            d="d"
+            c="c"
+            // eslint-disable-next-line
+            a="a"
+            b="b"
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block eslint-disable-next-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            <Element
-              b="b"
-              c="c"
-              // eslint-disable-next-line
-              a="a"
-            />
-          `,
-        },
-      ],
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            /* eslint-disable-next-line */
+            a="a"
+          />
+        `,
+        code: dedent`
+          <Element
+            c="c"
+            b="b"
+            /* eslint-disable-next-line */
+            a="a"
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles inline block eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            a="a" /* eslint-disable-line */
+          />
+        `,
+        code: dedent`
+          <Element
+            c="c"
+            b="b"
+            a="a" /* eslint-disable-line */
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('sorts props around eslint-disable/enable block', async () => {
+      await invalid({
+        output: dedent`
+          <Element
+            a="a"
+            d="d"
+            /* eslint-disable */
+            c="c"
+            b="b"
+            // Shouldn't move
+            /* eslint-enable */
+            e="e"
+          />
+        `,
+        code: dedent`
+          <Element
+            d="d"
+            e="e"
+            /* eslint-disable */
+            c="c"
+            b="b"
+            // Shouldn't move
+            /* eslint-enable */
+            a="a"
+          />
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable-next-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            // eslint-disable-next-line rule-to-test/sort-jsx-props
+            a="a"
+          />
+        `,
+        code: dedent`
+          <Element
+            c="c"
+            b="b"
+            // eslint-disable-next-line rule-to-test/sort-jsx-props
+            a="a"
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            a="a" // eslint-disable-line rule-to-test/sort-jsx-props
+          />
+        `,
+        code: dedent`
+          <Element
+            c="c"
+            b="b"
+            a="a" // eslint-disable-line rule-to-test/sort-jsx-props
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific block eslint-disable-next-line comments', async () => {
+      await invalid({
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            /* eslint-disable-next-line rule-to-test/sort-jsx-props */
+            a="a"
+          />
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        code: dedent`
+          <Element
+            c="c"
+            b="b"
+            /* eslint-disable-next-line rule-to-test/sort-jsx-props */
+            a="a"
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific inline block eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        output: dedent`
+          <Element
+            b="b"
+            c="c"
+            a="a" /* eslint-disable-line rule-to-test/sort-jsx-props */
+          />
+        `,
+        code: dedent`
+          <Element
+            c="c"
+            b="b"
+            a="a" /* eslint-disable-line rule-to-test/sort-jsx-props */
+          />
+        `,
+        options: [{}],
+      })
+    })
+
+    it('sorts props around rule-specific eslint-disable/enable block', async () => {
+      await invalid({
+        output: dedent`
+          <Element
+            a="a"
+            d="d"
+            /* eslint-disable rule-to-test/sort-jsx-props */
+            c="c"
+            b="b"
+            // Shouldn't move
+            /* eslint-enable */
+            e="e"
+          />
+        `,
+        code: dedent`
+          <Element
+            d="d"
+            e="e"
+            /* eslint-disable rule-to-test/sort-jsx-props */
+            c="c"
+            b="b"
+            // Shouldn't move
+            /* eslint-enable */
+            a="a"
+          />
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+        ],
+        options: [{}],
+      })
     })
   })
 })

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1,2516 +1,986 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-maps'
 
-let ruleName = 'sort-maps'
+describe('sort-maps', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-maps',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: "'a'",
-                  left: "'b'",
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-            output: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['a', 'aa'],
-                ['b', 'b'],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['b', 'b'],
-                ['a', 'aa'],
-              ])
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              new Map([
-                ['a', 'a'],
-              ])
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['a', 'aa'],
-                ['b', 'b'],
-              ])
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): not sorts spread elements`, rule, {
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              ...aaa,
-              ...bb,
-            ])
-          `,
-          options: [options],
-        },
-        {
-          code: dedent`
-            new Map([
-              ...bb,
-              ...aaa,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): works with variables as keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'aa',
-                left: 'b',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [b, b],
-              [aa, aa],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): works with numbers as keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '1',
-                left: '2',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [1, 'one'],
-              [2, 'two'],
-              [3, 'three'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [2, 'two'],
-              [1, 'one'],
-              [3, 'three'],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [1, 'one'],
-              [2, 'two'],
-              [3, 'three'],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts variable identifiers`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'cc',
-                left: 'd',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              aaaa,
-              bbb,
-              cc,
-              d,
-            ])
-          `,
-          code: dedent`
-            new Map([
-              aaaa,
-              d,
-              cc,
-              bbb,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              aaaa,
-              bbb,
-              cc,
-              d,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'd',
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-              {
-                data: {
-                  right: 'b',
-                  left: 'e',
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-            output: dedent`
-              new Map([
-                [a, 'a'],
-                [d, 'd'],
-
-                [c, 'c'],
-
-                [b, 'b'],
-                [e, 'e'],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                [d, 'd'],
-                [a, 'a'],
-
-                [c, 'c'],
-
-                [e, 'e'],
-                [b, 'b'],
-              ])
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): partition comments`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                new Map([
-                  // Part: A
-                  // Not partition comment
-                  [bbb, 'bbb'],
-                  [cc, 'cc'],
-                  [d, 'd'],
-                  // Part: B
-                  [aaaa, 'aaaa'],
-                  [e, 'e'],
-                  // Part: C
-                  // Not partition comment
-                  [fff, 'fff'],
-                  [gg, 'gg'],
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  // Part: A
-                  [cc, 'cc'],
-                  [d, 'd'],
-                  // Not partition comment
-                  [bbb, 'bbb'],
-                  // Part: B
-                  [aaaa, 'aaaa'],
-                  [e, 'e'],
-                  // Part: C
-                  [gg, 'gg'],
-                  // Not partition comment
-                  [fff, 'fff'],
-                ])
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'bbb',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-                {
-                  data: {
-                    right: 'fff',
-                    left: 'gg',
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                new Map([
-                  // Comment
-                  [bb, 'bb'],
-                  // Other comment
-                  [a, 'a'],
-                ])
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                new Map([
-                  /* Partition Comment */
-                  // Part: A
-                  [d, 'd'],
-                  // Part: B
-                  [aaa, 'aaa'],
-                  [bb, 'bb'],
-                  [c, 'c'],
-                  /* Other */
-                  [e, 'e'],
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  /* Partition Comment */
-                  // Part: A
-                  [d, 'd'],
-                  // Part: B
-                  [aaa, 'aaa'],
-                  [c, 'c'],
-                  [bb, 'bb'],
-                  /* Other */
-                  [e, 'e'],
-                ])
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}): allows to use regex`, rule, {
-        valid: [
-          {
-            code: dedent`
-              new Map([
-                ['e', 'e'],
-                ['f', 'f'],
-                // I am a partition comment because I don't have f o o
-                ['a', 'a'],
-                ['b', 'b'],
-              ])
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
+    it('preserves spread elements position when sorting map entries', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['a', 'a'],
+          ])
+        `,
+        options: [options],
       })
 
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: "'a'",
-                    left: "'b'",
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                new Map([
-                  /* Comment */
-                  ['a', 'a'],
-                  ['b', 'b'],
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  ['b', 'b'],
-                  /* Comment */
-                  ['a', 'a'],
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  new Map([
-                    ['b', 'b'],
-                    // Comment
-                    ['a', 'a'],
-                  ])
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  new Map([
-                    ['c', 'c'],
-                    // b
-                    ['b', 'b'],
-                    // a
-                    ['a', 'a'],
-                  ])
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['a', 'b'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  new Map([
-                    ['b', 'b'],
-                    // I am a partition comment because I don't have f o o
-                    ['a', 'a'],
-                  ])
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['a', 'aa'],
+            ['b', 'b'],
+          ])
+        `,
+        options: [options],
       })
 
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: "'a'",
-                    left: "'b'",
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                new Map([
-                  // Comment
-                  ['a', 'a'],
-                  ['b', 'b'],
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  ['b', 'b'],
-                  // Comment
-                  ['a', 'a'],
-                ])
-              `,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: "'b'",
             },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  new Map([
-                    ['b', 'b'],
-                    /* Comment */
-                    ['a', 'a'],
-                  ])
-                `,
-              },
-            ],
-            invalid: [],
+            messageId: 'unexpectedMapElementsOrder',
           },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  new Map([
-                    ['c', 'c'],
-                    /* b */
-                    ['b', 'b'],
-                    /* a */
-                    ['a', 'a'],
-                  ])
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['a', 'b'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  new Map([
-                    ['b', 'b'],
-                    /* I am a partition comment because I don't have f o o */
-                    ['a', 'a'],
-                  ])
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
+        ],
+        output: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['a', 'aa'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['b', 'b'],
+            ['a', 'aa'],
+          ])
+        `,
+        options: [options],
       })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              new Map([
-                [_a, 'a'],
-                [b, 'b'],
-                [_c, 'c'],
-              ])
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              new Map([
-                [ab, 'ab'],
-                [a_c, 'ac'],
-              ])
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [你好, '你好'],
-              [世界, '世界'],
-              [a, 'a'],
-              [A, 'A'],
-              [b, 'b'],
-              [B, 'B'],
-            ])
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'keysStartingWithHello',
-                  leftGroup: 'unknown',
-                  right: "'helloKey'",
-                  left: "'b'",
-                },
-                messageId: 'unexpectedMapElementsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'keysStartingWithHello',
-                    elementNamePattern: 'hello',
-                  },
-                ],
-                groups: ['keysStartingWithHello', 'unknown'],
-              },
-            ],
-            output: dedent`
-              new Map([
-                ['helloKey', 3],
-                ['a', 1],
-                ['b', 2]
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['a', 1],
-                ['b', 2],
-                ['helloKey', 3]
-              ])
-            `,
-          },
-        ],
-        valid: [],
+    it('allows any order for spread elements', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ...aaa,
+            ...bb,
+          ])
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '_bb',
-                    left: '_a',
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-                {
-                  data: {
-                    right: '_ccc',
-                    left: '_bb',
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-                {
-                  data: {
-                    right: '_dddd',
-                    left: '_ccc',
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedStartingWith_ByLineLength',
-                    leftGroup: 'unknown',
-                    right: '_eee',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedMapElementsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedStartingWith_ByLineLength',
-                      elementNamePattern: '_',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedStartingWith_ByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                new Map([
-                  [_dddd, null],
-                  [_ccc, null],
-                  [_eee, null],
-                  [_bb, null],
-                  [_ff, null],
-                  [_a, null],
-                  [_g, null],
-                  [m, null],
-                  [o, null],
-                  [p, null]
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  [_a, null],
-                  [_bb, null],
-                  [_ccc, null],
-                  [_dddd, null],
-                  [m, null],
-                  [_eee, null],
-                  [_ff, null],
-                  [_g, null],
-                  [o, null],
-                  [p, null]
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
+      await valid({
+        code: dedent`
+          new Map([
+            ...bb,
+            ...aaa,
+          ])
+        `,
+        options: [options],
+      })
+    })
 
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedMapElementsOrder',
-                },
-              ],
-              output: dedent`
-                new Map([
-                  [fooBar, fooBar],
-                  [fooZar, fooZar],
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  [fooZar, fooZar],
-                  [fooBar, fooBar],
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedStartingWith_',
-                      elementNamePattern: '_',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedStartingWith_', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedStartingWith_',
-                    leftGroup: 'unknown',
-                    right: "'_c'",
-                    left: "'m'",
-                  },
-                  messageId: 'unexpectedMapElementsGroupOrder',
-                },
-              ],
-              output: dedent`
-                new Map([
-                  ['_b', null],
-                  ['_a', null],
-                  ['_d', null],
-                  ['_e', null],
-                  ['_c', null],
-                  ['m', null]
-                ])
-              `,
-              code: dedent`
-                new Map([
-                  ['_b', null],
-                  ['_a', null],
-                  ['_d', null],
-                  ['_e', null],
-                  ['m', null],
-                  ['_c', null]
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo',
-                      },
-                      {
-                        elementNamePattern: 'Foo',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: "'...foo'",
-                  left: "'a'",
-                },
-                messageId: 'unexpectedMapElementsGroupOrder',
-              },
-            ],
-            output: dedent`
-              new Map([
-                ['...foo', null],
-                ['cFoo', null],
-                ['a', null]
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['a', null],
-                ['...foo', null],
-                ['cFoo', null]
-              ])
-            `,
-          },
-        ],
-        valid: [],
+    it('sorts entries with variable identifiers as keys', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                new Map([
-                  ['iHaveFooInMyName', null],
-                  ['meTooIHaveFoo', null],
-                  ['a', null],
-                  ['b', null]
-                ])
-              `,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
             },
-          ],
-          invalid: [],
-        },
-      )
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, b],
+            [aa, aa],
+          ])
+        `,
+        options: [options],
+      })
     })
 
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenMapElementsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedMapElementsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenMapElementsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  new Map([
-                    [a, null],
-
-
-                   [y, null],
-                  [z, null],
-
-                      [b, null]
-                  ])
-                `,
-                output: dedent`
-                  new Map([
-                    [a, null],
-                   [b, null],
-                  [y, null],
-                      [z, null]
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenMapElementsMembers',
-                  },
-                ],
-                output: dedent`
-                  new Map([
-                    [a, 'a'], 
-
-                  [b, 'b'],
-                  ])
-                `,
-                code: dedent`
-                  new Map([
-                    [a, 'a'], [b, 'b'],
-                  ])
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenMapElementsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedMapElementsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenMapElementsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  new Map([
-                    [a, null],
-
-                   [y, null],
-                  [z, null],
-
-                      [b, null],
-                  ])
-                `,
-                code: dedent`
-                  new Map([
-                    [a, null],
-
-
-                   [z, null],
-                  [y, null],
-                      [b, null],
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenMapElementsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenMapElementsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenMapElementsMembers',
-                  },
-                ],
-                output: dedent`
-                  new Map([
-                    [a, null],
-
-                    [b, null],
-
-                    [c, null],
-                    [d, null],
-
-
-                    [e, null]
-                  ])
-                `,
-                code: dedent`
-                  new Map([
-                    [a, null],
-                    [b, null],
-
-
-                    [c, null],
-
-                    [d, null],
-
-
-                    [e, null]
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenMapElementsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      new Map([
-                        [a, 'a'],
-
-
-                        [b, 'b'],
-                      ])
-                    `,
-                    code: dedent`
-                      new Map([
-                        [a, 'a'],
-                        [b, 'b'],
-                      ])
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenMapElementsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      new Map([
-                        [a, 'a'],
-                        [b, 'b'],
-                      ])
-                    `,
-                    code: dedent`
-                      new Map([
-                        [a, 'a'],
-
-                        [b, 'b'],
-                      ])
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      new Map([
-                        [a, 'a'],
-
-                        [b, 'b'],
-                      ])
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      new Map([
-                        [a, 'a'],
-                        [b, 'b'],
-                      ])
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
+    it('sorts entries with numeric keys', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [1, 'one'],
+            [2, 'two'],
+            [3, 'three'],
+          ])
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  new Map([
-                    [a, null], // Comment after
-                    [b, null],
-
-                    [c, null]
-                  ])
-                `,
-                dedent`
-                  new Map([
-                    [a, null], // Comment after
-
-                    [b, null],
-                    [c, null]
-                  ])
-                `,
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'b|c',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedMapElementsGroupOrder',
-                },
-              ],
-              code: dedent`
-                new Map([
-                  [b, null],
-                  [a, null], // Comment after
-
-                  [c, null]
-                ])
-              `,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '1',
+              left: '2',
             },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedMapElementsOrder',
-                  },
-                ],
-                output: dedent`
-                  new Map([
-                    [a, 'a'],
-
-                    // Partition comment
-
-                    [b, 'b'],
-                    [c, 'c'],
-                  ])
-                `,
-                code: dedent`
-                  new Map([
-                    [a, 'a'],
-
-                    // Partition comment
-
-                    [c, 'c'],
-                    [b, 'b'],
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      for (let allNamesMatchPattern of [
-        'foo',
-        ['noMatch', 'foo'],
-        { pattern: 'FOO', flags: 'i' },
-        ['noMatch', { pattern: 'FOO', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    useConfigurationIf: {
-                      allNamesMatchPattern,
-                    },
-                  },
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: '^r$',
-                        groupName: 'r',
-                      },
-                      {
-                        elementNamePattern: '^g$',
-                        groupName: 'g',
-                      },
-                      {
-                        elementNamePattern: '^b$',
-                        groupName: 'b',
-                      },
-                    ],
-                    useConfigurationIf: {
-                      allNamesMatchPattern: '^r|g|b$',
-                    },
-                    groups: ['r', 'g', 'b'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'g',
-                      leftGroup: 'b',
-                      right: 'g',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedMapElementsGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'r',
-                      leftGroup: 'g',
-                      right: 'r',
-                      left: 'g',
-                    },
-                    messageId: 'unexpectedMapElementsGroupOrder',
-                  },
-                ],
-                output: dedent`
-                  new Map([
-                    [r, null],
-                    [g, null],
-                    [b, null]
-                  ])
-                `,
-                code: dedent`
-                  new Map([
-                    [b, null],
-                    [g, null],
-                    [r, null]
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: "'a'",
-                  left: "'b'",
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-            output: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['a', 'aa'],
-                ['b', 'b'],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['b', 'b'],
-                ['a', 'aa'],
-              ])
-            `,
-            options: [options],
+            messageId: 'unexpectedMapElementsOrder',
           },
         ],
-        valid: [
+        output: dedent`
+          new Map([
+            [1, 'one'],
+            [2, 'two'],
+            [3, 'three'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [2, 'two'],
+            [1, 'one'],
+            [3, 'three'],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts variable identifiers without array notation', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            aaaa,
+            bbb,
+            cc,
+            d,
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['a', 'aa'],
-                ['b', 'b'],
-              ])
-            `,
-            options: [options],
+            data: {
+              right: 'cc',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedMapElementsOrder',
           },
         ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): not sorts spread elements`, rule, {
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              ...aaa,
-              ...bb,
-            ])
-          `,
-          options: [options],
-        },
-        {
-          code: dedent`
-            new Map([
-              ...bb,
-              ...aaa,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+        output: dedent`
+          new Map([
+            aaaa,
+            bbb,
+            cc,
+            d,
+          ])
+        `,
+        code: dedent`
+          new Map([
+            aaaa,
+            d,
+            cc,
+            bbb,
+          ])
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): works with variables as keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'aa',
-                left: 'b',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [b, b],
-              [aa, aa],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): works with numbers as keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '1',
-                left: '2',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [1, 'one'],
-              [2, 'two'],
-              [3, 'three'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [2, 'two'],
-              [1, 'one'],
-              [3, 'three'],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [1, 'one'],
-              [2, 'two'],
-              [3, 'three'],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts variable identifiers`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'cc',
-                left: 'd',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              aaaa,
-              bbb,
-              cc,
-              d,
-            ])
-          `,
-          code: dedent`
-            new Map([
-              aaaa,
-              d,
-              cc,
-              bbb,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              aaaa,
-              bbb,
-              cc,
-              d,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): works with variables as keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'aa',
-                left: 'b',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [b, b],
-              [aa, aa],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
+    it('sorts entries within newline-separated groups independently', async () => {
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: "'a'",
-                  left: "'b'",
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-            output: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['a', 'aa'],
-                ['b', 'b'],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['b', 'b'],
-                ['a', 'aa'],
-              ])
-            `,
-            options: [options],
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedMapElementsOrder',
           },
         ],
-        valid: [
+        output: dedent`
+          new Map([
+            [a, 'a'],
+            [d, 'd'],
+
+            [c, 'c'],
+
+            [b, 'b'],
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [d, 'd'],
+            [a, 'a'],
+
+            [c, 'c'],
+
+            [e, 'e'],
+            [b, 'b'],
+          ])
+        `,
+        options: [
           {
-            code: dedent`
-              new Map([
-                ['c', 'cc'],
-                ['d', 'd'],
-                ...rest,
-                ['a', 'aa'],
-                ['b', 'b'],
-              ])
-            `,
-            options: [options],
+            ...options,
+            partitionByNewLine: true,
           },
         ],
-      },
-    )
+      })
+    })
 
-    ruleTester.run(
-      `${ruleName}(${type}): both key and value affect sorting by length`,
-      rule,
-      {
-        invalid: [
+    it('creates partitions based on matching comments', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            // Part: A
+            // Not partition comment
+            [bbb, 'bbb'],
+            [cc, 'cc'],
+            [d, 'd'],
+            // Part: B
+            [aaaa, 'aaaa'],
+            [e, 'e'],
+            // Part: C
+            // Not partition comment
+            [fff, 'fff'],
+            [gg, 'gg'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            // Part: A
+            [cc, 'cc'],
+            [d, 'd'],
+            // Not partition comment
+            [bbb, 'bbb'],
+            // Part: B
+            [aaaa, 'aaaa'],
+            [e, 'e'],
+            // Part: C
+            [gg, 'gg'],
+            // Not partition comment
+            [fff, 'fff'],
+          ])
+        `,
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: "'USD'",
-                  left: "'EUR'",
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-            output: dedent`
-              new Map([
-                ['USD', 'United States dollar'],
-                ['EUR', 'Euro'],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['EUR', 'Euro'],
-                ['USD', 'United States dollar'],
-              ])
-            `,
-            options: [options],
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
           },
           {
-            errors: [
-              {
-                data: {
-                  right: "'United States'",
-                  left: "'Europe'",
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-            output: dedent`
-              new Map([
-                ['United States', 'USD'],
-                ['Europe', 'EUR'],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['Europe', 'EUR'],
-                ['United States', 'USD'],
-              ])
-            `,
-            options: [options],
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedMapElementsOrder',
           },
         ],
-        valid: [
+        options: [
           {
-            code: dedent`
-              new Map([
-                ['USD', 'United States dollar'],
-                ['RUB', 'Russian ruble'],
-                ['CNY', 'Renminbi'],
-                ['GBP', 'Sterling'],
-                ['EUR', 'Euro'],
-              ])
-            `,
-            options: [options],
+            ...options,
+            partitionByComment: '^Part',
           },
         ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): not sorts spread elements`, rule, {
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              ...aaa,
-              ...bb,
-            ])
-          `,
-          options: [options],
-        },
-        {
-          code: dedent`
-            new Map([
-              ...bb,
-              ...aaa,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): works with variables as keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'aa',
-                left: 'b',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [b, b],
-              [aa, aa],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [aa, aa],
-              [b, b],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): works with numbers as keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '3',
-                left: '1',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [3, 'three'],
-              [2, 'two'],
-              [1, 'one'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [2, 'two'],
-              [1, 'one'],
-              [3, 'three'],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [3, 'three'],
-              [1, 'one'],
-              [2, 'two'],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts variable identifiers`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'cc',
-                left: 'd',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              aaaa,
-              bbb,
-              cc,
-              d,
-            ])
-          `,
-          code: dedent`
-            new Map([
-              aaaa,
-              d,
-              cc,
-              bbb,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              aaaa,
-              bbb,
-              cc,
-              d,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            // Comment
+            [bb, 'bb'],
+            // Other comment
+            [a, 'a'],
+          ])
+        `,
+        options: [
           {
-            errors: [
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            /* Partition Comment */
+            // Part: A
+            [d, 'd'],
+            // Part: B
+            [aaa, 'aaa'],
+            [bb, 'bb'],
+            [c, 'c'],
+            /* Other */
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            /* Partition Comment */
+            // Part: A
+            [d, 'd'],
+            // Part: B
+            [aaa, 'aaa'],
+            [c, 'c'],
+            [bb, 'bb'],
+            /* Other */
+            [e, 'e'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['e', 'e'],
+            ['f', 'f'],
+            // I am a partition comment because I don't have f o o
+            ['a', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          new Map([
+            /* Comment */
+            ['a', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* Comment */
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // Comment
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'c'],
+            // b
+            ['b', 'b'],
+            // a
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // I am a partition comment because I don't have f o o
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          new Map([
+            // Comment
+            ['a', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // Comment
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* Comment */
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'c'],
+            /* b */
+            ['b', 'b'],
+            /* a */
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* I am a partition comment because I don't have f o o */
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [_a, 'a'],
+            [b, 'b'],
+            [_c, 'c'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          new Map([
+            [ab, 'ab'],
+            [a_c, 'ac'],
+          ])
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [你好, '你好'],
+            [世界, '世界'],
+            [a, 'a'],
+            [A, 'A'],
+            [b, 'b'],
+            [B, 'B'],
+          ])
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('applies custom groups based on element name patterns', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'keysStartingWithHello',
+              leftGroup: 'unknown',
+              right: "'helloKey'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
               {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedMapElementsOrder',
+                groupName: 'keysStartingWithHello',
+                elementNamePattern: 'hello',
               },
             ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              new Map([
-                [bb, bb],
-                [c, c],
-                [a, a],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                [a, a],
-                [bb, bb],
-                [c, c],
-              ])
-            `,
+            groups: ['keysStartingWithHello', 'unknown'],
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['helloKey', 3],
+            ['a', 1],
+            ['b', 2]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['a', 1],
+            ['b', 2],
+            ['helloKey', 3]
+          ])
+        `,
+      })
+    })
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '_bb',
+              left: '_a',
+            },
+            messageId: 'unexpectedMapElementsOrder',
           },
           {
-            errors: [
+            data: {
+              right: '_ccc',
+              left: '_bb',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: '_dddd',
+              left: '_ccc',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedStartingWith_ByLineLength',
+              leftGroup: 'unknown',
+              right: '_eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
               {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedMapElementsOrder',
+                groupName: 'reversedStartingWith_ByLineLength',
+                elementNamePattern: '_',
+                type: 'line-length',
+                order: 'desc',
               },
             ],
-            options: [
+            groups: ['reversedStartingWith_ByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [_dddd, null],
+            [_ccc, null],
+            [_eee, null],
+            [_bb, null],
+            [_ff, null],
+            [_a, null],
+            [_g, null],
+            [m, null],
+            [o, null],
+            [p, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [_a, null],
+            [_bb, null],
+            [_ccc, null],
+            [_dddd, null],
+            [m, null],
+            [_eee, null],
+            [_ff, null],
+            [_g, null],
+            [o, null],
+            [p, null]
+          ])
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
               {
-                ...options,
                 fallbackSort: {
                   type: 'alphabetical',
                   order: 'asc',
                 },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
               },
             ],
-            output: dedent`
-              new Map([
-                [bb, bb],
-                [a, a],
-                [c, c],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                [c, c],
-                [bb, bb],
-                [a, a],
-              ])
-            `,
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
           },
         ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [b, b],
-              [c, c],
-              [a, a],
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [fooBar, fooBar],
+            [fooZar, fooZar],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [fooZar, fooZar],
+            [fooBar, fooBar],
+          ])
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['b', 'a'],
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedStartingWith_',
+                elementNamePattern: '_',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedStartingWith_', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedStartingWith_',
+              leftGroup: 'unknown',
+              right: "'_c'",
+              left: "'m'",
             },
-          ],
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['_b', null],
+            ['_a', null],
+            ['_d', null],
+            ['_e', null],
+            ['_c', null],
+            ['m', null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['_b', null],
+            ['_a', null],
+            ['_d', null],
+            ['_e', null],
+            ['m', null],
+            ['_c', null]
+          ])
+        `,
+      })
+    })
+
+    it('combines multiple patterns with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo',
+                  },
+                  {
+                    elementNamePattern: 'Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'...foo'",
+              left: "'a'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['...foo', null],
+            ['cFoo', null],
+            ['a', null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['a', null],
+            ['...foo', null],
+            ['cFoo', null]
+          ])
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['iHaveFooInMyName', null],
+            ['meTooIHaveFoo', null],
+            ['a', null],
+            ['b', null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'removes extra newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                right: 'y',
+                left: 'a',
               },
-              messageId: 'unexpectedMapElementsGroupOrder',
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
             },
           ],
-          output: dedent`
-            new Map([
-              [ba, ba],
-              [bb, bb],
-              [ab, ab],
-              [aa, aa],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [ab, ab],
-              [aa, aa],
-              [ba, ba],
-              [bb, bb],
-            ])
-          `,
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
           options: [
             {
               ...options,
@@ -2519,546 +989,3983 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, null],
+
+
+             [y, null],
+            [z, null],
+
+                [b, null]
+            ])
+          `,
+          output: dedent`
+            new Map([
+              [a, null],
+             [b, null],
+            [y, null],
+                [z, null]
+            ])
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, null],
+
+            [b, null],
+
+            [c, null],
+            [d, null],
+
+
+            [e, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [a, null],
+            [b, null],
+
+
+            [c, null],
+
+            [d, null],
+
+
+            [e, null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['2 spaces globally with never in group', 2, 'never'],
+      ['2 spaces globally with 0 in group', 2, 0],
+      ['2 spaces globally with ignore in group', 2, 'ignore'],
+      ['never globally with 2 spaces in group', 'never', 2],
+      ['0 globally with 2 spaces in group', 0, 2],
+      ['ignore globally with 2 spaces in group', 'ignore', 2],
+    ])(
+      'adds newlines between groups when %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenMapElementsMembers',
             },
           ],
           output: dedent`
             new Map([
-              [b, b],
+              [a, 'a'],
 
-              [a, a],
+
+              [b, 'b'],
             ])
           `,
           code: dedent`
             new Map([
-              [b, b],
-              [a, a],
+              [a, 'a'],
+              [b, 'b'],
             ])
           `,
-        },
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always'],
+      ['2 spaces', 2],
+      ['ignore', 'ignore'],
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'removes newlines when never is between groups despite %s global setting',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore globally with never in group', 'ignore', 'never'],
+      ['ignore globally with 0 in group', 'ignore', 0],
+      ['never globally with ignore in group', 'never', 'ignore'],
+      ['0 globally with ignore in group', 0, 'ignore'],
+    ])(
+      'allows any spacing when %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              [b, 'b'],
+            ])
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, null], // Comment after
+
+            [b, null],
+            [c, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, null],
+            [a, null], // Comment after
+
+            [c, null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'preserves partition boundaries when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+
+              // Partition comment
+
+              [b, 'b'],
+              [c, 'c'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              // Partition comment
+
+              [c, 'c'],
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array with string patterns', ['noMatch', 'foo']],
+      ['regex pattern object', { pattern: 'FOO', flags: 'i' }],
+      [
+        'array with regex pattern object',
+        ['noMatch', { pattern: 'FOO', flags: 'i' }],
       ],
-      valid: [],
+    ])(
+      'applies conditional configuration when all names match %s',
+      async (_description, allNamesMatchPattern) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern,
+              },
+            },
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: '^r$',
+                  groupName: 'r',
+                },
+                {
+                  elementNamePattern: '^g$',
+                  groupName: 'g',
+                },
+                {
+                  elementNamePattern: '^b$',
+                  groupName: 'b',
+                },
+              ],
+              useConfigurationIf: {
+                allNamesMatchPattern: '^r|g|b$',
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedMapElementsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedMapElementsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [r, null],
+              [g, null],
+              [b, null]
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [b, null],
+              [g, null],
+              [r, null]
+            ])
+          `,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('preserves spread elements position when sorting map entries', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['a', 'a'],
+          ])
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['a', 'aa'],
+            ['b', 'b'],
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['a', 'aa'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['b', 'b'],
+            ['a', 'aa'],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows any order for spread elements', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ...aaa,
+            ...bb,
+          ])
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          new Map([
+            ...bb,
+            ...aaa,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts entries with variable identifiers as keys', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, b],
+            [aa, aa],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts entries with numeric keys', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [1, 'one'],
+            [2, 'two'],
+            [3, 'three'],
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '1',
+              left: '2',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [1, 'one'],
+            [2, 'two'],
+            [3, 'three'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [2, 'two'],
+            [1, 'one'],
+            [3, 'three'],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts variable identifiers without array notation', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            aaaa,
+            bbb,
+            cc,
+            d,
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'cc',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            aaaa,
+            bbb,
+            cc,
+            d,
+          ])
+        `,
+        code: dedent`
+          new Map([
+            aaaa,
+            d,
+            cc,
+            bbb,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts entries within newline-separated groups independently', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, 'a'],
+            [d, 'd'],
+
+            [c, 'c'],
+
+            [b, 'b'],
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [d, 'd'],
+            [a, 'a'],
+
+            [c, 'c'],
+
+            [e, 'e'],
+            [b, 'b'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            // Part: A
+            // Not partition comment
+            [bbb, 'bbb'],
+            [cc, 'cc'],
+            [d, 'd'],
+            // Part: B
+            [aaaa, 'aaaa'],
+            [e, 'e'],
+            // Part: C
+            // Not partition comment
+            [fff, 'fff'],
+            [gg, 'gg'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            // Part: A
+            [cc, 'cc'],
+            [d, 'd'],
+            // Not partition comment
+            [bbb, 'bbb'],
+            // Part: B
+            [aaaa, 'aaaa'],
+            [e, 'e'],
+            // Part: C
+            [gg, 'gg'],
+            // Not partition comment
+            [fff, 'fff'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            // Comment
+            [bb, 'bb'],
+            // Other comment
+            [a, 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            /* Partition Comment */
+            // Part: A
+            [d, 'd'],
+            // Part: B
+            [aaa, 'aaa'],
+            [bb, 'bb'],
+            [c, 'c'],
+            /* Other */
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            /* Partition Comment */
+            // Part: A
+            [d, 'd'],
+            // Part: B
+            [aaa, 'aaa'],
+            [c, 'c'],
+            [bb, 'bb'],
+            /* Other */
+            [e, 'e'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['e', 'e'],
+            ['f', 'f'],
+            // I am a partition comment because I don't have f o o
+            ['a', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          new Map([
+            /* Comment */
+            ['a', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* Comment */
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // Comment
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'c'],
+            // b
+            ['b', 'b'],
+            // a
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // I am a partition comment because I don't have f o o
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          new Map([
+            // Comment
+            ['a', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // Comment
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* Comment */
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'c'],
+            /* b */
+            ['b', 'b'],
+            /* a */
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* I am a partition comment because I don't have f o o */
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [_a, 'a'],
+            [b, 'b'],
+            [_c, 'c'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          new Map([
+            [ab, 'ab'],
+            [a_c, 'ac'],
+          ])
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [你好, '你好'],
+            [世界, '世界'],
+            [a, 'a'],
+            [A, 'A'],
+            [b, 'b'],
+            [B, 'B'],
+          ])
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('applies custom groups based on element name patterns', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'keysStartingWithHello',
+              leftGroup: 'unknown',
+              right: "'helloKey'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'keysStartingWithHello',
+                elementNamePattern: 'hello',
+              },
+            ],
+            groups: ['keysStartingWithHello', 'unknown'],
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['helloKey', 3],
+            ['a', 1],
+            ['b', 2]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['a', 1],
+            ['b', 2],
+            ['helloKey', 3]
+          ])
+        `,
+      })
+    })
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '_bb',
+              left: '_a',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: '_ccc',
+              left: '_bb',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: '_dddd',
+              left: '_ccc',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedStartingWith_ByLineLength',
+              leftGroup: 'unknown',
+              right: '_eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedStartingWith_ByLineLength',
+                elementNamePattern: '_',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedStartingWith_ByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [_dddd, null],
+            [_ccc, null],
+            [_eee, null],
+            [_bb, null],
+            [_ff, null],
+            [_a, null],
+            [_g, null],
+            [m, null],
+            [o, null],
+            [p, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [_a, null],
+            [_bb, null],
+            [_ccc, null],
+            [_dddd, null],
+            [m, null],
+            [_eee, null],
+            [_ff, null],
+            [_g, null],
+            [o, null],
+            [p, null]
+          ])
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [fooBar, fooBar],
+            [fooZar, fooZar],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [fooZar, fooZar],
+            [fooBar, fooBar],
+          ])
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedStartingWith_',
+                elementNamePattern: '_',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedStartingWith_', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedStartingWith_',
+              leftGroup: 'unknown',
+              right: "'_c'",
+              left: "'m'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['_b', null],
+            ['_a', null],
+            ['_d', null],
+            ['_e', null],
+            ['_c', null],
+            ['m', null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['_b', null],
+            ['_a', null],
+            ['_d', null],
+            ['_e', null],
+            ['m', null],
+            ['_c', null]
+          ])
+        `,
+      })
+    })
+
+    it('combines multiple patterns with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo',
+                  },
+                  {
+                    elementNamePattern: 'Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'...foo'",
+              left: "'a'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['...foo', null],
+            ['cFoo', null],
+            ['a', null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['a', null],
+            ['...foo', null],
+            ['cFoo', null]
+          ])
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['iHaveFooInMyName', null],
+            ['meTooIHaveFoo', null],
+            ['a', null],
+            ['b', null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'removes extra newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, null],
+
+
+             [y, null],
+            [z, null],
+
+                [b, null]
+            ])
+          `,
+          output: dedent`
+            new Map([
+              [a, null],
+             [b, null],
+            [y, null],
+                [z, null]
+            ])
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, null],
+
+            [b, null],
+
+            [c, null],
+            [d, null],
+
+
+            [e, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [a, null],
+            [b, null],
+
+
+            [c, null],
+
+            [d, null],
+
+
+            [e, null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['2 spaces globally with never in group', 2, 'never'],
+      ['2 spaces globally with 0 in group', 2, 0],
+      ['2 spaces globally with ignore in group', 2, 'ignore'],
+      ['never globally with 2 spaces in group', 'never', 2],
+      ['0 globally with 2 spaces in group', 0, 2],
+      ['ignore globally with 2 spaces in group', 'ignore', 2],
+    ])(
+      'adds newlines between groups when %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenMapElementsMembers',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+
+
+              [b, 'b'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always'],
+      ['2 spaces', 2],
+      ['ignore', 'ignore'],
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'removes newlines when never is between groups despite %s global setting',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore globally with never in group', 'ignore', 'never'],
+      ['ignore globally with 0 in group', 'ignore', 0],
+      ['never globally with ignore in group', 'never', 'ignore'],
+      ['0 globally with ignore in group', 0, 'ignore'],
+    ])(
+      'allows any spacing when %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              [b, 'b'],
+            ])
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, null], // Comment after
+
+            [b, null],
+            [c, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, null],
+            [a, null], // Comment after
+
+            [c, null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'preserves partition boundaries when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+
+              // Partition comment
+
+              [b, 'b'],
+              [c, 'c'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              // Partition comment
+
+              [c, 'c'],
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array with string patterns', ['noMatch', 'foo']],
+      ['regex pattern object', { pattern: 'FOO', flags: 'i' }],
+      [
+        'array with regex pattern object',
+        ['noMatch', { pattern: 'FOO', flags: 'i' }],
+      ],
+    ])(
+      'applies conditional configuration when all names match %s',
+      async (_description, allNamesMatchPattern) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern,
+              },
+            },
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: '^r$',
+                  groupName: 'r',
+                },
+                {
+                  elementNamePattern: '^g$',
+                  groupName: 'g',
+                },
+                {
+                  elementNamePattern: '^b$',
+                  groupName: 'b',
+                },
+              ],
+              useConfigurationIf: {
+                allNamesMatchPattern: '^r|g|b$',
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedMapElementsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedMapElementsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [r, null],
+              [g, null],
+              [b, null]
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [b, null],
+              [g, null],
+              [r, null]
+            ])
+          `,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('preserves spread elements position when sorting map entries', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['a', 'a'],
+          ])
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['a', 'aa'],
+            ['b', 'b'],
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['a', 'aa'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['c', 'cc'],
+            ['d', 'd'],
+            ...rest,
+            ['b', 'b'],
+            ['a', 'aa'],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows any order for spread elements', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ...aaa,
+            ...bb,
+          ])
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          new Map([
+            ...bb,
+            ...aaa,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts entries with variable identifiers as keys', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, b],
+            [aa, aa],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts entries with numeric keys', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [3, 'three'],
+            [1, 'one'],
+            [2, 'two'],
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '3',
+              left: '1',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [3, 'three'],
+            [2, 'two'],
+            [1, 'one'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [2, 'two'],
+            [1, 'one'],
+            [3, 'three'],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts variable identifiers without array notation', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            aaaa,
+            bbb,
+            cc,
+            d,
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'cc',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            aaaa,
+            bbb,
+            cc,
+            d,
+          ])
+        `,
+        code: dedent`
+          new Map([
+            aaaa,
+            d,
+            cc,
+            bbb,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts entries within newline-separated groups independently', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, 'aaaaa'],
+            [d, 'dd'],
+
+            [c, 'ccc'],
+
+            [b, 'bbbb'],
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [d, 'dd'],
+            [a, 'aaaaa'],
+
+            [c, 'ccc'],
+
+            [e, 'e'],
+            [b, 'bbbb'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            // Part: A
+            // Not partition comment
+            [bbb, 'bbb'],
+            [cc, 'cc'],
+            [d, 'd'],
+            // Part: B
+            [aaaa, 'aaaa'],
+            [e, 'e'],
+            // Part: C
+            // Not partition comment
+            [fff, 'fff'],
+            [gg, 'gg'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            // Part: A
+            [cc, 'cc'],
+            [d, 'd'],
+            // Not partition comment
+            [bbb, 'bbb'],
+            // Part: B
+            [aaaa, 'aaaa'],
+            [e, 'e'],
+            // Part: C
+            [gg, 'gg'],
+            // Not partition comment
+            [fff, 'fff'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            // Comment
+            [bb, 'bb'],
+            // Other comment
+            [a, 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            /* Partition Comment */
+            // Part: A
+            [d, 'd'],
+            // Part: B
+            [aaa, 'aaa'],
+            [bb, 'bb'],
+            [c, 'c'],
+            /* Other */
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            /* Partition Comment */
+            // Part: A
+            [d, 'd'],
+            // Part: B
+            [aaa, 'aaa'],
+            [c, 'c'],
+            [bb, 'bb'],
+            /* Other */
+            [e, 'e'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['e', 'e'],
+            ['f', 'f'],
+            // I am a partition comment because I don't have f o o
+            ['a', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'aa'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          new Map([
+            /* Comment */
+            ['aa', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* Comment */
+            ['aa', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // Comment
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'c'],
+            // b
+            ['b', 'b'],
+            // a
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // I am a partition comment because I don't have f o o
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'aa'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          new Map([
+            // Comment
+            ['aa', 'a'],
+            ['b', 'b'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            // Comment
+            ['aa', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* Comment */
+            ['a', 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['c', 'c'],
+            /* b */
+            ['b', 'b'],
+            /* a */
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            ['b', 'b'],
+            /* I am a partition comment because I don't have f o o */
+            ['a', 'a'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [_aa, 'a'],
+            [bb, 'b'],
+            [_c, 'c'],
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          new Map([
+            [abc, 'ab'],
+            [a_c, 'ac'],
+          ])
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [你好, '你好'],
+            [世界, '世界'],
+            [a, 'a'],
+            [A, 'A'],
+            [b, 'b'],
+            [B, 'B'],
+          ])
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('applies custom groups based on element name patterns', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'keysStartingWithHello',
+              leftGroup: 'unknown',
+              right: "'helloKey'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'keysStartingWithHello',
+                elementNamePattern: 'hello',
+              },
+            ],
+            groups: ['keysStartingWithHello', 'unknown'],
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['helloKey', 3],
+            ['a', 1],
+            ['b', 2]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['a', 1],
+            ['b', 2],
+            ['helloKey', 3]
+          ])
+        `,
+      })
+    })
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '_bb',
+              left: '_a',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: '_ccc',
+              left: '_bb',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: '_dddd',
+              left: '_ccc',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedStartingWith_ByLineLength',
+              leftGroup: 'unknown',
+              right: '_eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedStartingWith_ByLineLength',
+                elementNamePattern: '_',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedStartingWith_ByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [_dddd, null],
+            [_ccc, null],
+            [_eee, null],
+            [_bb, null],
+            [_ff, null],
+            [_a, null],
+            [_g, null],
+            [m, null],
+            [o, null],
+            [p, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [_a, null],
+            [_bb, null],
+            [_ccc, null],
+            [_dddd, null],
+            [m, null],
+            [_eee, null],
+            [_ff, null],
+            [_g, null],
+            [o, null],
+            [p, null]
+          ])
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [fooBar, fooBar],
+            [fooZar, fooZar],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [fooZar, fooZar],
+            [fooBar, fooBar],
+          ])
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedStartingWith_',
+                elementNamePattern: '_',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedStartingWith_', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedStartingWith_',
+              leftGroup: 'unknown',
+              right: "'_c'",
+              left: "'m'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['_b', null],
+            ['_a', null],
+            ['_d', null],
+            ['_e', null],
+            ['_c', null],
+            ['m', null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['_b', null],
+            ['_a', null],
+            ['_d', null],
+            ['_e', null],
+            ['m', null],
+            ['_c', null]
+          ])
+        `,
+      })
+    })
+
+    it('combines multiple patterns with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo',
+                  },
+                  {
+                    elementNamePattern: 'Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'...foo'",
+              left: "'a'",
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['...foo', null],
+            ['cFoo', null],
+            ['a', null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['a', null],
+            ['...foo', null],
+            ['cFoo', null]
+          ])
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          new Map([
+            ['iHaveFooInMyName', null],
+            ['meTooIHaveFoo', null],
+            ['a', null],
+            ['b', null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'removes extra newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [aaaa, null],
+
+
+             [yy, null],
+            [z, null],
+
+                [bbb, null]
+            ])
+          `,
+          output: dedent`
+            new Map([
+              [aaaa, null],
+             [bbb, null],
+            [yy, null],
+                [z, null]
+            ])
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, null],
+
+            [b, null],
+
+            [c, null],
+            [d, null],
+
+
+            [e, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [a, null],
+            [b, null],
+
+
+            [c, null],
+
+            [d, null],
+
+
+            [e, null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['2 spaces globally with never in group', 2, 'never'],
+      ['2 spaces globally with 0 in group', 2, 0],
+      ['2 spaces globally with ignore in group', 2, 'ignore'],
+      ['never globally with 2 spaces in group', 'never', 2],
+      ['0 globally with 2 spaces in group', 0, 2],
+      ['ignore globally with 2 spaces in group', 'ignore', 2],
+    ])(
+      'adds newlines between groups when %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenMapElementsMembers',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+
+
+              [b, 'b'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always'],
+      ['2 spaces', 2],
+      ['ignore', 'ignore'],
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'removes newlines when never is between groups despite %s global setting',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenMapElementsMembers',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore globally with never in group', 'ignore', 'never'],
+      ['ignore globally with 0 in group', 'ignore', 0],
+      ['never globally with ignore in group', 'never', 'ignore'],
+      ['0 globally with ignore in group', 0, 'ignore'],
+    ])(
+      'allows any spacing when %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, 'a'],
+
+              [b, 'b'],
+            ])
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, null], // Comment after
+
+            [b, null],
+            [c, null]
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, null],
+            [a, null], // Comment after
+
+            [c, null]
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never'],
+      ['0', 0],
+    ])(
+      'preserves partition boundaries when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [aaa, 'a'],
+
+              // Partition comment
+
+              [bb, 'b'],
+              [c, 'c'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [aaa, 'a'],
+
+              // Partition comment
+
+              [c, 'c'],
+              [bb, 'b'],
+            ])
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array with string patterns', ['noMatch', 'foo']],
+      ['regex pattern object', { pattern: 'FOO', flags: 'i' }],
+      [
+        'array with regex pattern object',
+        ['noMatch', { pattern: 'FOO', flags: 'i' }],
+      ],
+    ])(
+      'applies conditional configuration when all names match %s',
+      async (_description, allNamesMatchPattern) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern,
+              },
+            },
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: '^r$',
+                  groupName: 'r',
+                },
+                {
+                  elementNamePattern: '^g$',
+                  groupName: 'g',
+                },
+                {
+                  elementNamePattern: '^b$',
+                  groupName: 'b',
+                },
+              ],
+              useConfigurationIf: {
+                allNamesMatchPattern: '^r|g|b$',
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedMapElementsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedMapElementsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [r, null],
+              [g, null],
+              [b, null]
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [b, null],
+              [g, null],
+              [r, null]
+            ])
+          `,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts entries with variable identifiers as keys', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [aa, aa],
+            [b, b],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, b],
+            [aa, aa],
+          ])
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('allows any order when type is unsorted', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [b, b],
+            [c, c],
+            [a, a],
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces grouping even with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: '^b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedMapElementsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [ba, ba],
+            [bb, bb],
+            [ab, ab],
+            [aa, aa],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [ab, ab],
+            [aa, aa],
+            [ba, ba],
+            [bb, bb],
+          ])
+        `,
+      })
+    })
+
+    it('enforces newlines between groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenMapElementsMembers',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, b],
+
+            [a, a],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [b, b],
+            [a, a],
+          ])
+        `,
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              new Map([
-                ['CNY', 'Renminbi'],
-                ['EUR', 'Euro'],
-                ['GBP', 'Sterling'],
-                ['RUB', 'Russian ruble'],
-                ['USD', 'United States dollar'],
-              ])
-            `,
-            code: dedent`
-              new Map([
-                ['CNY', 'Renminbi'],
-                ['RUB', 'Russian ruble'],
-                ['USD', 'United States dollar'],
-                ['EUR', 'Euro'],
-                ['GBP', 'Sterling'],
-              ])
-            `,
-            errors: [
-              {
-                data: {
-                  right: "'EUR'",
-                  left: "'USD'",
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-          },
-        ],
-        valid: [
-          dedent`
-            new Map([
-              ['CNY', 'Renminbi'],
-              ['EUR', 'Euro'],
-              ['GBP', 'Sterling'],
-              ['RUB', 'Russian ruble'],
-              ['USD', 'United States dollar'],
-            ])
-          `,
-          {
-            code: dedent`
-              new Map([
-                ['img1.png', '/img1.png'],
-                ['img10.png', '/img10.png'],
-                ['img12.png', '/img12.png'],
-                ['img2.png', '/img2.png']
-              ])
-            `,
-            options: [{}],
-          },
-        ],
-      },
-    )
+    it('uses alphabetical ascending order by default', async () => {
+      await valid(
+        dedent`
+          new Map([
+            ['CNY', 'Renminbi'],
+            ['EUR', 'Euro'],
+            ['GBP', 'Sterling'],
+            ['RUB', 'Russian ruble'],
+            ['USD', 'United States dollar'],
+          ])
+        `,
+      )
 
-    ruleTester.run(`${ruleName}: works with empty map`, rule, {
-      valid: ['new Map([[], []])', 'new Map()'],
-      invalid: [],
+      await valid({
+        code: dedent`
+          new Map([
+            ['img1.png', '/img1.png'],
+            ['img10.png', '/img10.png'],
+            ['img12.png', '/img12.png'],
+            ['img2.png', '/img2.png']
+          ])
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          new Map([
+            ['CNY', 'Renminbi'],
+            ['EUR', 'Euro'],
+            ['GBP', 'Sterling'],
+            ['RUB', 'Russian ruble'],
+            ['USD', 'United States dollar'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            ['CNY', 'Renminbi'],
+            ['RUB', 'Russian ruble'],
+            ['USD', 'United States dollar'],
+            ['EUR', 'Euro'],
+            ['GBP', 'Sterling'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: "'EUR'",
+              left: "'USD'",
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}: respect numeric separators with natural sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-               new Map([
-                [1, "first"],
-                [2, "second"],
-                [3, "third"],
-                [100, "hundredth"],
-                [1_000, "thousandth"],
-                [1_000_000, "millionth"]
-              ])
-            `,
-            code: dedent`
-               new Map([
-                [1, "first"],
-                [2, "second"],
-                [3, "third"],
-                [1_000, "thousandth"],
-                [100, "hundredth"],
-                [1_000_000, "millionth"]
-              ])
-            `,
-            errors: [
-              {
-                data: {
-                  left: '1_000',
-                  right: '100',
-                },
-                messageId: 'unexpectedMapElementsOrder',
-              },
-            ],
-            options: [
-              {
-                type: 'natural',
-                order: 'asc',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-               new Map([
-                [1, "first"],
-                [2, "second"],
-                [3, "third"],
-                [100, "hundredth"],
-                [1_000, "thousandth"],
-                [1_000_000, "millionth"]
-              ])
-            `,
-            options: [
-              {
-                type: 'natural',
-                order: 'asc',
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              // eslint-disable-next-line
-              [a, 'a']
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              // eslint-disable-next-line
-              [a, 'a']
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              // eslint-disable-next-line
-              [a, 'a'],
-              [d, 'd']
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [d, 'd'],
-              [c, 'c'],
-              // eslint-disable-next-line
-              [a, 'a'],
-              [b, 'b']
-            ])
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              [a, 'a'] // eslint-disable-line
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              [a, 'a'] // eslint-disable-line
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              /* eslint-disable-next-line */
-              [a, 'a']
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              /* eslint-disable-next-line */
-              [a, 'a']
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              [a, 'a'] /* eslint-disable-line */
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              [a, 'a'] /* eslint-disable-line */
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Map([
-              [a, 'a'],
-              [d, 'd'],
-              /* eslint-disable */
-              [c, 'c'],
-              [b, 'b'],
-              // Shouldn't move
-              /* eslint-enable */
-              [e, 'e'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [d, 'd'],
-              [e, 'e'],
-              /* eslint-disable */
-              [c, 'c'],
-              [b, 'b'],
-              // Shouldn't move
-              /* eslint-enable */
-              [a, 'a'],
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              [a, 'a']
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              [a, 'a']
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              [a, 'a'] // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              [a, 'a'] // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              [a, 'a']
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              [a, 'a']
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              [a, 'a'] /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [c, 'c'],
-              [b, 'b'],
-              [a, 'a'] /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Map([
-              [a, 'a'],
-              [d, 'd'],
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              [c, 'c'],
-              [b, 'b'],
-              // Shouldn't move
-              /* eslint-enable */
-              [e, 'e'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [d, 'd'],
-              [e, 'e'],
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              [c, 'c'],
-              [b, 'b'],
-              // Shouldn't move
-              /* eslint-enable */
-              [a, 'a'],
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Map([
-              [b, 'b'],
-              [c, 'c'],
-              // eslint-disable-next-line
-              [a, 'a'],
-            ])
-          `,
-        },
-      ],
+    it('handles empty maps and single-element maps', async () => {
+      await valid('new Map([[], []])')
+      await valid('new Map()')
     })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+    it('respects natural sorting with numeric separators', async () => {
+      await valid({
+        code: dedent`
+           new Map([
+            [1, "first"],
+            [2, "second"],
+            [3, "third"],
+            [100, "hundredth"],
+            [1_000, "thousandth"],
+            [1_000_000, "millionth"]
+          ])
+        `,
+        options: [
           {
-            code: dedent`
-              new Map([
-                ['a', 'a'],
-                ['b', 'b'],
-                ['c', 'c'],
-              ])
-            `,
-            options: [{}],
+            type: 'natural',
+            order: 'asc',
           },
         ],
-        invalid: [],
-      },
-    )
+      })
+
+      await invalid({
+        output: dedent`
+           new Map([
+            [1, "first"],
+            [2, "second"],
+            [3, "third"],
+            [100, "hundredth"],
+            [1_000, "thousandth"],
+            [1_000_000, "millionth"]
+          ])
+        `,
+        code: dedent`
+           new Map([
+            [1, "first"],
+            [2, "second"],
+            [3, "third"],
+            [1_000, "thousandth"],
+            [100, "hundredth"],
+            [1_000_000, "millionth"]
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              left: '1_000',
+              right: '100',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [
+          {
+            type: 'natural',
+            order: 'asc',
+          },
+        ],
+      })
+    })
+
+    it('excludes disabled elements from sorting', async () => {
+      await valid({
+        code: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            // eslint-disable-next-line
+            [a, 'a'],
+          ])
+        `,
+      })
+    })
+
+    it('handles inline eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            // eslint-disable-next-line
+            [a, 'a']
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            // eslint-disable-next-line
+            [a, 'a']
+          ])
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            [a, 'a'] // eslint-disable-line
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            [a, 'a'] // eslint-disable-line
+          ])
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            /* eslint-disable-next-line */
+            [a, 'a']
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            /* eslint-disable-next-line */
+            [a, 'a']
+          ])
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            [a, 'a'] /* eslint-disable-line */
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            [a, 'a'] /* eslint-disable-line */
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable blocks', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            [a, 'a'],
+            [d, 'd'],
+            /* eslint-disable */
+            [c, 'c'],
+            [b, 'b'],
+            // Shouldn't move
+            /* eslint-enable */
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [d, 'd'],
+            [e, 'e'],
+            /* eslint-disable */
+            [c, 'c'],
+            [b, 'b'],
+            // Shouldn't move
+            /* eslint-enable */
+            [a, 'a'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable comments', async () => {
+      await invalid({
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            // eslint-disable-next-line rule-to-test/sort-maps
+            [a, 'a']
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            // eslint-disable-next-line rule-to-test/sort-maps
+            [a, 'a']
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            [a, 'a'] // eslint-disable-line rule-to-test/sort-maps
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            [a, 'a'] // eslint-disable-line rule-to-test/sort-maps
+          ])
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            /* eslint-disable-next-line rule-to-test/sort-maps */
+            [a, 'a']
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            /* eslint-disable-next-line rule-to-test/sort-maps */
+            [a, 'a']
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            [a, 'a'] /* eslint-disable-line rule-to-test/sort-maps */
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [c, 'c'],
+            [b, 'b'],
+            [a, 'a'] /* eslint-disable-line rule-to-test/sort-maps */
+          ])
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          new Map([
+            [a, 'a'],
+            [d, 'd'],
+            /* eslint-disable rule-to-test/sort-maps */
+            [c, 'c'],
+            [b, 'b'],
+            // Shouldn't move
+            /* eslint-enable */
+            [e, 'e'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [d, 'd'],
+            [e, 'e'],
+            /* eslint-disable rule-to-test/sort-maps */
+            [c, 'c'],
+            [b, 'b'],
+            // Shouldn't move
+            /* eslint-enable */
+            [a, 'a'],
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles eslint-disable with partitionByComment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [b, 'b'],
+            [c, 'c'],
+            // eslint-disable-next-line
+            [a, 'a'],
+            [d, 'd']
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [d, 'd'],
+            [c, 'c'],
+            // eslint-disable-next-line
+            [a, 'a'],
+            [b, 'b']
+          ])
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
   })
 })

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -1,3647 +1,1845 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-modules'
 
-let ruleName = 'sort-modules'
+describe('sort-modules', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-modules',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts modules`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'export-interface',
-                left: 'FindUserInput',
-                right: 'CacheType',
-                rightGroup: 'enum',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
+    it('sorts modules according to group hierarchy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'export-interface',
+              left: 'FindUserInput',
+              right: 'CacheType',
+              rightGroup: 'enum',
             },
-            {
-              data: {
-                rightGroup: 'export-function',
-                left: 'assertInputIsCorrect',
-                leftGroup: 'function',
-                right: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'export-function',
+              left: 'assertInputIsCorrect',
+              leftGroup: 'function',
+              right: 'findUser',
             },
-            {
-              data: {
-                leftGroup: 'export-function',
-                right: 'FindAllUsersInput',
-                rightGroup: 'export-type',
-                left: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              right: 'FindAllUsersInput',
+              rightGroup: 'export-type',
+              left: 'findUser',
             },
-            {
-              data: {
-                leftGroup: 'export-function',
-                left: 'findAllUsers',
-                rightGroup: 'class',
-                right: 'Cache',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              left: 'findAllUsers',
+              rightGroup: 'class',
+              right: 'Cache',
             },
-          ],
-          output: dedent`
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
 
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
+          export type FindAllUsersInput = {
+            ids: string[]
+            cache: CacheType
+          }
 
-            export type FindAllUsersOutput = FindUserOutput[]
+          export type FindAllUsersOutput = FindUserOutput[]
 
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
 
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
+          export type FindUserOutput = {
+            id: string
+            name: string
+            age: number
+          }
 
-            class Cache {
-              // Some logic
-            }
+          class Cache {
+            // Some logic
+          }
 
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
 
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
 
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
-          `,
-          code: dedent`
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
+        `,
+        code: dedent`
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
 
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
 
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
+          export type FindUserOutput = {
+            id: string
+            name: string
+            age: number
+          }
 
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
 
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
 
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
+          export type FindAllUsersInput = {
+            ids: string[]
+            cache: CacheType
+          }
 
-            export type FindAllUsersOutput = FindUserOutput[]
+          export type FindAllUsersOutput = FindUserOutput[]
 
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
 
-            class Cache {
-              // Some logic
-            }
-          `,
-          options: [options],
-        },
+          class Cache {
+            // Some logic
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts modules within modules and namespaces', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          module ModuleB {
+            interface A {}
+            interface B {}
+          }
+          module ModuleA {
+            interface A {}
+            interface B {}
+          }
+        `,
+        code: dedent`
+          module ModuleB {
+            interface B {}
+            interface A {}
+          }
+          module ModuleA {
+            interface B {}
+            interface A {}
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          namespace NamespaceB {
+            interface A {}
+            interface B {}
+          }
+          namespace NamespaceA {
+            interface A {}
+            interface B {}
+          }
+        `,
+        code: dedent`
+          namespace NamespaceB {
+            interface B {}
+            interface A {}
+          }
+          namespace NamespaceA {
+            interface B {}
+            interface A {}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('creates partitions at variable declarations', async () => {
+      await valid({
+        code: dedent`
+          interface B {}
+          let a;
+          interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('creates partitions at function call expressions', async () => {
+      await valid({
+        code: dedent`
+          interface B {}
+          iAmCallingAFunction();
+          interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('accepts complex predefined group configurations', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'export-declare-interface',
+              'export-default-interface',
+              'export-declare-function',
+              'export-default-async-function',
+              'export-decorated-class',
+              'export-default-decorated-class',
+              'export-declare-type',
+              'export-enum',
+              'export-declare-enum',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          export declare interface Interface {}
+
+          export default interface Interface2 {}
+
+          export declare function f2()
+
+          export default async function f1()
+
+          export @Decorator declare class Class1 {}
+
+          export @Decorator default class Class2 {}
+
+          export declare type Type = {}
+
+          export enum Enum1 {}
+
+          export declare enum Enum2 {}
+        `,
+      })
+    })
+
+    it('filters elements based on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['export'],
+                selector: 'type',
+              },
+              {
+                groupName: 'exportInterfaceGroup',
+                selector: 'interface',
+                modifiers: ['export'],
+              },
+              {
+                groupName: 'interfaceGroup',
+                selector: 'interface',
+              },
+            ],
+            groups: ['interfaceGroup', 'exportInterfaceGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'exportInterfaceGroup',
+              rightGroup: 'interfaceGroup',
+              right: 'C',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface C {}
+          export interface A {}
+          export interface B {}
+        `,
+        code: dedent`
+          export interface A {}
+          export interface B {}
+          interface C {}
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex object',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
       ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts modules withing modules and namespaces`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            output: dedent`
-              module ModuleB {
-                interface A {}
-                interface B {}
-              }
-              module ModuleA {
-                interface A {}
-                interface B {}
-              }
-            `,
-            code: dedent`
-              module ModuleB {
-                interface B {}
-                interface A {}
-              }
-              module ModuleA {
-                interface B {}
-                interface A {}
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            output: dedent`
-              namespace NamespaceB {
-                interface A {}
-                interface B {}
-              }
-              namespace NamespaceA {
-                interface A {}
-                interface B {}
-              }
-            `,
-            code: dedent`
-              namespace NamespaceB {
-                interface B {}
-                interface A {}
-              }
-              namespace NamespaceA {
-                interface B {}
-                interface A {}
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): partitions when encountering a variable declaration`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface B {}
-              let a;
-              interface A {}
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): partitions when encountering expressions`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              interface B {}
-              iAmCallingAFunction();
-              interface A {}
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts complex predefined groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groups: [
-                  'export-declare-interface',
-                  'export-default-interface',
-                  'export-declare-function',
-                  'export-default-async-function',
-                  'export-decorated-class',
-                  'export-default-decorated-class',
-                  'export-declare-type',
-                  'export-enum',
-                  'export-declare-enum',
-                  'unknown',
-                ],
-              },
-            ],
-            code: dedent`
-              export declare interface Interface {}
-
-              export default interface Interface2 {}
-
-              export declare function f2()
-
-              export default async function f1()
-
-              export @Decorator declare class Class1 {}
-
-              export @Decorator default class Class2 {}
-
-              export declare type Type = {}
-
-              export enum Enum1 {}
-
-              export declare enum Enum2 {}
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector and modifiers`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'unusedCustomGroup',
-                    modifiers: ['export'],
-                    selector: 'type',
-                  },
-                  {
-                    groupName: 'exportInterfaceGroup',
-                    selector: 'interface',
-                    modifiers: ['export'],
-                  },
-                  {
-                    groupName: 'interfaceGroup',
-                    selector: 'interface',
-                  },
-                ],
-                groups: ['interfaceGroup', 'exportInterfaceGroup'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  leftGroup: 'exportInterfaceGroup',
-                  rightGroup: 'interfaceGroup',
-                  right: 'C',
-                  left: 'B',
-                },
-                messageId: 'unexpectedModulesGroupOrder',
-              },
-            ],
-            output: dedent`
-              interface C {}
-              export interface A {}
-              export interface B {}
-            `,
-            code: dedent`
-              export interface A {}
-              export interface B {}
-              interface C {}
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'functionsStartingWithHello',
-                      selector: 'function',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['functionsStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'functionsStartingWithHello',
-                    right: 'helloFunction',
-                    leftGroup: 'unknown',
-                    left: 'func',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              output: dedent`
-                function helloFunction() {}
-                interface A {}
-                interface B {}
-                function func() {}
-              `,
-              code: dedent`
-                interface A {}
-                interface B {}
-                function func() {}
-                function helloFunction() {}
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      for (let decoratorNamePattern of [
-        'Hello',
-        ['noMatch', 'Hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on decoratorNamePattern`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'classesWithDecoratorStartingWithHello',
-                    leftGroup: 'unknown',
-                    left: 'func',
-                    right: 'C',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-                {
-                  data: {
-                    right: 'AnotherClass',
-                    left: 'C',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'classesWithDecoratorStartingWithHello',
-                      decoratorNamePattern,
-                      selector: 'class',
-                    },
-                  ],
-                  groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
-                },
-              ],
-              output: dedent`
-                @HelloDecorator()
-                class AnotherClass {}
-
-                @HelloDecorator
-                class C {}
-
-                @Decorator
-                class A {}
-
-                class B {}
-
-                function func() {}
-              `,
-              code: dedent`
-                @Decorator
-                class A {}
-
-                class B {}
-
-                function func() {}
-
-                @HelloDecorator
-                class C {}
-
-                @HelloDecorator()
-                class AnotherClass {}
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: filters on complex decoratorNamePattern`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      decoratorNamePattern: 'B',
-                      groupName: 'B',
-                    },
-                    {
-                      decoratorNamePattern: 'A',
-                      groupName: 'A',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['B', 'A'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'B',
-                    leftGroup: 'A',
-                    right: 'B',
-                    left: 'A',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              output: dedent`
-                @B.B()
-                class B {}
-
-                @A.A.A(() => A)
-                class A {}
-              `,
-              code: dedent`
-                @A.A.A(() => A)
-                class A {}
-
-                @B.B()
-                class B {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'reversedFunctionsByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'aFunction',
-                    left: 'DDDD',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedFunctionsByLineLength',
-                    right: 'anotherFunction',
-                    leftGroup: 'unknown',
-                    left: 'G',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-                {
-                  data: {
-                    right: 'yetAnotherFunction',
-                    left: 'anotherFunction',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedFunctionsByLineLength',
-                      selector: 'function',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedFunctionsByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                function yetAnotherFunction() {}
-
-                function anotherFunction() {}
-
-                function aFunction() {}
-
-                interface A {}
-
-                interface BB {}
-
-                interface CCC {}
-
-                interface DDDD {}
-
-                interface EEE {}
-
-                interface FF {}
-
-                interface G {}
-              `,
-              code: dedent`
-                interface A {}
-
-                interface BB {}
-
-                interface CCC {}
-
-                interface DDDD {}
-
-                function aFunction() {}
-
-                interface EEE {}
-
-                interface FF {}
-
-                interface G {}
-
-                function anotherFunction() {}
-
-                function yetAnotherFunction() {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                function fooBar() {}
-                function fooZar() {}
-              `,
-              code: dedent`
-                function fooZar() {}
-                function fooBar() {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedFunctions',
-                      selector: 'function',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedFunctions', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedFunctions',
-                    leftGroup: 'unknown',
-                    left: 'Interface',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              output: dedent`
-                function b() {}
-
-                function a() {}
-
-                function d() {}
-
-                function e() {}
-
-                function c() {}
-
-                interface Interface {}
-              `,
-              code: dedent`
-                function b() {}
-
-                function a() {}
-
-                function d() {}
-
-                function e() {}
-
-                interface Interface {}
-
-                function c() {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'unknown',
-                  rightGroup: 'class',
-                  left: 'func',
-                  right: 'C',
-                },
-                messageId: 'unexpectedModulesGroupOrder',
-              },
-              {
-                data: {
-                  right: 'aFunction',
-                  left: 'C',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-              {
-                data: {
-                  right: 'anotherFunction',
-                  left: 'D',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        selector: 'interface',
-                        modifiers: ['export'],
-                      },
-                      {
-                        selector: 'function',
-                        modifiers: ['async'],
-                      },
-                    ],
-                    groupName: 'exportInterfacesAndAsyncFunctions',
-                  },
-                ],
-                groups: [
-                  ['exportInterfacesAndAsyncFunctions', 'class'],
-                  'unknown',
-                ],
-              },
-            ],
-            output: dedent`
-              export interface A {}
-
-              async function aFunction() {}
-
-              async function anotherFunction() {}
-
-              class b {}
-
-              class C {}
-
-              export interface D {}
-
-              class E {}
-
-              function func() {}
-            `,
-            code: dedent`
-              export interface A {}
-
-              class b {}
-
-              class E {}
-
-              function func() {}
-
-              class C {}
-
-              async function aFunction() {}
-
-              export interface D {}
-
-              async function anotherFunction() {}
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                function iHaveFooInMyName() {}
-                function meTooIHaveFoo() {}
-                function a() {}
-                function b() {}
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for decorator names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      decoratorNamePattern: '^.*Foo.*$',
-                      groupName: 'decoratorsWithFoo',
-                    },
-                  ],
-                  groups: ['decoratorsWithFoo', 'unknown'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                @IHaveFooInMyName
-                class X {}
-                @MeTooIHaveFoo
-                class Y {}
-                class A {}
-                class B {}
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe('newlinesInside', () => {
-        for (let newlinesInside of ['always', 1] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          groupName: 'group1',
-                          selector: 'type',
-                          newlinesInside,
-                        },
-                      ],
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'B',
-                        left: 'A',
-                      },
-                      messageId: 'missedSpacingBetweenModulesMembers',
-                    },
-                  ],
-                  output: dedent`
-                    type A = {}
-
-                    type B = {}
-                  `,
-                  code: dedent`
-                    type A = {}
-                    type B = {}
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-
-        for (let newlinesInside of ['never', 0] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          groupName: 'group1',
-                          selector: 'type',
-                          newlinesInside,
-                        },
-                      ],
-                      type: 'alphabetical',
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'B',
-                        left: 'A',
-                      },
-                      messageId: 'extraSpacingBetweenModulesMembers',
-                    },
-                  ],
-                  output: dedent`
-                    type A = {}
-                    type B = {}
-                  `,
-                  code: dedent`
-                    type A = {}
-
-                    type B = {}
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-      })
-    })
-
-    describe(`${ruleName}(${type}): interface modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize declare over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'declare-interface',
-                    leftGroup: 'function',
-                    right: 'Interface',
-                    left: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['declare-interface', 'function', 'export-interface'],
-                },
-              ],
-              output: dedent`
-                export declare interface Interface {}
-
-                function f() {}
-              `,
-              code: dedent`
-                function f() {}
-
-                export declare interface Interface {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize default over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'default-interface',
-                    leftGroup: 'function',
-                    right: 'Interface',
-                    left: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['default-interface', 'function', 'export-interface'],
-                },
-              ],
-              output: dedent`
-                export default interface Interface {}
-
-                function f() {}
-              `,
-              code: dedent`
-                function f() {}
-
-                export default interface Interface {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): type modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize declare over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'declare-type',
-                    leftGroup: 'function',
-                    right: 'Type',
-                    left: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['declare-type', 'function', 'export-type'],
-                },
-              ],
-              output: dedent`
-                export declare type Type = {}
-
-                function f() {}
-              `,
-              code: dedent`
-                function f() {}
-
-                export declare type Type = {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): class modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize declare over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'declare-class',
-                    leftGroup: 'function',
-                    right: 'Class',
-                    left: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['declare-class', 'function', 'export-class'],
-                },
-              ],
-              output: dedent`
-                export declare class Class {}
-
-                function f() {}
-              `,
-              code: dedent`
-                function f() {}
-
-                export declare class Class {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      /* Currently not handled correctly
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize default over decorated`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'default-class',
-                    leftGroup: 'function',
-                    right: 'Class',
-                    left: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['default-class', 'function', 'decorated-class'],
-                },
-              ],
-              output: dedent`
-                export default @Decorator class Class {}
-
-                function f() {}
-              `,
-              code: dedent`
-                function f() {}
-
-                export default @Decorator class Class {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize decorated over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'decorated-class',
-                    leftGroup: 'function',
-                    right: 'Class',
-                    left: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['decorated-class', 'function', 'export-class'],
-                },
-              ],
-              output: dedent`
-                export @Decorator class Class {}
-
-                function f() {}
-              `,
-              code: dedent`
-                function f() {}
-
-                export @Decorator class Class {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-      */
-    })
-
-    describe(`${ruleName}(${type}): function modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize declare over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'declare-function',
-                    leftGroup: 'interface',
-                    left: 'Interface',
-                    right: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['declare-function', 'interface', 'export-function'],
-                },
-              ],
-              output: dedent`
-                export declare function f()
-
-                interface Interface {}
-              `,
-              code: dedent`
-                interface Interface {}
-
-                export declare function f()
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize default over async`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'default-function',
-                    leftGroup: 'interface',
-                    left: 'Interface',
-                    right: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['default-function', 'interface', 'async-function'],
-                },
-              ],
-              output: dedent`
-                export default async function f() {}
-
-                interface Interface {}
-              `,
-              code: dedent`
-                interface Interface {}
-
-                export default async function f() {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize async over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'async-function',
-                    leftGroup: 'interface',
-                    left: 'Interface',
-                    right: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['async-function', 'interface', 'export-function'],
-                },
-              ],
-              output: dedent`
-                export async function f() {}
-
-                interface Interface {}
-              `,
-              code: dedent`
-                interface Interface {}
-
-                export async function f() {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): enum modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize declare over export`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'declare-enum',
-                    leftGroup: 'function',
-                    right: 'Enum',
-                    left: 'f',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['declare-enum', 'function', 'export-enum'],
-                },
-              ],
-              output: dedent`
-                export declare enum Enum {}
-
-                function f() {}
-              `,
-              code: dedent`
-                function f() {}
-
-                export declare enum Enum {}
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): detects dependencies`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}) ignores non-static class method dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class A {
-                  f() {
-                    return Enum.V
-                  }
-                }
-
-                enum Enum {
-                  V = 'V'
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) ignores static class method dependencies if no static block or static properties are present`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class A {
-                  static f() {
-                    return Enum.V
-                  }
-                }
-
-                enum Enum {
-                  V = 'V'
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects static class method dependencies if a static block is present`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                enum Enum {
-                  V = 'V'
-                }
-
-                class A {
-                  static {
-                    console.log(Enum.V)
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                enum Enum {
-                  V = 'V'
-                }
-
-                class A {
-                  static {
-                    console.log(A.f())
-                  }
-
-                  static f = () => {
-                    return Enum.V
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                enum Enum {
-                  V = 'V'
-                }
-
-                class Class {
-                  static {
-                    const method = () => {
-                      return Enum.V || true;
-                    };
-                    method();
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects static class method dependencies if a static property is present`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                enum Enum {
-                  V = 'V'
-                }
-
-                class A {
-                  static a = Enum.V
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                enum Enum {
-                  V = 'V'
-                }
-
-                class A {
-                  static accessor a = Enum.V
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                enum Enum {
-                  V = 'V'
-                }
-
-                class A {
-                  static a = Object.values(Enum)
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) ignores non-static arrow-method dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class A {
-                  f = () => {
-                    return Enum.V
-                  }
-                }
-
-                enum Enum {
-                  V = 'V'
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-            {
-              code: dedent`
-                class A {
-                  accessor f = () => {
-                    return Enum.V
-                  }
-                }
-
-                enum Enum {
-                  V = 'V'
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) ignores static arrow-method dependencies if no static block or static properties are present`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class A {
-                  static f = () => {
-                    return Enum.V
-                  }
-                }
-
-                enum Enum {
-                  V = 'V'
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) ignores interface dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                interface A {
-                  a: Enum.V
-                }
-
-                enum Enum {
-                  V = 'V'
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}) ignores type dependencies`, rule, {
-        valid: [
-          {
-            code: dedent`
-              type A = {
-                a: Enum.V
-              }
-
-              enum Enum {
-                V = 'V'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      })
-
-      ruleTester.run(`${ruleName}(${type}) detects enum dependencies`, rule, {
-        valid: [
-          {
-            code: dedent`
-              enum B {
-                V = 'V'
-              }
-
-              enum A {
-                V = B.V
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      })
-
-      ruleTester.run(`${ruleName}(${type}) detects nested dependencies`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'A',
-                  right: 'B',
-                },
-                messageId: 'unexpectedModulesDependencyOrder',
-              },
-            ],
-            output: dedent`
-              class B {
-                static b = 1
-              }
-
-              class A {
-                static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
-              }
-            `,
-            code: dedent`
-              class A {
-                static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
-              }
-
-              class B {
-                static b = 1
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in template literal expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                class B {
-                  static b = 1
-                }
-
-                class A {
-                  static a = \`\${B.b}\`
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in classes extend`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-              code: dedent`
-                class B {}
-
-                class A extends B {}
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in decorators`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                enum B {}
-
-                class A {
-                  @SomeDecorator({
-                    a: {
-                      b: c.concat([B])
-                    }
-                  })
-                  property
-                }
-              `,
-              code: dedent`
-                class A {
-                  @SomeDecorator({
-                    a: {
-                      b: c.concat([B])
-                    }
-                  })
-                  property
-                }
-
-                enum B {}
-              `,
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'A',
-                    right: 'B',
-                  },
-                  messageId: 'unexpectedModulesDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['unknown'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects and ignores circular dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                class A {
-                  static a = B.b
-                }
-
-                class B {
-                  static b = C.c
-                }
-
-                class C {
-                  static c = A.a
-                }
-              `,
-              code: dedent`
-                class B {
-                  static b = C.c
-                }
-
-                class A {
-                  static a = B.b
-                }
-
-                class C {
-                  static c = A.a
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over group configuration`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  groups: ['export-class', 'class'],
-                },
-              ],
-              code: dedent`
-                class B { static b }
-                export class A { static a = B.b }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'B',
-                    right: 'A',
-                  },
-                  messageId: 'unexpectedModulesDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: 'Part',
-                },
-              ],
-              output: dedent`
-                class A { static a }
-                // Part1
-                class B { static b = A.a }
-              `,
-              code: dedent`
-                class B { static b = A.a }
-                // Part1
-                class A { static a }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'B',
-                    right: 'A',
-                  },
-                  messageId: 'unexpectedModulesDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByNewLine: true,
-                },
-              ],
-              output: dedent`
-                class A { static a }
-
-                class B { static = A.a }
-              `,
-              code: dedent`
-                class B { static = A.a }
-
-                class A { static a }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(`${ruleName}(${type}): should ignore unknown group`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'function',
-                rightGroup: 'unknown',
-                right: 'SomeClass',
-                left: 'b',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'function',
-                leftGroup: 'unknown',
-                left: 'SomeClass',
-                right: 'a',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-          ],
-          output: dedent`
-            function a() {}
-            class SomeClass {}
-            function b() {}
-          `,
+    ])(
+      'filters functions by element name pattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
           options: [
             {
-              ...options,
-              groups: ['function'],
-            },
-          ],
-          code: dedent`
-            function b() {}
-            class SomeClass {}
-            function a() {}
-          `,
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              function _a() {}
-              function b() {}
-              function _c() {}
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              function ab() {}
-              function a_c() {}
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            function 你好() {}
-            function 世界() {}
-            function a() {}
-            function A() {}
-            function b() {}
-            function B() {}
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      leftGroup: 'interface',
-                      rightGroup: 'unknown',
-                      right: 'y',
-                      left: 'A',
-                    },
-                    messageId: 'unexpectedModulesGroupOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedModulesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenModulesMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['unknown', 'interface'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                    interface A {}
-
-
-                   function y() {}
-                  function z() {}
-
-                      function b() {}
-                `,
-                output: dedent`
-                    function b() {}
-                   function y() {}
-                  function z() {}
-                      interface A {}
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenModulesMembers',
-                  },
-                ],
-                output: dedent`
-                  function a() {};
-
-                  function b() {}
-                `,
-                code: dedent`
-                  function a() {};function b() {}
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'A',
-                    },
-                    messageId: 'extraSpacingBetweenModulesMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedModulesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenModulesMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['interface', 'unknown', 'class'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                    interface A {}
-
-                   function y() {}
-                  function z() {}
-
-                      class B {}
-                `,
-                code: dedent`
-                    interface A {}
-
-
-                   function z() {}
-                  function y() {}
-                      class B {}
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenModulesMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenModulesMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenModulesMembers',
-                  },
-                ],
-                output: dedent`
-                  function a() {}
-
-                  function b() {}
-
-                  function c() {}
-                  function d() {}
-
-
-                  function e() {}
-                `,
-                code: dedent`
-                  function a() {}
-                  function b() {}
-
-
-                  function c() {}
-
-                  function d() {}
-
-
-                  function e() {}
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenModulesMembers',
-                      },
-                    ],
-                    output: dedent`
-                      function a() {}
-
-
-                      function b() {}
-                    `,
-                    code: dedent`
-                      function a() {}
-                      function b() {}
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenModulesMembers',
-                      },
-                    ],
-                    output: dedent`
-                      function a() {}
-                      function b() {}
-                    `,
-                    code: dedent`
-                      function a() {}
-
-                      function b() {}
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      function a() {}
-
-                      function b() {}
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      function a() {}
-                      function b() {}
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  function a() {} // Comment after
-                  type B = string
-
-                  type C = string
-                `,
-                dedent`
-                  function a() {} // Comment after
-
-                  type B = string
-                  type C = string
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'function',
-                    leftGroup: 'type',
-                    right: 'a',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  groups: ['function', 'type'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              code: dedent`
-                type B = string
-                function a() {} // Comment after
-
-                type C = string
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedModulesOrder',
-                  },
-                ],
-                output: dedent`
-                  function a() {}
-
-                  // Partition comment
-
-                  function b() {}
-                  function c() {}
-                `,
-                code: dedent`
-                  function a() {}
-
-                  // Partition comment
-
-                  function c() {}
-                  function b() {}
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    describe(`${ruleName}(${type}): sorts inline elements correctly`, () => {
-      describe(`${ruleName}(${type}): functions`, () => {
-        describe(`${ruleName}(${type}): non-declare functions`, () => {
-          ruleTester.run(
-            `${ruleName}(${type}): sorts inline non-declare functions correctly`,
-            rule,
-            {
-              invalid: [
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedModulesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    function a() {} function b() {}
-                  `,
-                  code: dedent`
-                    function b() {} function a() {}
-                  `,
-                  options: [options],
-                },
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedModulesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    function a() {} function b() {};
-                  `,
-                  code: dedent`
-                    function b() {} function a() {};
-                  `,
-                  options: [options],
-                },
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedModulesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    function a() {}; function b() {}
-                  `,
-                  code: dedent`
-                    function b() {}; function a() {}
-                  `,
-                  options: [options],
-                },
-              ],
-              valid: [],
-            },
-          )
-        })
-
-        describe(`${ruleName}(${type}): declare functions`, () => {
-          ruleTester.run(
-            `${ruleName}(${type}): sorts inline declare functions correctly`,
-            rule,
-            {
-              invalid: [
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedModulesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    declare function a(); declare function b();
-                  `,
-                  code: dedent`
-                    declare function b(); declare function a()
-                  `,
-                  options: [options],
-                },
-                {
-                  errors: [
-                    {
-                      data: {
-                        right: 'a',
-                        left: 'b',
-                      },
-                      messageId: 'unexpectedModulesOrder',
-                    },
-                  ],
-                  output: dedent`
-                    declare function a(); declare function b();
-                  `,
-                  code: dedent`
-                    declare function b(); declare function a();
-                  `,
-                  options: [options],
-                },
-              ],
-              valid: [],
-            },
-          )
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline interfaces correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                interface A {} interface B {}
-              `,
-              code: dedent`
-                interface B {} interface A {}
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                interface A {} interface B {};
-              `,
-              code: dedent`
-                interface B {} interface A {};
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                interface A {}; interface B {}
-              `,
-              code: dedent`
-                interface B {}; interface A {}
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline types correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                type a = {}; type b = {};
-              `,
-              code: dedent`
-                type b = {}; type a = {}
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                type a = {}; type b = {};
-              `,
-              code: dedent`
-                type b = {}; type a = {};
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline classes correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                class A {} class B {}
-              `,
-              code: dedent`
-                class B {} class A {}
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                class A {} class B {};
-              `,
-              code: dedent`
-                class B {} class A {};
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                class A {}; class B {}
-              `,
-              code: dedent`
-                class B {}; class A {}
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): sorts inline enums correctly`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                enum A {} enum B {}
-              `,
-              code: dedent`
-                enum B {} enum A {}
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                enum A {} enum B {};
-              `,
-              code: dedent`
-                enum B {} enum A {};
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              output: dedent`
-                enum A {}; enum B {}
-              `,
-              code: dedent`
-                enum B {}; enum A {}
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores exported decorated classes`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'B',
-                  left: 'C',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            output: dedent`
-              @B
-              class B {}
-
-              @A
-              export class A {}
-
-              @C
-              class C {}
-            `,
-            code: dedent`
-              @C
-              class C {}
-
-              @A
-              export class A {}
-
-              @B
-              class B {}
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts modules`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'export-interface',
-                left: 'FindUserInput',
-                right: 'CacheType',
-                rightGroup: 'enum',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'export-function',
-                left: 'assertInputIsCorrect',
-                leftGroup: 'function',
-                right: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'export-function',
-                right: 'FindAllUsersInput',
-                rightGroup: 'export-type',
-                left: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'export-function',
-                left: 'findAllUsers',
-                rightGroup: 'class',
-                right: 'Cache',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-          ],
-          output: dedent`
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
-
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
-
-            export type FindAllUsersOutput = FindUserOutput[]
-
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
-
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
-
-            class Cache {
-              // Some logic
-            }
-
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
-
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
-
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
-          `,
-          code: dedent`
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
-
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
-
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
-
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
-
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
-
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
-
-            export type FindAllUsersOutput = FindUserOutput[]
-
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
-
-            class Cache {
-              // Some logic
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts modules`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'export-interface',
-                left: 'FindUserInput',
-                right: 'CacheType',
-                rightGroup: 'enum',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'export-function',
-                left: 'assertInputIsCorrect',
-                leftGroup: 'function',
-                right: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'export-function',
-                right: 'FindAllUsersInput',
-                rightGroup: 'export-type',
-                left: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'export-function',
-                left: 'findAllUsers',
-                rightGroup: 'class',
-                right: 'Cache',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-          ],
-          output: dedent`
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
-
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
-
-            export type FindAllUsersOutput = FindUserOutput[]
-
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
-
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
-
-            class Cache {
-              // Some logic
-            }
-
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
-
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
-
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
-          `,
-          code: dedent`
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
-
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
-
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
-
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
-
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
-
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
-
-            export type FindAllUsersOutput = FindUserOutput[]
-
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
-
-            class Cache {
-              // Some logic
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line-length`, () => {
-    let type = 'line-length'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts modules`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'export-interface',
-                left: 'FindUserInput',
-                right: 'CacheType',
-                rightGroup: 'enum',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'export-function',
-                left: 'assertInputIsCorrect',
-                leftGroup: 'function',
-                right: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'export-function',
-                right: 'FindAllUsersInput',
-                rightGroup: 'export-type',
-                left: 'findUser',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'export-function',
-                left: 'findAllUsers',
-                rightGroup: 'class',
-                right: 'Cache',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
-            },
-          ],
-          output: dedent`
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
-
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
-
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
-
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
-
-            export type FindAllUsersOutput = FindUserOutput[]
-
-            class Cache {
-              // Some logic
-            }
-
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
-
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
-
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
-          `,
-          code: dedent`
-            export interface FindUserInput {
-              id: string
-              cache: CacheType
-            }
-
-            enum CacheType {
-              ALWAYS = 'ALWAYS',
-              NEVER = 'NEVER',
-            }
-
-            export type FindUserOutput = {
-              id: string
-              name: string
-              age: number
-            }
-
-            function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
-              // Some logic
-            }
-
-            export function findUser(input: FindUserInput): FindUserOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds([input.id])[0]
-            }
-
-            export type FindAllUsersInput = {
-              ids: string[]
-              cache: CacheType
-            }
-
-            export type FindAllUsersOutput = FindUserOutput[]
-
-            export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
-              assertInputIsCorrect(input)
-              return _findUserByIds(input.ids)
-            }
-
-            class Cache {
-              // Some logic
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              function bb() {}
-              function c() {}
-              function a() {}
-            `,
-            code: dedent`
-              function a() {}
-              function bb() {}
-              function c() {}
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              function bb() {}
-              function a() {}
-              function c() {}
-            `,
-            code: dedent`
-              function c() {}
-              function bb() {}
-              function a() {}
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            function b() {}
-            function c() {}
-            function a() {}
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
               customGroups: [
                 {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
+                  groupName: 'functionsStartingWithHello',
+                  selector: 'function',
+                  elementNamePattern,
                 },
               ],
-              groups: ['b', 'a'],
+              groups: ['functionsStartingWithHello', 'unknown'],
             },
           ],
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                rightGroup: 'functionsStartingWithHello',
+                right: 'helloFunction',
+                leftGroup: 'unknown',
+                left: 'func',
               },
               messageId: 'unexpectedModulesGroupOrder',
             },
           ],
           output: dedent`
-            function ba() {}
-            function bb() {}
-            function ab() {}
-            function aa() {}
+            function helloFunction() {}
+            interface A {}
+            interface B {}
+            function func() {}
           `,
           code: dedent`
-            function ab() {}
-            function aa() {}
-            function ba() {}
-            function bb() {}
+            interface A {}
+            interface B {}
+            function func() {}
+            function helloFunction() {}
           `,
-        },
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Hello'],
+      ['array with string pattern', ['noMatch', 'Hello']],
+      ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex object',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
       ],
-      valid: [],
+    ])(
+      'filters classes by decorator name pattern - %s',
+      async (_description, decoratorNamePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'classesWithDecoratorStartingWithHello',
+                leftGroup: 'unknown',
+                left: 'func',
+                right: 'C',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+            {
+              data: {
+                right: 'AnotherClass',
+                left: 'C',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'classesWithDecoratorStartingWithHello',
+                  decoratorNamePattern,
+                  selector: 'class',
+                },
+              ],
+              groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            @HelloDecorator()
+            class AnotherClass {}
+
+            @HelloDecorator
+            class C {}
+
+            @Decorator
+            class A {}
+
+            class B {}
+
+            function func() {}
+          `,
+          code: dedent`
+            @Decorator
+            class A {}
+
+            class B {}
+
+            function func() {}
+
+            @HelloDecorator
+            class C {}
+
+            @HelloDecorator()
+            class AnotherClass {}
+          `,
+        })
+      },
+    )
+
+    it('filters elements using complex decorator name patterns', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: 'B',
+                groupName: 'B',
+              },
+              {
+                decoratorNamePattern: 'A',
+                groupName: 'A',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['B', 'A'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'B',
+              leftGroup: 'A',
+              right: 'B',
+              left: 'A',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          @B.B()
+          class B {}
+
+          @A.A.A(() => A)
+          class A {}
+        `,
+        code: dedent`
+          @A.A.A(() => A)
+          class A {}
+
+          @B.B()
+          class B {}
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'reversedFunctionsByLineLength',
+              leftGroup: 'unknown',
+              right: 'aFunction',
+              left: 'DDDD',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedFunctionsByLineLength',
+              right: 'anotherFunction',
+              leftGroup: 'unknown',
+              left: 'G',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'yetAnotherFunction',
+              left: 'anotherFunction',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedFunctionsByLineLength',
+                selector: 'function',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedFunctionsByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          function yetAnotherFunction() {}
+
+          function anotherFunction() {}
+
+          function aFunction() {}
+
+          interface A {}
+
+          interface BB {}
+
+          interface CCC {}
+
+          interface DDDD {}
+
+          interface EEE {}
+
+          interface FF {}
+
+          interface G {}
+        `,
+        code: dedent`
+          interface A {}
+
+          interface BB {}
+
+          interface CCC {}
+
+          interface DDDD {}
+
+          function aFunction() {}
+
+          interface EEE {}
+
+          interface FF {}
+
+          interface G {}
+
+          function anotherFunction() {}
+
+          function yetAnotherFunction() {}
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in ties', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function fooBar() {}
+          function fooZar() {}
+        `,
+        code: dedent`
+          function fooZar() {}
+          function fooBar() {}
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedFunctions',
+                selector: 'function',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedFunctions', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedFunctions',
+              leftGroup: 'unknown',
+              left: 'Interface',
+              right: 'c',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+
+          function a() {}
+
+          function d() {}
+
+          function e() {}
+
+          function c() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          function b() {}
+
+          function a() {}
+
+          function d() {}
+
+          function e() {}
+
+          interface Interface {}
+
+          function c() {}
+        `,
+      })
+    })
+
+    it('sorts elements within custom group blocks', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'class',
+              left: 'func',
+              right: 'C',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'aFunction',
+              left: 'C',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'anotherFunction',
+              left: 'D',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    selector: 'interface',
+                    modifiers: ['export'],
+                  },
+                  {
+                    selector: 'function',
+                    modifiers: ['async'],
+                  },
+                ],
+                groupName: 'exportInterfacesAndAsyncFunctions',
+              },
+            ],
+            groups: [['exportInterfacesAndAsyncFunctions', 'class'], 'unknown'],
+          },
+        ],
+        output: dedent`
+          export interface A {}
+
+          async function aFunction() {}
+
+          async function anotherFunction() {}
+
+          class b {}
+
+          class C {}
+
+          export interface D {}
+
+          class E {}
+
+          function func() {}
+        `,
+        code: dedent`
+          export interface A {}
+
+          class b {}
+
+          class E {}
+
+          function func() {}
+
+          class C {}
+
+          async function aFunction() {}
+
+          export interface D {}
+
+          async function anotherFunction() {}
+        `,
+      })
+    })
+
+    it('supports negative regex patterns for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          function iHaveFooInMyName() {}
+          function meTooIHaveFoo() {}
+          function a() {}
+          function b() {}
+        `,
+      })
+    })
+
+    it('supports regex patterns for decorator names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: '^.*Foo.*$',
+                groupName: 'decoratorsWithFoo',
+              },
+            ],
+            groups: ['decoratorsWithFoo', 'unknown'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          @IHaveFooInMyName
+          class X {}
+          @MeTooIHaveFoo
+          class Y {}
+          class A {}
+          class B {}
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines between group members when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'type',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            type A = {}
+
+            type B = {}
+          `,
+          code: dedent`
+            type A = {}
+            type B = {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between group members when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'type',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            type A = {}
+            type B = {}
+          `,
+          code: dedent`
+            type A = {}
+
+            type B = {}
+          `,
+        })
+      },
+    )
+
+    it('prioritizes declare modifier over export modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-interface',
+              leftGroup: 'function',
+              right: 'Interface',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-interface', 'function', 'export-interface'],
+          },
+        ],
+        output: dedent`
+          export declare interface Interface {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare interface Interface {}
+        `,
+      })
+    })
+
+    it('prioritizes default modifier over export modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-interface',
+              leftGroup: 'function',
+              right: 'Interface',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-interface', 'function', 'export-interface'],
+          },
+        ],
+        output: dedent`
+          export default interface Interface {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export default interface Interface {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for type declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-type',
+              leftGroup: 'function',
+              right: 'Type',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-type', 'function', 'export-type'],
+          },
+        ],
+        output: dedent`
+          export declare type Type = {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare type Type = {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for class declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-class',
+              leftGroup: 'function',
+              right: 'Class',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-class', 'function', 'export-class'],
+          },
+        ],
+        output: dedent`
+          export declare class Class {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare class Class {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for function declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-function', 'interface', 'export-function'],
+          },
+        ],
+        output: dedent`
+          export declare function f()
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export declare function f()
+        `,
+      })
+    })
+
+    it('prioritizes default modifier over async modifier for functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-function', 'interface', 'async-function'],
+          },
+        ],
+        output: dedent`
+          export default async function f() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export default async function f() {}
+        `,
+      })
+    })
+
+    it('prioritizes async modifier over export modifier for functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'async-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['async-function', 'interface', 'export-function'],
+          },
+        ],
+        output: dedent`
+          export async function f() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export async function f() {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for enum declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-enum',
+              leftGroup: 'function',
+              right: 'Enum',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-enum', 'function', 'export-enum'],
+          },
+        ],
+        output: dedent`
+          export declare enum Enum {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare enum Enum {}
+        `,
+      })
+    })
+
+    it('ignores non-static class method dependencies', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            f() {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores static class method dependencies when no static block or properties exist', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            static f() {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects static class method dependencies when static block is present', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static {
+              console.log(Enum.V)
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static {
+              console.log(A.f())
+            }
+
+            static f = () => {
+              return Enum.V
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class Class {
+            static {
+              const method = () => {
+                return Enum.V || true;
+              };
+              method();
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects static class method dependencies when static property is present', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static a = Enum.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static accessor a = Enum.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static a = Object.values(Enum)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores non-static arrow method dependencies', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class A {
+            accessor f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores static arrow method dependencies when no static block or properties exist', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            static f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores interface type dependencies', async () => {
+      await valid({
+        code: dedent`
+          interface A {
+            a: Enum.V
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores type alias dependencies', async () => {
+      await valid({
+        code: dedent`
+          type A = {
+            a: Enum.V
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects enum value dependencies', async () => {
+      await valid({
+        code: dedent`
+          enum B {
+            V = 'V'
+          }
+
+          enum A {
+            V = B.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects deeply nested dependencies', async () => {
+      await invalid({
+        output: dedent`
+          class B {
+            static b = 1
+          }
+
+          class A {
+            static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
+          }
+        `,
+        code: dedent`
+          class A {
+            static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
+          }
+
+          class B {
+            static b = 1
+          }
+        `,
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'B',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literal expressions', async () => {
+      await valid({
+        code: dedent`
+          class B {
+            static b = 1
+          }
+
+          class A {
+            static a = \`\${B.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in class inheritance', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        code: dedent`
+          class B {}
+
+          class A extends B {}
+        `,
+      })
+    })
+
+    it('detects dependencies in decorator expressions', async () => {
+      await invalid({
+        output: dedent`
+          enum B {}
+
+          class A {
+            @SomeDecorator({
+              a: {
+                b: c.concat([B])
+              }
+            })
+            property
+          }
+        `,
+        code: dedent`
+          class A {
+            @SomeDecorator({
+              a: {
+                b: c.concat([B])
+              }
+            })
+            property
+          }
+
+          enum B {}
+        `,
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'B',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects and handles circular dependencies', async () => {
+      await invalid({
+        output: dedent`
+          class A {
+            static a = B.b
+          }
+
+          class B {
+            static b = C.c
+          }
+
+          class C {
+            static c = A.a
+          }
+        `,
+        code: dedent`
+          class B {
+            static b = C.c
+          }
+
+          class A {
+            static a = B.b
+          }
+
+          class C {
+            static c = A.a
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['export-class', 'class'],
+          },
+        ],
+        code: dedent`
+          class B { static b }
+          export class A { static a = B.b }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition by comment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'B',
+              right: 'A',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class A { static a }
+          // Part1
+          class B { static b = A.a }
+        `,
+        code: dedent`
+          class B { static b = A.a }
+          // Part1
+          class A { static a }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over partition by new line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'B',
+              right: 'A',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          class A { static a }
+
+          class B { static = A.a }
+        `,
+        code: dedent`
+          class B { static = A.a }
+
+          class A { static a }
+        `,
+      })
+    })
+
+    it('handles unknown groups correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function',
+              rightGroup: 'unknown',
+              right: 'SomeClass',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'function',
+              leftGroup: 'unknown',
+              left: 'SomeClass',
+              right: 'a',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          function a() {}
+          class SomeClass {}
+          function b() {}
+        `,
+        code: dedent`
+          function b() {}
+          class SomeClass {}
+          function a() {}
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['function'],
+          },
+        ],
+      })
+    })
+
+    it('trims special characters when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          function _a() {}
+          function b() {}
+          function _c() {}
+        `,
+      })
+    })
+
+    it('removes special characters when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          function ab() {}
+          function a_c() {}
+        `,
+      })
+    })
+
+    it('sorts using locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          function 你好() {}
+          function 世界() {}
+          function a() {}
+          function A() {}
+          function b() {}
+          function B() {}
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                leftGroup: 'interface',
+                rightGroup: 'unknown',
+                right: 'y',
+                left: 'A',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['unknown', 'interface'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+              interface A {}
+
+
+             function y() {}
+            function z() {}
+
+                function b() {}
+          `,
+          output: dedent`
+              function b() {}
+             function y() {}
+            function z() {}
+                interface A {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'maintains single newline between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
@@ -3655,929 +1853,6966 @@ describe(ruleName, () => {
                   groupName: 'b',
                 },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'b'],
+              newlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenModulesMembers',
             },
           ],
           output: dedent`
-            function b() {}
+            function a() {};
 
-            function a() {}
+            function b() {}
           `,
           code: dedent`
-            function b() {}
-            function a() {}
+            function a() {};function b() {}
           `,
-        },
-      ],
-      valid: [],
-    })
+        })
 
-    ruleTester.run(`${ruleName}(${type}): enforces dependency sorting`, rule, {
-      invalid: [
-        {
+        await invalid({
           errors: [
             {
               data: {
-                nodeDependentOnRight: 'A',
-                right: 'B',
+                right: 'z',
+                left: 'A',
               },
-              messageId: 'unexpectedModulesDependencyOrder',
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+            {
+              data: {
+                right: 'y',
+                left: 'z',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'y',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['interface', 'unknown', 'class'],
+              newlinesBetween,
             },
           ],
           output: dedent`
-            class B {}
-            class A extends B {}
+              interface A {}
+
+             function y() {}
+            function z() {}
+
+                class B {}
           `,
           code: dedent`
-            class A extends B {}
-            class B {}
+              interface A {}
+
+
+             function z() {}
+            function y() {}
+                class B {}
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it('handles newlinesBetween settings between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          function a() {}
+
+          function b() {}
+
+          function c() {}
+          function d() {}
+
+
+          function e() {}
+        `,
+        code: dedent`
+          function a() {}
+          function b() {}
+
+
+          function c() {}
+
+          function d() {}
+
+
+          function e() {}
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {}
+
+
+            function b() {}
+          `,
+          code: dedent`
+            function a() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {}
+            function b() {}
+          `,
+          code: dedent`
+            function a() {}
+
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            function a() {}
+
+            function b() {}
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            function a() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comments after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'function',
+              leftGroup: 'type',
+              right: 'a',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['function', 'type'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          function a() {} // Comment after
+
+          type B = string
+          type C = string
+        `,
+        code: dedent`
+          type B = string
+          function a() {} // Comment after
+
+          type C = string
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+          ],
+          output: dedent`
+            function a() {}
+
+            // Partition comment
+
+            function b() {}
+            function c() {}
+          `,
+          code: dedent`
+            function a() {}
+
+            // Partition comment
+
+            function c() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it('sorts inline non-declare functions correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {} function b() {}
+        `,
+        code: dedent`
+          function b() {} function a() {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {} function b() {};
+        `,
+        code: dedent`
+          function b() {} function a() {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {}; function b() {}
+        `,
+        code: dedent`
+          function b() {}; function a() {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline declare functions correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          declare function a(); declare function b();
+        `,
+        code: dedent`
+          declare function b(); declare function a()
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          declare function a(); declare function b();
+        `,
+        code: dedent`
+          declare function b(); declare function a();
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline interfaces correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface A {} interface B {}
+        `,
+        code: dedent`
+          interface B {} interface A {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface A {} interface B {};
+        `,
+        code: dedent`
+          interface B {} interface A {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface A {}; interface B {}
+        `,
+        code: dedent`
+          interface B {}; interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline type aliases correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          type a = {}; type b = {};
+        `,
+        code: dedent`
+          type b = {}; type a = {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          type a = {}; type b = {};
+        `,
+        code: dedent`
+          type b = {}; type a = {};
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline classes correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class A {} class B {}
+        `,
+        code: dedent`
+          class B {} class A {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class A {} class B {};
+        `,
+        code: dedent`
+          class B {} class A {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class A {}; class B {}
+        `,
+        code: dedent`
+          class B {}; class A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline enums correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum A {} enum B {}
+        `,
+        code: dedent`
+          enum B {} enum A {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum A {} enum B {};
+        `,
+        code: dedent`
+          enum B {} enum A {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum A {}; enum B {}
+        `,
+        code: dedent`
+          enum B {}; enum A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores exported decorated classes when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          @B
+          class B {}
+
+          @A
+          export class A {}
+
+          @C
+          class C {}
+        `,
+        code: dedent`
+          @C
+          class C {}
+
+          @A
+          export class A {}
+
+          @B
+          class B {}
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts modules according to group hierarchy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'export-interface',
+              left: 'FindUserInput',
+              right: 'CacheType',
+              rightGroup: 'enum',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'export-function',
+              left: 'assertInputIsCorrect',
+              leftGroup: 'function',
+              right: 'findUser',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              right: 'FindAllUsersInput',
+              rightGroup: 'export-type',
+              left: 'findUser',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              left: 'findAllUsers',
+              rightGroup: 'class',
+              right: 'Cache',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
+
+          export type FindAllUsersInput = {
+            ids: string[]
+            cache: CacheType
+          }
+
+          export type FindAllUsersOutput = FindUserOutput[]
+
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
+
+          export type FindUserOutput = {
+            id: string
+            name: string
+            age: number
+          }
+
+          class Cache {
+            // Some logic
+          }
+
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
+
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
+
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
+        `,
+        code: dedent`
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
+
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
+
+          export type FindUserOutput = {
+            id: string
+            name: string
+            age: number
+          }
+
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
+
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
+
+          export type FindAllUsersInput = {
+            ids: string[]
+            cache: CacheType
+          }
+
+          export type FindAllUsersOutput = FindUserOutput[]
+
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
+
+          class Cache {
+            // Some logic
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts modules within modules and namespaces', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          module ModuleB {
+            interface A {}
+            interface B {}
+          }
+          module ModuleA {
+            interface A {}
+            interface B {}
+          }
+        `,
+        code: dedent`
+          module ModuleB {
+            interface B {}
+            interface A {}
+          }
+          module ModuleA {
+            interface B {}
+            interface A {}
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          namespace NamespaceB {
+            interface A {}
+            interface B {}
+          }
+          namespace NamespaceA {
+            interface A {}
+            interface B {}
+          }
+        `,
+        code: dedent`
+          namespace NamespaceB {
+            interface B {}
+            interface A {}
+          }
+          namespace NamespaceA {
+            interface B {}
+            interface A {}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('creates partitions at variable declarations', async () => {
+      await valid({
+        code: dedent`
+          interface B {}
+          let a;
+          interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('creates partitions at function call expressions', async () => {
+      await valid({
+        code: dedent`
+          interface B {}
+          iAmCallingAFunction();
+          interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('accepts complex predefined group configurations', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'export-declare-interface',
+              'export-default-interface',
+              'export-declare-function',
+              'export-default-async-function',
+              'export-decorated-class',
+              'export-default-decorated-class',
+              'export-declare-type',
+              'export-enum',
+              'export-declare-enum',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          export declare interface Interface {}
+
+          export default interface Interface2 {}
+
+          export declare function f2()
+
+          export default async function f1()
+
+          export @Decorator declare class Class1 {}
+
+          export @Decorator default class Class2 {}
+
+          export declare type Type = {}
+
+          export enum Enum1 {}
+
+          export declare enum Enum2 {}
+        `,
+      })
+    })
+
+    it('filters elements based on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['export'],
+                selector: 'type',
+              },
+              {
+                groupName: 'exportInterfaceGroup',
+                selector: 'interface',
+                modifiers: ['export'],
+              },
+              {
+                groupName: 'interfaceGroup',
+                selector: 'interface',
+              },
+            ],
+            groups: ['interfaceGroup', 'exportInterfaceGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'exportInterfaceGroup',
+              rightGroup: 'interfaceGroup',
+              right: 'C',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface C {}
+          export interface A {}
+          export interface B {}
+        `,
+        code: dedent`
+          export interface A {}
+          export interface B {}
+          interface C {}
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex object',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters functions by element name pattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'functionsStartingWithHello',
+                  selector: 'function',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['functionsStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'functionsStartingWithHello',
+                right: 'helloFunction',
+                leftGroup: 'unknown',
+                left: 'func',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+          ],
+          output: dedent`
+            function helloFunction() {}
+            interface A {}
+            interface B {}
+            function func() {}
+          `,
+          code: dedent`
+            interface A {}
+            interface B {}
+            function func() {}
+            function helloFunction() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Hello'],
+      ['array with string pattern', ['noMatch', 'Hello']],
+      ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex object',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters classes by decorator name pattern - %s',
+      async (_description, decoratorNamePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'classesWithDecoratorStartingWithHello',
+                leftGroup: 'unknown',
+                left: 'func',
+                right: 'C',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+            {
+              data: {
+                right: 'AnotherClass',
+                left: 'C',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'classesWithDecoratorStartingWithHello',
+                  decoratorNamePattern,
+                  selector: 'class',
+                },
+              ],
+              groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            @HelloDecorator()
+            class AnotherClass {}
+
+            @HelloDecorator
+            class C {}
+
+            @Decorator
+            class A {}
+
+            class B {}
+
+            function func() {}
+          `,
+          code: dedent`
+            @Decorator
+            class A {}
+
+            class B {}
+
+            function func() {}
+
+            @HelloDecorator
+            class C {}
+
+            @HelloDecorator()
+            class AnotherClass {}
+          `,
+        })
+      },
+    )
+
+    it('filters elements using complex decorator name patterns', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: 'B',
+                groupName: 'B',
+              },
+              {
+                decoratorNamePattern: 'A',
+                groupName: 'A',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['B', 'A'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'B',
+              leftGroup: 'A',
+              right: 'B',
+              left: 'A',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          @B.B()
+          class B {}
+
+          @A.A.A(() => A)
+          class A {}
+        `,
+        code: dedent`
+          @A.A.A(() => A)
+          class A {}
+
+          @B.B()
+          class B {}
+        `,
+      })
+    })
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'reversedFunctionsByLineLength',
+              leftGroup: 'unknown',
+              right: 'aFunction',
+              left: 'DDDD',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedFunctionsByLineLength',
+              right: 'anotherFunction',
+              leftGroup: 'unknown',
+              left: 'G',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'yetAnotherFunction',
+              left: 'anotherFunction',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedFunctionsByLineLength',
+                selector: 'function',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedFunctionsByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          function yetAnotherFunction() {}
+
+          function anotherFunction() {}
+
+          function aFunction() {}
+
+          interface A {}
+
+          interface BB {}
+
+          interface CCC {}
+
+          interface DDDD {}
+
+          interface EEE {}
+
+          interface FF {}
+
+          interface G {}
+        `,
+        code: dedent`
+          interface A {}
+
+          interface BB {}
+
+          interface CCC {}
+
+          interface DDDD {}
+
+          function aFunction() {}
+
+          interface EEE {}
+
+          interface FF {}
+
+          interface G {}
+
+          function anotherFunction() {}
+
+          function yetAnotherFunction() {}
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in ties', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function fooBar() {}
+          function fooZar() {}
+        `,
+        code: dedent`
+          function fooZar() {}
+          function fooBar() {}
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedFunctions',
+                selector: 'function',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedFunctions', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedFunctions',
+              leftGroup: 'unknown',
+              left: 'Interface',
+              right: 'c',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+
+          function a() {}
+
+          function d() {}
+
+          function e() {}
+
+          function c() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          function b() {}
+
+          function a() {}
+
+          function d() {}
+
+          function e() {}
+
+          interface Interface {}
+
+          function c() {}
+        `,
+      })
+    })
+
+    it('sorts elements within custom group blocks', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'class',
+              left: 'func',
+              right: 'C',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'aFunction',
+              left: 'C',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'anotherFunction',
+              left: 'D',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    selector: 'interface',
+                    modifiers: ['export'],
+                  },
+                  {
+                    selector: 'function',
+                    modifiers: ['async'],
+                  },
+                ],
+                groupName: 'exportInterfacesAndAsyncFunctions',
+              },
+            ],
+            groups: [['exportInterfacesAndAsyncFunctions', 'class'], 'unknown'],
+          },
+        ],
+        output: dedent`
+          export interface A {}
+
+          async function aFunction() {}
+
+          async function anotherFunction() {}
+
+          class b {}
+
+          class C {}
+
+          export interface D {}
+
+          class E {}
+
+          function func() {}
+        `,
+        code: dedent`
+          export interface A {}
+
+          class b {}
+
+          class E {}
+
+          function func() {}
+
+          class C {}
+
+          async function aFunction() {}
+
+          export interface D {}
+
+          async function anotherFunction() {}
+        `,
+      })
+    })
+
+    it('supports negative regex patterns for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          function iHaveFooInMyName() {}
+          function meTooIHaveFoo() {}
+          function a() {}
+          function b() {}
+        `,
+      })
+    })
+
+    it('supports regex patterns for decorator names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: '^.*Foo.*$',
+                groupName: 'decoratorsWithFoo',
+              },
+            ],
+            groups: ['decoratorsWithFoo', 'unknown'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          @IHaveFooInMyName
+          class X {}
+          @MeTooIHaveFoo
+          class Y {}
+          class A {}
+          class B {}
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines between group members when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'type',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            type A = {}
+
+            type B = {}
+          `,
+          code: dedent`
+            type A = {}
+            type B = {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between group members when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'type',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            type A = {}
+            type B = {}
+          `,
+          code: dedent`
+            type A = {}
+
+            type B = {}
+          `,
+        })
+      },
+    )
+
+    it('prioritizes declare modifier over export modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-interface',
+              leftGroup: 'function',
+              right: 'Interface',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-interface', 'function', 'export-interface'],
+          },
+        ],
+        output: dedent`
+          export declare interface Interface {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare interface Interface {}
+        `,
+      })
+    })
+
+    it('prioritizes default modifier over export modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-interface',
+              leftGroup: 'function',
+              right: 'Interface',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-interface', 'function', 'export-interface'],
+          },
+        ],
+        output: dedent`
+          export default interface Interface {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export default interface Interface {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for type declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-type',
+              leftGroup: 'function',
+              right: 'Type',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-type', 'function', 'export-type'],
+          },
+        ],
+        output: dedent`
+          export declare type Type = {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare type Type = {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for class declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-class',
+              leftGroup: 'function',
+              right: 'Class',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-class', 'function', 'export-class'],
+          },
+        ],
+        output: dedent`
+          export declare class Class {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare class Class {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for function declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-function', 'interface', 'export-function'],
+          },
+        ],
+        output: dedent`
+          export declare function f()
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export declare function f()
+        `,
+      })
+    })
+
+    it('prioritizes default modifier over async modifier for functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-function', 'interface', 'async-function'],
+          },
+        ],
+        output: dedent`
+          export default async function f() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export default async function f() {}
+        `,
+      })
+    })
+
+    it('prioritizes async modifier over export modifier for functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'async-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['async-function', 'interface', 'export-function'],
+          },
+        ],
+        output: dedent`
+          export async function f() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export async function f() {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for enum declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-enum',
+              leftGroup: 'function',
+              right: 'Enum',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-enum', 'function', 'export-enum'],
+          },
+        ],
+        output: dedent`
+          export declare enum Enum {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare enum Enum {}
+        `,
+      })
+    })
+
+    it('ignores non-static class method dependencies', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            f() {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores static class method dependencies when no static block or properties exist', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            static f() {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects static class method dependencies when static block is present', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static {
+              console.log(Enum.V)
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static {
+              console.log(A.f())
+            }
+
+            static f = () => {
+              return Enum.V
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class Class {
+            static {
+              const method = () => {
+                return Enum.V || true;
+              };
+              method();
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects static class method dependencies when static property is present', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static a = Enum.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static accessor a = Enum.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static a = Object.values(Enum)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores non-static arrow method dependencies', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class A {
+            accessor f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores static arrow method dependencies when no static block or properties exist', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            static f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores interface type dependencies', async () => {
+      await valid({
+        code: dedent`
+          interface A {
+            a: Enum.V
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores type alias dependencies', async () => {
+      await valid({
+        code: dedent`
+          type A = {
+            a: Enum.V
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects enum value dependencies', async () => {
+      await valid({
+        code: dedent`
+          enum B {
+            V = 'V'
+          }
+
+          enum A {
+            V = B.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects deeply nested dependencies', async () => {
+      await invalid({
+        output: dedent`
+          class B {
+            static b = 1
+          }
+
+          class A {
+            static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
+          }
+        `,
+        code: dedent`
+          class A {
+            static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
+          }
+
+          class B {
+            static b = 1
+          }
+        `,
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'B',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literal expressions', async () => {
+      await valid({
+        code: dedent`
+          class B {
+            static b = 1
+          }
+
+          class A {
+            static a = \`\${B.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in class inheritance', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        code: dedent`
+          class B {}
+
+          class A extends B {}
+        `,
+      })
+    })
+
+    it('detects dependencies in decorator expressions', async () => {
+      await invalid({
+        output: dedent`
+          enum B {}
+
+          class A {
+            @SomeDecorator({
+              a: {
+                b: c.concat([B])
+              }
+            })
+            property
+          }
+        `,
+        code: dedent`
+          class A {
+            @SomeDecorator({
+              a: {
+                b: c.concat([B])
+              }
+            })
+            property
+          }
+
+          enum B {}
+        `,
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'B',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects and handles circular dependencies', async () => {
+      await invalid({
+        output: dedent`
+          class A {
+            static a = B.b
+          }
+
+          class B {
+            static b = C.c
+          }
+
+          class C {
+            static c = A.a
+          }
+        `,
+        code: dedent`
+          class B {
+            static b = C.c
+          }
+
+          class A {
+            static a = B.b
+          }
+
+          class C {
+            static c = A.a
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['export-class', 'class'],
+          },
+        ],
+        code: dedent`
+          class B { static b }
+          export class A { static a = B.b }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition by comment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'B',
+              right: 'A',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class A { static a }
+          // Part1
+          class B { static b = A.a }
+        `,
+        code: dedent`
+          class B { static b = A.a }
+          // Part1
+          class A { static a }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over partition by new line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'B',
+              right: 'A',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          class A { static a }
+
+          class B { static = A.a }
+        `,
+        code: dedent`
+          class B { static = A.a }
+
+          class A { static a }
+        `,
+      })
+    })
+
+    it('handles unknown groups correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'function',
+              rightGroup: 'unknown',
+              right: 'SomeClass',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'function',
+              leftGroup: 'unknown',
+              left: 'SomeClass',
+              right: 'a',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          function a() {}
+          class SomeClass {}
+          function b() {}
+        `,
+        code: dedent`
+          function b() {}
+          class SomeClass {}
+          function a() {}
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['function'],
+          },
+        ],
+      })
+    })
+
+    it('trims special characters when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          function _a() {}
+          function b() {}
+          function _c() {}
+        `,
+      })
+    })
+
+    it('removes special characters when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          function ab() {}
+          function a_c() {}
+        `,
+      })
+    })
+
+    it('sorts using locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          function 你好() {}
+          function 世界() {}
+          function a() {}
+          function A() {}
+          function b() {}
+          function B() {}
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                leftGroup: 'interface',
+                rightGroup: 'unknown',
+                right: 'y',
+                left: 'A',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['unknown', 'interface'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+              interface A {}
+
+
+             function y() {}
+            function z() {}
+
+                function b() {}
+          `,
+          output: dedent`
+              function b() {}
+             function y() {}
+            function z() {}
+                interface A {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'maintains single newline between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+                {
+                  elementNamePattern: 'b',
+                  groupName: 'b',
+                },
+              ],
+              groups: ['a', 'b'],
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {};
+
+            function b() {}
+          `,
+          code: dedent`
+            function a() {};function b() {}
+          `,
+        })
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'z',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+            {
+              data: {
+                right: 'y',
+                left: 'z',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'y',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['interface', 'unknown', 'class'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+              interface A {}
+
+             function y() {}
+            function z() {}
+
+                class B {}
+          `,
+          code: dedent`
+              interface A {}
+
+
+             function z() {}
+            function y() {}
+                class B {}
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween settings between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          function a() {}
+
+          function b() {}
+
+          function c() {}
+          function d() {}
+
+
+          function e() {}
+        `,
+        code: dedent`
+          function a() {}
+          function b() {}
+
+
+          function c() {}
+
+          function d() {}
+
+
+          function e() {}
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {}
+
+
+            function b() {}
+          `,
+          code: dedent`
+            function a() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {}
+            function b() {}
+          `,
+          code: dedent`
+            function a() {}
+
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            function a() {}
+
+            function b() {}
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            function a() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comments after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'function',
+              leftGroup: 'type',
+              right: 'a',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['function', 'type'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          function a() {} // Comment after
+
+          type B = string
+          type C = string
+        `,
+        code: dedent`
+          type B = string
+          function a() {} // Comment after
+
+          type C = string
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+          ],
+          output: dedent`
+            function a() {}
+
+            // Partition comment
+
+            function b() {}
+            function c() {}
+          `,
+          code: dedent`
+            function a() {}
+
+            // Partition comment
+
+            function c() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it('sorts inline non-declare functions correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {} function b() {}
+        `,
+        code: dedent`
+          function b() {} function a() {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {} function b() {};
+        `,
+        code: dedent`
+          function b() {} function a() {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {}; function b() {}
+        `,
+        code: dedent`
+          function b() {}; function a() {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline declare functions correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          declare function a(); declare function b();
+        `,
+        code: dedent`
+          declare function b(); declare function a()
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          declare function a(); declare function b();
+        `,
+        code: dedent`
+          declare function b(); declare function a();
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline interfaces correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface A {} interface B {}
+        `,
+        code: dedent`
+          interface B {} interface A {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface A {} interface B {};
+        `,
+        code: dedent`
+          interface B {} interface A {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface A {}; interface B {}
+        `,
+        code: dedent`
+          interface B {}; interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline type aliases correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          type a = {}; type b = {};
+        `,
+        code: dedent`
+          type b = {}; type a = {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          type a = {}; type b = {};
+        `,
+        code: dedent`
+          type b = {}; type a = {};
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline classes correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class A {} class B {}
+        `,
+        code: dedent`
+          class B {} class A {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class A {} class B {};
+        `,
+        code: dedent`
+          class B {} class A {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class A {}; class B {}
+        `,
+        code: dedent`
+          class B {}; class A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline enums correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum A {} enum B {}
+        `,
+        code: dedent`
+          enum B {} enum A {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum A {} enum B {};
+        `,
+        code: dedent`
+          enum B {} enum A {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum A {}; enum B {}
+        `,
+        code: dedent`
+          enum B {}; enum A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores exported decorated classes when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          @B
+          class B {}
+
+          @A
+          export class A {}
+
+          @C
+          class C {}
+        `,
+        code: dedent`
+          @C
+          class C {}
+
+          @A
+          export class A {}
+
+          @B
+          class B {}
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts modules according to group hierarchy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'export-interface',
+              left: 'FindUserInput',
+              right: 'CacheType',
+              rightGroup: 'enum',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'export-function',
+              left: 'assertInputIsCorrect',
+              leftGroup: 'function',
+              right: 'findUser',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              right: 'FindAllUsersInput',
+              rightGroup: 'export-type',
+              left: 'findUser',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              left: 'findAllUsers',
+              rightGroup: 'class',
+              right: 'Cache',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
+
+          export type FindUserOutput = {
+            name: string
+            age: number
+            id: string
+          }
+
+          export type FindAllUsersInput = {
+            cache: CacheType
+            ids: string[]
+          }
+
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
+
+          export type FindAllUsersOutput = FindUserOutput[]
+
+          class Cache {
+            // Some logic
+          }
+
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
+
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
+
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
+
+        `,
+        code: dedent`
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
+
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
+
+          export type FindUserOutput = {
+            name: string
+            age: number
+            id: string
+          }
+
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
+
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
+
+          export type FindAllUsersInput = {
+            cache: CacheType
+            ids: string[]
+          }
+
+          export type FindAllUsersOutput = FindUserOutput[]
+
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
+
+          class Cache {
+            // Some logic
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts modules within modules and namespaces', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          module ModuleB {
+            interface AA {}
+            interface B {}
+          }
+          module ModuleA {
+            interface AA {}
+            interface B {}
+          }
+        `,
+        code: dedent`
+          module ModuleB {
+            interface B {}
+            interface AA {}
+          }
+          module ModuleA {
+            interface B {}
+            interface AA {}
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          namespace NamespaceB {
+            interface AA {}
+            interface B {}
+          }
+          namespace NamespaceA {
+            interface AA {}
+            interface B {}
+          }
+        `,
+        code: dedent`
+          namespace NamespaceB {
+            interface B {}
+            interface AA {}
+          }
+          namespace NamespaceA {
+            interface B {}
+            interface AA {}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('creates partitions at variable declarations', async () => {
+      await valid({
+        code: dedent`
+          interface B {}
+          let a;
+          interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('creates partitions at function call expressions', async () => {
+      await valid({
+        code: dedent`
+          interface B {}
+          iAmCallingAFunction();
+          interface A {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('accepts complex predefined group configurations', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'export-declare-interface',
+              'export-default-interface',
+              'export-declare-function',
+              'export-default-async-function',
+              'export-decorated-class',
+              'export-default-decorated-class',
+              'export-declare-type',
+              'export-enum',
+              'export-declare-enum',
+              'unknown',
+            ],
+          },
+        ],
+        code: dedent`
+          export declare interface Interface {}
+
+          export default interface Interface2 {}
+
+          export declare function f2()
+
+          export default async function f1()
+
+          export @Decorator declare class Class1 {}
+
+          export @Decorator default class Class2 {}
+
+          export declare type Type = {}
+
+          export enum Enum1 {}
+
+          export declare enum Enum2 {}
+        `,
+      })
+    })
+
+    it('filters elements based on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['export'],
+                selector: 'type',
+              },
+              {
+                groupName: 'exportInterfaceGroup',
+                selector: 'interface',
+                modifiers: ['export'],
+              },
+              {
+                groupName: 'interfaceGroup',
+                selector: 'interface',
+              },
+            ],
+            groups: ['interfaceGroup', 'exportInterfaceGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'exportInterfaceGroup',
+              rightGroup: 'interfaceGroup',
+              right: 'C',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          interface C {}
+          export interface A {}
+          export interface B {}
+        `,
+        code: dedent`
+          export interface A {}
+          export interface B {}
+          interface C {}
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex object',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters functions by element name pattern - %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'functionsStartingWithHello',
+                  selector: 'function',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['functionsStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'functionsStartingWithHello',
+                right: 'helloFunction',
+                leftGroup: 'unknown',
+                left: 'func',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+          ],
+          output: dedent`
+            function helloFunction() {}
+            interface A {}
+            interface B {}
+            function func() {}
+          `,
+          code: dedent`
+            interface A {}
+            interface B {}
+            function func() {}
+            function helloFunction() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Hello'],
+      ['array with string pattern', ['noMatch', 'Hello']],
+      ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex object',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters classes by decorator name pattern - %s',
+      async (_description, decoratorNamePattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'classesWithDecoratorStartingWithHello',
+                leftGroup: 'unknown',
+                left: 'func',
+                right: 'C',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+            {
+              data: {
+                right: 'AnotherClass',
+                left: 'C',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'classesWithDecoratorStartingWithHello',
+                  decoratorNamePattern,
+                  selector: 'class',
+                },
+              ],
+              groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
+            },
+          ],
+          output: dedent`
+            @HelloDecorator()
+            class AnotherClass {}
+
+            @HelloDecorator
+            class C {}
+
+            @Decorator
+            class A {}
+
+            class B {}
+
+            function func() {}
+          `,
+          code: dedent`
+            @Decorator
+            class A {}
+
+            class B {}
+
+            function func() {}
+
+            @HelloDecorator
+            class C {}
+
+            @HelloDecorator()
+            class AnotherClass {}
+          `,
+        })
+      },
+    )
+
+    it('filters elements using complex decorator name patterns', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: 'B',
+                groupName: 'B',
+              },
+              {
+                decoratorNamePattern: 'A',
+                groupName: 'A',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['B', 'A'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'B',
+              leftGroup: 'A',
+              right: 'B',
+              left: 'A',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          @B.B()
+          class B {}
+
+          @A.A.A(() => A)
+          class A {}
+        `,
+        code: dedent`
+          @A.A.A(() => A)
+          class A {}
+
+          @B.B()
+          class B {}
+        `,
+      })
+    })
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'reversedFunctionsByLineLength',
+              leftGroup: 'unknown',
+              right: 'aFunction',
+              left: 'DDDD',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedFunctionsByLineLength',
+              right: 'anotherFunction',
+              leftGroup: 'unknown',
+              left: 'G',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'yetAnotherFunction',
+              left: 'anotherFunction',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedFunctionsByLineLength',
+                selector: 'function',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedFunctionsByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          function yetAnotherFunction() {}
+
+          function anotherFunction() {}
+
+          function aFunction() {}
+
+          interface A {}
+
+          interface BB {}
+
+          interface CCC {}
+
+          interface DDDD {}
+
+          interface EEE {}
+
+          interface FF {}
+
+          interface G {}
+        `,
+        code: dedent`
+          interface A {}
+
+          interface BB {}
+
+          interface CCC {}
+
+          interface DDDD {}
+
+          function aFunction() {}
+
+          interface EEE {}
+
+          interface FF {}
+
+          interface G {}
+
+          function anotherFunction() {}
+
+          function yetAnotherFunction() {}
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in ties', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function fooBar() {}
+          function fooZar() {}
+        `,
+        code: dedent`
+          function fooZar() {}
+          function fooBar() {}
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedFunctions',
+                selector: 'function',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedFunctions', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedFunctions',
+              leftGroup: 'unknown',
+              left: 'Interface',
+              right: 'c',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+
+          function a() {}
+
+          function d() {}
+
+          function e() {}
+
+          function c() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          function b() {}
+
+          function a() {}
+
+          function d() {}
+
+          function e() {}
+
+          interface Interface {}
+
+          function c() {}
+        `,
+      })
+    })
+
+    it('sorts elements within custom group blocks', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'class',
+              left: 'func',
+              right: 'C',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'aFunction',
+              left: 'C',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'anotherFunction',
+              left: 'D',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    selector: 'interface',
+                    modifiers: ['export'],
+                  },
+                  {
+                    selector: 'function',
+                    modifiers: ['async'],
+                  },
+                ],
+                groupName: 'exportInterfacesAndAsyncFunctions',
+              },
+            ],
+            groups: [['exportInterfacesAndAsyncFunctions', 'class'], 'unknown'],
+          },
+        ],
+        output: dedent`
+          export interface A {}
+
+          async function aFunction() {}
+
+          async function anotherFunction() {}
+
+          class b {}
+
+          class C {}
+
+          export interface D {}
+
+          class E {}
+
+          function func() {}
+        `,
+        code: dedent`
+          export interface A {}
+
+          class b {}
+
+          class E {}
+
+          function func() {}
+
+          class C {}
+
+          async function aFunction() {}
+
+          export interface D {}
+
+          async function anotherFunction() {}
+        `,
+      })
+    })
+
+    it('supports negative regex patterns for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          function iHaveFooInMyName() {}
+          function meTooIHaveFoo() {}
+          function a() {}
+          function b() {}
+        `,
+      })
+    })
+
+    it('supports regex patterns for decorator names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                decoratorNamePattern: '^.*Foo.*$',
+                groupName: 'decoratorsWithFoo',
+              },
+            ],
+            groups: ['decoratorsWithFoo', 'unknown'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          @IHaveFooInMyName
+          class X {}
+          @MeTooIHaveFoo
+          class Y {}
+          class A {}
+          class B {}
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines between group members when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'type',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            type A = {}
+
+            type B = {}
+          `,
+          code: dedent`
+            type A = {}
+            type B = {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between group members when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'type',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            type A = {}
+            type B = {}
+          `,
+          code: dedent`
+            type A = {}
+
+            type B = {}
+          `,
+        })
+      },
+    )
+
+    it('prioritizes declare modifier over export modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-interface',
+              leftGroup: 'function',
+              right: 'Interface',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-interface', 'function', 'export-interface'],
+          },
+        ],
+        output: dedent`
+          export declare interface Interface {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare interface Interface {}
+        `,
+      })
+    })
+
+    it('prioritizes default modifier over export modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-interface',
+              leftGroup: 'function',
+              right: 'Interface',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-interface', 'function', 'export-interface'],
+          },
+        ],
+        output: dedent`
+          export default interface Interface {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export default interface Interface {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for type declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-type',
+              leftGroup: 'function',
+              right: 'Type',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-type', 'function', 'export-type'],
+          },
+        ],
+        output: dedent`
+          export declare type Type = {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare type Type = {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for class declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-class',
+              leftGroup: 'function',
+              right: 'Class',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-class', 'function', 'export-class'],
+          },
+        ],
+        output: dedent`
+          export declare class Class {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare class Class {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for function declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-function', 'interface', 'export-function'],
+          },
+        ],
+        output: dedent`
+          export declare function f()
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export declare function f()
+        `,
+      })
+    })
+
+    it('prioritizes default modifier over async modifier for functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'default-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['default-function', 'interface', 'async-function'],
+          },
+        ],
+        output: dedent`
+          export default async function f() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export default async function f() {}
+        `,
+      })
+    })
+
+    it('prioritizes async modifier over export modifier for functions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'async-function',
+              leftGroup: 'interface',
+              left: 'Interface',
+              right: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['async-function', 'interface', 'export-function'],
+          },
+        ],
+        output: dedent`
+          export async function f() {}
+
+          interface Interface {}
+        `,
+        code: dedent`
+          interface Interface {}
+
+          export async function f() {}
+        `,
+      })
+    })
+
+    it('prioritizes declare modifier over export modifier for enum declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'declare-enum',
+              leftGroup: 'function',
+              right: 'Enum',
+              left: 'f',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['declare-enum', 'function', 'export-enum'],
+          },
+        ],
+        output: dedent`
+          export declare enum Enum {}
+
+          function f() {}
+        `,
+        code: dedent`
+          function f() {}
+
+          export declare enum Enum {}
+        `,
+      })
+    })
+
+    it('ignores non-static class method dependencies', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            f() {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores static class method dependencies when no static block or properties exist', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            static f() {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects static class method dependencies when static block is present', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static {
+              console.log(Enum.V)
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static {
+              console.log(A.f())
+            }
+
+            static f = () => {
+              return Enum.V
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class Class {
+            static {
+              const method = () => {
+                return Enum.V || true;
+              };
+              method();
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects static class method dependencies when static property is present', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static a = Enum.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static accessor a = Enum.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+            V = 'V'
+          }
+
+          class A {
+            static a = Object.values(Enum)
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores non-static arrow method dependencies', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+
+      await valid({
+        code: dedent`
+          class A {
+            accessor f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores static arrow method dependencies when no static block or properties exist', async () => {
+      await valid({
+        code: dedent`
+          class A {
+            static f = () => {
+              return Enum.V
+            }
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores interface type dependencies', async () => {
+      await valid({
+        code: dedent`
+          interface A {
+            a: Enum.V
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('ignores type alias dependencies', async () => {
+      await valid({
+        code: dedent`
+          type A = {
+            a: Enum.V
+          }
+
+          enum Enum {
+            V = 'V'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects enum value dependencies', async () => {
+      await valid({
+        code: dedent`
+          enum B {
+            V = 'V'
+          }
+
+          enum A {
+            V = B.V
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects deeply nested dependencies', async () => {
+      await invalid({
+        output: dedent`
+          class B {
+            static b = 1
+          }
+
+          class A {
+            static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
+          }
+        `,
+        code: dedent`
+          class A {
+            static a = x > y ? new Class([...{...!!method(1 + <any>(B?.b! as any))}]) : null
+          }
+
+          class B {
+            static b = 1
+          }
+        `,
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'B',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literal expressions', async () => {
+      await valid({
+        code: dedent`
+          class B {
+            static b = 1
+          }
+
+          class A {
+            static a = \`\${B.b}\`
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects dependencies in class inheritance', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+        code: dedent`
+          class B {}
+
+          class A extends B {}
+        `,
+      })
+    })
+
+    it('detects dependencies in decorator expressions', async () => {
+      await invalid({
+        output: dedent`
+          enum B {}
+
+          class A {
+            @SomeDecorator({
+              a: {
+                b: c.concat([B])
+              }
+            })
+            property
+          }
+        `,
+        code: dedent`
+          class A {
+            @SomeDecorator({
+              a: {
+                b: c.concat([B])
+              }
+            })
+            property
+          }
+
+          enum B {}
+        `,
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'B',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+
+    it('detects and handles circular dependencies', async () => {
+      await invalid({
+        output: dedent`
+          class AAA {
+            static a = BB.b
+          }
+
+          class C {
+            static c = AAA.a
+          }
+
+          class BB {
+            static b = C.c
+          }
+        `,
+        code: dedent`
+          class BB {
+            static b = C.c
+          }
+
+          class AAA {
+            static a = BB.b
+          }
+
+          class C {
+            static c = AAA.a
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'AAA',
+              left: 'BB',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            groups: ['export-class', 'class'],
+          },
+        ],
+        code: dedent`
+          class B { static b }
+          export class A { static a = B.b }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition by comment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'B',
+              right: 'A',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class A { static a }
+          // Part1
+          class B { static b = A.a }
+        `,
+        code: dedent`
+          class B { static b = A.a }
+          // Part1
+          class A { static a }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: 'Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over partition by new line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'B',
+              right: 'A',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          class A { static a }
+
+          class B { static = A.a }
+        `,
+        code: dedent`
+          class B { static = A.a }
+
+          class A { static a }
+        `,
+      })
+    })
+
+    it('trims special characters when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          function _a() {}
+          function bb() {}
+          function _c() {}
+        `,
+      })
+    })
+
+    it('removes special characters when configured', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          function abc() {}
+          function a_c() {}
+        `,
+      })
+    })
+
+    it('sorts using locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          function 你好() {}
+          function 世界() {}
+          function a() {}
+          function A() {}
+          function b() {}
+          function B() {}
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                leftGroup: 'interface',
+                rightGroup: 'unknown',
+                left: 'AAAA',
+                right: 'yy',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['unknown', 'interface'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+              interface AAAA {}
+
+
+             function yy() {}
+            function z() {}
+
+                function bbb() {}
+          `,
+          output: dedent`
+              function bbb() {}
+             function yy() {}
+            function z() {}
+                interface AAAA {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'maintains single newline between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+                {
+                  elementNamePattern: 'b',
+                  groupName: 'b',
+                },
+              ],
+              groups: ['a', 'b'],
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {};
+
+            function b() {}
+          `,
+          code: dedent`
+            function a() {};function b() {}
+          `,
+        })
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'AAAA',
+                right: 'z',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+            {
+              data: {
+                right: 'yy',
+                left: 'z',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+            {
+              data: {
+                right: 'BBB',
+                left: 'yy',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['interface', 'unknown', 'class'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+              interface AAAA {}
+
+             function yy() {}
+            function z() {}
+
+                class BBB {}
+          `,
+          code: dedent`
+              interface AAAA {}
+
+
+             function z() {}
+            function yy() {}
+                class BBB {}
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween settings between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          function a() {}
+
+          function b() {}
+
+          function c() {}
+          function d() {}
+
+
+          function e() {}
+        `,
+        code: dedent`
+          function a() {}
+          function b() {}
+
+
+          function c() {}
+
+          function d() {}
+
+
+          function e() {}
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {}
+
+
+            function b() {}
+          `,
+          code: dedent`
+            function a() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenModulesMembers',
+            },
+          ],
+          output: dedent`
+            function a() {}
+            function b() {}
+          `,
+          code: dedent`
+            function a() {}
+
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            function a() {}
+
+            function b() {}
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            function a() {}
+            function b() {}
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comments after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'function',
+              leftGroup: 'type',
+              right: 'a',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['function', 'type'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          function a() {} // Comment after
+
+          type B = string
+          type C = string
+        `,
+        code: dedent`
+          type B = string
+          function a() {} // Comment after
+
+          type C = string
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedModulesOrder',
+            },
+          ],
+          output: dedent`
+            function a() {}
+
+            // Partition comment
+
+            function bb() {}
+            function c() {}
+          `,
+          code: dedent`
+            function a() {}
+
+            // Partition comment
+
+            function c() {}
+            function bb() {}
+          `,
+        })
+      },
+    )
+
+    it('sorts inline non-declare functions correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function aa() {} function b() {}
+        `,
+        code: dedent`
+          function b() {} function aa() {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function aa() {} function b() {};
+        `,
+        code: dedent`
+          function b() {} function aa() {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function aa() {}; function b() {}
+        `,
+        code: dedent`
+          function b() {}; function aa() {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline declare functions correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          declare function aa(); declare function b();
+        `,
+        code: dedent`
+          declare function b(); declare function aa();
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          declare function aa(); declare function b();
+        `,
+        code: dedent`
+          declare function b(); declare function aa();
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline interfaces correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface AA {} interface B {}
+        `,
+        code: dedent`
+          interface B {} interface AA {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface AA {} interface B {};
+        `,
+        code: dedent`
+          interface B {} interface AA {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          interface AA {}; interface B {}
+        `,
+        code: dedent`
+          interface B {}; interface AA {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline type aliases correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          type aa = {}; type b = {};
+        `,
+        code: dedent`
+          type b = {}; type aa = {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          type aa = {}; type b = {};
+        `,
+        code: dedent`
+          type b = {}; type aa = {};
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline classes correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class AA {} class B {}
+        `,
+        code: dedent`
+          class B {} class AA {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class AA {} class B {};
+        `,
+        code: dedent`
+          class B {} class AA {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class AA {}; class B {}
+        `,
+        code: dedent`
+          class B {}; class AA {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline enums correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum AA {} enum B {}
+        `,
+        code: dedent`
+          enum B {} enum AA {}
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum AA {} enum B {};
+        `,
+        code: dedent`
+          enum B {} enum AA {};
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          enum AA {}; enum B {}
+        `,
+        code: dedent`
+          enum B {}; enum AA {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores exported decorated classes when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          @B
+          class BB {}
+
+          @A
+          export class AAA {}
+
+          @C
+          class C {}
+        `,
+        code: dedent`
+          @C
+          class C {}
+
+          @A
+          export class AAA {}
+
+          @B
+          class BB {}
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['unknown'],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts modules according to group hierarchy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'export-interface',
+              left: 'FindUserInput',
+              right: 'CacheType',
+              rightGroup: 'enum',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'export-function',
+              left: 'assertInputIsCorrect',
+              leftGroup: 'function',
+              right: 'findUser',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              right: 'FindAllUsersInput',
+              rightGroup: 'export-type',
+              left: 'findUser',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'export-function',
+              left: 'findAllUsers',
+              rightGroup: 'class',
+              right: 'Cache',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
+
+          export type FindAllUsersInput = {
+            ids: string[]
+            cache: CacheType
+          }
+
+          export type FindAllUsersOutput = FindUserOutput[]
+
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
+
+          export type FindUserOutput = {
+            id: string
+            name: string
+            age: number
+          }
+
+          class Cache {
+            // Some logic
+          }
+
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
+
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
+
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
+        `,
+        code: dedent`
+          export interface FindUserInput {
+            id: string
+            cache: CacheType
+          }
+
+          enum CacheType {
+            ALWAYS = 'ALWAYS',
+            NEVER = 'NEVER',
+          }
+
+          export type FindUserOutput = {
+            id: string
+            name: string
+            age: number
+          }
+
+          function assertInputIsCorrect(input: FindUserInput | FindAllUsersInput): void {
+            // Some logic
+          }
+
+          export function findUser(input: FindUserInput): FindUserOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds([input.id])[0]
+          }
+
+          export type FindAllUsersInput = {
+            ids: string[]
+            cache: CacheType
+          }
+
+          export type FindAllUsersOutput = FindUserOutput[]
+
+          export function findAllUsers(input: FindAllUsersInput): FindAllUsersOutput {
+            assertInputIsCorrect(input)
+            return _findUserByIds(input.ids)
+          }
+
+          class Cache {
+            // Some logic
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce element sorting within groups', async () => {
+      await valid({
+        code: dedent`
+          function b() {}
+          function c() {}
+          function a() {}
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces group ordering with custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: '^b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+        ],
+        output: dedent`
+          function ba() {}
+          function bb() {}
+          function ab() {}
+          function aa() {}
+        `,
+        code: dedent`
+          function ab() {}
+          function aa() {}
+          function ba() {}
+          function bb() {}
+        `,
+      })
+    })
+
+    it('enforces newlines between groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          function b() {}
+
+          function a() {}
+        `,
+        code: dedent`
+          function b() {}
+          function a() {}
+        `,
+      })
+    })
+
+    it('enforces dependency-based ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'A',
+              right: 'B',
+            },
+            messageId: 'unexpectedModulesDependencyOrder',
+          },
+        ],
+        output: dedent`
+          class B {}
+          class A extends B {}
+        `,
+        code: dedent`
+          class A extends B {}
+          class B {}
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
+    it('uses alphabetical ascending order by default', async () => {
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'B',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            output: dedent`
-              function a() {}
-              function A() {}
-              function b() {}
-              function B() {}
-            `,
-            code: dedent`
-              function b() {}
-              function B() {}
-              function a() {}
-              function A() {}
-            `,
+            data: {
+              right: 'a',
+              left: 'B',
+            },
+            messageId: 'unexpectedModulesOrder',
           },
         ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: sorts using default groups`, rule, {
-      valid: [
-        {
-          code: dedent`
-            declare enum O {}
-
-            export enum N {}
-
-            enum M {}
-
-            declare interface K {}
-            declare type L = {}
-
-            export interface I {}
-            export type J = {}
-
-            interface G {}
-            type H = {}
-
-            declare class F {}
-
-            class E {}
-
-            export class D {}
-
-            declare function c()
-
-            export function b() {}
-
-            function a() {}
-          `,
-          options: [
-            {
-              newlinesBetween: 'always',
-            },
-          ],
-        },
-      ],
-      invalid: [],
+        output: dedent`
+          function a() {}
+          function A() {}
+          function b() {}
+          function B() {}
+        `,
+        code: dedent`
+          function b() {}
+          function B() {}
+          function a() {}
+          function A() {}
+        `,
+      })
     })
 
-    describe('handles complex comment cases', () => {
-      ruleTester.run(`keeps comments associated to their node`, rule, {
-        invalid: [
+    it('sorts elements using default group order', async () => {
+      await valid({
+        code: dedent`
+          declare enum O {}
+
+          export enum N {}
+
+          enum M {}
+
+          declare interface K {}
+          declare type L = {}
+
+          export interface I {}
+          export type J = {}
+
+          interface G {}
+          type H = {}
+
+          declare class F {}
+
+          class E {}
+
+          export class D {}
+
+          declare function c()
+
+          export function b() {}
+
+          function a() {}
+        `,
+        options: [
           {
-            output: dedent`
-              // Ignore this comment
-
-              // A4
-              // A3
-              /*
-               * A2
-               */
-              // A1
-              function a() {}
-
-              /**
-               * Ignore this comment as well
-               */
-
-              // B1
-              function b() {}
-            `,
-            code: dedent`
-              // Ignore this comment
-
-              // B1
-              function b() {}
-
-              /**
-               * Ignore this comment as well
-               */
-
-              // A4
-              // A3
-              /*
-               * A2
-               */
-              // A1
-              function a() {}
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      })
-
-      describe('partition comments', () => {
-        ruleTester.run(`handles partition comments`, rule, {
-          invalid: [
-            {
-              output: dedent`
-                // Ignore this comment
-
-                // B2
-                /**
-                  * B1
-                  */
-                function b() {}
-
-                // C2
-                // C1
-                function c() {}
-
-                // Above a partition comment ignore me
-                // PartitionComment: 1
-                function a() {}
-
-                /**
-                  * D2
-                  */
-                // D1
-                function d() {}
-              `,
-              code: dedent`
-                // Ignore this comment
-
-                // C2
-                // C1
-                function c() {}
-
-                // B2
-                /**
-                  * B1
-                  */
-                function b() {}
-
-                // Above a partition comment ignore me
-                // PartitionComment: 1
-                /**
-                  * D2
-                  */
-                // D1
-                function d() {}
-
-                function a() {}
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-                {
-                  data: {
-                    right: 'a',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedModulesOrder',
-                },
-              ],
-              options: [
-                {
-                  partitionByComment: 'PartitionComment:',
-                  type: 'alphabetical',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}: allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  function e() {}
-                  function f() {}
-                  // I am a partition comment because I don't have f o o
-                  function a() {}
-                  function b() {}
-                `,
-                options: [
-                  {
-                    partitionByComment: ['^(?!.*foo).*$'],
-                    type: 'alphabetical',
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        describe(`${ruleName}: allows to use "partitionByComment.line"`, () => {
-          ruleTester.run(`${ruleName}: ignores block comments`, rule, {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'a',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedModulesOrder',
-                  },
-                ],
-                options: [
-                  {
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                output: dedent`
-                  /* Comment */
-                  function a() {}
-                  function b() {}
-                `,
-                code: dedent`
-                  function b() {}
-                  /* Comment */
-                  function a() {}
-                `,
-              },
-            ],
-            valid: [],
-          })
-
-          ruleTester.run(
-            `${ruleName}: allows to use all comments as parts`,
-            rule,
-            {
-              valid: [
-                {
-                  options: [
-                    {
-                      partitionByComment: {
-                        line: true,
-                      },
-                    },
-                  ],
-                  code: dedent`
-                    function b() {}
-                    // Comment
-                    function a() {}
-                  `,
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use multiple partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  code: dedent`
-                    function c() {}
-                    // b
-                    function b() {}
-                    // a
-                    function a() {}
-                  `,
-                  options: [
-                    {
-                      partitionByComment: {
-                        line: ['a', 'b'],
-                      },
-                    },
-                  ],
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use regex for partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  options: [
-                    {
-                      partitionByComment: {
-                        line: ['^(?!.*foo).*$'],
-                      },
-                    },
-                  ],
-                  code: dedent`
-                    function b() {}
-                    // I am a partition comment because I don't have f o o
-                    function a() {}
-                  `,
-                },
-              ],
-              invalid: [],
-            },
-          )
-        })
-
-        describe(`${ruleName}: allows to use "partitionByComment.block"`, () => {
-          ruleTester.run(`${ruleName}: ignores line comments`, rule, {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'a',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedModulesOrder',
-                  },
-                ],
-                options: [
-                  {
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                output: dedent`
-                  // Comment
-                  function a() {}
-                  function b() {}
-                `,
-                code: dedent`
-                  function b() {}
-                  // Comment
-                  function a() {}
-                `,
-              },
-            ],
-            valid: [],
-          })
-
-          ruleTester.run(
-            `${ruleName}: allows to use all comments as parts`,
-            rule,
-            {
-              valid: [
-                {
-                  options: [
-                    {
-                      partitionByComment: {
-                        block: true,
-                      },
-                    },
-                  ],
-                  code: dedent`
-                    function b() {}
-                    /* Comment */
-                    function a() {}
-                  `,
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use multiple partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  code: dedent`
-                    function c() {}
-                    /* b */
-                    function b() {}
-                    /* a */
-                    function a() {}
-                  `,
-                  options: [
-                    {
-                      partitionByComment: {
-                        block: ['a', 'b'],
-                      },
-                    },
-                  ],
-                },
-              ],
-              invalid: [],
-            },
-          )
-
-          ruleTester.run(
-            `${ruleName}: allows to use regex for partition comments`,
-            rule,
-            {
-              valid: [
-                {
-                  options: [
-                    {
-                      partitionByComment: {
-                        block: ['^(?!.*foo).*$'],
-                      },
-                    },
-                  ],
-                  code: dedent`
-                    function b() {}
-                    /* I am a partition comment because I don't have f o o */
-                    function a() {}
-                  `,
-                },
-              ],
-              invalid: [],
-            },
-          )
-        })
-      })
-
-      ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedModulesOrder',
-              },
-            ],
-            output: dedent`
-              function d() {}
-              function e() {}
-
-              function c() {}
-
-              function a() {}
-              function b() {}
-            `,
-            code: dedent`
-              function e() {}
-              function d() {}
-
-              function c() {}
-
-              function b() {}
-              function a() {}
-            `,
-            options: [
-              {
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function d() {}
-              function e() {}
-
-              function c() {}
-
-              function a() {}
-              function b() {}
-            `,
-            options: [
-              {
-                partitionByNewLine: true,
-              },
-            ],
+            newlinesBetween: 'always',
           },
         ],
       })
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            function b() {}
-            function c() {}
-            // eslint-disable-next-line
-            function a() {}
-          `,
-          code: dedent`
-            function c() {}
-            function b() {}
-            // eslint-disable-next-line
-            function a() {}
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            function b() {}
-            function c() {}
-            // eslint-disable-next-line
-            function a() {}
-            function d() {}
-          `,
-          code: dedent`
-            function d() {}
-            function c() {}
-            // eslint-disable-next-line
-            function a() {}
-            function b() {}
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            class B extends A {}
-            class C {}
-            // eslint-disable-next-line
-            class A {}
-          `,
-          code: dedent`
-            class C {}
-            class B extends A {}
-            // eslint-disable-next-line
-            class A {}
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            function b() {}
-            function c() {}
-            function a() {} // eslint-disable-line
-          `,
-          code: dedent`
-            function c() {}
-            function b() {}
-            function a() {} // eslint-disable-line
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            function b() {}
-            function c() {}
-            /* eslint-disable-next-line */
-            function a() {}
-          `,
-          code: dedent`
-            function c() {}
-            function b() {}
-            /* eslint-disable-next-line */
-            function a() {}
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            function b() {}
-            function c() {}
-            function a() {} /* eslint-disable-line */
-          `,
-          code: dedent`
-            function c() {}
-            function b() {}
-            function a() {} /* eslint-disable-line */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            function a() {}
-            function d() {}
-            /* eslint-disable */
-            function c() {}
-            function b() {}
-            // Shouldn't move
-            /* eslint-enable */
-            function e() {}
-          `,
-          code: dedent`
-            function d() {}
-            function e() {}
-            /* eslint-disable */
-            function c() {}
-            function b() {}
-            // Shouldn't move
-            /* eslint-enable */
-            function a() {}
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            function b() {}
-            function c() {}
-            // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-            function a() {}
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          code: dedent`
-            function c() {}
-            function b() {}
-            // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-            function a() {}
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            function b() {}
-            function c() {}
-            function a() {} // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          code: dedent`
-            function c() {}
-            function b() {}
-            function a() {} // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            function b() {}
-            function c() {}
-            /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-            function a() {}
-          `,
-          code: dedent`
-            function c() {}
-            function b() {}
-            /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-            function a() {}
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          output: dedent`
-            function b() {}
-            function c() {}
-            function a() {} /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          code: dedent`
-            function c() {}
-            function b() {}
-            function a() {} /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            function a() {}
-            function d() {}
-            /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-            function c() {}
-            function b() {}
-            // Shouldn't move
-            /* eslint-enable */
-            function e() {}
-          `,
-          code: dedent`
-            function d() {}
-            function e() {}
-            /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-            function c() {}
-            function b() {}
-            // Shouldn't move
-            /* eslint-enable */
-            function a() {}
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            function b() {}
-            function c() {}
-            // eslint-disable-next-line
-            function a() {}
-          `,
-        },
-      ],
-    })
+    it('preserves comments attached to their respective nodes', async () => {
+      await invalid({
+        output: dedent`
+          // Ignore this comment
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+          // A4
+          // A3
+          /*
+           * A2
+           */
+          // A1
+          function a() {}
+
+          /**
+           * Ignore this comment as well
+           */
+
+          // B1
+          function b() {}
+        `,
+        code: dedent`
+          // Ignore this comment
+
+          // B1
+          function b() {}
+
+          /**
+           * Ignore this comment as well
+           */
+
+          // A4
+          // A3
+          /*
+           * A2
+           */
+          // A1
+          function a() {}
+        `,
+        errors: [
           {
-            code: dedent`
-              class A {}
-
-              function func() {}
-            `,
-            options: [{}],
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('handles partition comments correctly', async () => {
+      await invalid({
+        output: dedent`
+          // Ignore this comment
+
+          // B2
+          /**
+            * B1
+            */
+          function b() {}
+
+          // C2
+          // C1
+          function c() {}
+
+          // Above a partition comment ignore me
+          // PartitionComment: 1
+          function a() {}
+
+          /**
+            * D2
+            */
+          // D1
+          function d() {}
+        `,
+        code: dedent`
+          // Ignore this comment
+
+          // C2
+          // C1
+          function c() {}
+
+          // B2
+          /**
+            * B1
+            */
+          function b() {}
+
+          // Above a partition comment ignore me
+          // PartitionComment: 1
+          /**
+            * D2
+            */
+          // D1
+          function d() {}
+
+          function a() {}
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            partitionByComment: 'PartitionComment:',
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          function e() {}
+          function f() {}
+          // I am a partition comment because I don't have f o o
+          function a() {}
+          function b() {}
+        `,
+        options: [
+          {
+            partitionByComment: ['^(?!.*foo).*$'],
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          /* Comment */
+          function a() {}
+          function b() {}
+        `,
+        code: dedent`
+          function b() {}
+          /* Comment */
+          function a() {}
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          function b() {}
+          // Comment
+          function a() {}
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        code: dedent`
+          function c() {}
+          // b
+          function b() {}
+          // a
+          function a() {}
+        `,
+        options: [
+          {
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          function b() {}
+          // I am a partition comment because I don't have f o o
+          function a() {}
+        `,
+        options: [
+          {
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [
+          {
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          // Comment
+          function a() {}
+          function b() {}
+        `,
+        code: dedent`
+          function b() {}
+          // Comment
+          function a() {}
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          function b() {}
+          /* Comment */
+          function a() {}
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          function c() {}
+          /* b */
+          function b() {}
+          /* a */
+          function a() {}
+        `,
+        options: [
+          {
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          function b() {}
+          /* I am a partition comment because I don't have f o o */
+          function a() {}
+        `,
+        options: [
+          {
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('uses newlines as partition boundaries', async () => {
+      await valid({
+        code: dedent`
+          function d() {}
+          function e() {}
+
+          function c() {}
+
+          function a() {}
+          function b() {}
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function d() {}
+          function e() {}
+
+          function c() {}
+
+          function a() {}
+          function b() {}
+        `,
+        code: dedent`
+          function e() {}
+          function d() {}
+
+          function c() {}
+
+          function b() {}
+          function a() {}
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('ignores nodes with eslint-disable-next-line comments', async () => {
+      await valid({
+        code: dedent`
+          function b() {}
+          function c() {}
+          // eslint-disable-next-line
+          function a() {}
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          // eslint-disable-next-line
+          function a() {}
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          // eslint-disable-next-line
+          function a() {}
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles eslint-disable with partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          // eslint-disable-next-line
+          function a() {}
+          function d() {}
+        `,
+        code: dedent`
+          function d() {}
+          function c() {}
+          // eslint-disable-next-line
+          function a() {}
+          function b() {}
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('handles eslint-disable with class dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          class B extends A {}
+          class C {}
+          // eslint-disable-next-line
+          class A {}
+        `,
+        code: dedent`
+          class C {}
+          class B extends A {}
+          // eslint-disable-next-line
+          class A {}
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles inline eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          function a() {} // eslint-disable-line
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          function a() {} // eslint-disable-line
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block eslint-disable-next-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          /* eslint-disable-next-line */
+          function a() {}
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          /* eslint-disable-next-line */
+          function a() {}
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles inline block eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          function a() {} /* eslint-disable-line */
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          function a() {} /* eslint-disable-line */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles eslint-disable/enable blocks', async () => {
+      await invalid({
+        output: dedent`
+          function a() {}
+          function d() {}
+          /* eslint-disable */
+          function c() {}
+          function b() {}
+          // Shouldn't move
+          /* eslint-enable */
+          function e() {}
+        `,
+        code: dedent`
+          function d() {}
+          function e() {}
+          /* eslint-disable */
+          function c() {}
+          function b() {}
+          // Shouldn't move
+          /* eslint-enable */
+          function a() {}
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable-next-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          // eslint-disable-next-line rule-to-test/sort-modules
+          function a() {}
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          // eslint-disable-next-line rule-to-test/sort-modules
+          function a() {}
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific inline eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          function a() {} // eslint-disable-line rule-to-test/sort-modules
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          function a() {} // eslint-disable-line rule-to-test/sort-modules
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific block eslint-disable-next-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          /* eslint-disable-next-line rule-to-test/sort-modules */
+          function a() {}
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          /* eslint-disable-next-line rule-to-test/sort-modules */
+          function a() {}
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific inline block eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function b() {}
+          function c() {}
+          function a() {} /* eslint-disable-line rule-to-test/sort-modules */
+        `,
+        code: dedent`
+          function c() {}
+          function b() {}
+          function a() {} /* eslint-disable-line rule-to-test/sort-modules */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable/enable blocks', async () => {
+      await invalid({
+        output: dedent`
+          function a() {}
+          function d() {}
+          /* eslint-disable rule-to-test/sort-modules */
+          function c() {}
+          function b() {}
+          // Shouldn't move
+          /* eslint-enable */
+          function e() {}
+        `,
+        code: dedent`
+          function d() {}
+          function e() {}
+          /* eslint-disable rule-to-test/sort-modules */
+          function c() {}
+          function b() {}
+          // Shouldn't move
+          /* eslint-enable */
+          function a() {}
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
   })
 })

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1,2247 +1,1085 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-named-exports'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-named-exports'
+describe('sort-named-exports', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-named-exports',
+    parser: typescriptParser,
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts named exports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              aaa,
-              bb,
-              c
-            }
-          `,
-          code: dedent`
-            export {
-              aaa,
-              c,
-              bb
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: 'export { a }',
-          options: [options],
-        },
-        {
-          code: 'export { aaa, bb, c }',
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts named exports grouping by their kind`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { AAA, type BB, BB, type C }
-            `,
-            code: dedent`
-              export { AAA, type C, type BB, BB }
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'AAA',
-                  left: 'BB',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { AAA, BB, type BB, type C }
-            `,
-            code: dedent`
-              export { type BB, AAA, type C, BB }
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            code: dedent`
-              export { type BB, AAA, type C, BB }
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              export { AAA, type BB, BB, type C }
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            code: dedent`
-              export { AAA, BB, type BB, type C }
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            code: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'D',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-              {
-                data: {
-                  right: 'B',
-                  left: 'E',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export {
-                A,
-                D,
-
-                C,
-
-                B,
-                E,
-              }
-            `,
-            code: dedent`
-              export {
-                D,
-                A,
-
-                C,
-
-                E,
-                B,
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe('partition comments', () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: 'CC',
-                    right: 'D',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-                {
-                  data: {
-                    right: 'FFF',
-                    left: 'GG',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-              ],
-              output: dedent`
-                export {
-                  // Part: A
-                  type D,
-                  // Not partition comment
-                  BBB,
-                  CC,
-                  // Part: B
-                  AAAA,
-                  E,
-                  // Part: C
-                  // Not partition comment
-                  FFF,
-                  GG,
-                }
-              `,
-              code: dedent`
-                export {
-                  // Part: A
-                  CC,
-                  type D,
-                  // Not partition comment
-                  BBB,
-                  // Part: B
-                  AAAA,
-                  E,
-                  // Part: C
-                  GG,
-                  // Not partition comment
-                  FFF,
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                  groupKind: 'types-first',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                export {
-                  // Comment
-                  BB,
-                  // Other comment
-                  A,
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                export {
-                  /* Partition Comment */
-                  // Part: A
-                  D,
-                  // Part: B
-                  AAA,
-                  BB,
-                  C,
-                  /* Other */
-                  E,
-                }
-              `,
-              code: dedent`
-                export {
-                  /* Partition Comment */
-                  // Part: A
-                  D,
-                  // Part: B
-                  AAA,
-                  C,
-                  BB,
-                  /* Other */
-                  E,
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'BB',
-                    left: 'C',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                export {
-                  E,
-                  F,
-                  // I am a partition comment because I don't have f o o
-                  A,
-                  B,
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['^(?!.*foo).*$'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                export {
-                  /* Comment */
-                  A,
-                  B,
-                }
-              `,
-              code: dedent`
-                export {
-                  B,
-                  /* Comment */
-                  A,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  export {
-                    B,
-                    // Comment
-                    A,
-                  }
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['A', 'B'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  export {
-                    C,
-                    // B
-                    B,
-                    // A
-                    A,
-                  }
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  export {
-                    B,
-                    // I am a partition comment because I don't have f o o
-                    A,
-                  }
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
+    it(`sorts named exports`, async () => {
+      await valid({
+        code: 'export { a }',
+        options: [options],
       })
 
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                export {
-                  // Comment
-                  A,
-                  B,
-                }
-              `,
-              code: dedent`
-                export {
-                  B,
-                  // Comment
-                  A,
-                }
-              `,
+      await valid({
+        code: 'export { aaa, bb, c }',
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  export {
-                    B,
-                    /* Comment */
-                    A,
-                  }
-                `,
-              },
-            ],
-            invalid: [],
+            messageId: 'unexpectedNamedExportsOrder',
           },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['A', 'B'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  export {
-                    C,
-                    /* B */
-                    B,
-                    /* A */
-                    A,
-                  }
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  export {
-                    B,
-                    /* I am a partition comment because I don't have f o o */
-                    A,
-                  }
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
+        ],
+        output: dedent`
+          export {
+            aaa,
+            bb,
+            c
+          }
+        `,
+        code: dedent`
+          export {
+            aaa,
+            c,
+            bb
+          }
+        `,
+        options: [options],
       })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
+    it('sorts named exports grouping by their kind', async () => {
+      await valid({
+        code: dedent`
+          export { AAA, type BB, BB, type C }
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await valid({
+        code: dedent`
+          export { AAA, BB, type BB, type C }
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await valid({
+        code: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+
+      await invalid({
+        errors: [
           {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              export { _a, b, _c }
-            `,
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          export { AAA, type BB, BB, type C }
+        `,
+        code: dedent`
+          export { AAA, type C, type BB, BB }
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
+      await invalid({
+        errors: [
           {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              export { ab, a_c }
-            `,
+            data: {
+              right: 'AAA',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          export { AAA, BB, type BB, type C }
+        `,
+        code: dedent`
+          export { type BB, AAA, type C, BB }
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
 
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            export { 你好, 世界, a, A, b, B }
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAA',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        code: dedent`
+          export { type BB, AAA, type C, BB }
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): works with arbitrary names`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export { a as "A", b as "B" };
-          `,
-          code: dedent`
-            export { b as "B", a as "A" };
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export { a as "A", b as "B" };
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export {
-                a, b
-              }
-            `,
-            code: dedent`
-              export {
-                b, a
-              }
-            `,
-            options: [options],
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
           },
           {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export {
-                a, b,
-              }
-            `,
-            code: dedent`
-              export {
-                b, a,
-              }
-            `,
-            options: [options],
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
           },
         ],
-        valid: [],
-      },
-    )
+        output: dedent`
+          export {
+            A,
+            D,
 
-    ruleTester.run(`${ruleName}(${type}): handles "ignoreAlias" option`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
+            C,
+
+            B,
+            E,
+          }
+        `,
+        code: dedent`
+          export {
+            D,
+            A,
+
+            C,
+
+            E,
+            B,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'CC',
+              right: 'D',
             },
-          ],
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            // Part: A
+            type D,
+            // Not partition comment
+            BBB,
+            CC,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            // Not partition comment
+            FFF,
+            GG,
+          }
+        `,
+        code: dedent`
+          export {
+            // Part: A
+            CC,
+            type D,
+            // Not partition comment
+            BBB,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            GG,
+            // Not partition comment
+            FFF,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          export {
+            // Comment
+            BB,
+            // Other comment
+            A,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          export {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            BB,
+            C,
+            /* Other */
+            E,
+          }
+        `,
+        code: dedent`
+          export {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            C,
+            BB,
+            /* Other */
+            E,
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          export {
+            E,
+            F,
+            // I am a partition comment because I don't have f o o
+            A,
+            B,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when partitioning by line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          export {
+            /* Comment */
+            A,
+            B,
+          }
+        `,
+        code: dedent`
+          export {
+            B,
+            /* Comment */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('treats all line comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            // Comment
+            A,
+          }
+        `,
+      })
+    })
+
+    it('uses specific line comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            C,
+            // B
+            B,
+            // A
+            A,
+          }
+        `,
+      })
+    })
+
+    it('matches line comments by regex with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            // I am a partition comment because I don't have f o o
+            A,
+          }
+        `,
+      })
+    })
+
+    it('ignores line comments when partitioning by block comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          export {
+            // Comment
+            A,
+            B,
+          }
+        `,
+        code: dedent`
+          export {
+            B,
+            // Comment
+            A,
+          }
+        `,
+      })
+    })
+
+    it('treats all block comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            /* Comment */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('uses specific block comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            C,
+            /* B */
+            B,
+            /* A */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('matches block comments by regex with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            /* I am a partition comment because I don't have f o o */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          export { _a, b, _c }
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          export { ab, a_c }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          export { 你好, 世界, a, A, b, B }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('works with arbitrary names', async () => {
+      await valid({
+        code: dedent`
+          export { a as "A", b as "B" };
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a as "A", b as "B" };
+        `,
+        code: dedent`
+          export { b as "B", a as "A" };
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a, b
+          }
+        `,
+        code: dedent`
+          export {
+            b, a
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a, b,
+          }
+        `,
+        code: dedent`
+          export {
+            b, a,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles "ignoreAlias" option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          export {
+            a as b,
+            b as a,
+          }
+        `,
+        code: dedent`
+          export {
+            b as a,
+            a as b,
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            'a' as b,
+            'b' as a,
+          } from './module'
+        `,
+        code: dedent`
+          export {
+            'b' as a,
+            'a' as b,
+          } from './module'
+        `,
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'typeElements',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'typeElements',
+                modifiers: ['type'],
+              },
+            ],
+            groups: ['typeElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          export {
+            type b,
+            a,
+          }
+        `,
+        code: dedent`
+          export {
+            a,
+            type b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['object pattern with flags', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters on elementNamePattern with %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
           options: [
             {
-              ...options,
-              ignoreAlias: true,
+              customGroups: [
+                {
+                  groupName: 'typesStartingWithHello',
+                  modifiers: ['type'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['typesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'typesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloType',
+                left: 'b',
+              },
+              messageId: 'unexpectedNamedExportsGroupOrder',
             },
           ],
           output: dedent`
             export {
-              a as b,
-              b as a,
+              type helloType,
+              a,
+              b,
             }
           `,
           code: dedent`
             export {
-              b as a,
-              a as b,
+              a,
+              b,
+              type helloType,
             }
           `,
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              'a' as b,
-              'b' as a,
-            } from './module'
-          `,
-          code: dedent`
-            export {
-              'b' as a,
-              'a' as b,
-            } from './module'
-          `,
-          options: [
-            {
-              ...options,
-              ignoreAlias: true,
-            },
-          ],
-        },
-      ],
-      valid: [],
-    })
+        })
+      },
+    )
 
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on modifier`, rule, {
-        invalid: [
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
           {
-            errors: [
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedTypesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
               {
-                data: {
-                  rightGroup: 'typeElements',
-                  leftGroup: 'unknown',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedNamedExportsGroupOrder',
+                groupName: 'reversedTypesByLineLength',
+                modifiers: ['type'],
+                type: 'line-length',
+                order: 'desc',
               },
             ],
-            options: [
+            groups: ['reversedTypesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          export {
+            type dddd,
+            type ccc,
+            type eee,
+            type bb,
+            type ff,
+            type a,
+            type g,
+            m,
+            o,
+            p,
+          }
+        `,
+        code: dedent`
+          export {
+            type a,
+            type bb,
+            type ccc,
+            type dddd,
+            m,
+            type eee,
+            type ff,
+            type g,
+            o,
+            p,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
               {
-                customGroups: [
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            fooBar,
+            fooZar,
+          }
+        `,
+        code: dedent`
+          export {
+            fooZar,
+            fooBar,
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedTypes',
+                modifiers: ['type'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedTypes', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedTypes',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            type b,
+            type a,
+            type d,
+            type e,
+            type c,
+            m,
+          }
+        `,
+        code: dedent`
+          export {
+            type b,
+            type a,
+            type d,
+            type e,
+            m,
+            type c,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
                   {
-                    groupName: 'typeElements',
+                    elementNamePattern: 'foo|Foo',
                     modifiers: ['type'],
                   },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
                 ],
-                groups: ['typeElements', 'unknown'],
+                groupName: 'elementsIncludingFoo',
               },
             ],
-            output: dedent`
-              export {
-                type b,
-                a,
-              }
-            `,
-            code: dedent`
-              export {
-                a,
-                type b,
-              }
-            `,
+            groups: ['elementsIncludingFoo', 'unknown'],
           },
         ],
-        valid: [],
-      })
-
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'typesStartingWithHello',
-                      modifiers: ['type'],
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['typesStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'typesStartingWithHello',
-                    leftGroup: 'unknown',
-                    right: 'helloType',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedNamedExportsGroupOrder',
-                },
-              ],
-              output: dedent`
-                export {
-                  type helloType,
-                  a,
-                  b,
-                }
-              `,
-              code: dedent`
-                export {
-                  a,
-                  b,
-                  type helloType,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedTypesByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'eee',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedNamedExportsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedTypesByLineLength',
-                      modifiers: ['type'],
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedTypesByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                export {
-                  type dddd,
-                  type ccc,
-                  type eee,
-                  type bb,
-                  type ff,
-                  type a,
-                  type g,
-                  m,
-                  o,
-                  p,
-                }
-              `,
-              code: dedent`
-                export {
-                  type a,
-                  type bb,
-                  type ccc,
-                  type dddd,
-                  m,
-                  type eee,
-                  type ff,
-                  type g,
-                  o,
-                  p,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedNamedExportsOrder',
-                },
-              ],
-              output: dedent`
-                export {
-                  fooBar,
-                  fooZar,
-                }
-              `,
-              code: dedent`
-                export {
-                  fooZar,
-                  fooBar,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedTypes',
-                      modifiers: ['type'],
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedTypes', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedTypes',
-                    leftGroup: 'unknown',
-                    right: 'c',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedNamedExportsGroupOrder',
-                },
-              ],
-              output: dedent`
-                export {
-                  type b,
-                  type a,
-                  type d,
-                  type e,
-                  type c,
-                  m,
-                }
-              `,
-              code: dedent`
-                export {
-                  type b,
-                  type a,
-                  type d,
-                  type e,
-                  m,
-                  type c,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
+        errors: [
           {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        modifiers: ['type'],
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: 'cFoo',
-                  left: 'a',
-                },
-                messageId: 'unexpectedNamedExportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              export {
-                type cFoo,
-                foo,
-                type a,
-              }
-            `,
-            code: dedent`
-              export {
-                type a,
-                type cFoo,
-                foo,
-              }
-            `,
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
           },
         ],
-        valid: [],
+        output: dedent`
+          export {
+            type cFoo,
+            foo,
+            type a,
+          }
+        `,
+        code: dedent`
+          export {
+            type a,
+            type cFoo,
+            foo,
+          }
+        `,
       })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                export {
-                  iHaveFooInMyName,
-                  meTooIHaveFoo,
-                  a,
-                  b,
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
     })
 
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
           {
-            invalid: [
+            customGroups: [
               {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenNamedExports',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedNamedExportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenNamedExports',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  export {
-                      a,
-
-
-                     y,
-                    z,
-
-                        b,
-                  }
-                `,
-                output: dedent`
-                  export {
-                      a,
-                     b,
-                    y,
-                        z,
-                  }
-                `,
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
               },
             ],
-            valid: [],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
           },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenNamedExports',
-                  },
-                ],
-                output: dedent`
-                  export {
-                    a, 
-
-                  b
-                  } from 'module'
-                `,
-                code: dedent`
-                  export {
-                    a, b
-                  } from 'module'
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenNamedExports',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedNamedExportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenNamedExports',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  export {
-                      a,
-
-                     y,
-                    z,
-
-                        b,
-                  }
-                `,
-                code: dedent`
-                  export {
-                      a,
-
-
-                     z,
-                    y,
-                        b,
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenNamedExports',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenNamedExports',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenNamedExports',
-                  },
-                ],
-                code: dedent`
-                    export {
-                    a,
-                    b,
-
-
-                    c,
-
-                    d,
-
-
-                    e,
-                  }
-                `,
-                output: dedent`
-                  export {
-                    a,
-
-                    b,
-
-                    c,
-                    d,
-
-
-                    e,
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenNamedExports',
-                      },
-                    ],
-                    output: dedent`
-                      export {
-                        a,
-
-
-                        b,
-                      }
-                    `,
-                    code: dedent`
-                      export {
-                        a,
-                        b,
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
+        ],
+        code: dedent`
+          export {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
           }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenNamedExports',
-                      },
-                    ],
-                    output: dedent`
-                      export {
-                        a,
-                        b,
-                      }
-                    `,
-                    code: dedent`
-                      export {
-                        a,
-
-                        b,
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      export {
-                        a,
-
-                        b,
-                      }
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      export {
-                        a,
-                        b,
-                      }
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
+        `,
       })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  export {
-                    a, // Comment after
-                    b,
-
-                    c,
-                  }
-                `,
-                dedent`
-                  export {
-                    a, // Comment after
-
-                    b,
-                    c,
-                  }
-                `,
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'b|c',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedNamedExportsGroupOrder',
-                },
-              ],
-              code: dedent`
-                export {
-                  b,
-                  a, // Comment after
-
-                  c,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedNamedExportsOrder',
-                  },
-                ],
-                output: dedent`
-                  export {
-                    a,
-
-                    // Partition comment
-
-                    b,
-                    c,
-                  } from 'module'
-                `,
-                code: dedent`
-                  export {
-                    a,
-
-                    // Partition comment
-
-                    c,
-                    b,
-                  } from 'module'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
     })
-  })
 
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts named exports`, rule, {
-      invalid: [
-        {
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'bb',
-                left: 'c',
+                right: 'y',
+                left: 'a',
               },
-              messageId: 'unexpectedNamedExportsOrder',
+              messageId: 'extraSpacingBetweenNamedExports',
             },
-          ],
-          output: dedent`
-            export {
-              aaa,
-              bb,
-              c
-            }
-          `,
-          code: dedent`
-            export {
-              aaa,
-              c,
-              bb
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: 'export { aaa, bb, c }',
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts named exports grouping by their kind`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { AAA, type BB, BB, type C }
-            `,
-            code: dedent`
-              export { AAA, type C, type BB, BB }
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'AAA',
-                  left: 'BB',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { AAA, BB, type BB, type C }
-            `,
-            code: dedent`
-              export { type BB, AAA, type C, BB }
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            code: dedent`
-              export { type BB, AAA, type C, BB }
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              export { AAA, type BB, BB, type C }
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            code: dedent`
-              export { AAA, BB, type BB, type C }
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            code: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-      },
-    )
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts named exports`, rule, {
-      invalid: [
-        {
-          errors: [
             {
               data: {
-                right: 'bb',
-                left: 'c',
+                right: 'b',
+                left: 'z',
               },
               messageId: 'unexpectedNamedExportsOrder',
             },
-          ],
-          output: dedent`
-            export {
-              aaa,
-              bb,
-              c
-            }
-          `,
-          code: dedent`
-            export {
-              aaa,
-              c,
-              bb
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: 'export { a }',
-          options: [options],
-        },
-        {
-          code: 'export { aaa, bb, c }',
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts named exports`, rule, {
-      invalid: [
-        {
-          errors: [
             {
               data: {
-                right: 'bb',
-                left: 'c',
+                right: 'b',
+                left: 'z',
               },
-              messageId: 'unexpectedNamedExportsOrder',
+              messageId: 'extraSpacingBetweenNamedExports',
             },
           ],
-          output: dedent`
-            export {
-              aaa,
-              bb,
-              c
-            }
-          `,
-          code: dedent`
-            export {
-              aaa,
-              c,
-              bb
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: 'export { aaa, bb, c }',
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts named exports grouping by their kind`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            code: dedent`
-              export { AAA, type C, type BB, BB }
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'AAA',
-                  left: 'BB',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { AAA, BB, type BB, type C }
-            `,
-            code: dedent`
-              export { type BB, AAA, type C, BB }
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'C',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            code: dedent`
-              export { type BB, AAA, type C, BB }
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            code: dedent`
-              export { AAA, BB, type BB, type C }
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            code: dedent`
-              export { type BB, type C, AAA, BB }
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              export {
-                bb,
-                c,
-                a,
-              }
-            `,
-            code: dedent`
-              export {
-                a,
-                bb,
-                c,
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              export {
-                bb,
-                a,
-                c,
-              }
-            `,
-            code: dedent`
-              export {
-                c,
-                bb,
-                a,
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            export {
-              b,
-              c,
-              a,
-            }
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
           options: [
             {
               ...options,
@@ -2250,444 +1088,3814 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+                a,
+
+
+               y,
+              z,
+
+                  b,
+            }
+          `,
+          output: dedent`
+            export {
+                a,
+               b,
+              y,
+                  z,
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+        ],
+        code: dedent`
+            export {
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e,
+          }
+        `,
+        output: dedent`
+          export {
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['2 and never', 2, 'never' as const],
+      ['2 and 0', 2, 0 as const],
+      ['2 and ignore', 2, 'ignore' as const],
+      ['never and 2', 'never' as const, 2],
+      ['0 and 2', 0 as const, 2],
+      ['ignore and 2', 'ignore' as const, 2],
+    ])(
+      'enforces newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenNamedExports',
             },
           ],
           output: dedent`
             export {
-                b,
+              a,
 
-                a,
+
+              b,
             }
           `,
           code: dedent`
             export {
-                b,
-                a,
+              a,
+              b,
             }
           `,
-        },
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['2', 2 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline when global option is %s and never exists between all groups',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedExports',
+            },
+          ],
+          output: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+          code: dedent`
+            export {
+              a,
+
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore and never', 'ignore' as const, 'never' as const],
+      ['ignore and 0', 'ignore' as const, 0 as const],
+      ['never and ignore', 'never' as const, 'ignore' as const],
+      ['0 and ignore', 0 as const, 'ignore' as const],
+    ])(
+      'does not enforce newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+              a,
+
+              b,
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a, // Comment after
+
+            b,
+            c,
+          }
+        `,
+        code: dedent`
+          export {
+            b,
+            a, // Comment after
+
+            c,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedNamedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export {
+              a,
+
+              // Partition comment
+
+              b,
+              c,
+            } from 'module'
+          `,
+          code: dedent`
+            export {
+              a,
+
+              // Partition comment
+
+              c,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it(`sorts named exports`, async () => {
+      await valid({
+        code: 'export { a }',
+        options: [options],
+      })
+
+      await valid({
+        code: 'export { aaa, bb, c }',
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            aaa,
+            bb,
+            c
+          }
+        `,
+        code: dedent`
+          export {
+            aaa,
+            c,
+            bb
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts named exports grouping by their kind', async () => {
+      await valid({
+        code: dedent`
+          export { AAA, type BB, BB, type C }
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await valid({
+        code: dedent`
+          export { AAA, BB, type BB, type C }
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await valid({
+        code: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { AAA, type BB, BB, type C }
+        `,
+        code: dedent`
+          export { AAA, type C, type BB, BB }
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAA',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { AAA, BB, type BB, type C }
+        `,
+        code: dedent`
+          export { type BB, AAA, type C, BB }
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAA',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        code: dedent`
+          export { type BB, AAA, type C, BB }
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            A,
+            D,
+
+            C,
+
+            B,
+            E,
+          }
+        `,
+        code: dedent`
+          export {
+            D,
+            A,
+
+            C,
+
+            E,
+            B,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'CC',
+              right: 'D',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            // Part: A
+            type D,
+            // Not partition comment
+            BBB,
+            CC,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            // Not partition comment
+            FFF,
+            GG,
+          }
+        `,
+        code: dedent`
+          export {
+            // Part: A
+            CC,
+            type D,
+            // Not partition comment
+            BBB,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            GG,
+            // Not partition comment
+            FFF,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          export {
+            // Comment
+            BB,
+            // Other comment
+            A,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          export {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            BB,
+            C,
+            /* Other */
+            E,
+          }
+        `,
+        code: dedent`
+          export {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            C,
+            BB,
+            /* Other */
+            E,
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          export {
+            E,
+            F,
+            // I am a partition comment because I don't have f o o
+            A,
+            B,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when partitioning by line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          export {
+            /* Comment */
+            A,
+            B,
+          }
+        `,
+        code: dedent`
+          export {
+            B,
+            /* Comment */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('treats all line comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            // Comment
+            A,
+          }
+        `,
+      })
+    })
+
+    it('uses specific line comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            C,
+            // B
+            B,
+            // A
+            A,
+          }
+        `,
+      })
+    })
+
+    it('matches line comments by regex with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            // I am a partition comment because I don't have f o o
+            A,
+          }
+        `,
+      })
+    })
+
+    it('ignores line comments when partitioning by block comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          export {
+            // Comment
+            A,
+            B,
+          }
+        `,
+        code: dedent`
+          export {
+            B,
+            // Comment
+            A,
+          }
+        `,
+      })
+    })
+
+    it('treats all block comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            /* Comment */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('uses specific block comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            C,
+            /* B */
+            B,
+            /* A */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('matches block comments by regex with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            /* I am a partition comment because I don't have f o o */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          export { _a, b, _c }
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          export { ab, a_c }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          export { 你好, 世界, a, A, b, B }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('works with arbitrary names', async () => {
+      await valid({
+        code: dedent`
+          export { a as "A", b as "B" };
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a as "A", b as "B" };
+        `,
+        code: dedent`
+          export { b as "B", a as "A" };
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a, b
+          }
+        `,
+        code: dedent`
+          export {
+            b, a
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a, b,
+          }
+        `,
+        code: dedent`
+          export {
+            b, a,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles "ignoreAlias" option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          export {
+            a as b,
+            b as a,
+          }
+        `,
+        code: dedent`
+          export {
+            b as a,
+            a as b,
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            'a' as b,
+            'b' as a,
+          } from './module'
+        `,
+        code: dedent`
+          export {
+            'b' as a,
+            'a' as b,
+          } from './module'
+        `,
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'typeElements',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'typeElements',
+                modifiers: ['type'],
+              },
+            ],
+            groups: ['typeElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          export {
+            type b,
+            a,
+          }
+        `,
+        code: dedent`
+          export {
+            a,
+            type b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['object pattern with flags', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
       ],
-      valid: [],
+    ])(
+      'filters on elementNamePattern with %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'typesStartingWithHello',
+                  modifiers: ['type'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['typesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'typesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloType',
+                left: 'b',
+              },
+              messageId: 'unexpectedNamedExportsGroupOrder',
+            },
+          ],
+          output: dedent`
+            export {
+              type helloType,
+              a,
+              b,
+            }
+          `,
+          code: dedent`
+            export {
+              a,
+              b,
+              type helloType,
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedTypesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedTypesByLineLength',
+                modifiers: ['type'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedTypesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          export {
+            type dddd,
+            type ccc,
+            type eee,
+            type bb,
+            type ff,
+            type a,
+            type g,
+            m,
+            o,
+            p,
+          }
+        `,
+        code: dedent`
+          export {
+            type a,
+            type bb,
+            type ccc,
+            type dddd,
+            m,
+            type eee,
+            type ff,
+            type g,
+            o,
+            p,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            fooBar,
+            fooZar,
+          }
+        `,
+        code: dedent`
+          export {
+            fooZar,
+            fooBar,
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedTypes',
+                modifiers: ['type'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedTypes', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedTypes',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            type b,
+            type a,
+            type d,
+            type e,
+            type c,
+            m,
+          }
+        `,
+        code: dedent`
+          export {
+            type b,
+            type a,
+            type d,
+            type e,
+            m,
+            type c,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['type'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            type cFoo,
+            foo,
+            type a,
+          }
+        `,
+        code: dedent`
+          export {
+            type a,
+            type cFoo,
+            foo,
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          export {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedExports',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedNamedExportsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenNamedExports',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+                a,
+
+
+               y,
+              z,
+
+                  b,
+            }
+          `,
+          output: dedent`
+            export {
+                a,
+               b,
+              y,
+                  z,
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+        ],
+        code: dedent`
+            export {
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e,
+          }
+        `,
+        output: dedent`
+          export {
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['2 and never', 2, 'never' as const],
+      ['2 and 0', 2, 0 as const],
+      ['2 and ignore', 2, 'ignore' as const],
+      ['never and 2', 'never' as const, 2],
+      ['0 and 2', 0 as const, 2],
+      ['ignore and 2', 'ignore' as const, 2],
+    ])(
+      'enforces newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenNamedExports',
+            },
+          ],
+          output: dedent`
+            export {
+              a,
+
+
+              b,
+            }
+          `,
+          code: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['2', 2 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline when global option is %s and never exists between all groups',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedExports',
+            },
+          ],
+          output: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+          code: dedent`
+            export {
+              a,
+
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore and never', 'ignore' as const, 'never' as const],
+      ['ignore and 0', 'ignore' as const, 0 as const],
+      ['never and ignore', 'never' as const, 'ignore' as const],
+      ['0 and ignore', 0 as const, 'ignore' as const],
+    ])(
+      'does not enforce newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+              a,
+
+              b,
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a, // Comment after
+
+            b,
+            c,
+          }
+        `,
+        code: dedent`
+          export {
+            b,
+            a, // Comment after
+
+            c,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedNamedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export {
+              a,
+
+              // Partition comment
+
+              b,
+              c,
+            } from 'module'
+          `,
+          code: dedent`
+            export {
+              a,
+
+              // Partition comment
+
+              c,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it(`sorts named exports`, async () => {
+      await valid({
+        code: 'export { a }',
+        options: [options],
+      })
+
+      await valid({
+        code: 'export { aaa, bb, c }',
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            aaa,
+            bb,
+            c
+          }
+        `,
+        code: dedent`
+          export {
+            aaa,
+            c,
+            bb
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts named exports grouping by their kind', async () => {
+      await valid({
+        code: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await valid({
+        code: dedent`
+          export { AAA, BB, type BB, type C }
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await valid({
+        code: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAA',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        code: dedent`
+          export { AAA, type C, type BB, BB }
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAA',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { AAA, BB, type BB, type C }
+        `,
+        code: dedent`
+          export { type BB, AAA, type C, BB }
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAA',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { type BB, type C, AAA, BB }
+        `,
+        code: dedent`
+          export { type BB, AAA, type C, BB }
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAAAA',
+              left: 'DD',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'BBBB',
+              left: 'E',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            AAAAA,
+            DD,
+
+            CCC,
+
+            BBBB,
+            E,
+          }
+        `,
+        code: dedent`
+          export {
+            DD,
+            AAAAA,
+
+            CCC,
+
+            E,
+            BBBB,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'CC',
+              right: 'D',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            // Part: A
+            type D,
+            // Not partition comment
+            BBB,
+            CC,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            // Not partition comment
+            FFF,
+            GG,
+          }
+        `,
+        code: dedent`
+          export {
+            // Part: A
+            CC,
+            type D,
+            // Not partition comment
+            BBB,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            GG,
+            // Not partition comment
+            FFF,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          export {
+            // Comment
+            BB,
+            // Other comment
+            A,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          export {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            BB,
+            C,
+            /* Other */
+            E,
+          }
+        `,
+        code: dedent`
+          export {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            C,
+            BB,
+            /* Other */
+            E,
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          export {
+            E,
+            F,
+            // I am a partition comment because I don't have f o o
+            A,
+            B,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when partitioning by line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          export {
+            /* Comment */
+            AA,
+            B,
+          }
+        `,
+        code: dedent`
+          export {
+            B,
+            /* Comment */
+            AA,
+          }
+        `,
+      })
+    })
+
+    it('treats all line comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            // Comment
+            A,
+          }
+        `,
+      })
+    })
+
+    it('uses specific line comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            C,
+            // B
+            B,
+            // A
+            A,
+          }
+        `,
+      })
+    })
+
+    it('matches line comments by regex with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            // I am a partition comment because I don't have f o o
+            A,
+          }
+        `,
+      })
+    })
+
+    it('ignores line comments when partitioning by block comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          export {
+            // Comment
+            AA,
+            B,
+          }
+        `,
+        code: dedent`
+          export {
+            B,
+            // Comment
+            AA,
+          }
+        `,
+      })
+    })
+
+    it('treats all block comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            /* Comment */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('uses specific block comments as partitions with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            C,
+            /* B */
+            B,
+            /* A */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('matches block comments by regex with object config', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          export {
+            B,
+            /* I am a partition comment because I don't have f o o */
+            A,
+          }
+        `,
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          export { _aa, bbb, _c }
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          export { abc, a_c }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          export { 你好, 世界, a, A, b, B }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('works with arbitrary names', async () => {
+      await valid({
+        code: dedent`
+          export { a as "A", b as "B" };
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a as "AA", b as "B" };
+        `,
+        code: dedent`
+          export { b as "B", a as "AA" };
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            aa, b
+          }
+        `,
+        code: dedent`
+          export {
+            b, aa
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            aa, b,
+          }
+        `,
+        code: dedent`
+          export {
+            b, aa,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles "ignoreAlias" option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          export {
+            aa as b,
+            b as a,
+          }
+        `,
+        code: dedent`
+          export {
+            b as a,
+            aa as b,
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            'aa' as b,
+            'b' as a,
+          } from './module'
+        `,
+        code: dedent`
+          export {
+            'b' as a,
+            'aa' as b,
+          } from './module'
+        `,
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'typeElements',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'typeElements',
+                modifiers: ['type'],
+              },
+            ],
+            groups: ['typeElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          export {
+            type b,
+            a,
+          }
+        `,
+        code: dedent`
+          export {
+            a,
+            type b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['object pattern with flags', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with object pattern',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters on elementNamePattern with %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'typesStartingWithHello',
+                  modifiers: ['type'],
+                  elementNamePattern,
+                },
+              ],
+              groups: ['typesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'typesStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloType',
+                left: 'b',
+              },
+              messageId: 'unexpectedNamedExportsGroupOrder',
+            },
+          ],
+          output: dedent`
+            export {
+              type helloType,
+              a,
+              b,
+            }
+          `,
+          code: dedent`
+            export {
+              a,
+              b,
+              type helloType,
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedTypesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedTypesByLineLength',
+                modifiers: ['type'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedTypesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          export {
+            type dddd,
+            type ccc,
+            type eee,
+            type bb,
+            type ff,
+            type a,
+            type g,
+            m,
+            o,
+            p,
+          }
+        `,
+        code: dedent`
+          export {
+            type a,
+            type bb,
+            type ccc,
+            type dddd,
+            m,
+            type eee,
+            type ff,
+            type g,
+            o,
+            p,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            fooBar,
+            fooZar,
+          }
+        `,
+        code: dedent`
+          export {
+            fooZar,
+            fooBar,
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedTypes',
+                modifiers: ['type'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedTypes', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedTypes',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            type b,
+            type a,
+            type d,
+            type e,
+            type c,
+            m,
+          }
+        `,
+        code: dedent`
+          export {
+            type b,
+            type a,
+            type d,
+            type e,
+            m,
+            type c,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['type'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            type cFoo,
+            foo,
+            type a,
+          }
+        `,
+        code: dedent`
+          export {
+            type a,
+            type cFoo,
+            foo,
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          export {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenNamedExports',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedNamedExportsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenNamedExports',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+                aaaa,
+
+
+               yy,
+              z,
+
+                  bbb,
+            }
+          `,
+          output: dedent`
+            export {
+                aaaa,
+               bbb,
+              yy,
+                  z,
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+        ],
+        code: dedent`
+            export {
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e,
+          }
+        `,
+        output: dedent`
+          export {
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['2 and never', 2, 'never' as const],
+      ['2 and 0', 2, 0 as const],
+      ['2 and ignore', 2, 'ignore' as const],
+      ['never and 2', 'never' as const, 2],
+      ['0 and 2', 0 as const, 2],
+      ['ignore and 2', 'ignore' as const, 2],
+    ])(
+      'enforces newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenNamedExports',
+            },
+          ],
+          output: dedent`
+            export {
+              a,
+
+
+              b,
+            }
+          `,
+          code: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['2', 2 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline when global option is %s and never exists between all groups',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedExports',
+            },
+          ],
+          output: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+          code: dedent`
+            export {
+              a,
+
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore and never', 'ignore' as const, 'never' as const],
+      ['ignore and 0', 'ignore' as const, 0 as const],
+      ['never and ignore', 'never' as const, 'ignore' as const],
+      ['0 and ignore', 0 as const, 'ignore' as const],
+    ])(
+      'does not enforce newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+              a,
+
+              b,
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            export {
+              a,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a, // Comment after
+
+            b,
+            c,
+          }
+        `,
+        code: dedent`
+          export {
+            b,
+            a, // Comment after
+
+            c,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedNamedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export {
+              aaa,
+
+              // Partition comment
+
+              bb,
+              c,
+            } from 'module'
+          `,
+          code: dedent`
+            export {
+              aaa,
+
+              // Partition comment
+
+              c,
+              bb,
+            } from 'module'
+          `,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts named exports', async () => {
+      await valid({
+        code: 'export { a }',
+        options: [options],
+      })
+
+      await valid({
+        code: 'export { aaa, bb, c }',
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            aaa,
+            bb,
+            c
+          }
+        `,
+        code: dedent`
+          export {
+            aaa,
+            c,
+            bb
+          }
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          export {
+            b,
+            c,
+            a,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces newlines between groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenNamedExports',
+          },
+        ],
+        output: dedent`
+          export {
+              b,
+
+              a,
+          }
+        `,
+        code: dedent`
+          export {
+              b,
+              a,
+          }
+        `,
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedNamedExportsOrder',
-              },
-            ],
-            output: dedent`
-              export { A, B }
-            `,
-            code: dedent`
-              export { B, A }
-            `,
-          },
-        ],
-        valid: [
-          'export { A, B }',
-          {
-            code: 'export { log, log10, log1p, log2 }',
-            options: [{}],
-          },
-        ],
-      },
-    )
+    it('sets alphabetical asc sorting as default', async () => {
+      await valid('export { A, B }')
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
+      await valid({
+        code: 'export { log, log10, log1p, log2 }',
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
             },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              // eslint-disable-next-line
-              a
-            }
-          `,
-          code: dedent`
-            export {
-              c,
-              b,
-              // eslint-disable-next-line
-              a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              // eslint-disable-next-line
-              a,
-              d
-            }
-          `,
-          code: dedent`
-            export {
-              d,
-              c,
-              // eslint-disable-next-line
-              a,
-              b
-            }
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              a // eslint-disable-line
-            }
-          `,
-          code: dedent`
-            export {
-              c,
-              b,
-              a // eslint-disable-line
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              /* eslint-disable-next-line */
-              a
-            }
-          `,
-          code: dedent`
-            export {
-              c,
-              b,
-              /* eslint-disable-next-line */
-              a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              a /* eslint-disable-line */
-            }
-          `,
-          code: dedent`
-            export {
-              c,
-              b,
-              a /* eslint-disable-line */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export {
-              a,
-              d,
-              /* eslint-disable */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              e,
-            }
-          `,
-          code: dedent`
-            export {
-              d,
-              e,
-              /* eslint-disable */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              a,
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-            }
-          `,
-          code: dedent`
-            export {
-              c,
-              b,
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          code: dedent`
-            export {
-              c,
-              b,
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export {
-              b,
-              c,
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          code: dedent`
-            export {
-              c,
-              b,
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          output: dedent`
-            export {
-              b,
-              c,
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          code: dedent`
-            export {
-              c,
-              b,
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            export {
-              a,
-              d,
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              e,
-            }
-          `,
-          code: dedent`
-            export {
-              d,
-              e,
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              a,
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            export {
-              b,
-              c,
-              // eslint-disable-next-line
-              a
-            }
-          `,
-        },
-      ],
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { A, B }
+        `,
+        code: dedent`
+          export { B, A }
+        `,
+      })
     })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+    it('respects eslint-disable-next-line comments', async () => {
+      await valid({
+        code: dedent`
+          export {
+            b,
+            c,
+            // eslint-disable-next-line
+            a
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              export { a, b, c } from './module';
-            `,
-            options: [{}],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          export {
+            b,
+            c,
+            // eslint-disable-next-line
+            a
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            // eslint-disable-next-line
+            a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            /* eslint-disable-next-line */
+            a
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            /* eslint-disable-next-line */
+            a
+          }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            a // eslint-disable-line
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            a // eslint-disable-line
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            a /* eslint-disable-line */
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            a /* eslint-disable-line */
+          }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable-next-line with specific rule', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            // eslint-disable-next-line rule-to-test/sort-named-exports
+            a
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            // eslint-disable-next-line rule-to-test/sort-named-exports
+            a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            /* eslint-disable-next-line rule-to-test/sort-named-exports */
+            a
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            /* eslint-disable-next-line rule-to-test/sort-named-exports */
+            a
+          }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable-line with specific rule', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            a // eslint-disable-line rule-to-test/sort-named-exports
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            a // eslint-disable-line rule-to-test/sort-named-exports
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            a /* eslint-disable-line rule-to-test/sort-named-exports */
+          }
+        `,
+        code: dedent`
+          export {
+            c,
+            b,
+            a /* eslint-disable-line rule-to-test/sort-named-exports */
+          }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable/enable block comments', async () => {
+      await invalid({
+        output: dedent`
+          export {
+            a,
+            d,
+            /* eslint-disable */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            e,
+          }
+        `,
+        code: dedent`
+          export {
+            d,
+            e,
+            /* eslint-disable */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            a,
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          export {
+            a,
+            d,
+            /* eslint-disable rule-to-test/sort-named-exports */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            e,
+          }
+        `,
+        code: dedent`
+          export {
+            d,
+            e,
+            /* eslint-disable rule-to-test/sort-named-exports */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            a,
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles eslint-disable with partitionByComment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            b,
+            c,
+            // eslint-disable-next-line
+            a,
+            d
+          }
+        `,
+        code: dedent`
+          export {
+            d,
+            c,
+            // eslint-disable-next-line
+            a,
+            b
+          }
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
   })
 })

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1,2791 +1,1233 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-named-imports'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-named-imports'
+describe('sort-named-imports', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-named-imports',
+    parser: typescriptParser,
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts named imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'AAA',
-                left: 'BB',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
+    it('sorts named imports', async () => {
+      await valid({
+        code: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAA',
+              left: 'BB',
             },
-          ],
-          output: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          code: dedent`
-            import { BB, AAA, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        code: dedent`
+          import { BB, AAA, C } from 'module'
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts named multiline imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'BBB',
-                left: 'CC',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
+    it('sorts named multiline imports', async () => {
+      await valid({
+        code: dedent`
+          import {
+            AAAA,
+            BBB,
+            CC,
+            D,
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'CC',
             },
-          ],
-          output: dedent`
-            import {
-              AAAA,
-              BBB,
-              CC,
-              D,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              AAAA,
-              CC,
-              BBB,
-              D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-              AAAA,
-              BBB,
-              CC,
-              D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            AAAA,
+            BBB,
+            CC,
+            D,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            AAAA,
+            CC,
+            BBB,
+            D,
+          } from 'module'
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts named imports with aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'X0',
-                left: 'X1',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
+    it('sorts named imports with aliases', async () => {
+      await valid({
+        code: dedent`
+          import {
+            C,
+            BB as X0,
+            A as X1
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'X0',
+              left: 'X1',
             },
-            {
-              data: {
-                left: 'X0',
-                right: 'C',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              left: 'X0',
+              right: 'C',
             },
-          ],
-          output: dedent`
-            import {
-              C,
-              BB as X0,
-              A as X1
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              A as X1,
-              BB as X0,
-              C
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-              C,
-              BB as X0,
-              A as X1
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            C,
+            BB as X0,
+            A as X1
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            A as X1,
+            BB as X0,
+            C
+          } from 'module'
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: not sorts default specifiers`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import C, { b as A } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+    it('does not sort default specifiers', async () => {
+      await valid({
+        code: dedent`
+          import C, { b as A } from 'module'
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts with import aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
+    it('sorts imports with aliases', async () => {
+      await valid({
+        code: dedent`
+          import U, {
+            aaa as A,
+            B,
+            cc as C,
+            d as D,
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
             },
-            {
-              data: {
-                right: 'C',
-                left: 'D',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'C',
+              left: 'D',
             },
-          ],
-          output: dedent`
-            import U, {
-              aaa as A,
-              B,
-              cc as C,
-              d as D,
-            } from 'module'
-          `,
-          code: dedent`
-            import U, {
-              B,
-              aaa as A,
-              d as D,
-              cc as C,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import U, {
-              aaa as A,
-              B,
-              cc as C,
-              d as D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import U, {
+            aaa as A,
+            B,
+            cc as C,
+            d as D,
+          } from 'module'
+        `,
+        code: dedent`
+          import U, {
+            B,
+            aaa as A,
+            d as D,
+            cc as C,
+          } from 'module'
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: allows to ignore import aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
+    it('allows to ignore import aliases', async () => {
+      await valid({
+        code: dedent`
+          import {
               x as a,
               y as b,
               c,
             } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              x as a,
-              y as b,
-            } from 'module'
-          `,
-          options: [
-            {
-              ...options,
-              ignoreAlias: false,
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-                x as a,
-                y as b,
-                c,
-              } from 'module'
-          `,
-          options: [
-            {
-              ...options,
-              ignoreAlias: false,
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts named imports grouping by their kind`,
-      rule,
-      {
-        invalid: [
+        `,
+        options: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, type C, BB } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'BB',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { AAA, BB, type BB, type C } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'BB',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-              {
-                data: {
-                  left: 'BB',
-                  right: 'C',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
+            ...options,
+            ignoreAlias: false,
           },
         ],
-        valid: [
-          {
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            code: dedent`
-              import { AAA, BB, type BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            code: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: allows to use original import names`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              ignoreAlias: true,
-            },
-          ],
-          output: dedent`
-            import { A as B, B as A } from 'module'
-          `,
-          code: dedent`
-            import { B as A, A as B } from 'module'
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              ignoreAlias: true,
-            },
-          ],
-          code: dedent`
-            import { A as B, B as A } from 'module'
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'D',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-              {
-                data: {
-                  right: 'B',
-                  left: 'E',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import {
-                A,
-                D,
-
-                C,
-
-                B,
-                E,
-              } from 'module'
-            `,
-            code: dedent`
-              import {
-                D,
-                A,
-
-                C,
-
-                E,
-                B,
-              } from 'module'
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe('partition comments', () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: 'CC',
-                    right: 'D',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-                {
-                  data: {
-                    right: 'FFF',
-                    left: 'GG',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-              ],
-              output: dedent`
-                import {
-                  // Part: A
-                  type D,
-                  // Not partition comment
-                  BBB,
-                  CC,
-                  // Part: B
-                  AAAA,
-                  E,
-                  // Part: C
-                  // Not partition comment
-                  FFF,
-                  GG,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  // Part: A
-                  CC,
-                  type D,
-                  // Not partition comment
-                  BBB,
-                  // Part: B
-                  AAAA,
-                  E,
-                  // Part: C
-                  GG,
-                  // Not partition comment
-                  FFF,
-                } from 'module'
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                  groupKind: 'types-first',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                import {
-                  // Comment
-                  BB,
-                  // Other comment
-                  A,
-                } from 'module'
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                import {
-                  /* Partition Comment */
-                  // Part: A
-                  D,
-                  // Part: B
-                  AAA,
-                  BB,
-                  C,
-                  /* Other */
-                  E,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  /* Partition Comment */
-                  // Part: A
-                  D,
-                  // Part: B
-                  AAA,
-                  C,
-                  BB,
-                  /* Other */
-                  E,
-                } from 'module'
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'BB',
-                    left: 'C',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                import {
-                  /* Comment */
-                  A,
-                  B,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  B,
-                  /* Comment */
-                  A,
-                } from 'module'
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  import {
-                    B,
-                    // Comment
-                    A,
-                  } from 'module'
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  import {
-                    C,
-                    // B
-                    B,
-                    // A
-                    A,
-                  } from 'module'
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['A', 'B'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  import {
-                    B,
-                    // I am a partition comment because I don't have f o o
-                    A,
-                  } from 'module'
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
       })
 
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                import {
-                  // Comment
-                  A,
-                  B,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  B,
-                  // Comment
-                  A,
-                } from 'module'
-              `,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
             },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  import {
-                    B,
-                    /* Comment */
-                    A,
-                  } from 'module'
-                `,
-              },
-            ],
-            invalid: [],
+            messageId: 'unexpectedNamedImportsOrder',
           },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
+        ],
+        output: dedent`
+          import {
+            x as a,
+            y as b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            x as a,
+            y as b,
+          } from 'module'
+        `,
+        options: [
           {
-            valid: [
-              {
-                code: dedent`
-                  import {
-                    C,
-                    /* B */
-                    B,
-                    /* A */
-                    A,
-                  } from 'module'
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['A', 'B'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
+            ...options,
+            ignoreAlias: false,
           },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  import {
-                    B,
-                    /* I am a partition comment because I don't have f o o */
-                    A,
-                  } from 'module'
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
+        ],
       })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
+    it('sorts named imports grouping by their kind', async () => {
+      await valid({
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await valid({
+        code: dedent`
+          import { AAA, BB, type BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await valid({
+        code: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+
+      await invalid({
+        errors: [
           {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              import { _a, b, _c } from 'module'
-            `,
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, type C, BB } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
+      await invalid({
+        errors: [
           {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              import { ab, a_c } from 'module'
-            `,
+            data: {
+              right: 'BB',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          import { AAA, BB, type BB, type C } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
 
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import { 你好, 世界, a, A, b, B } from 'module'
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAA',
+              right: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              left: 'BB',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): works with arbitrary names`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              ignoreAlias: true,
-            },
-          ],
-          output: dedent`
-            import { "A" as a, "B" as b } from 'module';
-          `,
-          code: dedent`
-            import { "B" as b, "A" as a } from 'module';
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              ignoreAlias: true,
-            },
-          ],
-          code: dedent`
-            import { "A" as a, "B" as b } from 'module';
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
+    it('allows to use original import names', async () => {
+      await valid({
+        options: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import {
-                a, b
-              } from 'module'
-            `,
-            code: dedent`
-              import {
-                b, a
-              } from 'module'
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import {
-                a, b,
-              } from 'module'
-            `,
-            code: dedent`
-              import {
-                b, a,
-              } from 'module'
-            `,
-            options: [options],
+            ...options,
+            ignoreAlias: true,
           },
         ],
-        valid: [],
-      },
-    )
+        code: dedent`
+          import { A as B, B as A } from 'module'
+        `,
+      })
 
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on modifier`, rule, {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          import { A as B, B as A } from 'module'
+        `,
+        code: dedent`
+          import { B as A, A as B } from 'module'
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            A,
+            D,
+
+            C,
+
+            B,
+            E,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            D,
+            A,
+
+            C,
+
+            E,
+            B,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'CC',
+              right: 'D',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            // Part: A
+            type D,
+            // Not partition comment
+            BBB,
+            CC,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            // Not partition comment
+            FFF,
+            GG,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            // Part: A
+            CC,
+            type D,
+            // Not partition comment
+            BBB,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            GG,
+            // Not partition comment
+            FFF,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as partitions', async () => {
+      await valid({
+        code: dedent`
+          import {
+            // Comment
+            BB,
+            // Other comment
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          import {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            BB,
+            C,
+            /* Other */
+            E,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            C,
+            BB,
+            /* Other */
+            E,
+          } from 'module'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are used for partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          import {
+            /* Comment */
+            A,
+            B,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            B,
+            /* Comment */
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            B,
+            // Comment
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            C,
+            // B
+            B,
+            // A
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          import {
+            B,
+            // I am a partition comment because I don't have f o o
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are used for partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          import {
+            // Comment
+            A,
+            B,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            B,
+            // Comment
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            B,
+            /* Comment */
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          import {
+            C,
+            /* B */
+            B,
+            /* A */
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          import {
+            B,
+            /* I am a partition comment because I don't have f o o */
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          import { _a, b, _c } from 'module'
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          import { ab, a_c } from 'module'
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          import { 你好, 世界, a, A, b, B } from 'module'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('works with arbitrary names', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        code: dedent`
+          import { "A" as a, "B" as b } from 'module';
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          import { "A" as a, "B" as b } from 'module';
+        `,
+        code: dedent`
+          import { "B" as b, "A" as a } from 'module';
+        `,
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a, b
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, a
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a, b,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, a,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'typeElements',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
               {
-                data: {
-                  rightGroup: 'typeElements',
-                  leftGroup: 'unknown',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedNamedImportsGroupOrder',
+                groupName: 'typeElements',
+                modifiers: ['type'],
               },
             ],
-            options: [
+            groups: ['typeElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          import {
+            type b,
+            a,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            type b,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])('filters on elementNamePattern - %s', async (_, elementNamePattern) => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
               {
-                customGroups: [
+                groupName: 'typesStartingWithHello',
+                modifiers: ['type'],
+                elementNamePattern,
+              },
+            ],
+            groups: ['typesStartingWithHello', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'typesStartingWithHello',
+              leftGroup: 'unknown',
+              right: 'helloType',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type helloType,
+            a,
+            b,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            b,
+            type helloType,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedTypesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedTypesByLineLength',
+                modifiers: ['type'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedTypesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          import {
+            type dddd,
+            type ccc,
+            type eee,
+            type bb,
+            type ff,
+            type a,
+            type g,
+            m,
+            o,
+            p,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type a,
+            type bb,
+            type ccc,
+            type dddd,
+            m,
+            type eee,
+            type ff,
+            type g,
+            o,
+            p,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            fooBar,
+            fooZar,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            fooZar,
+            fooBar,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedTypes',
+                modifiers: ['type'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedTypes', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedTypes',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type b,
+            type a,
+            type d,
+            type e,
+            type c,
+            m,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type b,
+            type a,
+            type d,
+            type e,
+            m,
+            type c,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
                   {
-                    groupName: 'typeElements',
+                    elementNamePattern: 'foo|Foo',
                     modifiers: ['type'],
                   },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
                 ],
-                groups: ['typeElements', 'unknown'],
+                groupName: 'elementsIncludingFoo',
               },
             ],
-            output: dedent`
-              import {
-                type b,
-                a,
-              } from 'module'
-            `,
-            code: dedent`
-              import {
-                a,
-                type b,
-              } from 'module'
-            `,
+            groups: ['elementsIncludingFoo', 'unknown'],
           },
         ],
-        valid: [],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type cFoo,
+            foo,
+            type a,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type a,
+            type cFoo,
+            foo,
+          } from 'module'
+        `,
       })
+    })
 
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'typesStartingWithHello',
-                      modifiers: ['type'],
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['typesStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'typesStartingWithHello',
-                    leftGroup: 'unknown',
-                    right: 'helloType',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedNamedImportsGroupOrder',
-                },
-              ],
-              output: dedent`
-                import {
-                  type helloType,
-                  a,
-                  b,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  a,
-                  b,
-                  type helloType,
-                } from 'module'
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedTypesByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'eee',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedNamedImportsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedTypesByLineLength',
-                      modifiers: ['type'],
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedTypesByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                import {
-                  type dddd,
-                  type ccc,
-                  type eee,
-                  type bb,
-                  type ff,
-                  type a,
-                  type g,
-                  m,
-                  o,
-                  p,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  type a,
-                  type bb,
-                  type ccc,
-                  type dddd,
-                  m,
-                  type eee,
-                  type ff,
-                  type g,
-                  o,
-                  p,
-                } from 'module'
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-              ],
-              output: dedent`
-                import {
-                  fooBar,
-                  fooZar,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  fooZar,
-                  fooBar,
-                } from 'module'
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedTypes',
-                      modifiers: ['type'],
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedTypes', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedTypes',
-                    leftGroup: 'unknown',
-                    right: 'c',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedNamedImportsGroupOrder',
-                },
-              ],
-              output: dedent`
-                import {
-                  type b,
-                  type a,
-                  type d,
-                  type e,
-                  type c,
-                  m,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  type b,
-                  type a,
-                  type d,
-                  type e,
-                  m,
-                  type c,
-                } from 'module'
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
           {
-            options: [
+            customGroups: [
               {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        modifiers: ['type'],
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
               },
             ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: 'cFoo',
-                  left: 'a',
-                },
-                messageId: 'unexpectedNamedImportsGroupOrder',
-              },
-            ],
-            output: dedent`
-              import {
-                type cFoo,
-                foo,
-                type a,
-              } from 'module'
-            `,
-            code: dedent`
-              import {
-                type a,
-                type cFoo,
-                foo,
-              } from 'module'
-            `,
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
           },
         ],
-        valid: [],
+        code: dedent`
+          import {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          } from 'module'
+        `,
       })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                import {
-                  iHaveFooInMyName,
-                  meTooIHaveFoo,
-                  a,
-                  b,
-                } from 'module'
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
     })
 
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenNamedImports',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedNamedImportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenNamedImports',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  import {
-                      a,
-
-
-                     y,
-                    z,
-
-                        b,
-                  } from 'module'
-                `,
-                output: dedent`
-                  import {
-                      a,
-                     b,
-                    y,
-                        z,
-                  } from 'module'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenNamedImports',
-                  },
-                ],
-                output: dedent`
-                  import {
-                    a, 
-
-                  b
-                  } from 'module'
-                `,
-                code: dedent`
-                  import {
-                    a, b
-                  } from 'module'
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenNamedImports',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedNamedImportsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenNamedImports',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  import {
-                      a,
-
-                     y,
-                    z,
-
-                        b,
-                  } from 'module'
-                `,
-                code: dedent`
-                  import {
-                      a,
-
-
-                     z,
-                    y,
-                        b,
-                  } from 'module'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenNamedImports',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenNamedImports',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenNamedImports',
-                  },
-                ],
-                code: dedent`
-                    import {
-                    a,
-                    b,
-
-
-                    c,
-
-                    d,
-
-
-                    e,
-                  } from 'module'
-                `,
-                output: dedent`
-                  import {
-                    a,
-
-                    b,
-
-                    c,
-                    d,
-
-
-                    e,
-                  } from 'module'
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenNamedImports',
-                      },
-                    ],
-                    output: dedent`
-                      import {
-                        a,
-
-
-                        b,
-                      } from 'module'
-                    `,
-                    code: dedent`
-                      import {
-                        a,
-                        b,
-                      } from 'module'
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenNamedImports',
-                      },
-                    ],
-                    output: dedent`
-                      import {
-                        a,
-                        b,
-                      } from 'module'
-                    `,
-                    code: dedent`
-                      import {
-                        a,
-
-                        b,
-                      } from 'module'
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      import {
-                        a,
-
-                        b,
-                      } from 'module'
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      import {
-                        a,
-                        b,
-                      } from 'module'
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  import {
-                    a, // Comment after
-                    b,
-
-                    c,
-                  } from 'module'
-                `,
-                dedent`
-                  import {
-                    a, // Comment after
-
-                    b,
-                    c,
-                  } from 'module'
-                `,
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'b|c',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedNamedImportsGroupOrder',
-                },
-              ],
-              code: dedent`
-                import {
-                  b,
-                  a, // Comment after
-
-                  c,
-                } from 'module'
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    for (let newlinesBetween of ['never', 0] as const) {
-      ruleTester.run(
-        `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      elementNamePattern: 'a',
-                      groupName: 'a',
-                    },
-                  ],
-                  groups: ['a', 'unknown'],
-                  partitionByComment: true,
-                  newlinesBetween,
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedNamedImportsOrder',
-                },
-              ],
-              output: dedent`
-                import {
-                  a,
-
-                  // Partition comment
-
-                  b,
-                  c,
-                } from 'module'
-              `,
-              code: dedent`
-                import {
-                  a,
-
-                  // Partition comment
-
-                  c,
-                  b,
-                } from 'module'
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    }
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts named imports`, rule, {
-      invalid: [
-        {
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                right: 'AAA',
-                left: 'BB',
+                right: 'y',
+                left: 'a',
               },
-              messageId: 'unexpectedNamedImportsOrder',
+              messageId: 'extraSpacingBetweenNamedImports',
             },
-          ],
-          output: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          code: dedent`
-            import { BB, AAA, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: sorts named multiline imports`, rule, {
-      invalid: [
-        {
-          errors: [
             {
               data: {
-                right: 'BBB',
-                left: 'CC',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              AAAA,
-              BBB,
-              CC,
-              D,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              AAAA,
-              CC,
-              BBB,
-              D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-              AAAA,
-              BBB,
-              CC,
-              D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: sorts named imports with aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'X0',
-                left: 'X1',
+                right: 'b',
+                left: 'z',
               },
               messageId: 'unexpectedNamedImportsOrder',
             },
             {
               data: {
-                left: 'X0',
-                right: 'C',
+                right: 'b',
+                left: 'z',
               },
-              messageId: 'unexpectedNamedImportsOrder',
+              messageId: 'extraSpacingBetweenNamedImports',
             },
           ],
-          output: dedent`
-            import {
-              C,
-              BB as X0,
-              A as X1
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              A as X1,
-              BB as X0,
-              C
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-              C,
-              BB as X0,
-              A as X1
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: not sorts default specifiers`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import C, { b as A } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts with import aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-            {
-              data: {
-                right: 'C',
-                left: 'D',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import U, {
-              aaa as A,
-              B,
-              cc as C,
-              d as D,
-            } from 'module'
-          `,
-          code: dedent`
-            import U, {
-              B,
-              aaa as A,
-              d as D,
-              cc as C,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import U, {
-              aaa as A,
-              B,
-              cc as C,
-              d as D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: allows to ignore import aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              x as a,
-              y as b,
-              c,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              x as a,
-              y as b,
-            } from 'module'
-          `,
-          options: [
-            {
-              ...options,
-              ignoreAlias: false,
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-                x as a,
-                y as b,
-                c,
-              } from 'module'
-          `,
-          options: [
-            {
-              ...options,
-              ignoreAlias: false,
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts named imports grouping by their kind`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, type C, BB } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'BB',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { AAA, BB, type BB, type C } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'BB',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-              {
-                data: {
-                  left: 'BB',
-                  right: 'C',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            code: dedent`
-              import { AAA, BB, type BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            code: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: allows to use original import names`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              ignoreAlias: true,
-            },
-          ],
-          output: dedent`
-            import { A as B, B as A } from 'module'
-          `,
-          code: dedent`
-            import { B as A, A as B } from 'module'
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              ignoreAlias: true,
-            },
-          ],
-          code: dedent`
-            import { A as B, B as A } from 'module'
-          `,
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts named imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'AAA',
-                left: 'BB',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          code: dedent`
-            import { BB, AAA, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts named imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'AAA',
-                left: 'BB',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          code: dedent`
-            import { BB, AAA, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import { AAA, BB, C } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: sorts named multiline imports`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'BBB',
-                left: 'CC',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              AAAA,
-              BBB,
-              CC,
-              D,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              AAAA,
-              CC,
-              BBB,
-              D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-              AAAA,
-              BBB,
-              CC,
-              D,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: sorts named imports with aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'X0',
-                left: 'X1',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              BB as X0,
-              A as X1,
-              C
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              A as X1,
-              BB as X0,
-              C
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-              BB as X0,
-              A as X1,
-              C
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: not sorts default specifiers`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import C, { b as A } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts with import aliases`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-            {
-              data: {
-                right: 'C',
-                left: 'D',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import U, {
-              aaa as A,
-              cc as C,
-              d as D,
-              B,
-            } from 'module'
-          `,
-          code: dedent`
-            import U, {
-              B,
-              aaa as A,
-              d as D,
-              cc as C,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import U, {
-              aaa as A,
-              cc as C,
-              d as D,
-              B,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}: sorts named imports grouping by their kind`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'BB',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, type C, BB } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'BB',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { AAA, BB, type BB, type C } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  left: 'AAA',
-                  right: 'BB',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-              {
-                data: {
-                  left: 'BB',
-                  right: 'C',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            code: dedent`
-              import { AAA, type BB, BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'mixed' }],
-          },
-          {
-            code: dedent`
-              import { AAA, BB, type BB, type C } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'values-first' }],
-          },
-          {
-            code: dedent`
-              import { type BB, type C, AAA, BB } from 'module'
-            `,
-            options: [{ ...options, groupKind: 'types-first' }],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              import {
-                bb,
-                c,
-                a,
-              } from 'module'
-            `,
-            code: dedent`
-              import {
-                a,
-                bb,
-                c,
-              } from 'module'
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              import {
-                bb,
-                a,
-                c,
-              } from 'module'
-            `,
-            code: dedent`
-              import {
-                c,
-                bb,
-                a,
-              } from 'module'
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            import {
-              b,
-              c,
-              a,
-            } from 'module'
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
           options: [
             {
               ...options,
@@ -2794,444 +1236,4075 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+                a,
+
+
+               y,
+              z,
+
+                  b,
+            } from 'module'
+          `,
+          output: dedent`
+            import {
+                a,
+               b,
+              y,
+                  z,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+        ],
+        output: dedent`
+          import {
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenNamedImports',
             },
           ],
           output: dedent`
             import {
-                b,
+              a,
 
-                a,
+
+              b,
             } from 'module'
           `,
           code: dedent`
             import {
-                b,
-                a,
+              a,
+              b,
             } from 'module'
           `,
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedImports',
+            },
+          ],
+          output: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              a,
+
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+              a,
+
+              b,
+            } from 'module'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements with newlines', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a, // Comment after
+
+            b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b,
+            a, // Comment after
+
+            c,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedNamedImportsOrder',
+            },
+          ],
+          output: dedent`
+            import {
+              a,
+
+              // Partition comment
+
+              b,
+              c,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              a,
+
+              // Partition comment
+
+              c,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts named imports', async () => {
+      await valid({
+        code: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAA',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        code: dedent`
+          import { BB, AAA, C } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts named multiline imports', async () => {
+      await valid({
+        code: dedent`
+          import {
+            AAAA,
+            BBB,
+            CC,
+            D,
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'CC',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            AAAA,
+            BBB,
+            CC,
+            D,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            AAAA,
+            CC,
+            BBB,
+            D,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts named imports with aliases', async () => {
+      await valid({
+        code: dedent`
+          import {
+            C,
+            BB as X0,
+            A as X1
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'X0',
+              left: 'X1',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              left: 'X0',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            C,
+            BB as X0,
+            A as X1
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            A as X1,
+            BB as X0,
+            C
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort default specifiers', async () => {
+      await valid({
+        code: dedent`
+          import C, { b as A } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts imports with aliases', async () => {
+      await valid({
+        code: dedent`
+          import U, {
+            aaa as A,
+            B,
+            cc as C,
+            d as D,
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'C',
+              left: 'D',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import U, {
+            aaa as A,
+            B,
+            cc as C,
+            d as D,
+          } from 'module'
+        `,
+        code: dedent`
+          import U, {
+            B,
+            aaa as A,
+            d as D,
+            cc as C,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to ignore import aliases', async () => {
+      await valid({
+        code: dedent`
+          import {
+              x as a,
+              y as b,
+              c,
+            } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            ignoreAlias: false,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            x as a,
+            y as b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            x as a,
+            y as b,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            ignoreAlias: false,
+          },
+        ],
+      })
+    })
+
+    it('sorts named imports grouping by their kind', async () => {
+      await valid({
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await valid({
+        code: dedent`
+          import { AAA, BB, type BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await valid({
+        code: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, type C, BB } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { AAA, BB, type BB, type C } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAA',
+              right: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              left: 'BB',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+    })
+
+    it('allows to use original import names', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        code: dedent`
+          import { A as B, B as A } from 'module'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          import { A as B, B as A } from 'module'
+        `,
+        code: dedent`
+          import { B as A, A as B } from 'module'
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            A,
+            D,
+
+            C,
+
+            B,
+            E,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            D,
+            A,
+
+            C,
+
+            E,
+            B,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'CC',
+              right: 'D',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            // Part: A
+            type D,
+            // Not partition comment
+            BBB,
+            CC,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            // Not partition comment
+            FFF,
+            GG,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            // Part: A
+            CC,
+            type D,
+            // Not partition comment
+            BBB,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            GG,
+            // Not partition comment
+            FFF,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as partitions', async () => {
+      await valid({
+        code: dedent`
+          import {
+            // Comment
+            BB,
+            // Other comment
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          import {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            BB,
+            C,
+            /* Other */
+            E,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            C,
+            BB,
+            /* Other */
+            E,
+          } from 'module'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are used for partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          import {
+            /* Comment */
+            A,
+            B,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            B,
+            /* Comment */
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            B,
+            // Comment
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            C,
+            // B
+            B,
+            // A
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          import {
+            B,
+            // I am a partition comment because I don't have f o o
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are used for partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          import {
+            // Comment
+            A,
+            B,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            B,
+            // Comment
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            B,
+            /* Comment */
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          import {
+            C,
+            /* B */
+            B,
+            /* A */
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          import {
+            B,
+            /* I am a partition comment because I don't have f o o */
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          import { _a, b, _c } from 'module'
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          import { ab, a_c } from 'module'
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          import { 你好, 世界, a, A, b, B } from 'module'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('works with arbitrary names', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        code: dedent`
+          import { "A" as a, "B" as b } from 'module';
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          import { "A" as a, "B" as b } from 'module';
+        `,
+        code: dedent`
+          import { "B" as b, "A" as a } from 'module';
+        `,
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a, b
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, a
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a, b,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, a,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'typeElements',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'typeElements',
+                modifiers: ['type'],
+              },
+            ],
+            groups: ['typeElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          import {
+            type b,
+            a,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            type b,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])('filters on elementNamePattern - %s', async (_, elementNamePattern) => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'typesStartingWithHello',
+                modifiers: ['type'],
+                elementNamePattern,
+              },
+            ],
+            groups: ['typesStartingWithHello', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'typesStartingWithHello',
+              leftGroup: 'unknown',
+              right: 'helloType',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type helloType,
+            a,
+            b,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            b,
+            type helloType,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedTypesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedTypesByLineLength',
+                modifiers: ['type'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedTypesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          import {
+            type dddd,
+            type ccc,
+            type eee,
+            type bb,
+            type ff,
+            type a,
+            type g,
+            m,
+            o,
+            p,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type a,
+            type bb,
+            type ccc,
+            type dddd,
+            m,
+            type eee,
+            type ff,
+            type g,
+            o,
+            p,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            fooBar,
+            fooZar,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            fooZar,
+            fooBar,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedTypes',
+                modifiers: ['type'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedTypes', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedTypes',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type b,
+            type a,
+            type d,
+            type e,
+            type c,
+            m,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type b,
+            type a,
+            type d,
+            type e,
+            m,
+            type c,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['type'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type cFoo,
+            foo,
+            type a,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type a,
+            type cFoo,
+            foo,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          import {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedImports',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedNamedImportsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenNamedImports',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+                a,
+
+
+               y,
+              z,
+
+                  b,
+            } from 'module'
+          `,
+          output: dedent`
+            import {
+                a,
+               b,
+              y,
+                  z,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+        ],
+        output: dedent`
+          import {
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenNamedImports',
+            },
+          ],
+          output: dedent`
+            import {
+              a,
+
+
+              b,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedImports',
+            },
+          ],
+          output: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              a,
+
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+              a,
+
+              b,
+            } from 'module'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements with newlines', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a, // Comment after
+
+            b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b,
+            a, // Comment after
+
+            c,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedNamedImportsOrder',
+            },
+          ],
+          output: dedent`
+            import {
+              a,
+
+              // Partition comment
+
+              b,
+              c,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              a,
+
+              // Partition comment
+
+              c,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts named imports', async () => {
+      await valid({
+        code: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAA',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        code: dedent`
+          import { BB, AAA, C } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts named multiline imports', async () => {
+      await valid({
+        code: dedent`
+          import {
+            AAAA,
+            BBB,
+            CC,
+            D,
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'CC',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            AAAA,
+            BBB,
+            CC,
+            D,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            AAAA,
+            CC,
+            BBB,
+            D,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts named imports with aliases', async () => {
+      await valid({
+        code: dedent`
+          import {
+            BB as X0,
+            A as X1,
+            C
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'X0',
+              left: 'X1',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            BB as X0,
+            A as X1,
+            C
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            A as X1,
+            BB as X0,
+            C
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort default specifiers', async () => {
+      await valid({
+        code: dedent`
+          import C, { b as A } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts imports with aliases', async () => {
+      await valid({
+        code: dedent`
+          import U, {
+            aaa as A,
+            cc as C,
+            d as D,
+            B,
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'C',
+              left: 'D',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import U, {
+            aaa as A,
+            cc as C,
+            d as D,
+            B,
+          } from 'module'
+        `,
+        code: dedent`
+          import U, {
+            B,
+            aaa as A,
+            d as D,
+            cc as C,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to ignore import aliases', async () => {
+      await valid({
+        code: dedent`
+          import {
+              x as a,
+              y as b,
+              c,
+            } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            ignoreAlias: false,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            x as a,
+            y as b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            x as a,
+            y as b,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            ignoreAlias: false,
+          },
+        ],
+      })
+    })
+
+    it('sorts named imports grouping by their kind', async () => {
+      await valid({
+        code: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await valid({
+        code: dedent`
+          import { AAA, BB, type BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await valid({
+        code: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'AAA',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, type C, BB } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'mixed' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { AAA, BB, type BB, type C } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'values-first' }],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAA',
+              right: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              left: 'BB',
+              right: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { type BB, type C, AAA, BB } from 'module'
+        `,
+        code: dedent`
+          import { AAA, type BB, BB, type C } from 'module'
+        `,
+        options: [{ ...options, groupKind: 'types-first' }],
+      })
+    })
+
+    it('allows to use original import names', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        code: dedent`
+          import { AA as B, B as A } from 'module'
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          import { AA as B, B as A } from 'module'
+        `,
+        code: dedent`
+          import { B as A, AA as B } from 'module'
+        `,
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAAAA',
+              left: 'DD',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'BBBB',
+              left: 'E',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            AAAAA,
+            DD,
+
+            CCC,
+
+            BBBB,
+            E,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            DD,
+            AAAAA,
+
+            CCC,
+
+            E,
+            BBBB,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'CC',
+              right: 'D',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            // Part: A
+            type D,
+            // Not partition comment
+            BBB,
+            CC,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            // Not partition comment
+            FFF,
+            GG,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            // Part: A
+            CC,
+            type D,
+            // Not partition comment
+            BBB,
+            // Part: B
+            AAAA,
+            E,
+            // Part: C
+            GG,
+            // Not partition comment
+            FFF,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+            groupKind: 'types-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as partitions', async () => {
+      await valid({
+        code: dedent`
+          import {
+            // Comment
+            BB,
+            // Other comment
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          import {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            BB,
+            C,
+            /* Other */
+            E,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            /* Partition Comment */
+            // Part: A
+            D,
+            // Part: B
+            AAA,
+            C,
+            BB,
+            /* Other */
+            E,
+          } from 'module'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are used for partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          import {
+            /* Comment */
+            AA,
+            B,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            B,
+            /* Comment */
+            AA,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            B,
+            // Comment
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            C,
+            // B
+            B,
+            // A
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        code: dedent`
+          import {
+            B,
+            // I am a partition comment because I don't have f o o
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are used for partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          import {
+            // Comment
+            AA,
+            B,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            B,
+            // Comment
+            AA,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          import {
+            B,
+            /* Comment */
+            A,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        code: dedent`
+          import {
+            C,
+            /* B */
+            B,
+            /* A */
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          import {
+            B,
+            /* I am a partition comment because I don't have f o o */
+            A,
+          } from 'module'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          import { _aa, bb, _c } from 'module'
+        `,
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          import { abc, a_c } from 'module'
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          import { 你好, 世界, a, A, b, B } from 'module'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('works with arbitrary names', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        code: dedent`
+          import { "AA" as a, "B" as b } from 'module';
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            ignoreAlias: true,
+          },
+        ],
+        output: dedent`
+          import { "AA" as a, "B" as b } from 'module';
+        `,
+        code: dedent`
+          import { "B" as b, "AA" as a } from 'module';
+        `,
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            aa, b
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, aa
+          } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            aa, b,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, aa,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('filters on modifier', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'typeElements',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'typeElements',
+                modifiers: ['type'],
+              },
+            ],
+            groups: ['typeElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          import {
+            type b,
+            a,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            type b,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])('filters on elementNamePattern - %s', async (_, elementNamePattern) => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'typesStartingWithHello',
+                modifiers: ['type'],
+                elementNamePattern,
+              },
+            ],
+            groups: ['typesStartingWithHello', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'typesStartingWithHello',
+              leftGroup: 'unknown',
+              right: 'helloType',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type helloType,
+            a,
+            b,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            b,
+            type helloType,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('overrides sort type and order for custom groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedTypesByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedTypesByLineLength',
+                modifiers: ['type'],
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedTypesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          import {
+            type dddd,
+            type ccc,
+            type eee,
+            type bb,
+            type ff,
+            type a,
+            type g,
+            m,
+            o,
+            p,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type a,
+            type bb,
+            type ccc,
+            type dddd,
+            m,
+            type eee,
+            type ff,
+            type g,
+            o,
+            p,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            fooBar,
+            fooZar,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            fooZar,
+            fooBar,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedTypes',
+                modifiers: ['type'],
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedTypes', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedTypes',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type b,
+            type a,
+            type d,
+            type e,
+            type c,
+            m,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type b,
+            type a,
+            type d,
+            type e,
+            m,
+            type c,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    modifiers: ['type'],
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            type cFoo,
+            foo,
+            type a,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            type a,
+            type cFoo,
+            foo,
+          } from 'module'
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          import {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenNamedImports',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedNamedImportsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenNamedImports',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+                aaaa,
+
+
+               yy,
+              z,
+
+                  bbb,
+            } from 'module'
+          `,
+          output: dedent`
+            import {
+                aaaa,
+               bbb,
+              yy,
+                  z,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+        ],
+        output: dedent`
+          import {
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenNamedImports',
+            },
+          ],
+          output: dedent`
+            import {
+              a,
+
+
+              b,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenNamedImports',
+            },
+          ],
+          output: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              a,
+
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+              a,
+
+              b,
+            } from 'module'
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            import {
+              a,
+              b,
+            } from 'module'
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements with newlines', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsGroupOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a, // Comment after
+
+            b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            b,
+            a, // Comment after
+
+            c,
+          } from 'module'
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedNamedImportsOrder',
+            },
+          ],
+          output: dedent`
+            import {
+              aaa,
+
+              // Partition comment
+
+              bb,
+              c,
+            } from 'module'
+          `,
+          code: dedent`
+            import {
+              aaa,
+
+              // Partition comment
+
+              c,
+              bb,
+            } from 'module'
+          `,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts named imports', async () => {
+      await valid({
+        code: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AAA',
+              left: 'BB',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { AAA, BB, C } from 'module'
+        `,
+        code: dedent`
+          import { BB, AAA, C } from 'module'
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          import {
+            b,
+            c,
+            a,
+          } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces newlines between groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenNamedImports',
+          },
+        ],
+        output: dedent`
+          import {
+              b,
+
+              a,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+              b,
+              a,
+          } from 'module'
+        `,
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'C',
-                },
-                messageId: 'unexpectedNamedImportsOrder',
-              },
-            ],
-            output: dedent`
-              import { A, B, C } from 'module'
-            `,
-            code: dedent`
-              import { B, C, A } from 'module'
-            `,
-          },
-        ],
-        valid: [
-          "import { A, B, C } from 'module'",
-          {
-            code: "import { log, log10, log1p, log2 } from 'module'",
-            options: [{}],
-          },
-        ],
-      },
-    )
+    it('sets alphabetical asc sorting as default', async () => {
+      await valid("import { A, B, C } from 'module'")
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
+      await valid({
+        code: "import { log, log10, log1p, log2 } from 'module'",
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            import {
-              b,
-              c,
-              // eslint-disable-next-line
-              a
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              // eslint-disable-next-line
-              a
-            } from 'module'
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              b,
-              c,
-              // eslint-disable-next-line
-              a,
-              d
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              d,
-              c,
-              // eslint-disable-next-line
-              a,
-              b
-            } from 'module'
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              b,
-              c,
-              a // eslint-disable-line
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              a // eslint-disable-line
-            } from 'module'
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              b,
-              c,
-              /* eslint-disable-next-line */
-              a
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              /* eslint-disable-next-line */
-              a
-            } from 'module'
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              b,
-              c,
-              a /* eslint-disable-line */
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              a /* eslint-disable-line */
-            } from 'module'
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import {
-              a,
-              d,
-              /* eslint-disable */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              e,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              d,
-              e,
-              /* eslint-disable */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              a,
-            } from 'module'
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import {
-              b,
-              c,
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-            } from 'module'
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              b,
-              c,
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            } from 'module'
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import {
-              b,
-              c,
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-            } from 'module'
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          output: dedent`
-            import {
-              b,
-              c,
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              c,
-              b,
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            } from 'module'
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            import {
-              a,
-              d,
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              e,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              d,
-              e,
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              a,
-            } from 'module'
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            import {
-              b,
-              c,
-              // eslint-disable-next-line
-              a
-            } from 'module'
-          `,
-        },
-      ],
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import { A, B, C } from 'module'
+        `,
+        code: dedent`
+          import { B, C, A } from 'module'
+        `,
+      })
     })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+    it('handles eslint-disable comments correctly', async () => {
+      await valid({
+        code: dedent`
+          import {
+            b,
+            c,
+            // eslint-disable-next-line
+            a
+          } from 'module'
+        `,
+      })
+
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              import { a, b, c } from './module';
-            `,
-            options: [{}],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          import {
+            b,
+            c,
+            // eslint-disable-next-line
+            a
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            // eslint-disable-next-line
+            a
+          } from 'module'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            b,
+            c,
+            // eslint-disable-next-line
+            a,
+            d
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            d,
+            c,
+            // eslint-disable-next-line
+            a,
+            b
+          } from 'module'
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            b,
+            c,
+            a // eslint-disable-line
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            a // eslint-disable-line
+          } from 'module'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            b,
+            c,
+            /* eslint-disable-next-line */
+            a
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            /* eslint-disable-next-line */
+            a
+          } from 'module'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            b,
+            c,
+            a /* eslint-disable-line */
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            a /* eslint-disable-line */
+          } from 'module'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import {
+            a,
+            d,
+            /* eslint-disable */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            e,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            d,
+            e,
+            /* eslint-disable */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            a,
+          } from 'module'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import {
+            b,
+            c,
+            // eslint-disable-next-line rule-to-test/sort-named-imports
+            a
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            // eslint-disable-next-line rule-to-test/sort-named-imports
+            a
+          } from 'module'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            b,
+            c,
+            a // eslint-disable-line rule-to-test/sort-named-imports
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            a // eslint-disable-line rule-to-test/sort-named-imports
+          } from 'module'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import {
+            b,
+            c,
+            /* eslint-disable-next-line rule-to-test/sort-named-imports */
+            a
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            /* eslint-disable-next-line rule-to-test/sort-named-imports */
+            a
+          } from 'module'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            b,
+            c,
+            a /* eslint-disable-line rule-to-test/sort-named-imports */
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            c,
+            b,
+            a /* eslint-disable-line rule-to-test/sort-named-imports */
+          } from 'module'
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          import {
+            a,
+            d,
+            /* eslint-disable rule-to-test/sort-named-imports */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            e,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            d,
+            e,
+            /* eslint-disable rule-to-test/sort-named-imports */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            a,
+          } from 'module'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
   })
 })

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -1,4665 +1,2287 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, it } from 'vitest'
 import dedent from 'dedent'
 
 import rule from '../../rules/sort-object-types'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-object-types'
+describe('sort-object-types', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-object-types',
+    parser: typescriptParser,
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts type members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              c: 'c'
-              b: 'bb'
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members in function args`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              let Func = (arguments: {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = (arguments: {
-                b: 'bb'
-                a: 'aaa'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Func = (arguments: {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members with computed keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key: string]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  left: 'value',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                [key: string]: string
-                a?: 'aaa'
-                b: 'bb'
-                c: 'c'
-                [value]: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a?: 'aaa'
-                [key: string]: string
-                b: 'bb'
-                [value]: string
-                c: 'c'
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                [key: string]: string
-                a?: 'aaa'
-                b: 'bb'
-                c: 'c'
-                [value]: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members with any key types`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              type Type = {
-                [...values]
-                [[data]]: string
-                [name in v]?
-                [8]: Value
-                arrowFunc?: () => void
-                func(): void
-              }
-            `,
-            code: dedent`
-              type Type = {
-                [...values]
-                [[data]]: string
-                [name in v]?
-                [8]: Value
-                func(): void
-                arrowFunc?: () => void
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'arrowFunc',
-                  left: 'func',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                [...values]
-                [[data]]: string
-                [name in v]?
-                [8]: Value
-                arrowFunc?: () => void
-                func(): void
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts inline type members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
-            },
-          ],
-          output: dedent`
-            func<{ a: 'aa'; b: 'b'; }>(/* ... */)
-          `,
-          code: dedent`
-            func<{ b: 'b'; a: 'aa' }>(/* ... */)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            func<{ a: 'aa'; b: 'b' }>(/* ... */)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts complex predefined groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'required-property',
-                  rightGroup: 'index-signature',
-                  right: '[key: string]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-              {
-                data: {
-                  rightGroup: 'optional-multiline',
-                  leftGroup: 'index-signature',
-                  left: '[key: string]',
-                  right: 'b',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'optional-multiline',
-                  rightGroup: 'required-method',
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: [
-                  'unknown',
-                  'required-method',
-                  'optional-multiline',
-                  'index-signature',
-                  'required-property',
-                ],
-              },
-            ],
-            output: dedent`
-              type Type = {
-                c(): void
-                b?: {
-                  property: string;
-                }
-                [key: string]: string;
-                a: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a: string
-                [key: string]: string;
-                b?: {
-                  property: string;
-                }
-                c(): void
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): prioritize selectors over modifiers quantity`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'required-property',
-                  rightGroup: 'method',
-                  left: 'property',
-                  right: 'method',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['method', 'required-property'],
-              },
-            ],
-            output: dedent`
-              type Type = {
-                method(): void
-                property: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                property: string
-                method(): void
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): selectors priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize index-signature over multiline`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'index-signature',
-                    left: 'multilineProperty',
-                    right: '[key: string]',
-                    leftGroup: 'multiline',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  [key: string]: string;
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  multilineProperty: {
-                    a: string
-                  }
-                  [key: string]: string;
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['index-signature', 'multiline'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize method over multiline`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: 'multilineProperty',
-                    leftGroup: 'multiline',
-                    rightGroup: 'method',
-                    right: 'method',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  method(): string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  multilineProperty: {
-                    a: string
-                  }
-                  method(): string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['method', 'multiline'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize multiline over property`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'multilineProperty',
-                    rightGroup: 'multiline',
-                    leftGroup: 'property',
-                    left: 'property',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  multilineProperty: {
-                    a: string
-                  }
-                  property: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  property: string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['multiline', 'property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize property over member`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'property',
-                    leftGroup: 'member',
-                    right: 'property',
-                    left: 'method',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  property: string
-                  method(): string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  method(): string
-                  property: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property', 'member'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): modifiers priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize multiline over optional`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'multiline-property',
-                    leftGroup: 'optional-property',
-                    right: 'multilineProperty',
-                    left: 'optionalProperty',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  multilineProperty: {
-                    a: string
-                  }
-                  optionalProperty?: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  optionalProperty?: string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['multiline-property', 'optional-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize multiline over required`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'multiline-property',
-                    leftGroup: 'required-property',
-                    right: 'multilineProperty',
-                    left: 'requiredProperty',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  multilineProperty: {
-                    a: string
-                  }
-                  requiredProperty: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  requiredProperty: string
-                  multilineProperty: {
-                    a: string
-                  }
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['multiline-property', 'required-property'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'multiline',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-              {
-                data: {
-                  leftGroup: 'multiline',
-                  rightGroup: 'g',
-                  right: 'g',
-                  left: 'd',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                g: 'g'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                g: 'g'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  g: 'g',
-                },
-                groups: ['g', 'multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                g: 'g'
-                d: {
-                  e: 'e'
-                  f: 'f'
-                }
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  g: 'g',
-                },
-                groups: ['g', 'multiline', 'unknown'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector and modifiers`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'unusedCustomGroup',
-                    modifiers: ['optional'],
-                    selector: 'method',
-                  },
-                  {
-                    groupName: 'optionalPropertyGroup',
-                    modifiers: ['optional'],
-                    selector: 'property',
-                  },
-                  {
-                    groupName: 'propertyGroup',
-                    selector: 'property',
-                  },
-                ],
-                groups: ['propertyGroup', 'optionalPropertyGroup'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  leftGroup: 'optionalPropertyGroup',
-                  rightGroup: 'propertyGroup',
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                c: string
-                a?: string
-                b?: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a?: string
-                b?: string
-                c: string
-              }
-            `,
-          },
-        ],
-        valid: [],
+    it('sorts type members', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [options],
       })
 
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            c: 'c'
+            b: 'bb'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members in function args', async () => {
+      await valid({
+        code: dedent`
+          let Func = (arguments: {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          let Func = (arguments: {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = (arguments: {
+            b: 'bb'
+            a: 'aaa'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members with computed keys', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            [key: string]: string
+            a?: 'aaa'
+            b: 'bb'
+            c: 'c'
+            [value]: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              left: 'value',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string
+            a?: 'aaa'
+            b: 'bb'
+            c: 'c'
+            [value]: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a?: 'aaa'
+            [key: string]: string
+            b: 'bb'
+            [value]: string
+            c: 'c'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members with any key types', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            [...values]
+            [[data]]: string
+            [name in v]?
+            [8]: Value
+            arrowFunc?: () => void
+            func(): void
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type = {
+            [...values]
+            [[data]]: string
+            [name in v]?
+            [8]: Value
+            arrowFunc?: () => void
+            func(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            [...values]
+            [[data]]: string
+            [name in v]?
+            [8]: Value
+            func(): void
+            arrowFunc?: () => void
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'arrowFunc',
+              left: 'func',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('sorts inline type members', async () => {
+      await valid({
+        code: dedent`
+          func<{ a: 'aa'; b: 'b' }>(/* ... */)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          func<{ a: 'aa'; b: 'b'; }>(/* ... */)
+        `,
+        code: dedent`
+          func<{ b: 'b'; a: 'aa' }>(/* ... */)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts complex predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'index-signature',
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'optional-multiline',
+              leftGroup: 'index-signature',
+              left: '[key: string]',
+              right: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'optional-multiline',
+              rightGroup: 'required-method',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'required-method',
+              'optional-multiline',
+              'index-signature',
+              'required-property',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            c(): void
+            b?: {
+              property: string;
+            }
+            [key: string]: string;
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            [key: string]: string;
+            b?: {
+              property: string;
+            }
+            c(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritizes selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'method',
+              left: 'property',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['method', 'required-property'],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            method(): void
+            property: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            property: string
+            method(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritizes index-signature over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'index-signature',
+              left: 'multilineProperty',
+              right: '[key: string]',
+              leftGroup: 'multiline',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string;
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            [key: string]: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['index-signature', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes method over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            method(): string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            method(): string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'multilineProperty',
+              rightGroup: 'multiline',
+              leftGroup: 'property',
+              left: 'property',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            property: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            property: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes property over member', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            property: string
+            method(): string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            method(): string
+            property: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over optional', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'optional-property',
+              right: 'multilineProperty',
+              left: 'optionalProperty',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            optionalProperty?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            optionalProperty?: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'optional-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over required', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'required-property',
+              right: 'multilineProperty',
+              left: 'requiredProperty',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            requiredProperty: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            requiredProperty: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'multiline',
+              rightGroup: 'g',
+              right: 'g',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            g: 'g'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('filters on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['optional'],
+                selector: 'method',
+              },
+              {
+                groupName: 'optionalPropertyGroup',
+                modifiers: ['optional'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'optionalPropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'optionalPropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            c: string
+            a?: string
+            b?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a?: string
+            b?: string
+            c: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['regex pattern', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex pattern',
         ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'propertiesStartingWithHello',
-                      selector: 'property',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['propertiesStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'propertiesStartingWithHello',
-                    right: 'helloProperty',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  helloProperty: string
-                  a: string
-                  b: string
-                  method(): void
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  a: string
-                  b: string
-                  method(): void
-                  helloProperty: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      for (let dateElementValuePattern of [
-        'Date',
-        ['noMatch', 'Date'],
-        { pattern: 'DATE', flags: 'i' },
-        ['noMatch', { pattern: 'DATE', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementValuePattern: dateElementValuePattern,
-                      groupName: 'date',
-                    },
-                    {
-                      elementValuePattern: 'number',
-                      groupName: 'number',
-                    },
-                  ],
-                  groups: ['number', 'date', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'number',
-                    leftGroup: 'date',
-                    right: 'z',
-                    left: 'y',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  a: number
-                  z: number
-                  b: Date
-                  y: Date
-                  c(): string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  a: number
-                  b: Date
-                  y: Date
-                  z: number
-                  c(): string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedPropertiesByLineLength',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                    right: 'eee',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedPropertiesByLineLength',
-                      selector: 'property',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedPropertiesByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  dddd: string
-                  ccc: string
-                  eee: string
-                  bb: string
-                  ff: string
-                  a: string
-                  g: string
-                  anotherMethod(): void
-                  method(): void
-                  yetAnotherMethod(): void
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  a: string
-                  bb: string
-                  ccc: string
-                  dddd: string
-                  method(): void
-                  eee: string
-                  ff: string
-                  g: string
-                  anotherMethod(): void
-                  yetAnotherMethod(): void
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  fooBar: string
-                  fooZar: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  fooZar: string
-                  fooBar: string
-                }
-              `,
-            },
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        sortBy: 'value',
-                      },
-                      elementValuePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  b: fooBar
-                  a: fooZar
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  a: fooZar
-                  b: fooBar
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'sortBy'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'fooElementsSortedByValue',
-                    leftGroup: 'unknown',
-                    right: 'fooC',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-                {
-                  data: {
-                    right: 'fooA',
-                    left: 'fooB',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'fooElementsSortedByValue',
-                    leftGroup: 'unknown',
-                    right: 'fooMethod',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'fooElementsSortedByValue',
-                      elementNamePattern: '^foo',
-                      sortBy: 'value',
-                    },
-                  ],
-                  groups: ['fooElementsSortedByValue', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  fooA: Date
-                  fooC: number
-                  fooB: string
-                  fooMethod(): void
-                  a: string
-                  z: boolean
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  z: boolean
-                  fooC: number
-                  fooB: string
-                  fooA: Date
-                  a: string
-                  fooMethod(): void
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedProperties',
-                      selector: 'property',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedProperties', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedProperties',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  b
-                  a
-                  d
-                  e
-                  c
-                  method(): void
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  b
-                  a
-                  d
-                  e
-                  method(): void
-                  c
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        modifiers: ['required'],
-                        selector: 'property',
-                      },
-                      {
-                        modifiers: ['optional'],
-                        selector: 'method',
-                      },
-                    ],
-                    groupName: 'requiredPropertiesAndOptionalMethods',
-                  },
-                ],
-                groups: [
-                  ['requiredPropertiesAndOptionalMethods', 'index-signature'],
-                  'unknown',
-                ],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'requiredPropertiesAndOptionalMethods',
-                  leftGroup: 'unknown',
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-              {
-                data: {
-                  right: '[key: string]',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                [key: string]: string
-                a: string
-                d?: () => void
-                e: string
-                b(): void
-                c?: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a: string
-                b(): void
-                c?: string
-                d?: () => void
-                e: string
-                [key: string]: string
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                type Type = {
-                  iHaveFooInMyName: string
-                  meTooIHaveFoo: string
-                  a: string
-                  b: string
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe('newlinesInside', () => {
-        for (let newlinesInside of ['always', 1] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          selector: 'property',
-                          groupName: 'group1',
-                          newlinesInside,
-                        },
-                      ],
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'b',
-                        left: 'a',
-                      },
-                      messageId: 'missedSpacingBetweenObjectTypeMembers',
-                    },
-                  ],
-                  output: dedent`
-                    type type = {
-                      a
-
-                      b
-                    }
-                  `,
-                  code: dedent`
-                    type type = {
-                      a
-                      b
-                    }
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-
-        for (let newlinesInside of ['never', 0] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          selector: 'property',
-                          groupName: 'group1',
-                          newlinesInside,
-                        },
-                      ],
-                      type: 'alphabetical',
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'b',
-                        left: 'a',
-                      },
-                      messageId: 'extraSpacingBetweenObjectTypeMembers',
-                    },
-                  ],
-                  output: dedent`
-                    type type = {
-                      a
-                      b
-                    }
-                  `,
-                  code: dedent`
-                    type type = {
-                      a
-
-                      b
-                    }
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-      })
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  elementsWithoutFoo: '^(?!.*Foo).*$',
-                },
-                groups: ['unknown', 'elementsWithoutFoo'],
-              },
-            ],
-            code: dedent`
-              type T = {
-                iHaveFooInMyName: string
-                meTooIHaveFoo: string
-                a: string
-                b: string
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use in class methods`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              class Class {
-                async method (data: {
-                  a: 'aaa'
-                  b: 'bb'
-                  c: 'c'
-                }) {}
-              }
-            `,
-            code: dedent`
-              class Class {
-                async method (data: {
-                  b: 'bb'
-                  a: 'aaa'
-                  c: 'c'
-                }) {}
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                d: 'dd'
-                e: 'e'
-
-                c: 'ccc'
-
-                a: 'aaaaa'
-                b: 'bbbb'
-              }
-            `,
-            code: dedent`
-              type Type = {
-                e: 'e'
-                d: 'dd'
-
-                c: 'ccc'
-
-                b: 'bbbb'
-                a: 'aaaaa'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                d: 'dd'
-                e: 'e'
-
-                c: 'ccc'
-
-                a: 'aaaaa'
-                b: 'bbbb'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    describe(`${ruleName}(${type}): partition comments`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                type Type = {
-                  // Part: A
-                  // Not partition comment
-                  bbb: string
-                  cc: string
-                  d: string
-                  // Part: B
-                  aaaa: string
-                  e: string
-                  // Part: C
-                  // Not partition comment
-                  fff: string
-                  'gg': string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  // Part: A
-                  cc: string
-                  d: string
-                  // Not partition comment
-                  bbb: string
-                  // Part: B
-                  aaaa: string
-                  e: string
-                  // Part: C
-                  'gg': string
-                  // Not partition comment
-                  fff: string
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'bbb',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'fff',
-                    left: 'gg',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                type Type = {
-                  // Comment
-                  bb: string
-                  // Other comment
-                  a: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                type Type = {
-                  /* Partition Comment */
-                  // Part: A
-                  d: string
-                  // Part: B
-                  aaa: string
-                  bb: string
-                  c: string
-                  /* Other */
-                  e: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  /* Partition Comment */
-                  // Part: A
-                  d: string
-                  // Part: B
-                  aaa: string
-                  c: string
-                  bb: string
-                  /* Other */
-                  e: string
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                type Type = {
-                  e: string
-                  f: string
-                  // I am a partition comment because I don't have f o o
-                  a: string
-                  b: string
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['^(?!.*foo).*$'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  /* Comment */
-                  a: string
-                  b: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  b: string
-                  /* Comment */
-                  a: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type = {
-                    b: string
-                    // Comment
-                    a: string
-                  }
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  type Type = {
-                    c: string
-                    // b
-                    b: string
-                    // a
-                    a: string
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['a', 'b'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  type Type = {
-                    b: string
-                    // I am a partition comment because I don't have f o o
-                    a: string
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  // Comment
-                  a: string
-                  b: string
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  b: string
-                  // Comment
-                  a: string
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type = {
-                    b: string
-                    /* Comment */
-                    a: string
-                  }
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  type Type = {
-                    c: string
-                    /* b */
-                    b: string
-                    /* a */
-                    a: string
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['a', 'b'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  type Type = {
-                    b: string
-                    /* I am a partition comment because I don't have f o o */
-                    a: string
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to sort required values first`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'bbbb',
-                  right: 'ccc',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  left: 'dd',
-                  right: 'e',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                ccc: string
-                e: string
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                ccc: string
-                dd?: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'required-first',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                ccc: string
-                e: string
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'required-first',
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to sort optional values first`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'ccc',
-                  right: 'dd',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-                ccc: string
-                e: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                ccc: string
-                dd?: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'optional-first',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-                ccc: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'optional-first',
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                _a: string
-                b: string
-                _c: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              type Type = {
-                ab: string
-                a_c: string
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              你好: string
-              世界: string
-              a: string
-              A: string
-              b: string
-              B: string
-            }
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
       ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              b(): void
-              c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
-              a: string
-              d: string
-            }
-          `,
+    ])(
+      'filters on elementNamePattern with %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
           options: [
             {
-              ...options,
-              groups: ['method', 'unknown'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenObjectTypeMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedObjectTypesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenObjectTypeMembers',
-                  },
-                ],
-                code: dedent`
-                  type Type = {
-                    a: () => null,
-
-
-                   y: "y",
-                  z: "z",
-
-                      b: "b",
-                  }
-                `,
-                output: dedent`
-                  type Type = {
-                    a: () => null,
-                   b: "b",
-                  y: "y",
-                      z: "z",
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    groups: ['method', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenObjectTypeMembers',
-                  },
-                ],
-                output: dedent`
-                  type Type = {
-                    a; 
-
-                  b;
-                  }
-                `,
-                code: dedent`
-                  type Type = {
-                    a; b;
-                  }
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenObjectTypeMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedObjectTypesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenObjectTypeMembers',
-                  },
-                ],
-                output: dedent`
-                  type Type = {
-                    a: () => null,
-
-                   y: "y",
-                  z: "z",
-
-                      b: {
-                        // Newline stuff
-                      },
-                  }
-                `,
-                code: dedent`
-                  type Type = {
-                    a: () => null,
-
-
-                   z: "z",
-                  y: "y",
-                      b: {
-                        // Newline stuff
-                      },
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    groups: ['method', 'unknown', 'multiline'],
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenObjectTypeMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenObjectTypeMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenObjectTypeMembers',
-                  },
-                ],
-                output: dedent`
-                  type Type = {
-                    a: string
-
-                    b: string
-
-                    c: string
-                    d: string
-
-
-                    e: string
-                  }
-                `,
-                code: dedent`
-                  type Type = {
-                    a: string
-                    b: string
-
-
-                    c: string
-
-                    d: string
-
-
-                    e: string
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenObjectTypeMembers',
-                      },
-                    ],
-                    output: dedent`
-                      type Type = {
-                        a: string
-
-
-                        b: string
-                      }
-                    `,
-                    code: dedent`
-                      type Type = {
-                        a: string
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenObjectTypeMembers',
-                      },
-                    ],
-                    output: dedent`
-                      type T = {
-                        a: string
-                        b: string
-                      }
-                    `,
-                    code: dedent`
-                      type T = {
-                        a: string
-
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      type Type = {
-                        a: string
-
-                        b: string
-                      }
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      type Type = {
-                        a: string
-                        b: string
-                      }
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  type Test = {
-                    a: string // Comment after
-                    b: () => void
-
-                    c: () => void
-                  };
-                `,
-                dedent`
-                  type Test = {
-                    a: string // Comment after
-
-                    b: () => void
-                    c: () => void
-                  };
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'property',
-                    leftGroup: 'method',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              code: dedent`
-                type Test = {
-                  b: () => void
-                  a: string // Comment after
-
-                  c: () => void
-                };
-              `,
-              options: [
-                {
-                  groups: ['property', 'method'],
-                  newlinesBetween: 'always',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedObjectTypesOrder',
-                  },
-                ],
-                output: dedent`
-                  type Type = {
-                    a: string
-
-                    // Partition comment
-
-                    b: string
-                    c: string
-                  }
-                `,
-                code: dedent`
-                  type Type = {
-                    a: string
-
-                    // Partition comment
-
-                    c: string
-                    b: string
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                a: string; b: string,
-              }
-            `,
-            code: dedent`
-              type Type = {
-                b: string, a: string
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                a: string; b: string,
-              }
-            `,
-            code: dedent`
-              type Type = {
-                b: string, a: string;
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                a: string, b: string,
-              }
-            `,
-            code: dedent`
-              type Type = {
-                b: string, a: string,
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort call signature declarations`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                <Parameters extends Record<string, number | string>>(
-                  input: AFunction<[Parameters], string>
-                ): Alternatives<Parameters>
-                <A extends CountA>(input: Input): AFunction<
-                  [number],
-                  A[keyof A]
-                >
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort constructor declarations`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                new (value: number | string): number;
-                new (value: number): unknown;
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              type Type = {
-                new (value: number): unknown;
-                new (value: number | string): number;
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      for (let rgbAllNamesMatchPattern of [
-        '^r|g|b$',
-        ['noMatch', '^r|g|b$'],
-        { pattern: '^R|G|B$', flags: 'i' },
-        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'g',
-                      leftGroup: 'b',
-                      right: 'g',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedObjectTypesGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'r',
-                      leftGroup: 'g',
-                      right: 'r',
-                      left: 'g',
-                    },
-                    messageId: 'unexpectedObjectTypesGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    useConfigurationIf: {
-                      allNamesMatchPattern: 'foo',
-                    },
-                  },
-                  {
-                    ...options,
-                    customGroups: {
-                      r: 'r',
-                      g: 'g',
-                      b: 'b',
-                    },
-                    useConfigurationIf: {
-                      allNamesMatchPattern: rgbAllNamesMatchPattern,
-                    },
-                    groups: ['r', 'g', 'b'],
-                  },
-                ],
-                output: dedent`
-                  type Type = {
-                    r: string
-                    g: string
-                    b: string
-                  }
-                `,
-                code: dedent`
-                  type Type = {
-                    b: string
-                    g: string
-                    r: string
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): allows to use 'declarationMatchesPattern'`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): detects declaration name by pattern`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    useConfigurationIf: {
-                      declarationMatchesPattern: '^Type$',
-                    },
-                    type: 'unsorted',
-                  },
-                  options,
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'a',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedObjectTypesOrder',
-                  },
-                ],
-                output: dedent`
-                  type OtherType = {
-                    a: string
-                    b: string
-                  }
-                `,
-                code: dedent`
-                  type OtherType = {
-                    b: string
-                    a: string
-                  }
-                `,
-              },
-            ],
-            valid: [
-              {
-                options: [
-                  {
-                    useConfigurationIf: {
-                      declarationMatchesPattern: '^Type$',
-                    },
-                    type: 'unsorted',
-                  },
-                  options,
-                ],
-                code: dedent`
-                  type Type = {
-                    b: string
-                    c: string
-                    a: string
-                  }
-                `,
-              },
-            ],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): does not match configuration if no declaration name`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    useConfigurationIf: {
-                      declarationMatchesPattern: '^Type$',
-                    },
-                    type: 'unsorted',
-                  },
-                  options,
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedObjectTypesOrder',
-                  },
-                ],
-                output: dedent`
-                  type Type = {
-                    a: {
-                      b: string
-                      c: string
-                    }
-                  }
-                `,
-                code: dedent`
-                  type Type = {
-                    a: {
-                      c: string
-                      b: string
-                    }
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      })
-    })
-
-    describe(`${ruleName}(${type}): sorting by value`, () => {
-      ruleTester.run(`${ruleName}(${type}): allows sorting by value`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                b: 'a'
-                a: 'b'
-              }
-            `,
-            options: [
-              {
-                sortBy: 'value',
-                ...options,
-              },
-            ],
-            code: dedent`
-              type Type = {
-                a: 'b'
-                b: 'a'
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): does not enforce sorting of non-properties in the same group`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'y',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  y: 'y'
-                  a(): void
-                  z: 'z'
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  z: 'z'
-                  a(): void
-                  y: 'y'
-                }
-              `,
-              options: [
-                {
-                  sortBy: 'value',
-                  ...options,
-                },
-              ],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: '[key: string]',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-                {
-                  data: {
-                    left: '[key: string]',
-                    right: 'y',
-                  },
-                  messageId: 'unexpectedObjectTypesOrder',
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  y: 'y'
-                  [key: string]
-                  z: 'z'
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  z: 'z'
-                  [key: string]
-                  y: 'y'
-                }
-              `,
-              options: [
-                {
-                  sortBy: 'value',
-                  ...options,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): enforces grouping but does not enforce sorting of non-properties`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'method',
-                    leftGroup: 'unknown',
-                    right: 'a',
-                    left: 'z',
-                  },
-                  messageId: 'unexpectedObjectTypesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  sortBy: 'value',
-                  ...options,
-                  groups: ['method', 'unknown'],
-                },
-              ],
-              output: dedent`
-                type Type = {
-                  b(): void
-                  a(): void
-                  z: 'z'
-                }
-              `,
-              code: dedent`
-                type Type = {
-                  b(): void
-                  z: 'z'
-                  a(): void
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts type members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              c: 'c'
-              b: 'bb'
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members in function args`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              let Func = (arguments: {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = (arguments: {
-                b: 'bb'
-                a: 'aaa'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Func = (arguments: {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members with computed keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key: string]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  left: 'value',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                [key: string]: string
-                a?: 'aaa'
-                b: 'bb'
-                c: 'c'
-                [value]: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a?: 'aaa'
-                [key: string]: string
-                b: 'bb'
-                [value]: string
-                c: 'c'
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                [key: string]: string
-                a?: 'aaa'
-                b: 'bb'
-                c: 'c'
-                [value]: string
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members with any key types`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '[name in v]',
-                  right: '8',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  right: 'arrowFunc',
-                  left: 'func',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                [8]: Value
-                [...values]
-                [[data]]: string
-                [name in v]?
-                arrowFunc?: () => void
-                func(): void
-              }
-            `,
-            code: dedent`
-              type Type = {
-                [...values]
-                [[data]]: string
-                [name in v]?
-                [8]: Value
-                func(): void
-                arrowFunc?: () => void
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                [8]: Value
-                [...values]
-                [[data]]: string
-                [name in v]?
-                arrowFunc?: () => void
-                func(): void
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts inline type members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
-            },
-          ],
-          output: dedent`
-            func<{ a: 'aa'; b: 'b'; }>(/* ... */)
-          `,
-          code: dedent`
-            func<{ b: 'b'; a: 'aa' }>(/* ... */)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            func<{ a: 'aa'; b: 'b' }>(/* ... */)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'unknown',
-                  rightGroup: 'b',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-              {
-                data: {
-                  right: 'e',
-                  left: 'f',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: [
-              dedent`
-                type Type = {
-                  b: 'bb'
-                  a: 'aaa'
-                  c: 'c'
-                  d: {
-                    e: 'ee'
-                    f: 'f'
-                  }
-                }
-              `,
-            ],
-            code: dedent`
-              type Type = {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-                d: {
-                  f: 'f'
-                  e: 'ee'
-                }
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  b: 'b',
-                },
-                groups: ['b', 'unknown', 'multiline'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                b: 'bb'
-                a: 'aaa'
-                c: 'c'
-                d: {
-                  e: 'ee'
-                  f: 'f'
-                }
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  b: 'b',
-                },
-                groups: ['b', 'unknown', 'multiline'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                d: 'dd'
-                e: 'e'
-
-                c: 'ccc'
-
-                a: 'aaaaa'
-                b: 'bbbb'
-              }
-            `,
-            code: dedent`
-              type Type = {
-                e: 'e'
-                d: 'dd'
-
-                c: 'ccc'
-
-                b: 'bbbb'
-                a: 'aaaaa'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                d: 'dd'
-                e: 'e'
-
-                c: 'ccc'
-
-                a: 'aaaaa'
-                b: 'bbbb'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to sort required values first`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'bbbb',
-                  right: 'ccc',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  left: 'dd',
-                  right: 'e',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                ccc: string
-                e: string
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                ccc: string
-                dd?: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'required-first',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                ccc: string
-                e: string
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'required-first',
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to sort optional values first`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'ccc',
-                  right: 'dd',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-                ccc: string
-                e: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                ccc: string
-                dd?: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'optional-first',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-                ccc: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'optional-first',
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              b(): void
-              c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
-              a: string
-              d: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts type members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              c: 'c'
-              b: 'bb'
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts type members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              c: 'c'
-              b: 'bb'
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              a: 'aaa'
-              b: 'bb'
-              c: 'c'
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members in function args`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              let Func = (arguments: {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = (arguments: {
-                b: 'bb'
-                a: 'aaa'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Func = (arguments: {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members with computed keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '[key: string]',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  right: 'value',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                [key: string]: string
-                [value]: string
-                a?: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a?: 'aaa'
-                [key: string]: string
-                b: 'bb'
-                [value]: string
-                c: 'c'
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                [key: string]: string
-                [value]: string
-                a?: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts type members with any key types`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '[...values]',
-                  right: '[[data]]',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  right: 'func',
-                  left: '8',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  right: 'arrowFunc',
-                  left: 'func',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                arrowFunc?: () => void
-                [[data]]: string
-                [name in v]?
-                func(): void
-                [...values]
-                [8]: Value
-              }
-            `,
-            code: dedent`
-              type Type = {
-                [...values]
-                [[data]]: string
-                [name in v]?
-                [8]: Value
-                func(): void
-                arrowFunc?: () => void
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                arrowFunc?: () => void
-                [[data]]: string
-                [name in v]?
-                func(): void
-                [...values]
-                [8]: Value
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts inline type members`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
-            },
-          ],
-          output: dedent`
-            func<{ a: 'aa'; b: 'b'; }>(/* ... */)
-          `,
-          code: dedent`
-            func<{ b: 'b'; a: 'aa' }>(/* ... */)
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            func<{ a: 'aa'; b: 'b' }>(/* ... */)
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'unknown',
-                  rightGroup: 'b',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesGroupOrder',
-              },
-              {
-                data: {
-                  right: 'e',
-                  left: 'f',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: [
-              dedent`
-                type Type = {
-                  b: 'bb'
-                  a: 'aaa'
-                  c: 'c'
-                  d: {
-                    e: 'ee'
-                    f: 'f'
-                  }
-                }
-              `,
-            ],
-            code: dedent`
-              type Type = {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-                d: {
-                  f: 'f'
-                  e: 'ee'
-                }
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  b: 'b',
-                },
-                groups: ['b', 'unknown', 'multiline'],
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                b: 'bb'
-                a: 'aaa'
-                c: 'c'
-                d: {
-                  e: 'ee'
-                  f: 'f'
-                }
-              }
-            `,
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  b: 'b',
-                },
-                groups: ['b', 'unknown', 'multiline'],
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                d: 'dd'
-                e: 'e'
-
-                c: 'ccc'
-
-                a: 'aaaaa'
-                b: 'bbbb'
-              }
-            `,
-            code: dedent`
-              type Type = {
-                e: 'e'
-                d: 'dd'
-
-                c: 'ccc'
-
-                b: 'bbbb'
-                a: 'aaaaa'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                d: 'dd'
-                e: 'e'
-
-                c: 'ccc'
-
-                a: 'aaaaa'
-                b: 'bbbb'
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to sort required values first`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'bbbb',
-                  right: 'ccc',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-              {
-                data: {
-                  left: 'dd',
-                  right: 'e',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                ccc: string
-                e: string
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                ccc: string
-                dd?: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'required-first',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                ccc: string
-                e: string
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'required-first',
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to sort optional values first`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'ccc',
-                  right: 'dd',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-                ccc: string
-                e: string
-              }
-            `,
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                ccc: string
-                dd?: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'optional-first',
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              type Type = {
-                aaaaa?: string
-                bbbb?: string
-                dd?: string
-                ccc: string
-                e: string
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groupKind: 'optional-first',
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use method group`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
-              b(): void
-              a: string
-              d: string
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              type Type = {
-                bb: string;
-                c: string;
-                a: string;
-              }
-            `,
-            code: dedent`
-              type Type = {
-                a: string;
-                bb: string;
-                c: string;
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              type Type = {
-                bb: string;
-                a: string;
-                c: string;
-              }
-            `,
-            code: dedent`
-              type Type = {
-                c: string;
-                bb: string;
-                a: string;
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  sortBy: 'value',
-                },
-              },
-            ],
-            output: dedent`
-              type Type = {
-                bb: string;
-                c: boolean;
-                a: number;
-              }
-            `,
-            code: dedent`
-              type Type = {
-                c: boolean;
-                bb: string;
-                a: number;
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              b: string;
-              c: string;
-              a: string;
-            }
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
               customGroups: [
                 {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
                 },
               ],
-              groups: ['b', 'a'],
+              groups: ['propertiesStartingWithHello', 'unknown'],
             },
           ],
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
               },
               messageId: 'unexpectedObjectTypesGroupOrder',
             },
           ],
           output: dedent`
             type Type = {
-              ba: string
-              bb: string
-              ab: string
-              aa: string
+              helloProperty: string
+              a: string
+              b: string
+              method(): void
             }
           `,
           code: dedent`
             type Type = {
-              ab: string
-              aa: string
-              ba: string
-              bb: string
+              a: string
+              b: string
+              method(): void
+              helloProperty: string
             }
           `,
-        },
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Date'],
+      ['array with string pattern', ['noMatch', 'Date']],
+      ['regex pattern', { pattern: 'DATE', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: 'DATE', flags: 'i' }],
       ],
-      valid: [],
+    ])(
+      'filters on elementValuePattern with %s',
+      async (_description, dateElementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: dateElementValuePattern,
+                  groupName: 'date',
+                },
+                {
+                  elementValuePattern: 'number',
+                  groupName: 'number',
+                },
+              ],
+              groups: ['number', 'date', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'number',
+                leftGroup: 'date',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: number
+              z: number
+              b: Date
+              y: Date
+              c(): string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: number
+              b: Date
+              y: Date
+              z: number
+              c(): string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            dddd: string
+            ccc: string
+            eee: string
+            bb: string
+            ff: string
+            a: string
+            g: string
+            anotherMethod(): void
+            method(): void
+            yetAnotherMethod(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            bb: string
+            ccc: string
+            dddd: string
+            method(): void
+            eee: string
+            ff: string
+            g: string
+            anotherMethod(): void
+            yetAnotherMethod(): void
+          }
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                elementValuePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: fooBar
+            a: fooZar
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: fooZar
+            b: fooBar
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding sortBy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooC',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              right: 'fooA',
+              left: 'fooB',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooMethod',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'fooElementsSortedByValue',
+                elementNamePattern: '^foo',
+                sortBy: 'value',
+              },
+            ],
+            groups: ['fooElementsSortedByValue', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            fooA: Date
+            fooC: number
+            fooB: string
+            fooMethod(): void
+            a: string
+            z: boolean
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: boolean
+            fooC: number
+            fooB: string
+            fooA: Date
+            a: string
+            fooMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b
+            a
+            d
+            e
+            c
+            method(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b
+            a
+            d
+            e
+            method(): void
+            c
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['required'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['optional'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'requiredPropertiesAndOptionalMethods',
+              },
+            ],
+            groups: [
+              ['requiredPropertiesAndOptionalMethods', 'index-signature'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'requiredPropertiesAndOptionalMethods',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              right: '[key: string]',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string
+            a: string
+            d?: () => void
+            e: string
+            b(): void
+            c?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            b(): void
+            c?: string
+            d?: () => void
+            e: string
+            [key: string]: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type type = {
+              a
+
+              b
+            }
+          `,
+          code: dedent`
+            type type = {
+              a
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type type = {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            type type = {
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows to use regex for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          type T = {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use in class methods', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            async method (data: {
+              a: 'aaa'
+              b: 'bb'
+              c: 'c'
+            }) {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            async method (data: {
+              b: 'bb'
+              a: 'aaa'
+              c: 'c'
+            }) {}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            d: 'dd'
+            e: 'e'
+
+            c: 'ccc'
+
+            a: 'aaaaa'
+            b: 'bbbb'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            d: 'dd'
+            e: 'e'
+
+            c: 'ccc'
+
+            a: 'aaaaa'
+            b: 'bbbb'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            e: 'e'
+            d: 'dd'
+
+            c: 'ccc'
+
+            b: 'bbbb'
+            a: 'aaaaa'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type Type = {
+            // Part: A
+            // Not partition comment
+            bbb: string
+            cc: string
+            d: string
+            // Part: B
+            aaaa: string
+            e: string
+            // Part: C
+            // Not partition comment
+            fff: string
+            'gg': string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            // Part: A
+            cc: string
+            d: string
+            // Not partition comment
+            bbb: string
+            // Part: B
+            aaaa: string
+            e: string
+            // Part: C
+            'gg': string
+            // Not partition comment
+            fff: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            // Comment
+            bb: string
+            // Other comment
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type Type = {
+            /* Partition Comment */
+            // Part: A
+            d: string
+            // Part: B
+            aaa: string
+            bb: string
+            c: string
+            /* Other */
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            /* Partition Comment */
+            // Part: A
+            d: string
+            // Part: B
+            aaa: string
+            c: string
+            bb: string
+            /* Other */
+            e: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            e: string
+            f: string
+            // I am a partition comment because I don't have f o o
+            a: string
+            b: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            /* Comment */
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all line comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple partition line comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            c: string
+            // b
+            b: string
+            // a
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition line comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string
+            // I am a partition comment because I don't have f o o
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            // Comment
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all block comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple partition block comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            c: string
+            /* b */
+            b: string
+            /* a */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition block comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string
+            /* I am a partition comment because I don't have f o o */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to sort required values first', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            ccc: string
+            e: string
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'required-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'bbbb',
+              right: 'ccc',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              left: 'dd',
+              right: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            ccc: string
+            e: string
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            ccc: string
+            dd?: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'required-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to sort optional values first', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+            ccc: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'ccc',
+              right: 'dd',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+            ccc: string
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            ccc: string
+            dd?: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            _a: string
+            b: string
+            _c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            ab: string
+            a_c: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            你好: string
+            世界: string
+            a: string
+            A: string
+            b: string
+            B: string
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('allows to use method group', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b(): void
+            c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
+            a: string
+            d: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedObjectTypesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: () => null,
+
+
+             y: "y",
+            z: "z",
+
+                b: "b",
+            }
+          `,
+          output: dedent`
+            type Type = {
+              a: () => null,
+             b: "b",
+            y: "y",
+                z: "z",
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['2 and never', 2 as const, 'never' as const],
+      ['2 and 0', 2 as const, 0 as const],
+      ['2 and ignore', 2 as const, 'ignore' as const],
+      ['never and 2', 'never' as const, 2 as const],
+      ['0 and 2', 0 as const, 2 as const],
+      ['ignore and 2', 'ignore' as const, 2 as const],
+    ])(
+      'enforces newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: string
+
+
+              b: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['2', 2 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type T = {
+              a: string
+              b: string
+            }
+          `,
+          code: dedent`
+            type T = {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore and never', 'ignore' as const, 'never' as const],
+      ['ignore and 0', 'ignore' as const, 0 as const],
+      ['never and ignore', 'never' as const, 'ignore' as const],
+      ['0 and ignore', 0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Test = {
+            a: string // Comment after
+
+            b: () => void
+            c: () => void
+          };
+        `,
+        code: dedent`
+          type Test = {
+            b: () => void
+            a: string // Comment after
+
+            c: () => void
+          };
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions with newlinesBetween: %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
@@ -4668,76 +2290,6215 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedObjectTypesOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: string
+
+              // Partition comment
+
+              b: string
+              c: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+
+              // Partition comment
+
+              c: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, a: string;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string, b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, a: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort call signature declarations', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            <Parameters extends Record<string, number | string>>(
+              input: AFunction<[Parameters], string>
+            ): Alternatives<Parameters>
+            <A extends CountA>(input: Input): AFunction<
+              [number],
+              A[keyof A]
+            >
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort constructor declarations', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            new (value: number | string): number;
+            new (value: number): unknown;
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          type Type = {
+            new (value: number): unknown;
+            new (value: number | string): number;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['string pattern', '^r|g|b$'],
+      ['array with string pattern', ['noMatch', '^r|g|b$']],
+      ['regex pattern', { pattern: '^R|G|B$', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ],
+    ])(
+      'allows to use allNamesMatchPattern with %s',
+      async (_description, rgbAllNamesMatchPattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
                 left: 'b',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
+            type Type = {
+              r: string
+              g: string
+              b: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              b: string
+              g: string
+              r: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('detects declaration name by pattern', async () => {
+      await valid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            c: string
+            a: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type OtherType = {
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type OtherType = {
+            b: string
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('does not match configuration if no declaration name', async () => {
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: {
+              b: string
+              c: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: {
+              c: string
+              b: string
+            }
+          }
+        `,
+      })
+    })
+
+    it('allows sorting by value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: 'a'
+            a: 'b'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+        code: dedent`
+          type Type = {
+            a: 'b'
+            b: 'a'
+          }
+        `,
+      })
+    })
+
+    it('does not enforce sorting of non-properties in the same group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            y: 'y'
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: 'z'
+            a(): void
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              left: '[key: string]',
+              right: 'y',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            y: 'y'
+            [key: string]
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: 'z'
+            [key: string]
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('enforces grouping but does not enforce sorting of non-properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'method',
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b(): void
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b(): void
+            z: 'z'
+            a(): void
+          }
+        `,
+      })
+    })
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts type members', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            c: 'c'
+            b: 'bb'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members in function args', async () => {
+      await valid({
+        code: dedent`
+          let Func = (arguments: {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          let Func = (arguments: {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = (arguments: {
+            b: 'bb'
+            a: 'aaa'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members with computed keys', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            [key: string]: string
+            a?: 'aaa'
+            b: 'bb'
+            c: 'c'
+            [value]: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              left: 'value',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string
+            a?: 'aaa'
+            b: 'bb'
+            c: 'c'
+            [value]: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a?: 'aaa'
+            [key: string]: string
+            b: 'bb'
+            [value]: string
+            c: 'c'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members with any key types', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            [8]: Value
+            [...values]
+            [[data]]: string
+            [name in v]?
+            arrowFunc?: () => void
+            func(): void
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '[name in v]',
+              right: '8',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'arrowFunc',
+              left: 'func',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [8]: Value
+            [...values]
+            [[data]]: string
+            [name in v]?
+            arrowFunc?: () => void
+            func(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            [...values]
+            [[data]]: string
+            [name in v]?
+            [8]: Value
+            func(): void
+            arrowFunc?: () => void
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline type members', async () => {
+      await valid({
+        code: dedent`
+          func<{ a: 'aa'; b: 'b' }>(/* ... */)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          func<{ a: 'aa'; b: 'b'; }>(/* ... */)
+        `,
+        code: dedent`
+          func<{ b: 'b'; a: 'aa' }>(/* ... */)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts complex predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'index-signature',
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'optional-multiline',
+              leftGroup: 'index-signature',
+              left: '[key: string]',
+              right: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'optional-multiline',
+              rightGroup: 'required-method',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'required-method',
+              'optional-multiline',
+              'index-signature',
+              'required-property',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            c(): void
+            b?: {
+              property: string;
+            }
+            [key: string]: string;
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            [key: string]: string;
+            b?: {
+              property: string;
+            }
+            c(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritizes selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'method',
+              left: 'property',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['method', 'required-property'],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            method(): void
+            property: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            property: string
+            method(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritizes index-signature over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'index-signature',
+              left: 'multilineProperty',
+              right: '[key: string]',
+              leftGroup: 'multiline',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string;
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            [key: string]: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['index-signature', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes method over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            method(): string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            method(): string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'multilineProperty',
+              rightGroup: 'multiline',
+              leftGroup: 'property',
+              left: 'property',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            property: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            property: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes property over member', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            property: string
+            method(): string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            method(): string
+            property: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over optional', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'optional-property',
+              right: 'multilineProperty',
+              left: 'optionalProperty',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            optionalProperty?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            optionalProperty?: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'optional-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over required', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'required-property',
+              right: 'multilineProperty',
+              left: 'requiredProperty',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            requiredProperty: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            requiredProperty: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'multiline',
+              rightGroup: 'g',
+              right: 'g',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            g: 'g'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('filters on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['optional'],
+                selector: 'method',
+              },
+              {
+                groupName: 'optionalPropertyGroup',
+                modifiers: ['optional'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'optionalPropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'optionalPropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            c: string
+            a?: string
+            b?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a?: string
+            b?: string
+            c: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['regex pattern', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters on elementNamePattern with %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              helloProperty: string
+              a: string
+              b: string
+              method(): void
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+              method(): void
+              helloProperty: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['string pattern', 'Date'],
+      ['array with string pattern', ['noMatch', 'Date']],
+      ['regex pattern', { pattern: 'DATE', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: 'DATE', flags: 'i' }],
+      ],
+    ])(
+      'filters on elementValuePattern with %s',
+      async (_description, dateElementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: dateElementValuePattern,
+                  groupName: 'date',
+                },
+                {
+                  elementValuePattern: 'number',
+                  groupName: 'number',
+                },
+              ],
+              groups: ['number', 'date', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'number',
+                leftGroup: 'date',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: number
+              z: number
+              b: Date
+              y: Date
+              c(): string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: number
+              b: Date
+              y: Date
+              z: number
+              c(): string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            dddd: string
+            ccc: string
+            eee: string
+            bb: string
+            ff: string
+            a: string
+            g: string
+            anotherMethod(): void
+            method(): void
+            yetAnotherMethod(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            bb: string
+            ccc: string
+            dddd: string
+            method(): void
+            eee: string
+            ff: string
+            g: string
+            anotherMethod(): void
+            yetAnotherMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                elementValuePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: fooBar
+            a: fooZar
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: fooZar
+            b: fooBar
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding sortBy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooC',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              right: 'fooA',
+              left: 'fooB',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooMethod',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'fooElementsSortedByValue',
+                elementNamePattern: '^foo',
+                sortBy: 'value',
+              },
+            ],
+            groups: ['fooElementsSortedByValue', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            fooA: Date
+            fooC: number
+            fooB: string
+            fooMethod(): void
+            a: string
+            z: boolean
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: boolean
+            fooC: number
+            fooB: string
+            fooA: Date
+            a: string
+            fooMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b
+            a
+            d
+            e
+            c
+            method(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b
+            a
+            d
+            e
+            method(): void
+            c
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['required'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['optional'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'requiredPropertiesAndOptionalMethods',
+              },
+            ],
+            groups: [
+              ['requiredPropertiesAndOptionalMethods', 'index-signature'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'requiredPropertiesAndOptionalMethods',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              right: '[key: string]',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string
+            a: string
+            d?: () => void
+            e: string
+            b(): void
+            c?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            b(): void
+            c?: string
+            d?: () => void
+            e: string
+            [key: string]: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type type = {
+              a
+
+              b
+            }
+          `,
+          code: dedent`
+            type type = {
+              a
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type type = {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            type type = {
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows to use regex for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          type T = {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use in class methods', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            async method (data: {
+              a: 'aaa'
+              b: 'bb'
+              c: 'c'
+            }) {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            async method (data: {
+              b: 'bb'
+              a: 'aaa'
+              c: 'c'
+            }) {}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            d: 'dd'
+            e: 'e'
+
+            c: 'ccc'
+
+            a: 'aaaaa'
+            b: 'bbbb'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            d: 'dd'
+            e: 'e'
+
+            c: 'ccc'
+
+            a: 'aaaaa'
+            b: 'bbbb'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            e: 'e'
+            d: 'dd'
+
+            c: 'ccc'
+
+            b: 'bbbb'
+            a: 'aaaaa'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type Type = {
+            // Part: A
+            // Not partition comment
+            bbb: string
+            cc: string
+            d: string
+            // Part: B
+            aaaa: string
+            e: string
+            // Part: C
+            // Not partition comment
+            fff: string
+            'gg': string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            // Part: A
+            cc: string
+            d: string
+            // Not partition comment
+            bbb: string
+            // Part: B
+            aaaa: string
+            e: string
+            // Part: C
+            'gg': string
+            // Not partition comment
+            fff: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            // Comment
+            bb: string
+            // Other comment
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type Type = {
+            /* Partition Comment */
+            // Part: A
+            d: string
+            // Part: B
+            aaa: string
+            bb: string
+            c: string
+            /* Other */
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            /* Partition Comment */
+            // Part: A
+            d: string
+            // Part: B
+            aaa: string
+            c: string
+            bb: string
+            /* Other */
+            e: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            e: string
+            f: string
+            // I am a partition comment because I don't have f o o
+            a: string
+            b: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            /* Comment */
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all line comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple partition line comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            c: string
+            // b
+            b: string
+            // a
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition line comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string
+            // I am a partition comment because I don't have f o o
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            // Comment
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all block comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple partition block comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            c: string
+            /* b */
+            b: string
+            /* a */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition block comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string
+            /* I am a partition comment because I don't have f o o */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to sort required values first', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            ccc: string
+            e: string
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'required-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'bbbb',
+              right: 'ccc',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              left: 'dd',
+              right: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            ccc: string
+            e: string
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            ccc: string
+            dd?: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'required-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to sort optional values first', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+            ccc: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'ccc',
+              right: 'dd',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+            ccc: string
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            ccc: string
+            dd?: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            _a: string
+            b: string
+            _c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            ab: string
+            a_c: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            你好: string
+            世界: string
+            a: string
+            A: string
+            b: string
+            B: string
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('allows to use method group', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b(): void
+            c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
+            a: string
+            d: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedObjectTypesOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: () => null,
+
+
+             y: "y",
+            z: "z",
+
+                b: "b",
+            }
+          `,
+          output: dedent`
+            type Type = {
+              a: () => null,
+             b: "b",
+            y: "y",
+                z: "z",
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['2 and never', 2 as const, 'never' as const],
+      ['2 and 0', 2 as const, 0 as const],
+      ['2 and ignore', 2 as const, 'ignore' as const],
+      ['never and 2', 'never' as const, 2 as const],
+      ['0 and 2', 0 as const, 2 as const],
+      ['ignore and 2', 'ignore' as const, 2 as const],
+    ])(
+      'enforces newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenObjectTypeMembers',
             },
           ],
           output: dedent`
             type Type = {
-              b: string
-
               a: string
+
+
+              b: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['2', 2 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type T = {
+              a: string
+              b: string
+            }
+          `,
+          code: dedent`
+            type T = {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore and never', 'ignore' as const, 'never' as const],
+      ['ignore and 0', 'ignore' as const, 0 as const],
+      ['never and ignore', 'never' as const, 'ignore' as const],
+      ['0 and ignore', 0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Test = {
+            a: string // Comment after
+
+            b: () => void
+            c: () => void
+          };
+        `,
+        code: dedent`
+          type Test = {
+            b: () => void
+            a: string // Comment after
+
+            c: () => void
+          };
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions with newlinesBetween: %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedObjectTypesOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: string
+
+              // Partition comment
+
+              b: string
+              c: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+
+              // Partition comment
+
+              c: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string; b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, a: string;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string, b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, a: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort call signature declarations', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            <Parameters extends Record<string, number | string>>(
+              input: AFunction<[Parameters], string>
+            ): Alternatives<Parameters>
+            <A extends CountA>(input: Input): AFunction<
+              [number],
+              A[keyof A]
+            >
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort constructor declarations', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            new (value: number | string): number;
+            new (value: number): unknown;
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          type Type = {
+            new (value: number): unknown;
+            new (value: number | string): number;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['string pattern', '^r|g|b$'],
+      ['array with string pattern', ['noMatch', '^r|g|b$']],
+      ['regex pattern', { pattern: '^R|G|B$', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ],
+    ])(
+      'allows to use allNamesMatchPattern with %s',
+      async (_description, rgbAllNamesMatchPattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
+            type Type = {
+              r: string
+              g: string
+              b: string
             }
           `,
           code: dedent`
             type Type = {
               b: string
-              a: string
+              g: string
+              r: string
             }
           `,
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it('detects declaration name by pattern', async () => {
+      await valid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            c: string
+            a: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type OtherType = {
+            a: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type OtherType = {
+            b: string
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('does not match configuration if no declaration name', async () => {
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: {
+              b: string
+              c: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: {
+              c: string
+              b: string
+            }
+          }
+        `,
+      })
+    })
+
+    it('allows sorting by value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: 'a'
+            a: 'b'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+        code: dedent`
+          type Type = {
+            a: 'b'
+            b: 'a'
+          }
+        `,
+      })
+    })
+
+    it('does not enforce sorting of non-properties in the same group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            y: 'y'
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: 'z'
+            a(): void
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              left: '[key: string]',
+              right: 'y',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            y: 'y'
+            [key: string]
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: 'z'
+            [key: string]
+            y: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('enforces grouping but does not enforce sorting of non-properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'method',
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b(): void
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b(): void
+            z: 'z'
+            a(): void
+          }
+        `,
+      })
     })
   })
 
-  describe(`${ruleName}: validating group configuration`, () => {
-    ruleTester.run(
-      `${ruleName}: allows predefined groups and defined custom groups`,
-      rule,
-      {
-        valid: [
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts type members', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
           {
-            options: [
-              {
-                customGroups: {
-                  myCustomGroup: 'x',
-                },
-                groups: ['multiline', 'method', 'unknown', 'myCustomGroup'],
-              },
-            ],
-            code: dedent`
-              type Type = {
-                a: 'aaa'
-                b: 'bb'
-                c: 'c'
-              }
-            `,
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
           },
         ],
-        invalid: [],
+        output: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            c: 'c'
+            b: 'bb'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members in function args', async () => {
+      await valid({
+        code: dedent`
+          let Func = (arguments: {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          let Func = (arguments: {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = (arguments: {
+            b: 'bb'
+            a: 'aaa'
+            c: 'c'
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members with computed keys', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            [key: string]: string
+            [value]: string
+            a?: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'value',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string
+            [value]: string
+            a?: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a?: 'aaa'
+            [key: string]: string
+            b: 'bb'
+            [value]: string
+            c: 'c'
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts type members with any key types', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            arrowFunc?: () => void
+            [[data]]: string
+            [name in v]?
+            func(): void
+            [...values]
+            [8]: Value
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '[...values]',
+              right: '[[data]]',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'func',
+              left: '8',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'arrowFunc',
+              left: 'func',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            arrowFunc?: () => void
+            [[data]]: string
+            [name in v]?
+            func(): void
+            [...values]
+            [8]: Value
+          }
+        `,
+        code: dedent`
+          type Type = {
+            [...values]
+            [[data]]: string
+            [name in v]?
+            [8]: Value
+            func(): void
+            arrowFunc?: () => void
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts inline type members', async () => {
+      await valid({
+        code: dedent`
+          func<{ a: 'aa'; b: 'b' }>(/* ... */)
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          func<{ a: 'aa'; b: 'b'; }>(/* ... */)
+        `,
+        code: dedent`
+          func<{ b: 'b'; a: 'aa' }>(/* ... */)
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts complex predefined groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'index-signature',
+              right: '[key: string]',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'optional-multiline',
+              leftGroup: 'index-signature',
+              left: '[key: string]',
+              right: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'optional-multiline',
+              rightGroup: 'required-method',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'unknown',
+              'required-method',
+              'optional-multiline',
+              'index-signature',
+              'required-property',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            c(): void
+            b?: {
+              property: string;
+            }
+            [key: string]: string;
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            [key: string]: string;
+            b?: {
+              property: string;
+            }
+            c(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritizes selectors over modifiers quantity', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'required-property',
+              rightGroup: 'method',
+              left: 'property',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['method', 'required-property'],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            method(): void
+            property: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            property: string
+            method(): void
+          }
+        `,
+      })
+    })
+
+    it('prioritizes index-signature over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'index-signature',
+              left: 'multilineProperty',
+              right: '[key: string]',
+              leftGroup: 'multiline',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string;
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            [key: string]: string;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['index-signature', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes method over multiline', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            method(): string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            method(): string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over property', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'multilineProperty',
+              rightGroup: 'multiline',
+              leftGroup: 'property',
+              left: 'property',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            property: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            property: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes property over member', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            property: string
+            method(): string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            method(): string
+            property: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over optional', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'optional-property',
+              right: 'multilineProperty',
+              left: 'optionalProperty',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            optionalProperty?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            optionalProperty?: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'optional-property'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes multiline over required', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline-property',
+              leftGroup: 'required-property',
+              right: 'multilineProperty',
+              left: 'requiredProperty',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            multilineProperty: {
+              a: string
+            }
+            requiredProperty: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            requiredProperty: string
+            multilineProperty: {
+              a: string
+            }
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline-property', 'required-property'],
+          },
+        ],
+      })
+    })
+
+    it('allows to set groups for sorting', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'multiline',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'multiline',
+              rightGroup: 'g',
+              right: 'g',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            g: 'g'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+            d: {
+              e: 'e'
+              f: 'f'
+            }
+            g: 'g'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            customGroups: {
+              g: 'g',
+            },
+            groups: ['g', 'multiline', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it('filters on selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['optional'],
+                selector: 'method',
+              },
+              {
+                groupName: 'optionalPropertyGroup',
+                modifiers: ['optional'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'optionalPropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'optionalPropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            c: string
+            a?: string
+            b?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a?: string
+            b?: string
+            c: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array with string pattern', ['noMatch', 'hello']],
+      ['regex pattern', { pattern: 'HELLO', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+      ],
+    ])(
+      'filters on elementNamePattern with %s',
+      async (_description, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              helloProperty: string
+              a: string
+              b: string
+              method(): void
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+              method(): void
+              helloProperty: string
+            }
+          `,
+        })
       },
     )
+
+    it.each([
+      ['string pattern', 'Date'],
+      ['array with string pattern', ['noMatch', 'Date']],
+      ['regex pattern', { pattern: 'DATE', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: 'DATE', flags: 'i' }],
+      ],
+    ])(
+      'filters on elementValuePattern with %s',
+      async (_description, dateElementValuePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: dateElementValuePattern,
+                  groupName: 'date',
+                },
+                {
+                  elementValuePattern: 'number',
+                  groupName: 'number',
+                },
+              ],
+              groups: ['number', 'date', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'number',
+                leftGroup: 'date',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: number
+              z: number
+              b: Date
+              y: Date
+              c(): string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: number
+              b: Date
+              y: Date
+              z: number
+              c(): string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups by overriding type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            dddd: string
+            ccc: string
+            eee: string
+            bb: string
+            ff: string
+            a: string
+            g: string
+            anotherMethod(): void
+            method(): void
+            yetAnotherMethod(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            bb: string
+            ccc: string
+            dddd: string
+            method(): void
+            eee: string
+            ff: string
+            g: string
+            anotherMethod(): void
+            yetAnotherMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                elementValuePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: fooBar
+            a: fooZar
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: fooZar
+            b: fooBar
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups by overriding sortBy', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooC',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              right: 'fooA',
+              left: 'fooB',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'fooElementsSortedByValue',
+              leftGroup: 'unknown',
+              right: 'fooMethod',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'fooElementsSortedByValue',
+                elementNamePattern: '^foo',
+                sortBy: 'value',
+              },
+            ],
+            groups: ['fooElementsSortedByValue', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            fooA: Date
+            fooC: number
+            fooB: string
+            fooMethod(): void
+            a: string
+            z: boolean
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: boolean
+            fooC: number
+            fooB: string
+            fooA: Date
+            a: string
+            fooMethod(): void
+          }
+        `,
+      })
+    })
+
+    it('does not sort custom groups with unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b
+            a
+            d
+            e
+            c
+            method(): void
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b
+            a
+            d
+            e
+            method(): void
+            c
+          }
+        `,
+      })
+    })
+
+    it('sorts custom group blocks', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['required'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['optional'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'requiredPropertiesAndOptionalMethods',
+              },
+            ],
+            groups: [
+              ['requiredPropertiesAndOptionalMethods', 'index-signature'],
+              'unknown',
+            ],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'requiredPropertiesAndOptionalMethods',
+              leftGroup: 'unknown',
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+          {
+            data: {
+              right: '[key: string]',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [key: string]: string
+            a: string
+            d?: () => void
+            e: string
+            b(): void
+            c?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            b(): void
+            c?: string
+            d?: () => void
+            e: string
+            [key: string]: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use regex for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type type = {
+              a
+
+              b
+            }
+          `,
+          code: dedent`
+            type type = {
+              a
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'allows to use newlinesInside: %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type type = {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            type type = {
+              a
+
+              b
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows to use regex for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          type T = {
+            iHaveFooInMyName: string
+            meTooIHaveFoo: string
+            a: string
+            b: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use in class methods', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            async method (data: {
+              a: 'aaa'
+              b: 'bb'
+              c: 'c'
+            }) {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            async method (data: {
+              b: 'bb'
+              a: 'aaa'
+              c: 'c'
+            }) {}
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to use new line as partition', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            d: 'dd'
+            e: 'e'
+
+            c: 'ccc'
+
+            a: 'aaaaa'
+            b: 'bbbb'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            d: 'dd'
+            e: 'e'
+
+            c: 'ccc'
+
+            a: 'aaaaa'
+            b: 'bbbb'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            e: 'e'
+            d: 'dd'
+
+            c: 'ccc'
+
+            b: 'bbbb'
+            a: 'aaaaa'
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type Type = {
+            // Part: A
+            // Not partition comment
+            bbb: string
+            cc: string
+            d: string
+            // Part: B
+            aaaa: string
+            e: string
+            // Part: C
+            'gg': string
+            // Not partition comment
+            fff: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            // Part: A
+            cc: string
+            d: string
+            // Not partition comment
+            bbb: string
+            // Part: B
+            aaaa: string
+            e: string
+            // Part: C
+            'gg': string
+            // Not partition comment
+            fff: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows to use all comments as parts', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            // Comment
+            bb: string
+            // Other comment
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows to use multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          type Type = {
+            /* Partition Comment */
+            // Part: A
+            d: string
+            // Part: B
+            aaa: string
+            bb: string
+            c: string
+            /* Other */
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            /* Partition Comment */
+            // Part: A
+            d: string
+            // Part: B
+            aaa: string
+            c: string
+            bb: string
+            /* Other */
+            e: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            e: string
+            f: string
+            // I am a partition comment because I don't have f o o
+            a: string
+            b: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            /* Comment */
+            aa: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string
+            /* Comment */
+            aa: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all line comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            // Comment
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple partition line comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            c: string
+            // b
+            b: string
+            // a
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition line comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string
+            // I am a partition comment because I don't have f o o
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            // Comment
+            aa: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string
+            // Comment
+            aa: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use all block comments as parts', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            /* Comment */
+            a: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use multiple partition block comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            c: string
+            /* b */
+            b: string
+            /* a */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to use regex for partition block comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string
+            /* I am a partition comment because I don't have f o o */
+            a: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows to sort required values first', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            ccc: string
+            e: string
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'required-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'bbbb',
+              right: 'ccc',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              left: 'dd',
+              right: 'e',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            ccc: string
+            e: string
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            ccc: string
+            dd?: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'required-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to sort optional values first', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+            ccc: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'ccc',
+              right: 'dd',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            dd?: string
+            ccc: string
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            aaaaa?: string
+            bbbb?: string
+            ccc: string
+            dd?: string
+            e: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groupKind: 'optional-first',
+          },
+        ],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            _a: string
+            bb: string
+            _c: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            abc: string
+            a_c: string
+          }
+        `,
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            你好: string
+            世界: string
+            a: string
+            A: string
+            b: string
+            B: string
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('allows to use method group', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            c: (((v: false) => 'false') | ((v: true) => 'true')) & ((v: any) => any)
+            b(): void
+            a: string
+            d: string
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedObjectTypesOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          code: dedent`
+            type Type = {
+              aaaa: () => null,
+
+
+             yy: "y",
+            z: "z",
+
+                bbb: "b",
+            }
+          `,
+          output: dedent`
+            type Type = {
+              aaaa: () => null,
+             bbb: "b",
+            yy: "y",
+                z: "z",
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string
+
+            b: string
+
+            c: string
+            d: string
+
+
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
+            b: string
+
+
+            c: string
+
+            d: string
+
+
+            e: string
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['2 and never', 2 as const, 'never' as const],
+      ['2 and 0', 2 as const, 0 as const],
+      ['2 and ignore', 2 as const, 'ignore' as const],
+      ['never and 2', 'never' as const, 2 as const],
+      ['0 and 2', 0 as const, 2 as const],
+      ['ignore and 2', 'ignore' as const, 2 as const],
+    ])(
+      'enforces newlines when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: string
+
+
+              b: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['2', 2 as const],
+      ['ignore', 'ignore' as const],
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      async (_description, globalNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            },
+          ],
+          output: dedent`
+            type T = {
+              a: string
+              b: string
+            }
+          `,
+          code: dedent`
+            type T = {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore and never', 'ignore' as const, 'never' as const],
+      ['ignore and 0', 'ignore' as const, 0 as const],
+      ['never and ignore', 'never' as const, 'ignore' as const],
+      ['0 and ignore', 0 as const, 'ignore' as const],
+    ])(
+      'does not enforce a newline when global option is %s',
+      async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: string
+
+              b: string
+            }
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type Type = {
+              a: string
+              b: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('handles newlines and comment after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Test = {
+            a: string // Comment after
+
+            b: () => void
+            c: () => void
+          };
+        `,
+        code: dedent`
+          type Test = {
+            b: () => void
+            a: string // Comment after
+
+            c: () => void
+          };
+        `,
+        options: [
+          {
+            groups: ['property', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'ignores newline fixes between different partitions with newlinesBetween: %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedObjectTypesOrder',
+            },
+          ],
+          output: dedent`
+            type Type = {
+              a: string
+
+              // Partition comment
+
+              bb: string
+              c: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              a: string
+
+              // Partition comment
+
+              c: string
+              bb: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            aa: string; b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, aa: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            aa: string; b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, aa: string;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            aa: string, b: string,
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string, aa: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort call signature declarations', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            <Parameters extends Record<string, number | string>>(
+              input: AFunction<[Parameters], string>
+            ): Alternatives<Parameters>
+            <A extends CountA>(input: Input): AFunction<
+              [number],
+              A[keyof A]
+            >
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('does not sort constructor declarations', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            new (value: number | string): number;
+            new (value: number): unknown;
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          type Type = {
+            new (value: number): unknown;
+            new (value: number | string): number;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      ['string pattern', '^r|g|b$'],
+      ['array with string pattern', ['noMatch', '^r|g|b$']],
+      ['regex pattern', { pattern: '^R|G|B$', flags: 'i' }],
+      [
+        'array with regex pattern',
+        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+      ],
+    ])(
+      'allows to use allNamesMatchPattern with %s',
+      async (_description, rgbAllNamesMatchPattern) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedObjectTypesGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
+            type Type = {
+              r: string
+              g: string
+              b: string
+            }
+          `,
+          code: dedent`
+            type Type = {
+              b: string
+              g: string
+              r: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('detects declaration name by pattern', async () => {
+      await valid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        code: dedent`
+          type Type = {
+            b: string
+            c: string
+            a: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type OtherType = {
+            aa: string
+            b: string
+          }
+        `,
+        code: dedent`
+          type OtherType = {
+            b: string
+            aa: string
+          }
+        `,
+      })
+    })
+
+    it('does not match configuration if no declaration name', async () => {
+      await invalid({
+        options: [
+          {
+            useConfigurationIf: {
+              declarationMatchesPattern: '^Type$',
+            },
+            type: 'unsorted',
+          },
+          options,
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: {
+              bb: string
+              c: string
+            }
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: {
+              c: string
+              bb: string
+            }
+          }
+        `,
+      })
+    })
+
+    it('allows sorting by value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: 'aa'
+            a: 'b'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+        code: dedent`
+          type Type = {
+            a: 'b'
+            b: 'aa'
+          }
+        `,
+      })
+    })
+
+    it('does not enforce sorting of non-properties in the same group', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'yy',
+              left: 'aaa',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            yy: 'y'
+            aaa(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            z: 'z'
+            aaa(): void
+            yy: 'y'
+          }
+        `,
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+          },
+        ],
+      })
+    })
+
+    it('enforces grouping but does not enforce sorting of non-properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'method',
+              right: 'a',
+              left: 'z',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            sortBy: 'value',
+            ...options,
+            groups: ['method', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b(): void
+            a(): void
+            z: 'z'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b(): void
+            z: 'z'
+            a(): void
+          }
+        `,
+      })
+    })
+
+    it('handles fallbackSort option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            bb: string;
+            c: string;
+            a: string;
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string;
+            bb: string;
+            c: string;
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+              order: 'asc',
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            bb: string;
+            a: string;
+            c: string;
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string;
+            bb: string;
+            a: string;
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            fallbackSort: {
+              type: 'alphabetical',
+              sortBy: 'value',
+            },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            bb: string;
+            c: boolean;
+            a: number;
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: boolean;
+            bb: string;
+            a: number;
+          }
+        `,
+      })
+    })
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts type members', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            c: 'c'
+            b: 'bb'
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string;
+            c: string;
+            a: string;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces grouping', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: '^b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedObjectTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            ba: string
+            bb: string
+            ab: string
+            aa: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            ab: string
+            aa: string
+            ba: string
+            bb: string
+          }
+        `,
+      })
+    })
+
+    it('enforces newlines between', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: string
+
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            b: string
+            a: string
+          }
+        `,
+      })
+    })
   })
 
   describe('misc', () => {
-    ruleTester.run(`${ruleName}: ignores semi at the end of value`, rule, {
-      valid: [
-        dedent`
+    it('allows predefined groups and defined custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: {
+              myCustomGroup: 'x',
+            },
+            groups: ['multiline', 'method', 'unknown', 'myCustomGroup'],
+          },
+        ],
+        code: dedent`
+          type Type = {
+            a: 'aaa'
+            b: 'bb'
+            c: 'c'
+          }
+        `,
+      })
+    })
+
+    it('ignores semi at the end of value', async () => {
+      await valid({
+        code: dedent`
           type Type<T> = T extends {
             (...args: any[]): infer R;
             (...args: any[]): infer R;
@@ -4753,431 +8514,589 @@ describe(ruleName, () => {
             ? R
             : any;
         `,
-      ],
-      invalid: [],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
+    it('sets alphabetical asc sorting as default', async () => {
+      await valid({
+        code: dedent`
+          type Calculator = {
+            log: (x: number) => number,
+            log10: (x: number) => number,
+            log1p: (x: number) => number,
+            log2: (x: number) => number,
+          }
+        `,
+      })
+
+      await valid({
+        code: dedent`
+          type Calculator = {
+            log: (x: number) => number,
+            log10: (x: number) => number,
+            log1p: (x: number) => number,
+            log2: (x: number) => number,
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Calculator = {
+            log: (x: number) => number,
+            log10: (x: number) => number,
+            log1p: (x: number) => number,
+            log2: (x: number) => number,
+          }
+        `,
+        code: dedent`
+          type Calculator = {
+            log: (x: number) => number,
+            log1p: (x: number) => number,
+            log2: (x: number) => number,
+            log10: (x: number) => number,
+          }
+        `,
+        errors: [
           {
-            output: dedent`
-              type Calculator = {
-                log: (x: number) => number,
-                log10: (x: number) => number,
-                log1p: (x: number) => number,
-                log2: (x: number) => number,
-              }
-            `,
-            code: dedent`
-              type Calculator = {
-                log: (x: number) => number,
-                log1p: (x: number) => number,
-                log2: (x: number) => number,
-                log10: (x: number) => number,
-              }
-            `,
-            errors: [
+            data: {
+              right: 'log10',
+              left: 'log2',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+      })
+    })
+
+    it('handles nested groups with custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
               {
-                data: {
-                  right: 'log10',
-                  left: 'log2',
-                },
-                messageId: 'unexpectedObjectTypesOrder',
+                elementValuePattern: 'string',
+                groupName: 'strings',
+              },
+              {
+                elementValuePattern: 'number',
+                groupName: 'numbers',
               },
             ],
+            groups: [['strings', 'numbers'], 'unknown'],
           },
         ],
-        valid: [
-          dedent`
-            type Calculator = {
-              log: (x: number) => number,
-              log10: (x: number) => number,
-              log1p: (x: number) => number,
-              log2: (x: number) => number,
-            }
-          `,
-          {
-            code: dedent`
-              type Calculator = {
-                log: (x: number) => number,
-                log10: (x: number) => number,
-                log1p: (x: number) => number,
-                log2: (x: number) => number,
-              }
-            `,
-            options: [{}],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: allows to ignore object types`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type IgnoreType = {
-              b: 'b'
-              a: 'a'
-            }
-          `,
-          options: [
-            {
-              ignorePattern: ['Ignore'],
-            },
-          ],
-        },
-      ],
-      invalid: [],
+        code: dedent`
+          type Type = {
+            a: string
+            b: string
+            c: number
+            d: number
+          }
+        `,
+      })
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('sorts custom groups by overriding fallbackSort', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
               },
-              messageId: 'unexpectedObjectTypesOrder',
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
             },
-          ],
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              // eslint-disable-next-line
-              a: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              // eslint-disable-next-line
-              a: string
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            fooBar: string
+            fooZar: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            fooZar: string
+            fooBar: string
+          }
+        `,
+      })
+
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  sortBy: 'value',
+                },
+                elementValuePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
               },
-              messageId: 'unexpectedObjectTypesOrder',
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: fooBar
+            a: fooZar
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: fooZar
+            b: fooBar
+          }
+        `,
+      })
+    })
+
+    it('allows to ignore object types', async () => {
+      await valid({
+        code: dedent`
+          type IgnoreType = {
+            b: 'b'
+            a: 'a'
+          }
+        `,
+        options: [
+          {
+            ignorePattern: ['Ignore'],
+          },
+        ],
+      })
+    })
+
+    it('sorts type members with computed keys without type annotations', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            [a]
+            [b]?
+            [c]
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              // eslint-disable-next-line
-              a: string
-              d: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              d: string
-              c: string
-              // eslint-disable-next-line
-              a: string
-              b: string
-            }
-          `,
-          options: [
-            {
-              partitionByComment: true,
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
             },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            [a]
+            [b]?
+            [c]
+          }
+        `,
+        code: dedent`
+          type Type = {
+            [c]
+            [b]?
+            [a]
+          }
+        `,
+      })
+    })
+
+    it('respects eslint-disable comments', async () => {
+      await valid({
+        code: dedent`
+          type Type = {
+            b: string;
+            c: string;
+            // eslint-disable-next-line
+            a: string;
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              a: string // eslint-disable-line
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              a: string // eslint-disable-line
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            // eslint-disable-next-line
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            // eslint-disable-next-line
+            a: string
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
             },
-          ],
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              /* eslint-disable-next-line */
-              a: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              /* eslint-disable-next-line */
-              a: string
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              a: string /* eslint-disable-line */
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              a: string /* eslint-disable-line */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type = {
-              a: string
-              d: string
-              /* eslint-disable */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              e: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              d: string
-              e: string
-              /* eslint-disable */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              a: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            // eslint-disable-next-line
+            a: string
+            d: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            d: string
+            c: string
+            // eslint-disable-next-line
+            a: string
+            b: string
+          }
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            a: string // eslint-disable-line
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            a: string // eslint-disable-line
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              a: string // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              a: string // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            /* eslint-disable-next-line */
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            /* eslint-disable-next-line */
+            a: string
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            a: string /* eslint-disable-line */
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            a: string /* eslint-disable-line */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type = {
+            a: string
+            d: string
+            /* eslint-disable */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            d: string
+            e: string
+            /* eslint-disable */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type = {
-              b: string
-              c: string
-              a: string /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          code: dedent`
-            type Type = {
-              c: string
-              b: string
-              a: string /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            // eslint-disable-next-line rule-to-test/sort-object-types
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            // eslint-disable-next-line rule-to-test/sort-object-types
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type = {
-              a: string
-              d: string
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              e: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              d: string
-              e: string
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c: string
-              b: string
-              // Shouldn't move
-              /* eslint-enable */
-              a: string
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = {
-              b: string;
-              c: string;
-              // eslint-disable-next-line
-              a: string;
-            }
-          `,
-        },
-      ],
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            a: string // eslint-disable-line rule-to-test/sort-object-types
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            a: string // eslint-disable-line rule-to-test/sort-object-types
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            /* eslint-disable-next-line rule-to-test/sort-object-types */
+            a: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            /* eslint-disable-next-line rule-to-test/sort-object-types */
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type = {
+            b: string
+            c: string
+            a: string /* eslint-disable-line rule-to-test/sort-object-types */
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            c: string
+            b: string
+            a: string /* eslint-disable-line rule-to-test/sort-object-types */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          type Type = {
+            a: string
+            d: string
+            /* eslint-disable rule-to-test/sort-object-types */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            e: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            d: string
+            e: string
+            /* eslint-disable rule-to-test/sort-object-types */
+            c: string
+            b: string
+            // Shouldn't move
+            /* eslint-enable */
+            a: string
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
     })
   })
 })

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1,5427 +1,2069 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-objects'
 
-let ruleName = 'sort-objects'
+describe('sort-objects', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-objects',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts object with identifier and literal keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aaaa',
-                b: 'bbb',
-                [c]: 'cc',
-                d: 'd',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                [c]: 'cc',
-                b: 'bbb',
-                d: 'd',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                b: 'bbb',
-                [c]: 'cc',
-                d: 'd',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
+    it('sorts object with identifier and literal keys', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bbb',
+            [c]: 'cc',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorting does not break object`,
-      rule,
-      {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                b: 'bb',
-                c: 'c',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                c: 'c',
-                b: 'bb',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            options: [options],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
           },
         ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                b: 'bb',
-                c: 'c',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts objects in objects`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              let Obj = {
-                x: {
-                  b: 'b',
-                  a: 'aa',
-                },
-                y: {
-                  b: 'b',
-                  a: 'aa',
-                },
-              }
-            `,
-            dedent`
-              let Obj = {
-                x: {
-                  a: 'aa',
-                  b: 'b',
-                },
-                y: {
-                  a: 'aa',
-                  b: 'b',
-                },
-              }
-            `,
-          ],
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'x',
-                left: 'y',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          code: dedent`
-            let Obj = {
-              y: {
-                b: 'b',
-                a: 'aa',
-              },
-              x: {
-                b: 'b',
-                a: 'aa',
-              },
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Obj = {
-              x: {
-                a: 'aa',
-                b: 'b',
-              },
-              y: {
-                a: 'aa',
-                b: 'b',
-              },
-            }
-          `,
-          options: [options],
-        },
-      ],
+        output: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bbb',
+            [c]: 'cc',
+            d: 'd',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            [c]: 'cc',
+            b: 'bbb',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): sorts objects computed keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: 'c[1]',
-                right: 'b()',
-              },
-              messageId: 'unexpectedObjectsOrder',
+    it('preserves object structure when sorting', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'c',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-            {
-              data: {
-                left: 'b()',
-                right: 'a',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let Obj = {
-              'a': 'aaa',
-              [b()]: 'bb',
-              [c[1]]: 'c',
-            }
-          `,
-          code: dedent`
-            let Obj = {
-              [c[1]]: 'c',
-              [b()]: 'bb',
-              'a': 'aaa',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Obj = {
-              'a': 'aaa',
-              [b()]: 'bb',
-              [c[1]]: 'c',
-            }
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'c',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            b: 'bb',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): allows to set priority keys`, rule, {
-      invalid: [
-        {
+    it('sorts nested objects', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            x: {
+              a: 'aa',
+              b: 'b',
+            },
+            y: {
+              a: 'aa',
+              b: 'b',
+            },
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'x',
+              left: 'y',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            x: {
+              a: 'aa',
+              b: 'b',
+            },
+            y: {
+              a: 'aa',
+              b: 'b',
+            },
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            y: {
+              b: 'b',
+              a: 'aa',
+            },
+            x: {
+              b: 'b',
+              a: 'aa',
+            },
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts objects with computed keys', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            'a': 'aaa',
+            [b()]: 'bb',
+            [c[1]]: 'c',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'c[1]',
+              right: 'b()',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              left: 'b()',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            'a': 'aaa',
+            [b()]: 'bb',
+            [c[1]]: 'c',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            [c[1]]: 'c',
+            [b()]: 'bb',
+            'a': 'aaa',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows setting priority keys in custom groups', async () => {
+      let customOptions = {
+        ...options,
+        customGroups: { top: ['c', 'b'] },
+        groups: ['top', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'ccc',
+            a: 'aaaa',
+            d: 'd',
+          }
+        `,
+        options: [customOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'top',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'ccc',
+            a: 'aaaa',
+            d: 'd',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bb',
+            c: 'ccc',
+            d: 'd',
+          }
+        `,
+        options: [customOptions],
+      })
+    })
+
+    it('allows using regex patterns for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            iHaveFooInMyName: string,
+            meTooIHaveFoo: string,
+            a: string,
+            b: "b",
+          }
+        `,
+      })
+    })
+
+    it('sorts with inline comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            b: 'bb', // Comment B
+            c: 'c' // Comment C
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            b: 'bb', // Comment B
+            c: 'c', // Comment C
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            c: 'c', // Comment C
+            b: 'bb', // Comment B
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts objects without trailing comma when last element has a comment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aa', // Comment A
+            b: 'b' // Comment B
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b', // Comment B
+            a: 'aa' // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts destructured object parameters', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 'aa',
+            b,
+            c
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            c,
+            a = 'aa',
+            b
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves order when right value depends on left value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 'a',
+            c,
+            b = c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            c,
+            b = c,
+            a = 'a',
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles complex dependencies between destructured parameters', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'd',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            d,
+            b = a + c + d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = a + c + d,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'c',
+              right: 'b',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            b,
+            c = 1 === 1 ? 1 === 1 ? a : b : b,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            c = 1 === 1 ? 1 === 1 ? a : b : b,
+            b,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'd',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            d,
+            b = ['a', 'b', 'c'].includes(d, c, a),
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = ['a', 'b', 'c'].includes(d, c, a),
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            b = c || c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = c || c,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            b = 1 === 1 ? a : c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = 1 === 1 ? a : c,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+              c = 10,
+              a = c,
+              b = 10,
+              }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+              a = c,
+              b = 10,
+              c = 10,
+              }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = () => 1,
+            a = b(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = function() { return 1 },
+            a = b(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = () => 1,
+            a = a.map(b),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object literals', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = {x: b},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = {[b]: 0},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects chained member expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = b.x,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = new Subject(),
+            a = b.asObservable(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chaining dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = b?.x,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects non-null assertion dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = b!,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects unary expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = true,
+            a = !b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects spread element dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = {...b},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = [1],
+            a = [...b],
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = b ? 1 : 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = x ? b : 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = x ? 0 : b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in type assertions', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = b as any,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = <any>b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literals', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = \`\${b}\`,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores function body dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = () => b,
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = function() { return b },
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = () => {return b},
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object destructuring patterns', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let {
+            b: bRenamed,
+            a = bRenamed,
+          } = obj;
+        `,
+        code: dedent`
+          let {
+            a = bRenamed,
+            b: bRenamed,
+          } = obj;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let [{
+            b: bRenamed,
+            a = bRenamed,
+          }] = [obj];
+        `,
+        code: dedent`
+          let [{
+            a = bRenamed,
+            b: bRenamed,
+          }] = [obj];
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let {
+            [b]: bRenamed,
+            a = bRenamed,
+          } = obj;
+        `,
+        code: dedent`
+          let {
+            a = bRenamed,
+            [b]: bRenamed,
+          } = obj;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects and handles circular dependencies', async () => {
+      await invalid({
+        output: dedent`
+          let Func = ({
+            a,
+            b = f + 1,
+            c,
+            d = b + 1,
+            e,
+            f = d + 1
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = f + 1,
+            a,
+            c,
+            d = b + 1,
+            e,
+            f = d + 1
+          }) => {
+            // ...
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              attributesStartingWithA: 'a',
+              attributesStartingWithB: 'b',
+            },
+            groups: ['attributesStartingWithA', 'attributesStartingWithB'],
+          },
+        ],
+        code: dedent`
+          let Func = ({
+            b,
+            a = b,
+          }) => {
+            // ...
+          }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 0,
+            // Part: 1
+            b = a,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = a,
+            // Part: 1
+            a = 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over newline partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 0,
+
+            b = a,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = a,
+
+            a = 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows using partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            // Part: 1
+            d: 'ddd',
+            e: 'ee',
+            // Part: 2
+            f: 'f',
+            // Part: 3
+            a: 'aaaaaa',
+            // Not partition comment
+            b: 'bbbbb',
+            c: 'cccc',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            // Part: 1
+            e: 'ee',
+            d: 'ddd',
+            // Part: 2
+            f: 'f',
+            // Part: 3
+            a: 'aaaaaa',
+            c: 'cccc',
+            // Not partition comment
+            b: 'bbbbb',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows treating all comments as partitions', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            // Some comment
+            b: 'b',
+            // Other comment
+            a: 'aa',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows using multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          let Object = {
+            /* Partition Comment */
+            // Part: 1
+            c: 'cc',
+            // Part: 2
+            a: 'aaaa',
+            b: 'bbb',
+            d: 'd',
+            /* Part: 3 */
+            e: 'e',
+          }
+        `,
+        code: dedent`
+          let Object = {
+            /* Partition Comment */
+            // Part: 1
+            c: 'cc',
+            // Part: 2
+            b: 'bbb',
+            a: 'aaaa',
+            d: 'd',
+            /* Part: 3 */
+            e: 'e',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:'],
+          },
+        ],
+      })
+    })
+
+    it('allows using regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            e = 'e',
+            f = 'f',
+            // I am a partition comment because I don't have f o o
+            a = 'a',
+            b = 'b',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when using line partition option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            /* Comment */
+            a: 'a',
+            b: 'b',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* Comment */
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('treats line comments as partitions when line option is enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // Comment
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('allows multiple line partition comments with specific patterns', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            // b
+            b: 'b',
+            // a
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows regex patterns for line partition comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // I am a partition comment because I don't have f o o
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block partition option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            // Comment
+            a: 'a',
+            b: 'b',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // Comment
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('treats block comments as partitions when block option is enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* Comment */
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('allows multiple block partition comments with specific patterns', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            /* b */
+            b: 'b',
+            /* a */
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows regex patterns for block partition comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* I am a partition comment because I don't have f o o */
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows using newlines as partitions', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            d: 'dd',
+            e: 'e',
+
+            c: 'ccc',
+
+            a: 'aaaaa',
+            b: 'bbbb',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            d: 'dd',
+            e: 'e',
+
+            c: 'ccc',
+
+            a: 'aaaaa',
+            b: 'bbbb',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            e: 'e',
+            d: 'dd',
+
+            c: 'ccc',
+
+            b: 'bbbb',
+            a: 'aaaaa',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows trimming special characters', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            _a = 'a',
+            b = 'b',
+            _c = 'c',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows removing special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          let obj = {
+            ab = 'ab',
+            a_c = 'ac',
+          }
+        `,
+      })
+    })
+
+    it('sorts using specified locale', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B',
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('prioritizes methods over multiline properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            method() {},
+            multilineProperty: {
+              // Some multiline stuff
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            multilineProperty: {
+              // Some multiline stuff
+            },
+            method() {},
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes properties over multiline methods', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineFunction',
+              leftGroup: 'multiline',
+              rightGroup: 'property',
+              right: 'property',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            property,
+            multilineFunction() {
+              // Some multiline stuff
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            multilineFunction() {
+              // Some multiline stuff
+            },
+            property,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes properties over methods when configured', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+        output: dedent`
+          let obj = {
+            property,
+            method() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            method() {},
+            property,
+          }
+        `,
+      })
+    })
+
+    it('sorts by configured groups', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            z: {
+              // Some multiline stuff
+            },
+            f: 'a',
+            a1: () => {},
+            a2: function() {},
+            a3() {},
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'unknown', 'method'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                leftGroup: 'unknown',
-                rightGroup: 'top',
-                right: 'b',
+                right: 'y',
                 left: 'a',
               },
-              messageId: 'unexpectedObjectsGroupOrder',
+              messageId: 'extraSpacingBetweenObjectMembers',
             },
-          ],
-          options: [
             {
-              ...options,
-              customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-          output: dedent`
-            let Obj = {
-              b: 'bb',
-              c: 'ccc',
-              a: 'aaaa',
-              d: 'd',
-            }
-          `,
-          code: dedent`
-            let Obj = {
-              a: 'aaaa',
-              b: 'bb',
-              c: 'ccc',
-              d: 'd',
-            }
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-          code: dedent`
-            let Obj = {
-              b: 'bb',
-              c: 'ccc',
-              a: 'aaaa',
-              d: 'd',
-            }
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for custom groups`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                customGroups: {
-                  elementsWithoutFoo: '^(?!.*Foo).*$',
-                },
-                groups: ['unknown', 'elementsWithoutFoo'],
+              data: {
+                right: 'b',
+                left: 'z',
               },
-            ],
-            code: dedent`
-              let Obj = {
-                iHaveFooInMyName: string,
-                meTooIHaveFoo: string,
-                a: string,
+              messageId: 'unexpectedObjectsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          code: dedent`
+            let Obj = {
+              a: () => null,
+
+
+             y: "y",
+            z: "z",
+
                 b: "b",
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts with comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                b: 'bb', // Comment B
-                c: 'c', // Comment C
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                c: 'c', // Comment C
-                b: 'bb', // Comment B
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                b: 'bb', // Comment B
-                c: 'c' // Comment C
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): do not sorts objects without a comma and with a comment in the last element`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aa', // Comment A
-                b: 'b' // Comment B
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                b: 'b', // Comment B
-                a: 'aa' // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts destructured object`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
+            }
+          `,
           output: dedent`
-            let Func = ({
-              a = 'aa',
-              b,
-              c
-            }) => {
-              // ...
+            let Obj = {
+              a: () => null,
+             b: "b",
+            y: "y",
+                z: "z",
             }
           `,
-          code: dedent`
-            let Func = ({
-              c,
-              a = 'aa',
-              b
-            }) => {
-              // ...
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort keys if the right value depends on the left value`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a = 'a',
-                c,
-                b = c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                c,
-                b = c,
-                a = 'a',
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe('detects dependencies', () => {
-      ruleTester.run(
-        `${ruleName}(${type}): works with complex dependencies`,
-        rule,
-        {
-          invalid: [
+          options: [
             {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'd',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                  a,
-                  c,
-                  d,
-                  b = a + c + d,
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  a,
-                  b = a + c + d,
-                  c,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'c',
-                    right: 'b',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                  a,
-                  b,
-                  c = 1 === 1 ? 1 === 1 ? a : b : b,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  a,
-                  c = 1 === 1 ? 1 === 1 ? a : b : b,
-                  b,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'd',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                  a,
-                  c,
-                  d,
-                  b = ['a', 'b', 'c'].includes(d, c, a),
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  a,
-                  b = ['a', 'b', 'c'].includes(d, c, a),
-                  c,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [
-                {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                  a,
-                  c,
-                  b = c || c,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  a,
-                  b = c || c,
-                  c,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                  a,
-                  c,
-                  b = 1 === 1 ? a : c,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  a,
-                  b = 1 === 1 ? a : c,
-                  c,
-                  d,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'a',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                    c = 10,
-                    a = c,
-                    b = 10,
-                    }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                    a = c,
-                    b = 10,
-                    c = 10,
-                    }) => {
-                  // ...
-                }
-              `,
-              options: [options],
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
             },
           ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): detects function expression dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = () => 1,
-                  a = b(),
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  b = function() { return 1 },
-                  a = b(),
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  b = () => 1,
-                  a = a.map(b),
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in objects`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = 1,
-                  a = {x: b},
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  b = 1,
-                  a = {[b]: 0},
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects chained dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = {x: 1},
-                  a = b.x,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  b = new Subject(),
-                  a = b.asObservable(),
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects optional chained dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = {x: 1},
-                  a = b?.x,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects non-null asserted dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = 1,
-                  a = b!,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}) detects unary dependencies`, rule, {
-        valid: [
-          {
-            code: dedent`
-              let Func = ({
-                b = true,
-                a = !b,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects spread elements dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = {x: 1},
-                  a = {...b},
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  b = [1],
-                  a = [...b],
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in conditional expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = 0,
-                  a = b ? 1 : 0,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  b = 0,
-                  a = x ? b : 0,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  b = 0,
-                  a = x ? 0 : b,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in 'as' expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = 'b',
-                  a = b as any,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in type assertion expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = 'b',
-                  a = <any>b,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in template literal expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  b = 'b',
-                  a = \`\${b}\`,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) ignores function body dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Func = ({
-                  a = () => b,
-                  b = 1,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  a = function() { return b },
-                  b = 1,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let Func = ({
-                  a = () => {return b},
-                  b = 1,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): detects dependencies in object destructuring`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'a',
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let {
-                  b: bRenamed,
-                  a = bRenamed,
-                } = obj;
-              `,
-              code: dedent`
-                let {
-                  a = bRenamed,
-                  b: bRenamed,
-                } = obj;
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'a',
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let [{
-                  b: bRenamed,
-                  a = bRenamed,
-                }] = [obj];
-              `,
-              code: dedent`
-                let [{
-                  a = bRenamed,
-                  b: bRenamed,
-                }] = [obj];
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'a',
-                    right: 'b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let {
-                  [b]: bRenamed,
-                  a = bRenamed,
-                } = obj;
-              `,
-              code: dedent`
-                let {
-                  a = bRenamed,
-                  [b]: bRenamed,
-                } = obj;
-              `,
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): detects and ignores circular dependencies`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                let Func = ({
-                  a,
-                  b = f + 1,
-                  c,
-                  d = b + 1,
-                  e,
-                  f = d + 1
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  b = f + 1,
-                  a,
-                  c,
-                  d = b + 1,
-                  e,
-                  f = d + 1
-                }) => {
-                  // ...
-                }
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedObjectsOrder',
-                },
-              ],
-              options: [options],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over group configuration`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: {
-                    attributesStartingWithA: 'a',
-                    attributesStartingWithB: 'b',
-                  },
-                  groups: [
-                    'attributesStartingWithA',
-                    'attributesStartingWithB',
-                  ],
-                },
-              ],
-              code: dedent`
-                let Func = ({
-                  b,
-                  a = b,
-                }) => {
-                  // ...
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'a',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                  a = 0,
-                  // Part: 1
-                  b = a,
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  b = a,
-                  // Part: 1
-                  a = 0,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'a',
-                  },
-                  messageId: 'unexpectedObjectsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let Func = ({
-                  a = 0,
-
-                  b = a,
-                }) => {
-                  // ...
-                }
-              `,
-              code: dedent`
-                let Func = ({
-                  b = a,
-
-                  a = 0,
-                }) => {
-                  // ...
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByNewLine: true,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                // Part: 1
-                d: 'ddd',
-                e: 'ee',
-                // Part: 2
-                f: 'f',
-                // Part: 3
-                a: 'aaaaaa',
-                // Not partition comment
-                b: 'bbbbb',
-                c: 'cccc',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                // Part: 1
-                e: 'ee',
-                d: 'ddd',
-                // Part: 2
-                f: 'f',
-                // Part: 3
-                a: 'aaaaaa',
-                c: 'cccc',
-                // Not partition comment
-                b: 'bbbbb',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                // Some comment
-                b: 'b',
-                // Other comment
-                a: 'aa',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              let Object = {
-                /* Partition Comment */
-                // Part: 1
-                c: 'cc',
-                // Part: 2
-                a: 'aaaa',
-                b: 'bbb',
-                d: 'd',
-                /* Part: 3 */
-                e: 'e',
-              }
-            `,
-            code: dedent`
-              let Object = {
-                /* Partition Comment */
-                // Part: 1
-                c: 'cc',
-                // Part: 2
-                b: 'bbb',
-                a: 'aaaa',
-                d: 'd',
-                /* Part: 3 */
-                e: 'e',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use regex for partition comments`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              let obj = {
-                e = 'e',
-                f = 'f',
-                // I am a partition comment because I don't have f o o
-                a = 'a',
-                b = 'b',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  line: true,
-                },
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                /* Comment */
-                a: 'a',
-                b: 'b',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                b: 'b',
-                /* Comment */
-                a: 'a',
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              code: dedent`
-                let Obj = {
-                  b: 'b',
-                  // Comment
-                  a: 'a',
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Obj = {
-                  c: 'c',
-                  // b
-                  b: 'b',
-                  // a
-                  a: 'a',
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['a', 'b'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Obj = {
-                  b: 'b',
-                  // I am a partition comment because I don't have f o o
-                  a: 'a',
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-      ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: {
-                  block: true,
-                },
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                // Comment
-                a: 'a',
-                b: 'b',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                b: 'b',
-                // Comment
-                a: 'a',
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              code: dedent`
-                let Obj = {
-                  b: 'b',
-                  /* Comment */
-                  a: 'a',
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Obj = {
-                  c: 'c',
-                  /* b */
-                  b: 'b',
-                  /* a */
-                  a: 'a',
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['a', 'b'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let Obj = {
-                  b: 'b',
-                  /* I am a partition comment because I don't have f o o */
-                  a: 'a',
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: ['^(?!.*foo).*$'],
-                  },
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                d: 'dd',
-                e: 'e',
-
-                c: 'ccc',
-
-                a: 'aaaaa',
-                b: 'bbbb',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                e: 'e',
-                d: 'dd',
-
-                c: 'ccc',
-
-                b: 'bbbb',
-                a: 'aaaaa',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                d: 'dd',
-                e: 'e',
-
-                c: 'ccc',
-
-                a: 'aaaaa',
-                b: 'bbbb',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              let obj = {
-                _a = 'a',
-                b = 'b',
-                _c = 'c',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              let obj = {
-                ab = 'ab',
-                a_c = 'ac',
-              }
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            let obj = {
-              你好 = '你好',
-              世界 = '世界',
-              a = 'a',
-              A = 'A',
-              b = 'b',
-              B = 'B',
-            }
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}(${type}): selectors priority`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize method over multiline`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: 'multilineProperty',
-                    leftGroup: 'multiline',
-                    rightGroup: 'method',
-                    right: 'method',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  method() {},
-                  multilineProperty: {
-                    // Some multiline stuff
-                  },
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  multilineProperty: {
-                    // Some multiline stuff
-                  },
-                  method() {},
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['method', 'multiline'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize property over multiline`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    left: 'multilineFunction',
-                    leftGroup: 'multiline',
-                    rightGroup: 'property',
-                    right: 'property',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  property,
-                  multilineFunction() {
-                    // Some multiline stuff
-                  },
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  multilineFunction() {
-                    // Some multiline stuff
-                  },
-                  property,
-                }
-              `,
-              options: [
-                {
-                  ...options,
-                  groups: ['property', 'multiline'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize property over member`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'property',
-                    leftGroup: 'member',
-                    right: 'property',
-                    left: 'method',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groups: ['property', 'member'],
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  property,
-                  method() {},
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  method() {},
-                  property,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to set groups for sorting`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              let obj = {
-                z: {
-                  // Some multiline stuff
-                },
-                f: 'a',
-                a1: () => {},
-                a2: function() {},
-                a3() {},
-              }
-            `,
-            options: [
-              {
-                ...options,
-                groups: ['multiline', 'unknown', 'method'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenObjectMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedObjectsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenObjectMembers',
-                  },
-                ],
-                code: dedent`
-                  let Obj = {
-                    a: () => null,
-
-
-                   y: "y",
-                  z: "z",
-
-                      b: "b",
-                  }
-                `,
-                output: dedent`
-                  let Obj = {
-                    a: () => null,
-                   b: "b",
-                  y: "y",
-                      z: "z",
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    groups: ['method', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenObjectMembers',
-                  },
-                ],
-                output: dedent`
-                  let obj = {
-                    a, 
-
-                  b,
-                  }
-                `,
-                code: dedent`
-                  let obj = {
-                    a, b,
-                  }
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenObjectMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedObjectsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenObjectMembers',
-                  },
-                ],
-                output: dedent`
-                  let Obj = {
-                    a: () => null,
-
-                   y: "y",
-                  z: "z",
-
-                      b: {
-                        // Newline stuff
-                      },
-                  }
-                `,
-                code: dedent`
-                  let Obj = {
-                    a: () => null,
-
-
-                   z: "z",
-                  y: "y",
-                      b: {
-                        // Newline stuff
-                      },
-                  }
-                `,
-                options: [
-                  {
-                    ...options,
-                    groups: ['method', 'unknown', 'multiline'],
-                    newlinesBetween,
-                  },
-                ],
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: {
-                      a: 'a',
-                      b: 'b',
-                      c: 'c',
-                      d: 'd',
-                      e: 'e',
-                    },
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenObjectMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenObjectMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenObjectMembers',
-                  },
-                ],
-                output: dedent`
-                  let obj = {
-                    a: 'a',
-
-                    b: 'b',
-
-                    c: 'c',
-                    d: 'd',
-
-
-                    e: 'e',
-                  }
-                `,
-                code: dedent`
-                  let obj = {
-                    a: 'a',
-                    b: 'b',
-
-
-                    c: 'c',
-
-                    d: 'd',
-
-
-                    e: 'e',
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenObjectMembers',
-                      },
-                    ],
-                    output: dedent`
-                      let obj = {
-                        a: null,
-
-
-                        b: null,
-                      }
-                    `,
-                    code: dedent`
-                      let obj = {
-                        a: null,
-                        b: null,
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenObjectMembers',
-                      },
-                    ],
-                    output: dedent`
-                      let obj = {
-                        a: null,
-                        b: null,
-                      }
-                    `,
-                    code: dedent`
-                      let obj = {
-                        a: null,
-
-                        b: null,
-                      }
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      let obj = {
-                        a: null,
-
-                        b: null,
-                      }
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      let obj = {
-                        a: null,
-                        b: null,
-                      }
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
         })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  let obj = {
-                    a, // Comment after
-                    b() {},
-
-                    c() {},
-                  };
-                `,
-                dedent`
-                  let obj = {
-                    a, // Comment after
-
-                    b() {},
-                    c() {},
-                  };
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'method',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              code: dedent`
-                let obj = {
-                  b() {},
-                  a, // Comment after
-
-                  c() {},
-                };
-              `,
-              options: [
-                {
-                  groups: ['unknown', 'method'],
-                  newlinesBetween: 'always',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedObjectsOrder',
-                  },
-                ],
-                output: dedent`
-                  let obj = {
-                    a,
-
-                    // Partition comment
-
-                    b,
-                    c,
-                  }
-                `,
-                code: dedent`
-                  let obj = {
-                    a,
-
-                    // Partition comment
-
-                    c,
-                    b,
-                  }
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let obj = {
-                a: string, b: string
-              }
-            `,
-            code: dedent`
-              let obj = {
-                b: string, a: string
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let obj = {
-                a: string, b: string,
-              }
-            `,
-            code: dedent`
-              let obj = {
-                b: string, a: string,
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
       },
     )
 
-    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      for (let rgbAllNamesMatchPattern of [
-        '^r|g|b$',
-        ['noMatch', '^r|g|b$'],
-        { pattern: '^R|G|B$', flags: 'i' },
-        ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-          rule,
+    it('handles newlinesBetween configuration between consecutive groups', async () => {
+      await invalid({
+        options: [
           {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'g',
-                      leftGroup: 'b',
-                      right: 'g',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedObjectsGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'r',
-                      leftGroup: 'g',
-                      right: 'r',
-                      left: 'g',
-                    },
-                    messageId: 'unexpectedObjectsGroupOrder',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    useConfigurationIf: {
-                      allNamesMatchPattern: 'foo',
-                    },
-                  },
-                  {
-                    ...options,
-                    customGroups: {
-                      r: 'r',
-                      g: 'g',
-                      b: 'b',
-                    },
-                    useConfigurationIf: {
-                      allNamesMatchPattern: rgbAllNamesMatchPattern,
-                    },
-                    groups: ['r', 'g', 'b'],
-                  },
-                ],
-                output: dedent`
-                  let obj = {
-                    r: string,
-                    g: string,
-                    b: string
-                  }
-                `,
-                code: dedent`
-                  let obj = {
-                    b: string,
-                    g: string,
-                    r: string
-                  }
-                `,
-              },
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
             ],
-            valid: [],
-          },
-        )
-      }
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use 'callingFunctionNamePattern'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'g',
-                    leftGroup: 'b',
-                    right: 'g',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'r',
-                    leftGroup: 'g',
-                    right: 'r',
-                    left: 'g',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  useConfigurationIf: {
-                    callingFunctionNamePattern: 'foo',
-                  },
-                },
-                {
-                  ...options,
-                  customGroups: {
-                    r: 'r',
-                    g: 'g',
-                    b: 'b',
-                  },
-                  useConfigurationIf: {
-                    callingFunctionNamePattern: '^someFunction$',
-                  },
-                  groups: ['r', 'g', 'b'],
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  b,
-                  g,
-                  r
-                }
-
-                someFunction(true, {
-                  r: string,
-                  g: string,
-                  b: string
-                })
-
-                let a = someFunction(true, {
-                  r: string,
-                  g: string,
-                  b: string
-                })
-              `,
-              code: dedent`
-                let obj = {
-                  b,
-                  g,
-                  r
-                }
-
-                someFunction(true, {
-                  b: string,
-                  g: string,
-                  r: string
-                })
-
-                let a = someFunction(true, {
-                  b: string,
-                  g: string,
-                  r: string
-                })
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector and modifiers`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'unusedCustomGroup',
-                    modifiers: ['multiline'],
-                    selector: 'method',
-                  },
-                  {
-                    groupName: 'multilinePropertyGroup',
-                    modifiers: ['multiline'],
-                    selector: 'property',
-                  },
-                  {
-                    groupName: 'propertyGroup',
-                    selector: 'property',
-                  },
-                ],
-                groups: ['propertyGroup', 'multilinePropertyGroup'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  leftGroup: 'multilinePropertyGroup',
-                  rightGroup: 'propertyGroup',
-                  right: 'c',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let obj = {
-                c,
-                a: {
-                  // Multiline
-                },
-                b: {
-                  // Multiline
-                },
-              }
-            `,
-            code: dedent`
-              let obj = {
-                a: {
-                  // Multiline
-                },
-                b: {
-                  // Multiline
-                },
-                c,
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'propertiesStartingWithHello',
-                      selector: 'property',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['propertiesStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'propertiesStartingWithHello',
-                    right: 'helloProperty',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  helloProperty,
-                  a,
-                  b,
-                  method() {},
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  a,
-                  b,
-                  method() {},
-                  helloProperty,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      for (let injectElementValuePattern of [
-        'inject',
-        ['noMatch', 'inject'],
-        { pattern: 'INJECT', flags: 'i' },
-        ['noMatch', { pattern: 'INJECT', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementValuePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementValuePattern: injectElementValuePattern,
-                      groupName: 'inject',
-                    },
-                    {
-                      elementValuePattern: 'computed',
-                      groupName: 'computed',
-                    },
-                  ],
-                  groups: ['computed', 'inject', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'computed',
-                    leftGroup: 'inject',
-                    right: 'z',
-                    left: 'y',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  a: computed(A),
-                  z: computed(Z),
-                  b: inject(B),
-                  y: inject(Y),
-                  c() {},
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  a: computed(A),
-                  b: inject(B),
-                  y: inject(Y),
-                  z: computed(Z),
-                  c() {},
-                }
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectsOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedObjectsOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedObjectsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedPropertiesByLineLength',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                    right: 'eee',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedPropertiesByLineLength',
-                      selector: 'property',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedPropertiesByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  dddd,
-                  ccc,
-                  eee,
-                  bb,
-                  ff,
-                  a,
-                  g,
-                  anotherMethod() {},
-                  method() {},
-                  yetAnotherMethod() {},
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  a,
-                  bb,
-                  ccc,
-                  dddd,
-                  method() {},
-                  eee,
-                  ff,
-                  g,
-                  anotherMethod() {},
-                  yetAnotherMethod() {},
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedObjectsOrder',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  fooBar: 'fooBar',
-                  fooZar: 'fooZar',
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  fooZar: 'fooZar',
-                  fooBar: 'fooBar',
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedProperties',
-                      selector: 'property',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedProperties', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedProperties',
-                    leftGroup: 'unknown',
-                    left: 'method',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              output: dedent`
-                let obj = {
-                  b,
-                  a,
-                  d,
-                  e,
-                  c,
-                  method() {},
-                }
-              `,
-              code: dedent`
-                let obj = {
-                  b,
-                  a,
-                  d,
-                  e,
-                  method() {},
-                  c,
-                }
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        modifiers: ['multiline'],
-                        selector: 'property',
-                      },
-                      {
-                        modifiers: ['multiline'],
-                        selector: 'method',
-                      },
-                    ],
-                    groupName: 'multilinePropertiesAndMultilineMethods',
-                  },
-                ],
-                groups: ['multilinePropertiesAndMultilineMethods', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'multilinePropertiesAndMultilineMethods',
-                  leftGroup: 'unknown',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let obj = {
-                b() {
-                  // Multiline
-                },
-                c: {
-                  // Multiline
-                },
-                a,
-                d() {},
-                e,
-              }
-            `,
-            code: dedent`
-              let obj = {
-                a,
-                b() {
-                  // Multiline
-                },
-                c: {
-                  // Multiline
-                },
-                d() {},
-                e,
-              }
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                let obj = {
-                  iHaveFooInMyName,
-                  meTooIHaveFoo,
-                  a,
-                  b,
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe('newlinesInside', () => {
-        for (let newlinesInside of ['always', 1] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          selector: 'property',
-                          groupName: 'group1',
-                          newlinesInside,
-                        },
-                      ],
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'b',
-                        left: 'a',
-                      },
-                      messageId: 'missedSpacingBetweenObjectMembers',
-                    },
-                  ],
-                  output: dedent`
-                    let obj = {
-                      a,
-
-                      b,
-                    }
-                  `,
-                  code: dedent`
-                    let obj = {
-                      a,
-                      b,
-                    }
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-
-        for (let newlinesInside of ['never', 0] as const) {
-          ruleTester.run(
-            `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-            rule,
-            {
-              invalid: [
-                {
-                  options: [
-                    {
-                      customGroups: [
-                        {
-                          selector: 'property',
-                          groupName: 'group1',
-                          newlinesInside,
-                        },
-                      ],
-                      type: 'alphabetical',
-                      groups: ['group1'],
-                    },
-                  ],
-                  errors: [
-                    {
-                      data: {
-                        right: 'b',
-                        left: 'a',
-                      },
-                      messageId: 'extraSpacingBetweenObjectMembers',
-                    },
-                  ],
-                  output: dedent`
-                    let obj = {
-                      a,
-                      b,
-                    }
-                  `,
-                  code: dedent`
-                    let obj = {
-                      a,
-
-                      b,
-                    }
-                  `,
-                },
-              ],
-              valid: [],
-            },
-          )
-        }
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: {
-                    elementsWithoutFoo: '^(?!.*Foo).*$',
-                  },
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                },
-              ],
-              code: dedent`
-                let obj = {
-                  iHaveFooInMyName,
-                  meTooIHaveFoo,
-                  a,
-                  b,
-                }
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts object with identifier and literal keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aaaa',
-                b: 'bbb',
-                [c]: 'cc',
-                d: 'd',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                [c]: 'cc',
-                b: 'bbb',
-                d: 'd',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                b: 'bbb',
-                [c]: 'cc',
-                d: 'd',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorting does not break object`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                b: 'bb',
-                c: 'c',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                c: 'c',
-                b: 'bb',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                b: 'bb',
-                c: 'c',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts objects in objects`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              let Obj = {
-                x: {
-                  b: 'b',
-                  a: 'aa',
-                },
-                y: {
-                  b: 'b',
-                  a: 'aa',
-                },
-              }
-            `,
-            dedent`
-              let Obj = {
-                x: {
-                  a: 'aa',
-                  b: 'b',
-                },
-                y: {
-                  a: 'aa',
-                  b: 'b',
-                },
-              }
-            `,
-          ],
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'x',
-                left: 'y',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          code: dedent`
-            let Obj = {
-              y: {
-                b: 'b',
-                a: 'aa',
-              },
-              x: {
-                b: 'b',
-                a: 'aa',
-              },
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Obj = {
-              x: {
-                a: 'aa',
-                b: 'b',
-              },
-              y: {
-                a: 'aa',
-                b: 'b',
-              },
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts objects computed keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: 'c[1]',
-                right: 'b()',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                left: 'b()',
-                right: 'a',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let Obj = {
-              'a': 'aaa',
-              [b()]: 'bb',
-              [c[1]]: 'c',
-            }
-          `,
-          code: dedent`
-            let Obj = {
-              [c[1]]: 'c',
-              [b()]: 'bb',
-              'a': 'aaa',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Obj = {
-              'a': 'aaa',
-              [b()]: 'bb',
-              [c[1]]: 'c',
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows to set priority keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'unknown',
-                rightGroup: 'top',
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedObjectsGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-          output: dedent`
-            let Obj = {
-              b: 'bb',
-              c: 'ccc',
-              a: 'aaaa',
-              d: 'd',
-            }
-          `,
-          code: dedent`
-            let Obj = {
-              a: 'aaaa',
-              b: 'bb',
-              c: 'ccc',
-              d: 'd',
-            }
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-          code: dedent`
-            let Obj = {
-              b: 'bb',
-              c: 'ccc',
-              a: 'aaaa',
-              d: 'd',
-            }
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts with comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                b: 'bb', // Comment B
-                c: 'c', // Comment C
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                c: 'c', // Comment C
-                b: 'bb', // Comment B
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                b: 'bb', // Comment B
-                c: 'c', // Comment C
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): do not sorts objects without a comma and with a comment in the last element`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aa', // Comment A
-                b: 'b' // Comment B
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                b: 'b', // Comment B
-                a: 'aa' // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts destructured object`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let Func = ({
-              a = 'aa',
-              b,
-              c
-            }) => {
-              // ...
-            }
-          `,
-          code: dedent`
-            let Func = ({
-              c,
-              a = 'aa',
-              b
-            }) => {
-              // ...
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort keys if the right value depends on the left value`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a = 'a',
-                c,
-                b = c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                c,
-                b = c,
-                a = 'a',
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with complex dependencies`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'd',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                c,
-                d,
-                b = a + c + d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                b = a + c + d,
-                c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'c',
-                  right: 'b',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                b,
-                c = 1 === 1 ? 1 === 1 ? a : b : b,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                c = 1 === 1 ? 1 === 1 ? a : b : b,
-                b,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'd',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                c,
-                d,
-                b = ['a', 'b', 'c'].includes(d, c, a),
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                b = ['a', 'b', 'c'].includes(d, c, a),
-                c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-                order: 'asc',
-              },
-            ],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                c,
-                b = c || c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                b = c || c,
-                c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                c,
-                b = 1 === 1 ? a : c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                b = 1 === 1 ? a : c,
-                c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                // Part: 1
-                d: 'ddd',
-                e: 'ee',
-                // Part: 2
-                f: 'f',
-                // Part: 3
-                a: 'aaaaaa',
-                // Not partition comment
-                b: 'bbbbb',
-                c: 'cccc',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                // Part: 1
-                e: 'ee',
-                d: 'ddd',
-                // Part: 2
-                f: 'f',
-                // Part: 3
-                a: 'aaaaaa',
-                c: 'cccc',
-                // Not partition comment
-                b: 'bbbbb',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                // Some comment
-                b: 'b',
-                // Other comment
-                a: 'aa',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              let Object = {
-                /* Partition Comment */
-                // Part: 1
-                c: 'cc',
-                // Part: 2
-                a: 'aaaa',
-                b: 'bbb',
-                d: 'd',
-                /* Part: 3 */
-                e: 'e',
-              }
-            `,
-            code: dedent`
-              let Object = {
-                /* Partition Comment */
-                // Part: 1
-                c: 'cc',
-                // Part: 2
-                b: 'bbb',
-                a: 'aaaa',
-                d: 'd',
-                /* Part: 3 */
-                e: 'e',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                d: 'dd',
-                e: 'e',
-
-                c: 'ccc',
-
-                a: 'aaaaa',
-                b: 'bbbb',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                e: 'e',
-                d: 'dd',
-
-                c: 'ccc',
-
-                b: 'bbbb',
-                a: 'aaaaa',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                d: 'dd',
-                e: 'e',
-
-                c: 'ccc',
-
-                a: 'aaaaa',
-                b: 'bbbb',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts object with identifier and literal keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aaaa',
-                b: 'bbb',
-                [c]: 'cc',
-                d: 'd',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                [c]: 'cc',
-                b: 'bbb',
-                d: 'd',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                b: 'bbb',
-                [c]: 'cc',
-                d: 'd',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts object with identifier and literal keys`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aaaa',
-                [c]: 'cc',
-                b: 'bbb',
-                d: 'd',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                b: 'bbb',
-                d: 'd',
-                [c]: 'cc',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                a: 'aaaa',
-                [c]: 'cc',
-                b: 'bbb',
-                d: 'd',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorting does not break object`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                b: 'bb',
-                c: 'c',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                c: 'c',
-                b: 'bb',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                b: 'bb',
-                c: 'c',
-                ...rest,
-                a: 'aaa',
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts objects in objects`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let Obj = {
-              x: {
-                a: 'aa',
-                b: 'b',
-              },
-              y: {
-                a: 'aa',
-                b: 'b',
-              },
-            }
-          `,
-          code: dedent`
-            let Obj = {
-              x: {
-                b: 'b',
-                a: 'aa',
-              },
-              y: {
-                b: 'b',
-                a: 'aa',
-              },
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Obj = {
-              x: {
-                a: 'aa',
-                b: 'b',
-              },
-              y: {
-                a: 'aa',
-                b: 'b',
-              },
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): sorts objects computed keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b()',
-                left: 'a',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let Obj = {
-              [b()]: 'bb',
-              [c[1]]: 'c',
-              'a': 'aaa',
-            }
-          `,
-          code: dedent`
-            let Obj = {
-              'a': 'aaa',
-              [b()]: 'bb',
-              [c[1]]: 'c',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let Obj = {
-              [b()]: 'bb',
-              [c[1]]: 'c',
-              'a': 'aaa',
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows to set priority keys`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'unknown',
-                rightGroup: 'top',
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedObjectsGroupOrder',
-            },
-            {
-              data: {
-                right: 'c',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-          output: dedent`
-            let Obj = {
-              c: 'ccc',
-              b: 'bb',
-              a: 'aaaa',
-              d: 'd',
-            }
-          `,
-          code: dedent`
-            let Obj = {
-              a: 'aaaa',
-              b: 'bb',
-              c: 'ccc',
-              d: 'd',
-            }
-          `,
-        },
-      ],
-      valid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: { top: ['c', 'b'] },
-              groups: ['top', 'unknown'],
-            },
-          ],
-          code: dedent`
-            let Obj = {
-              c: 'ccc',
-              b: 'bb',
-              a: 'aaaa',
-              d: 'd',
-            }
-          `,
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts with comments on the same line`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                b: 'bb', // Comment B
-                c: 'c', // Comment C
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                c: 'c', // Comment C
-                b: 'bb', // Comment B
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                a: 'aaa', // Comment A
-                b: 'bb', // Comment B
-                c: 'c' // Comment C
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): do not sorts objects without a comma and with a comment in the last element`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'aa', // Comment A
-                b: 'b' // Comment B
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                b: 'b', // Comment B
-                a: 'aa' // Comment A
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts destructured object`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let Func = ({
-              a = 'aa',
-              c,
-              b
-            }) => {
-              // ...
-            }
-          `,
-          code: dedent`
-            let Func = ({
-              c,
-              a = 'aa',
-              b
-            }) => {
-              // ...
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort keys if the right value depends on the left value`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a = 'a',
-                c,
-                b = c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                c,
-                b = c,
-                a = 'a',
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with complex dependencies`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'd',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                c,
-                d,
-                b = a + c + d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                b = a + c + d,
-                c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'c',
-                  right: 'b',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                b,
-                c = 1 === 1 ? 1 === 1 ? a : b : b,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                c = 1 === 1 ? 1 === 1 ? a : b : b,
-                b,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'd',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                c,
-                d,
-                b = ['a', 'b', 'c'].includes(d, c, a),
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                b = ['a', 'b', 'c'].includes(d, c, a),
-                c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [
-              {
-                type: 'alphabetical',
-                order: 'asc',
-              },
-            ],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'c',
-                },
-                messageId: 'unexpectedObjectsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let Func = ({
-                a,
-                c,
-                b = 1 === 1 ? a : c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            code: dedent`
-              let Func = ({
-                a,
-                b = 1 === 1 ? a : c,
-                c,
-                d,
-              }) => {
-                // ...
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                // Part: 1
-                d: 'ddd',
-                e: 'ee',
-                // Part: 2
-                f: 'f',
-                // Part: 3
-                a: 'aaaaaa',
-                // Not partition comment
-                b: 'bbbbb',
-                c: 'cccc',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                // Part: 1
-                e: 'ee',
-                d: 'ddd',
-                // Part: 2
-                f: 'f',
-                // Part: 3
-                a: 'aaaaaa',
-                c: 'cccc',
-                // Not partition comment
-                b: 'bbbbb',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: '^Part',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use all comments as parts`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                // Some comment
-                b: 'b',
-                // Other comment
-                a: 'aa',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: true,
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use multiple partition comments`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              let Object = {
-                /* Partition Comment */
-                // Part: 1
-                c: 'cc',
-                // Part: 2
-                a: 'aaaa',
-                b: 'bbb',
-                d: 'd',
-                /* Part: 3 */
-                e: 'e',
-              }
-            `,
-            code: dedent`
-              let Object = {
-                /* Partition Comment */
-                // Part: 1
-                c: 'cc',
-                // Part: 2
-                b: 'bbb',
-                a: 'aaaa',
-                d: 'd',
-                /* Part: 3 */
-                e: 'e',
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: ['Partition Comment', 'Part:'],
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): not changes order if the same length`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'e',
-                  left: 'd',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                partitionByComment: [
-                  'Public Safety Bureau',
-                  'Crime Coefficient:',
-                  'Victims',
-                ],
-              },
-            ],
-            output: dedent`
-              export const test = {
-                e: 'e12',
-                d: 'd1',
-                a: 'a',
-                b: 'b',
-                c: 'c',
-              }
-            `,
-            code: dedent`
-              export const test = {
-                a: 'a',
-                b: 'b',
-                c: 'c',
-                d: 'd1',
-                e: 'e12',
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'd',
-                  left: 'e',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                d: 'dd',
-                e: 'e',
-
-                c: 'ccc',
-
-                a: 'aaaaa',
-                b: 'bbbb',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                e: 'e',
-                d: 'dd',
-
-                c: 'ccc',
-
-                b: 'bbbb',
-                a: 'aaaaa',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              let Obj = {
-                d: 'dd',
-                e: 'e',
-
-                c: 'ccc',
-
-                a: 'aaaaa',
-                b: 'bbbb',
-              }
-            `,
-            options: [
-              {
-                ...options,
-                partitionByNewLine: true,
-              },
-            ],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              let obj = {
-                bb: 'bb',
-                c: 'c',
-                a: 'a',
-              }
-            `,
-            code: dedent`
-              let obj = {
-                a: 'a',
-                bb: 'bb',
-                c: 'c',
-              }
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              let obj = {
-                bb: 'bb',
-                a: 'a',
-                c: 'c',
-              }
-            `,
-            code: dedent`
-              let obj = {
-                c: 'c',
-                bb: 'bb',
-                a: 'a',
-              }
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            let obj = {
+            customGroups: {
+              a: 'a',
               b: 'b',
               c: 'c',
-              a: 'a',
-            }
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+              d: 'd',
+              e: 'e',
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: 'a',
+
+            b: 'b',
+
+            c: 'c',
+            d: 'd',
+
+
+            e: 'e',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a: 'a',
+            b: 'b',
+
+
+            c: 'c',
+
+            d: 'd',
+
+
+            e: 'e',
+          }
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines between non-consecutive groups when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
               customGroups: [
-                {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
-                },
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
               ],
-              groups: ['b', 'a'],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                right: 'b',
+                left: 'a',
               },
-              messageId: 'unexpectedObjectsGroupOrder',
+              messageId: 'missedSpacingBetweenObjectMembers',
             },
           ],
           output: dedent`
             let obj = {
-              ba: 'ba',
-              bb: 'bb',
-              ab: 'ab',
-              aa: 'aa',
+              a: null,
+
+
+              b: null,
             }
           `,
           code: dedent`
             let obj = {
-              ab: 'ab',
-              aa: 'aa',
-              ba: 'ba',
-              bb: 'bb',
+              a: null,
+              b: null,
             }
           `,
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'removes newlines when never is configured between all groups (global: %s)',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: null,
+
+              b: null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'],
+      ['ignore', 0],
+      ['never', 'ignore'],
+      [0, 'ignore'],
+    ] as const)(
+      'allows any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let testOptions = {
+          ...options,
+          customGroups: [
+            { elementNamePattern: 'a', groupName: 'a' },
+            { elementNamePattern: 'b', groupName: 'b' },
+            { groupName: 'unusedGroup', elementNamePattern: 'X' },
+          ],
+          groups: [
+            'a',
+            'unusedGroup',
+            { newlinesBetween: groupNewlinesBetween },
+            'b',
+          ],
+          newlinesBetween: globalNewlinesBetween,
+        }
+
+        await valid({
+          code: dedent`
+            let obj = {
+              a: null,
+
+              b: null,
+            }
+          `,
+          options: [testOptions],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+          options: [testOptions],
+        })
+      },
+    )
+
+    it('preserves comments and handles newlines after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a, // Comment after
+
+            b() {},
+            c() {},
+          };
+        `,
+        code: dedent`
+          let obj = {
+            b() {},
+            a, // Comment after
+
+            c() {},
+          };
+        `,
+        options: [
+          {
+            groups: ['unknown', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves newlines between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           options: [
             {
               ...options,
@@ -5430,1246 +2072,7758 @@ describe(ruleName, () => {
                   elementNamePattern: 'a',
                   groupName: 'a',
                 },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a,
+
+              // Partition comment
+
+              b,
+              c,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+
+              // Partition comment
+
+              c,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline object properties correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: string, b: string
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b: string, a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: string, b: string,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b: string, a: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      '^r|g|b$',
+      ['noMatch', '^r|g|b$'],
+      { pattern: '^R|G|B$', flags: 'i' },
+      ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+    ])(
+      'applies configuration when allNamesMatchPattern matches (pattern: %s)',
+      async rgbAllNamesMatchPattern => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
                 left: 'b',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
+            let obj = {
+              r: string,
+              g: string,
+              b: string
+            }
+          `,
+          code: dedent`
+            let obj = {
+              b: string,
+              g: string,
+              r: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('applies configuration when callingFunctionNamePattern matches', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'g',
+              leftGroup: 'b',
+              right: 'g',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'r',
+              leftGroup: 'g',
+              right: 'r',
+              left: 'g',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'g',
+              leftGroup: 'b',
+              right: 'g',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'r',
+              leftGroup: 'g',
+              right: 'r',
+              left: 'g',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            useConfigurationIf: {
+              callingFunctionNamePattern: 'foo',
+            },
+          },
+          {
+            ...options,
+            useConfigurationIf: {
+              callingFunctionNamePattern: '^someFunction$',
+            },
+            customGroups: {
+              r: 'r',
+              g: 'g',
+              b: 'b',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b,
+            g,
+            r
+          }
+
+          someFunction(true, {
+            r: string,
+            g: string,
+            b: string
+          })
+
+          let a = someFunction(true, {
+            r: string,
+            g: string,
+            b: string
+          })
+        `,
+        code: dedent`
+          let obj = {
+            b,
+            g,
+            r
+          }
+
+          someFunction(true, {
+            b: string,
+            g: string,
+            r: string
+          })
+
+          let a = someFunction(true, {
+            b: string,
+            g: string,
+            r: string
+          })
+        `,
+      })
+    })
+
+    it('filters custom groups by selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['multiline'],
+                selector: 'method',
+              },
+              {
+                groupName: 'multilinePropertyGroup',
+                modifiers: ['multiline'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'multilinePropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'multilinePropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            c,
+            a: {
+              // Multiline
+            },
+            b: {
+              // Multiline
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a: {
+              // Multiline
+            },
+            b: {
+              // Multiline
+            },
+            c,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      'hello',
+      ['noMatch', 'hello'],
+      { pattern: 'HELLO', flags: 'i' },
+      ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+    ])(
+      'filters custom groups by elementNamePattern (%s)',
+      async elementNamePattern => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              helloProperty,
+              a,
+              b,
+              method() {},
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+              b,
+              method() {},
+              helloProperty,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'inject',
+      ['noMatch', 'inject'],
+      { pattern: 'INJECT', flags: 'i' },
+      ['noMatch', { pattern: 'INJECT', flags: 'i' }],
+    ])(
+      'filters custom groups by elementValuePattern (%s)',
+      async injectElementValuePattern => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: injectElementValuePattern,
+                  groupName: 'inject',
+                },
+                {
+                  elementValuePattern: 'computed',
+                  groupName: 'computed',
+                },
+              ],
+              groups: ['computed', 'inject', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'computed',
+                leftGroup: 'inject',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: computed(A),
+              z: computed(Z),
+              b: inject(B),
+              y: inject(Y),
+              c() {},
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: computed(A),
+              b: inject(B),
+              y: inject(Y),
+              z: computed(Z),
+              c() {},
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups with overridden type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            dddd,
+            ccc,
+            eee,
+            bb,
+            ff,
+            a,
+            g,
+            anotherMethod() {},
+            method() {},
+            yetAnotherMethod() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            bb,
+            ccc,
+            dddd,
+            method() {},
+            eee,
+            ff,
+            g,
+            anotherMethod() {},
+            yetAnotherMethod() {},
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups with fallbackSort override', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            fooBar: 'fooBar',
+            fooZar: 'fooZar',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            fooZar: 'fooZar',
+            fooBar: 'fooBar',
+          }
+        `,
+      })
+    })
+
+    it('preserves order within unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b,
+            a,
+            d,
+            e,
+            c,
+            method() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b,
+            a,
+            d,
+            e,
+            method() {},
+            c,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups with anyOf conditions', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['multiline'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['multiline'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'multilinePropertiesAndMultilineMethods',
+              },
+            ],
+            groups: ['multilinePropertiesAndMultilineMethods', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'multilinePropertiesAndMultilineMethods',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b() {
+              // Multiline
+            },
+            c: {
+              // Multiline
+            },
+            a,
+            d() {},
+            e,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            b() {
+              // Multiline
+            },
+            c: {
+              // Multiline
+            },
+            d() {},
+            e,
+          }
+        `,
+      })
+    })
+
+    it('allows regex patterns for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          let obj = {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines within custom groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenObjectMembers',
             },
           ],
           output: dedent`
             let obj = {
-              b: 'b',
+              a,
 
-              a: 'a',
+              b,
             }
           `,
           code: dedent`
             let obj = {
-              b: 'b',
-              a: 'a',
+              a,
+              b,
             }
           `,
-        },
-      ],
-      valid: [],
-    })
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}(${type}): enforces dependency sorting`, rule, {
-      invalid: [
-        {
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within custom groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
           errors: [
             {
               data: {
-                nodeDependentOnRight: 'a',
                 right: 'b',
+                left: 'a',
               },
-              messageId: 'unexpectedObjectsDependencyOrder',
+              messageId: 'extraSpacingBetweenObjectMembers',
             },
           ],
           output: dedent`
-            let Func = ({
+            let obj = {
+              a,
               b,
-              a = b,
-            }) => {
-              // ...
             }
           `,
           code: dedent`
-            let Func = ({
-              a = b,
+            let obj = {
+              a,
+
               b,
-            }) => {
-              // ...
             }
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it('allows regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          let obj = {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts object with identifier and literal keys', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bbb',
+            [c]: 'cc',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bbb',
+            [c]: 'cc',
+            d: 'd',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            [c]: 'cc',
+            b: 'bbb',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves object structure when sorting', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'c',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'c',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            b: 'bb',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts nested objects', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            x: {
+              a: 'aa',
+              b: 'b',
+            },
+            y: {
+              a: 'aa',
+              b: 'b',
+            },
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'x',
+              left: 'y',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            x: {
+              a: 'aa',
+              b: 'b',
+            },
+            y: {
+              a: 'aa',
+              b: 'b',
+            },
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            y: {
+              b: 'b',
+              a: 'aa',
+            },
+            x: {
+              b: 'b',
+              a: 'aa',
+            },
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts objects with computed keys', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            'a': 'aaa',
+            [b()]: 'bb',
+            [c[1]]: 'c',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'c[1]',
+              right: 'b()',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              left: 'b()',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            'a': 'aaa',
+            [b()]: 'bb',
+            [c[1]]: 'c',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            [c[1]]: 'c',
+            [b()]: 'bb',
+            'a': 'aaa',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows setting priority keys in custom groups', async () => {
+      let customOptions = {
+        ...options,
+        customGroups: { top: ['c', 'b'] },
+        groups: ['top', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'ccc',
+            a: 'aaaa',
+            d: 'd',
+          }
+        `,
+        options: [customOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'top',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'ccc',
+            a: 'aaaa',
+            d: 'd',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bb',
+            c: 'ccc',
+            d: 'd',
+          }
+        `,
+        options: [customOptions],
+      })
+    })
+
+    it('allows using regex patterns for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            iHaveFooInMyName: string,
+            meTooIHaveFoo: string,
+            a: string,
+            b: "b",
+          }
+        `,
+      })
+    })
+
+    it('sorts with inline comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            b: 'bb', // Comment B
+            c: 'c' // Comment C
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            b: 'bb', // Comment B
+            c: 'c', // Comment C
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            c: 'c', // Comment C
+            b: 'bb', // Comment B
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts objects without trailing comma when last element has a comment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aa', // Comment A
+            b: 'b' // Comment B
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b', // Comment B
+            a: 'aa' // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts destructured object parameters', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 'aa',
+            b,
+            c
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            c,
+            a = 'aa',
+            b
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves order when right value depends on left value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 'a',
+            c,
+            b = c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            c,
+            b = c,
+            a = 'a',
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles complex dependencies between destructured parameters', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'd',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            d,
+            b = a + c + d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = a + c + d,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'c',
+              right: 'b',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            b,
+            c = 1 === 1 ? 1 === 1 ? a : b : b,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            c = 1 === 1 ? 1 === 1 ? a : b : b,
+            b,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'd',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            d,
+            b = ['a', 'b', 'c'].includes(d, c, a),
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = ['a', 'b', 'c'].includes(d, c, a),
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            b = c || c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = c || c,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            b = 1 === 1 ? a : c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = 1 === 1 ? a : c,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+              c = 10,
+              a = c,
+              b = 10,
+              }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+              a = c,
+              b = 10,
+              c = 10,
+              }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = () => 1,
+            a = b(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = function() { return 1 },
+            a = b(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = () => 1,
+            a = a.map(b),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object literals', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = {x: b},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = {[b]: 0},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects chained member expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = b.x,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = new Subject(),
+            a = b.asObservable(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chaining dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = b?.x,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects non-null assertion dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = b!,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects unary expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = true,
+            a = !b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects spread element dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = {...b},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = [1],
+            a = [...b],
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = b ? 1 : 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = x ? b : 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = x ? 0 : b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in type assertions', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = b as any,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = <any>b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literals', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = \`\${b}\`,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores function body dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = () => b,
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = function() { return b },
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = () => {return b},
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object destructuring patterns', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let {
+            b: bRenamed,
+            a = bRenamed,
+          } = obj;
+        `,
+        code: dedent`
+          let {
+            a = bRenamed,
+            b: bRenamed,
+          } = obj;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let [{
+            b: bRenamed,
+            a = bRenamed,
+          }] = [obj];
+        `,
+        code: dedent`
+          let [{
+            a = bRenamed,
+            b: bRenamed,
+          }] = [obj];
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let {
+            [b]: bRenamed,
+            a = bRenamed,
+          } = obj;
+        `,
+        code: dedent`
+          let {
+            a = bRenamed,
+            [b]: bRenamed,
+          } = obj;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects and handles circular dependencies', async () => {
+      await invalid({
+        output: dedent`
+          let Func = ({
+            a,
+            b = f + 1,
+            c,
+            d = b + 1,
+            e,
+            f = d + 1
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = f + 1,
+            a,
+            c,
+            d = b + 1,
+            e,
+            f = d + 1
+          }) => {
+            // ...
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              attributesStartingWithA: 'a',
+              attributesStartingWithB: 'b',
+            },
+            groups: ['attributesStartingWithA', 'attributesStartingWithB'],
+          },
+        ],
+        code: dedent`
+          let Func = ({
+            b,
+            a = b,
+          }) => {
+            // ...
+          }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 0,
+            // Part: 1
+            b = a,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = a,
+            // Part: 1
+            a = 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over newline partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 0,
+
+            b = a,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = a,
+
+            a = 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows using partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            // Part: 1
+            d: 'ddd',
+            e: 'ee',
+            // Part: 2
+            f: 'f',
+            // Part: 3
+            a: 'aaaaaa',
+            // Not partition comment
+            b: 'bbbbb',
+            c: 'cccc',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            // Part: 1
+            e: 'ee',
+            d: 'ddd',
+            // Part: 2
+            f: 'f',
+            // Part: 3
+            a: 'aaaaaa',
+            c: 'cccc',
+            // Not partition comment
+            b: 'bbbbb',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows treating all comments as partitions', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            // Some comment
+            b: 'b',
+            // Other comment
+            a: 'aa',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows using multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          let Object = {
+            /* Partition Comment */
+            // Part: 1
+            c: 'cc',
+            // Part: 2
+            a: 'aaaa',
+            b: 'bbb',
+            d: 'd',
+            /* Part: 3 */
+            e: 'e',
+          }
+        `,
+        code: dedent`
+          let Object = {
+            /* Partition Comment */
+            // Part: 1
+            c: 'cc',
+            // Part: 2
+            b: 'bbb',
+            a: 'aaaa',
+            d: 'd',
+            /* Part: 3 */
+            e: 'e',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:'],
+          },
+        ],
+      })
+    })
+
+    it('allows using regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            e = 'e',
+            f = 'f',
+            // I am a partition comment because I don't have f o o
+            a = 'a',
+            b = 'b',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when using line partition option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            /* Comment */
+            a: 'a',
+            b: 'b',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* Comment */
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('treats line comments as partitions when line option is enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // Comment
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('allows multiple line partition comments with specific patterns', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            // b
+            b: 'b',
+            // a
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows regex patterns for line partition comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // I am a partition comment because I don't have f o o
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block partition option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            // Comment
+            a: 'a',
+            b: 'b',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // Comment
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('treats block comments as partitions when block option is enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* Comment */
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('allows multiple block partition comments with specific patterns', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            /* b */
+            b: 'b',
+            /* a */
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows regex patterns for block partition comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* I am a partition comment because I don't have f o o */
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows using newlines as partitions', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            d: 'dd',
+            e: 'e',
+
+            c: 'ccc',
+
+            a: 'aaaaa',
+            b: 'bbbb',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            d: 'dd',
+            e: 'e',
+
+            c: 'ccc',
+
+            a: 'aaaaa',
+            b: 'bbbb',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            e: 'e',
+            d: 'dd',
+
+            c: 'ccc',
+
+            b: 'bbbb',
+            a: 'aaaaa',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows trimming special characters', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            _a = 'a',
+            b = 'b',
+            _c = 'c',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows removing special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          let obj = {
+            ab = 'ab',
+            a_c = 'ac',
+          }
+        `,
+      })
+    })
+
+    it('sorts using specified locale', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B',
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('prioritizes methods over multiline properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            method() {},
+            multilineProperty: {
+              // Some multiline stuff
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            multilineProperty: {
+              // Some multiline stuff
+            },
+            method() {},
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes properties over multiline methods', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineFunction',
+              leftGroup: 'multiline',
+              rightGroup: 'property',
+              right: 'property',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            property,
+            multilineFunction() {
+              // Some multiline stuff
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            multilineFunction() {
+              // Some multiline stuff
+            },
+            property,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes properties over methods when configured', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+        output: dedent`
+          let obj = {
+            property,
+            method() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            method() {},
+            property,
+          }
+        `,
+      })
+    })
+
+    it('sorts by configured groups', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            z: {
+              // Some multiline stuff
+            },
+            f: 'a',
+            a1: () => {},
+            a2: function() {},
+            a3() {},
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'unknown', 'method'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          code: dedent`
+            let Obj = {
+              a: () => null,
+
+
+             y: "y",
+            z: "z",
+
+                b: "b",
+            }
+          `,
+          output: dedent`
+            let Obj = {
+              a: () => null,
+             b: "b",
+            y: "y",
+                z: "z",
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween configuration between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              a: 'a',
+              b: 'b',
+              c: 'c',
+              d: 'd',
+              e: 'e',
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: 'a',
+
+            b: 'b',
+
+            c: 'c',
+            d: 'd',
+
+
+            e: 'e',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a: 'a',
+            b: 'b',
+
+
+            c: 'c',
+
+            d: 'd',
+
+
+            e: 'e',
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines between non-consecutive groups when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: null,
+
+
+              b: null,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'removes newlines when never is configured between all groups (global: %s)',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: null,
+
+              b: null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'],
+      ['ignore', 0],
+      ['never', 'ignore'],
+      [0, 'ignore'],
+    ] as const)(
+      'allows any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let testOptions = {
+          ...options,
+          customGroups: [
+            { elementNamePattern: 'a', groupName: 'a' },
+            { elementNamePattern: 'b', groupName: 'b' },
+            { groupName: 'unusedGroup', elementNamePattern: 'X' },
+          ],
+          groups: [
+            'a',
+            'unusedGroup',
+            { newlinesBetween: groupNewlinesBetween },
+            'b',
+          ],
+          newlinesBetween: globalNewlinesBetween,
+        }
+
+        await valid({
+          code: dedent`
+            let obj = {
+              a: null,
+
+              b: null,
+            }
+          `,
+          options: [testOptions],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+          options: [testOptions],
+        })
+      },
+    )
+
+    it('preserves comments and handles newlines after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a, // Comment after
+
+            b() {},
+            c() {},
+          };
+        `,
+        code: dedent`
+          let obj = {
+            b() {},
+            a, // Comment after
+
+            c() {},
+          };
+        `,
+        options: [
+          {
+            groups: ['unknown', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves newlines between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a,
+
+              // Partition comment
+
+              b,
+              c,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+
+              // Partition comment
+
+              c,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline object properties correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: string, b: string
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b: string, a: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: string, b: string,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b: string, a: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      '^r|g|b$',
+      ['noMatch', '^r|g|b$'],
+      { pattern: '^R|G|B$', flags: 'i' },
+      ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+    ])(
+      'applies configuration when allNamesMatchPattern matches (pattern: %s)',
+      async rgbAllNamesMatchPattern => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
+            let obj = {
+              r: string,
+              g: string,
+              b: string
+            }
+          `,
+          code: dedent`
+            let obj = {
+              b: string,
+              g: string,
+              r: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('applies configuration when callingFunctionNamePattern matches', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'g',
+              leftGroup: 'b',
+              right: 'g',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'r',
+              leftGroup: 'g',
+              right: 'r',
+              left: 'g',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'g',
+              leftGroup: 'b',
+              right: 'g',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'r',
+              leftGroup: 'g',
+              right: 'r',
+              left: 'g',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            useConfigurationIf: {
+              callingFunctionNamePattern: 'foo',
+            },
+          },
+          {
+            ...options,
+            useConfigurationIf: {
+              callingFunctionNamePattern: '^someFunction$',
+            },
+            customGroups: {
+              r: 'r',
+              g: 'g',
+              b: 'b',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b,
+            g,
+            r
+          }
+
+          someFunction(true, {
+            r: string,
+            g: string,
+            b: string
+          })
+
+          let a = someFunction(true, {
+            r: string,
+            g: string,
+            b: string
+          })
+        `,
+        code: dedent`
+          let obj = {
+            b,
+            g,
+            r
+          }
+
+          someFunction(true, {
+            b: string,
+            g: string,
+            r: string
+          })
+
+          let a = someFunction(true, {
+            b: string,
+            g: string,
+            r: string
+          })
+        `,
+      })
+    })
+
+    it('filters custom groups by selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['multiline'],
+                selector: 'method',
+              },
+              {
+                groupName: 'multilinePropertyGroup',
+                modifiers: ['multiline'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'multilinePropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'multilinePropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            c,
+            a: {
+              // Multiline
+            },
+            b: {
+              // Multiline
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a: {
+              // Multiline
+            },
+            b: {
+              // Multiline
+            },
+            c,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      'hello',
+      ['noMatch', 'hello'],
+      { pattern: 'HELLO', flags: 'i' },
+      ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+    ])(
+      'filters custom groups by elementNamePattern (%s)',
+      async elementNamePattern => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              helloProperty,
+              a,
+              b,
+              method() {},
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+              b,
+              method() {},
+              helloProperty,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'inject',
+      ['noMatch', 'inject'],
+      { pattern: 'INJECT', flags: 'i' },
+      ['noMatch', { pattern: 'INJECT', flags: 'i' }],
+    ])(
+      'filters custom groups by elementValuePattern (%s)',
+      async injectElementValuePattern => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: injectElementValuePattern,
+                  groupName: 'inject',
+                },
+                {
+                  elementValuePattern: 'computed',
+                  groupName: 'computed',
+                },
+              ],
+              groups: ['computed', 'inject', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'computed',
+                leftGroup: 'inject',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: computed(A),
+              z: computed(Z),
+              b: inject(B),
+              y: inject(Y),
+              c() {},
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: computed(A),
+              b: inject(B),
+              y: inject(Y),
+              z: computed(Z),
+              c() {},
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups with overridden type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            dddd,
+            ccc,
+            eee,
+            bb,
+            ff,
+            a,
+            g,
+            anotherMethod() {},
+            method() {},
+            yetAnotherMethod() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            bb,
+            ccc,
+            dddd,
+            method() {},
+            eee,
+            ff,
+            g,
+            anotherMethod() {},
+            yetAnotherMethod() {},
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups with fallbackSort override', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            fooBar: 'fooBar',
+            fooZar: 'fooZar',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            fooZar: 'fooZar',
+            fooBar: 'fooBar',
+          }
+        `,
+      })
+    })
+
+    it('preserves order within unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b,
+            a,
+            d,
+            e,
+            c,
+            method() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b,
+            a,
+            d,
+            e,
+            method() {},
+            c,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups with anyOf conditions', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['multiline'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['multiline'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'multilinePropertiesAndMultilineMethods',
+              },
+            ],
+            groups: ['multilinePropertiesAndMultilineMethods', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'multilinePropertiesAndMultilineMethods',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b() {
+              // Multiline
+            },
+            c: {
+              // Multiline
+            },
+            a,
+            d() {},
+            e,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            b() {
+              // Multiline
+            },
+            c: {
+              // Multiline
+            },
+            d() {},
+            e,
+          }
+        `,
+      })
+    })
+
+    it('allows regex patterns for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          let obj = {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines within custom groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a,
+
+              b,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within custom groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a,
+              b,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          let obj = {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
+    })
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts object with identifier and literal keys', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            [c]: 'cc',
+            b: 'bbb',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aaaa',
+            [c]: 'cc',
+            b: 'bbb',
+            d: 'd',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bbb',
+            [c]: 'cc',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves object structure when sorting', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'c',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            b: 'bb',
+            c: 'c',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            b: 'bb',
+            ...rest,
+            a: 'aaa',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts nested objects', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            x: {
+              a: 'aa',
+              b: 'b',
+            },
+            y: {
+              a: 'aa',
+              b: 'b',
+            },
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            y: {
+              a: 'aa',
+              b: 'b',
+            },
+            x: {
+              a: 'aa',
+              b: 'b',
+            },
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            y: {
+              b: 'b',
+              a: 'aa',
+            },
+            x: {
+              b: 'b',
+              a: 'aa',
+            },
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts objects with computed keys', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            [c[1]]: 'c',
+            [b()]: 'bb',
+            'a': 'aaa',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b()',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            [c[1]]: 'c',
+            [b()]: 'bb',
+            'a': 'aaa',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            [c[1]]: 'c',
+            'a': 'aaa',
+            [b()]: 'bb',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows setting priority keys in custom groups', async () => {
+      let customOptions = {
+        ...options,
+        customGroups: { top: ['c', 'b'] },
+        groups: ['top', 'unknown'],
+      }
+
+      await valid({
+        code: dedent`
+          let Obj = {
+            c: 'ccc',
+            b: 'bb',
+            a: 'aaaa',
+            d: 'd',
+          }
+        `,
+        options: [customOptions],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'top',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            c: 'ccc',
+            b: 'bb',
+            a: 'aaaa',
+            d: 'd',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bb',
+            c: 'ccc',
+            d: 'd',
+          }
+        `,
+        options: [customOptions],
+      })
+    })
+
+    it('allows using regex patterns for custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            iHaveFooInMyName: string,
+            meTooIHaveFoo: string,
+            a: string,
+            b: "b",
+          }
+        `,
+      })
+    })
+
+    it('sorts with inline comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            b: 'bb', // Comment B
+            c: 'c' // Comment C
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            b: 'bb', // Comment B
+            c: 'c', // Comment C
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaa', // Comment A
+            c: 'c', // Comment C
+            b: 'bb', // Comment B
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts objects without trailing comma when last element has a comment', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aa', // Comment A
+            b: 'b' // Comment B
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b', // Comment B
+            a: 'aa' // Comment A
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts destructured object parameters', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 'aa',
+            c,
+            b
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            c,
+            a = 'aa',
+            b
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves order when right value depends on left value', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 'a',
+            c,
+            b = c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            c,
+            b = c,
+            a = 'a',
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles complex dependencies between destructured parameters', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'd',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            d,
+            b = a + c + d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = a + c + d,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'c',
+              right: 'b',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            b,
+            c = 1 === 1 ? 1 === 1 ? a : b : b,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            c = 1 === 1 ? 1 === 1 ? a : b : b,
+            b,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'd',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            d,
+            b = ['a', 'b', 'c'].includes(d, c, a),
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = ['a', 'b', 'c'].includes(d, c, a),
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            c,
+            b = c || c,
+            a,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = c || c,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a,
+            c,
+            b = 1 === 1 ? a : c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a,
+            b = 1 === 1 ? a : c,
+            c,
+            d,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+              b = 10,
+              c = 10,
+              a = c,
+              }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+              a = c,
+              b = 10,
+              c = 10,
+              }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = () => 1,
+            a = b(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = function() { return 1 },
+            a = b(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = () => 1,
+            a = a.map(b),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object literals', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = {x: b},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = {[b]: 0},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects chained member expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = b.x,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = new Subject(),
+            a = b.asObservable(),
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chaining dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = b?.x,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects non-null assertion dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 1,
+            a = b!,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects unary expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = true,
+            a = !b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects spread element dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = {x: 1},
+            a = {...b},
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = [1],
+            a = [...b],
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = b ? 1 : 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = x ? b : 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 0,
+            a = x ? 0 : b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in type assertions', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = b as any,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = <any>b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literals', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            b = 'b',
+            a = \`\${b}\`,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores function body dependencies', async () => {
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = () => b,
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = function() { return b },
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let Func = ({
+            a = () => {return b},
+            b = 1,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object destructuring patterns', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let {
+            b: bRenamed,
+            a = bRenamed,
+          } = obj;
+        `,
+        code: dedent`
+          let {
+            a = bRenamed,
+            b: bRenamed,
+          } = obj;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let [{
+            b: bRenamed,
+            a = bRenamed,
+          }] = [obj];
+        `,
+        code: dedent`
+          let [{
+            a = bRenamed,
+            b: bRenamed,
+          }] = [obj];
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let {
+            [b]: bRenamed,
+            a = bRenamed,
+          } = obj;
+        `,
+        code: dedent`
+          let {
+            a = bRenamed,
+            [b]: bRenamed,
+          } = obj;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects and handles circular dependencies', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'f',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            b = f + 1,
+            d = b + 1,
+            f = d + 1,
+            a,
+            c,
+            e
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = f + 1,
+            a,
+            c,
+            d = b + 1,
+            e,
+            f = d + 1
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              attributesStartingWithA: 'a',
+              attributesStartingWithB: 'b',
+            },
+            groups: ['attributesStartingWithA', 'attributesStartingWithB'],
+          },
+        ],
+        code: dedent`
+          let Func = ({
+            b,
+            a = b,
+          }) => {
+            // ...
+          }
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 0,
+            // Part: 1
+            b = a,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = a,
+            // Part: 1
+            a = 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('prioritizes dependencies over newline partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            a = 0,
+
+            b = a,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            b = a,
+
+            a = 0,
+          }) => {
+            // ...
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows using partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            // Part: 1
+            d: 'ddd',
+            e: 'ee',
+            // Part: 2
+            f: 'f',
+            // Part: 3
+            a: 'aaaaaa',
+            // Not partition comment
+            b: 'bbbbb',
+            c: 'cccc',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            // Part: 1
+            e: 'ee',
+            d: 'ddd',
+            // Part: 2
+            f: 'f',
+            // Part: 3
+            a: 'aaaaaa',
+            c: 'cccc',
+            // Not partition comment
+            b: 'bbbbb',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('allows treating all comments as partitions', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            // Some comment
+            b: 'b',
+            // Other comment
+            a: 'aa',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('allows using multiple partition comments', async () => {
+      await invalid({
+        output: dedent`
+          let Object = {
+            /* Partition Comment */
+            // Part: 1
+            c: 'cc',
+            // Part: 2
+            a: 'aaaa',
+            b: 'bbb',
+            d: 'd',
+            /* Part: 3 */
+            e: 'e',
+          }
+        `,
+        code: dedent`
+          let Object = {
+            /* Partition Comment */
+            // Part: 1
+            c: 'cc',
+            // Part: 2
+            b: 'bbb',
+            a: 'aaaa',
+            d: 'd',
+            /* Part: 3 */
+            e: 'e',
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:'],
+          },
+        ],
+      })
+    })
+
+    it('allows using regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            e = 'e',
+            f = 'f',
+            // I am a partition comment because I don't have f o o
+            a = 'a',
+            b = 'b',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when using line partition option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            /* Comment */
+            aa: 'a',
+            b: 'b',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* Comment */
+            aa: 'a',
+          }
+        `,
+      })
+    })
+
+    it('treats line comments as partitions when line option is enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // Comment
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('allows multiple line partition comments with specific patterns', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            // b
+            b: 'b',
+            // a
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows regex patterns for line partition comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // I am a partition comment because I don't have f o o
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when using block partition option', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            // Comment
+            aa: 'a',
+            b: 'b',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            // Comment
+            aa: 'a',
+          }
+        `,
+      })
+    })
+
+    it('treats block comments as partitions when block option is enabled', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* Comment */
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('allows multiple block partition comments with specific patterns', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            c: 'c',
+            /* b */
+            b: 'b',
+            /* a */
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows regex patterns for block partition comments', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            b: 'b',
+            /* I am a partition comment because I don't have f o o */
+            a: 'a',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('allows using newlines as partitions', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            d: 'dd',
+            e: 'e',
+
+            c: 'ccc',
+
+            a: 'aaaaa',
+            b: 'bbbb',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'e',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            d: 'dd',
+            e: 'e',
+
+            c: 'ccc',
+
+            a: 'aaaaa',
+            b: 'bbbb',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            e: 'e',
+            d: 'dd',
+
+            c: 'ccc',
+
+            b: 'bbbb',
+            a: 'aaaaa',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+      })
+    })
+
+    it('allows trimming special characters', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            _a = 'a',
+            bb = 'b',
+            _c = 'c',
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows removing special characters', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          let obj = {
+            abc = 'ab',
+            a_c = 'ac',
+          }
+        `,
+      })
+    })
+
+    it('sorts using specified locale', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B',
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('prioritizes methods over multiline properties', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineProperty',
+              leftGroup: 'multiline',
+              rightGroup: 'method',
+              right: 'method',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            method() {},
+            multilineProperty: {
+              // Some multiline stuff
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            multilineProperty: {
+              // Some multiline stuff
+            },
+            method() {},
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes properties over multiline methods', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'multilineFunction',
+              leftGroup: 'multiline',
+              rightGroup: 'property',
+              right: 'property',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            property,
+            multilineFunction() {
+              // Some multiline stuff
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            multilineFunction() {
+              // Some multiline stuff
+            },
+            property,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['property', 'multiline'],
+          },
+        ],
+      })
+    })
+
+    it('prioritizes properties over methods when configured', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'property',
+              leftGroup: 'member',
+              right: 'property',
+              left: 'method',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'member'],
+          },
+        ],
+        output: dedent`
+          let obj = {
+            property,
+            method() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            method() {},
+            property,
+          }
+        `,
+      })
+    })
+
+    it('sorts by configured groups', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            z: {
+              // Some multiline stuff
+            },
+            f: 'a',
+            a2: function() {},
+            a1: () => {},
+            a3() {},
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['multiline', 'unknown', 'method'],
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          code: dedent`
+            let Obj = {
+              aaaa: () => null,
+
+
+             yy: "y",
+            z: "z",
+
+                bbb: "b",
+            }
+          `,
+          output: dedent`
+            let Obj = {
+              aaaa: () => null,
+             bbb: "b",
+            yy: "y",
+                z: "z",
+            }
+          `,
+          options: [
+            {
+              ...options,
+              groups: ['method', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
+    it('handles newlinesBetween configuration between consecutive groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            customGroups: {
+              a: 'a',
+              b: 'b',
+              c: 'c',
+              d: 'd',
+              e: 'e',
+            },
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: 'a',
+
+            b: 'b',
+
+            c: 'c',
+            d: 'd',
+
+
+            e: 'e',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a: 'a',
+            b: 'b',
+
+
+            c: 'c',
+
+            d: 'd',
+
+
+            e: 'e',
+          }
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never'],
+      [2, 0],
+      [2, 'ignore'],
+      ['never', 2],
+      [0, 2],
+      ['ignore', 2],
+    ] as const)(
+      'enforces newlines between non-consecutive groups when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: null,
+
+
+              b: null,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each(['always', 2, 'ignore', 'never', 0] as const)(
+      'removes newlines when never is configured between all groups (global: %s)',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: null,
+
+              b: null,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore', 'never'],
+      ['ignore', 0],
+      ['never', 'ignore'],
+      [0, 'ignore'],
+    ] as const)(
+      'allows any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let testOptions = {
+          ...options,
+          customGroups: [
+            { elementNamePattern: 'a', groupName: 'a' },
+            { elementNamePattern: 'b', groupName: 'b' },
+            { groupName: 'unusedGroup', elementNamePattern: 'X' },
+          ],
+          groups: [
+            'a',
+            'unusedGroup',
+            { newlinesBetween: groupNewlinesBetween },
+            'b',
+          ],
+          newlinesBetween: globalNewlinesBetween,
+        }
+
+        await valid({
+          code: dedent`
+            let obj = {
+              a: null,
+
+              b: null,
+            }
+          `,
+          options: [testOptions],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = {
+              a: null,
+              b: null,
+            }
+          `,
+          options: [testOptions],
+        })
+      },
+    )
+
+    it('preserves comments and handles newlines after fixes', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'method',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a, // Comment after
+
+            b() {},
+            c() {},
+          };
+        `,
+        code: dedent`
+          let obj = {
+            b() {},
+            a, // Comment after
+
+            c() {},
+          };
+        `,
+        options: [
+          {
+            groups: ['unknown', 'method'],
+            newlinesBetween: 'always',
+          },
+        ],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves newlines between different partitions when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a,
+
+              // Partition comment
+
+              bb,
+              c,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+
+              // Partition comment
+
+              c,
+              bb,
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts inline object properties correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            aa: string, b: string
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b: string, aa: string
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            aa: string, b: string,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b: string, aa: string,
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it.each([
+      '^r|g|b$',
+      ['noMatch', '^r|g|b$'],
+      { pattern: '^R|G|B$', flags: 'i' },
+      ['noMatch', { pattern: '^R|G|B$', flags: 'i' }],
+    ])(
+      'applies configuration when allNamesMatchPattern matches (pattern: %s)',
+      async rgbAllNamesMatchPattern => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: 'foo',
+              },
+            },
+            {
+              ...options,
+              customGroups: {
+                r: 'r',
+                g: 'g',
+                b: 'b',
+              },
+              useConfigurationIf: {
+                allNamesMatchPattern: rgbAllNamesMatchPattern,
+              },
+              groups: ['r', 'g', 'b'],
+            },
+          ],
+          output: dedent`
+            let obj = {
+              r: string,
+              g: string,
+              b: string
+            }
+          `,
+          code: dedent`
+            let obj = {
+              b: string,
+              g: string,
+              r: string
+            }
+          `,
+        })
+      },
+    )
+
+    it('applies configuration when callingFunctionNamePattern matches', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'g',
+              leftGroup: 'b',
+              right: 'g',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'r',
+              leftGroup: 'g',
+              right: 'r',
+              left: 'g',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'g',
+              leftGroup: 'b',
+              right: 'g',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'r',
+              leftGroup: 'g',
+              right: 'r',
+              left: 'g',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            useConfigurationIf: {
+              callingFunctionNamePattern: 'foo',
+            },
+          },
+          {
+            ...options,
+            useConfigurationIf: {
+              callingFunctionNamePattern: '^someFunction$',
+            },
+            customGroups: {
+              r: 'r',
+              g: 'g',
+              b: 'b',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b,
+            g,
+            r
+          }
+
+          someFunction(true, {
+            r: string,
+            g: string,
+            b: string
+          })
+
+          let a = someFunction(true, {
+            r: string,
+            g: string,
+            b: string
+          })
+        `,
+        code: dedent`
+          let obj = {
+            b,
+            g,
+            r
+          }
+
+          someFunction(true, {
+            b: string,
+            g: string,
+            r: string
+          })
+
+          let a = someFunction(true, {
+            b: string,
+            g: string,
+            r: string
+          })
+        `,
+      })
+    })
+
+    it('filters custom groups by selector and modifiers', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unusedCustomGroup',
+                modifiers: ['multiline'],
+                selector: 'method',
+              },
+              {
+                groupName: 'multilinePropertyGroup',
+                modifiers: ['multiline'],
+                selector: 'property',
+              },
+              {
+                groupName: 'propertyGroup',
+                selector: 'property',
+              },
+            ],
+            groups: ['propertyGroup', 'multilinePropertyGroup'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              leftGroup: 'multilinePropertyGroup',
+              rightGroup: 'propertyGroup',
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            c,
+            a: {
+              // Multiline
+            },
+            b: {
+              // Multiline
+            },
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a: {
+              // Multiline
+            },
+            b: {
+              // Multiline
+            },
+            c,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      'hello',
+      ['noMatch', 'hello'],
+      { pattern: 'HELLO', flags: 'i' },
+      ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+    ])(
+      'filters custom groups by elementNamePattern (%s)',
+      async elementNamePattern => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'propertiesStartingWithHello',
+                  selector: 'property',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['propertiesStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'propertiesStartingWithHello',
+                right: 'helloProperty',
+                leftGroup: 'unknown',
+                left: 'method',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              helloProperty,
+              a,
+              b,
+              method() {},
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+              b,
+              method() {},
+              helloProperty,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'inject',
+      ['noMatch', 'inject'],
+      { pattern: 'INJECT', flags: 'i' },
+      ['noMatch', { pattern: 'INJECT', flags: 'i' }],
+    ])(
+      'filters custom groups by elementValuePattern (%s)',
+      async injectElementValuePattern => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  elementValuePattern: injectElementValuePattern,
+                  groupName: 'inject',
+                },
+                {
+                  elementValuePattern: 'computed',
+                  groupName: 'computed',
+                },
+              ],
+              groups: ['computed', 'inject', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'computed',
+                leftGroup: 'inject',
+                right: 'z',
+                left: 'y',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: computed(A),
+              z: computed(Z),
+              b: inject(B),
+              y: inject(Y),
+              c() {},
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a: computed(A),
+              b: inject(B),
+              y: inject(Y),
+              z: computed(Z),
+              c() {},
+            }
+          `,
+        })
+      },
+    )
+
+    it('sorts custom groups with overridden type and order', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedPropertiesByLineLength',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'eee',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedPropertiesByLineLength',
+                selector: 'property',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedPropertiesByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            dddd,
+            ccc,
+            eee,
+            bb,
+            ff,
+            a,
+            g,
+            anotherMethod() {},
+            method() {},
+            yetAnotherMethod() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            bb,
+            ccc,
+            dddd,
+            method() {},
+            eee,
+            ff,
+            g,
+            anotherMethod() {},
+            yetAnotherMethod() {},
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups with fallbackSort override', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            fooBar: 'fooBar',
+            fooZar: 'fooZar',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            fooZar: 'fooZar',
+            fooBar: 'fooBar',
+          }
+        `,
+      })
+    })
+
+    it('preserves order within unsorted custom groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedProperties',
+                selector: 'property',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedProperties', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedProperties',
+              leftGroup: 'unknown',
+              left: 'method',
+              right: 'c',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b,
+            a,
+            d,
+            e,
+            c,
+            method() {},
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b,
+            a,
+            d,
+            e,
+            method() {},
+            c,
+          }
+        `,
+      })
+    })
+
+    it('sorts custom groups with anyOf conditions', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    modifiers: ['multiline'],
+                    selector: 'property',
+                  },
+                  {
+                    modifiers: ['multiline'],
+                    selector: 'method',
+                  },
+                ],
+                groupName: 'multilinePropertiesAndMultilineMethods',
+              },
+            ],
+            groups: ['multilinePropertiesAndMultilineMethods', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'multilinePropertiesAndMultilineMethods',
+              leftGroup: 'unknown',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b() {
+              // Multiline
+            },
+            c: {
+              // Multiline
+            },
+            a,
+            d() {},
+            e,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            b() {
+              // Multiline
+            },
+            c: {
+              // Multiline
+            },
+            d() {},
+            e,
+          }
+        `,
+      })
+    })
+
+    it('allows regex patterns for element names in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          let obj = {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'enforces newlines within custom groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a,
+
+              b,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within custom groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'property',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenObjectMembers',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a,
+              b,
+            }
+          `,
+          code: dedent`
+            let obj = {
+              a,
+
+              b,
+            }
+          `,
+        })
+      },
+    )
+
+    it('allows regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: {
+              elementsWithoutFoo: '^(?!.*Foo).*$',
+            },
+            groups: ['unknown', 'elementsWithoutFoo'],
+          },
+        ],
+        code: dedent`
+          let obj = {
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+          }
+        `,
+      })
+    })
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts objects with identifier and literal keys', async () => {
+      await valid({
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bbb',
+            [c]: 'cc',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let Obj = {
+            a: 'aaaa',
+            b: 'bbb',
+            [c]: 'cc',
+            d: 'd',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'aaaa',
+            [c]: 'cc',
+            b: 'bbb',
+            d: 'd',
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not enforce sorting when type is unsorted', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            b: 'b',
+            c: 'c',
+            a: 'a',
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces grouping for unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: '^b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            ba: 'ba',
+            bb: 'bb',
+            ab: 'ab',
+            aa: 'aa',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            ab: 'ab',
+            aa: 'aa',
+            ba: 'ba',
+            bb: 'bb',
+          }
+        `,
+      })
+    })
+
+    it('enforces newlines between groups for unsorted type', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b: 'b',
+
+            a: 'a',
+          }
+        `,
+        code: dedent`
+          let obj = {
+            b: 'b',
+            a: 'a',
+          }
+        `,
+      })
+    })
+
+    it('enforces dependency order for unsorted type', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+            },
+            messageId: 'unexpectedObjectsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let Func = ({
+            b,
+            a = b,
+          }) => {
+            // ...
+          }
+        `,
+        code: dedent`
+          let Func = ({
+            a = b,
+            b,
+          }) => {
+            // ...
+          }
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let Obj = {
-                a: 'a',
-                b: 'b',
-                c: 'c',
-              }
-            `,
-            code: dedent`
-              let Obj = {
-                a: 'a',
-                c: 'c',
-                b: 'b',
-              }
-            `,
-          },
-        ],
-        valid: [
-          dedent`
-            let Obj = {
-              a: 'a',
-              b: 'b',
-              c: 'c',
-            }
-          `,
-          {
-            code: dedent`
-              const calculator = {
-                log: () => undefined,
-                log10: () => undefined,
-                log1p: () => undefined,
-                log2: () => undefined,
-              }
-            `,
-            options: [{}],
-          },
-        ],
-      },
-    )
+    it('uses alphabetical ascending order by default', async () => {
+      await valid(
+        dedent`
+          let Obj = {
+            a: 'a',
+            b: 'b',
+            c: 'c',
+          }
+        `,
+      )
 
-    ruleTester.run(
-      `${ruleName}: allow to disable rule for styledComponents`,
-      rule,
-      {
-        valid: [
+      await valid({
+        code: dedent`
+          const calculator = {
+            log: () => undefined,
+            log10: () => undefined,
+            log1p: () => undefined,
+            log2: () => undefined,
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              const Box = styled.div({
-                background: "red",
-                width: "50px",
-                height: "50px",
-              })
-            `,
-            options: [
-              {
-                styledComponents: false,
-              },
-            ],
-          },
-          {
-            code: dedent`
-              const PropsBox = styled.div((props) => ({
-                background: props.background,
-                height: "50px",
-                width: "50px",
-              }))
-            `,
-            options: [
-              {
-                styledComponents: false,
-              },
-            ],
-          },
-          {
-            code: dedent`
-              export default styled('div')(() => ({
-                borderRadius: 0,
-                borderWidth: 0,
-                border: 0,
-                borderBottom: hasBorder && \`1px solid \${theme.palette.divider}\`,
-              }))
-            `,
-            options: [
-              {
-                styledComponents: false,
-              },
-            ],
-          },
-          {
-            code: dedent`
-              const headerClass = css({
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                marginTop: '3',
-                gridGap: '8',
-              });
-            `,
-            options: [
-              {
-                styledComponents: false,
-              },
-            ],
-          },
-          {
-            code: dedent`
-              const PropsBox = styled.div((props) => ({
-                nested1: {
-                  nested2: {
-                    [theme.breakpoints.down('mid2')]: {
-                      right: '24px',
-                    },
-                    [theme.breakpoints.down('mid1')]: {
-                      bottom: '-273px',
-                    }
-                  }
-                }
-              }))
-            `,
-            options: [
-              {
-                styledComponents: false,
-              },
-            ],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: allow to ignore pattern`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            export default {
-              data() {
-                return {
-                  background: "red",
-                  display: 'flex',
-                  flexDirection: 'column',
-                  width: "50px",
-                  height: "50px",
-                }
-              },
-              methods: {
-                foo() {},
-                bar() {},
-                baz() {},
-              },
-            }
-          `,
-          code: dedent`
-            export default {
-              methods: {
-                foo() {},
-                bar() {},
-                baz() {},
-              },
-              data() {
-                return {
-                  background: "red",
-                  display: 'flex',
-                  flexDirection: 'column',
-                  width: "50px",
-                  height: "50px",
-                }
-              },
-            }
-          `,
-          errors: [
-            {
-              data: {
-                left: 'methods',
-                right: 'data',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [
-            {
-              ignorePattern: ['data', 'methods'],
-            },
-          ],
-        },
-      ],
-      valid: [],
+        output: dedent`
+          let Obj = {
+            a: 'a',
+            b: 'b',
+            c: 'c',
+          }
+        `,
+        code: dedent`
+          let Obj = {
+            a: 'a',
+            c: 'c',
+            b: 'b',
+          }
+        `,
+      })
     })
 
-    for (let ignorePattern of [
-      'Styles$',
-      ['noMatch', 'Styles$'],
-      { pattern: 'STYLES$', flags: 'i' },
-      ['noMatch', { pattern: 'STYLES$', flags: 'i' }],
-    ]) {
-      ruleTester.run(`${ruleName}: allow to ignore pattern`, rule, {
-        valid: [
+    it('allows disabling sorting for styled components', async () => {
+      let styledComponentsOptions = [{ styledComponents: false }]
+
+      await valid({
+        code: dedent`
+          const Box = styled.div({
+            background: "red",
+            width: "50px",
+            height: "50px",
+          })
+        `,
+        options: styledComponentsOptions,
+      })
+
+      await valid({
+        code: dedent`
+          const PropsBox = styled.div((props) => ({
+            background: props.background,
+            height: "50px",
+            width: "50px",
+          }))
+        `,
+        options: styledComponentsOptions,
+      })
+
+      await valid({
+        code: dedent`
+          export default styled('div')(() => ({
+            borderRadius: 0,
+            borderWidth: 0,
+            border: 0,
+            borderBottom: hasBorder && \`1px solid \${theme.palette.divider}\`,
+          }))
+        `,
+        options: styledComponentsOptions,
+      })
+
+      await valid({
+        code: dedent`
+          const headerClass = css({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginTop: '3',
+            gridGap: '8',
+          });
+        `,
+        options: styledComponentsOptions,
+      })
+
+      await valid({
+        code: dedent`
+          const PropsBox = styled.div((props) => ({
+            nested1: {
+              nested2: {
+                [theme.breakpoints.down('mid2')]: {
+                  right: '24px',
+                },
+                [theme.breakpoints.down('mid1')]: {
+                  bottom: '-273px',
+                }
+              }
+            }
+          }))
+        `,
+        options: styledComponentsOptions,
+      })
+    })
+
+    it('ignores objects matching ignorePattern', async () => {
+      await valid({
+        code: dedent`
+          ignore({
+            c: 'c',
+            b: 'bb',
+            a: 'aaa',
+          })
+        `,
+        options: [
           {
-            code: dedent`
-              const buttonStyles = {
+            ignorePattern: ['ignore'],
+          },
+        ],
+      })
+
+      await invalid({
+        output: dedent`
+          export default {
+            data() {
+              return {
                 background: "red",
                 display: 'flex',
                 flexDirection: 'column',
                 width: "50px",
                 height: "50px",
               }
-            `,
-            options: [
-              {
-                ignorePattern,
-              },
-            ],
+            },
+            methods: {
+              foo() {},
+              bar() {},
+              baz() {},
+            },
+          }
+        `,
+        code: dedent`
+          export default {
+            methods: {
+              foo() {},
+              bar() {},
+              baz() {},
+            },
+            data() {
+              return {
+                background: "red",
+                display: 'flex',
+                flexDirection: 'column',
+                width: "50px",
+                height: "50px",
+              }
+            },
+          }
+        `,
+        errors: [
+          {
+            data: {
+              left: 'methods',
+              right: 'data',
+            },
+            messageId: 'unexpectedObjectsOrder',
           },
         ],
-        invalid: [],
+        options: [
+          {
+            ignorePattern: ['data', 'methods'],
+          },
+        ],
       })
-    }
-
-    ruleTester.run(`${ruleName}: allow to ignore pattern`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            export default {
-              data() {
-                return {
-                  background: "palevioletred",
-                  display: 'flex',
-                  flexDirection: 'column',
-                  width: "50px",
-                  height: "50px",
-                }
-              },
-              methods: {
-                foo() {},
-                bar() {},
-                baz() {},
-              },
-            }
-          `,
-          code: dedent`
-            export default {
-              methods: {
-                foo() {},
-                bar() {},
-                baz() {},
-              },
-              data() {
-                return {
-                  background: "palevioletred",
-                  display: 'flex',
-                  flexDirection: 'column',
-                  width: "50px",
-                  height: "50px",
-                }
-              },
-            }
-          `,
-          errors: [
-            {
-              data: {
-                left: 'methods',
-                right: 'data',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [
-            {
-              ignorePattern: ['data', 'methods'],
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            ignore({
-              c: 'c',
-              b: 'bb',
-              a: 'aaa',
-            })
-          `,
-          options: [
-            {
-              ignorePattern: ['ignore'],
-            },
-          ],
-        },
-      ],
     })
 
-    ruleTester.run(`${ruleName}: allow to use 'destructureOnly'`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              c: 'c',
-              b: 'b',
-              a: 'a',
-            }
-
-            let { a, b, c } = obj
-          `,
-          code: dedent`
-            let obj = {
-              c: 'c',
-              b: 'b',
-              a: 'a',
-            }
-
-            let { c, b, a } = obj
-          `,
-          options: [
-            {
-              destructureOnly: true,
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let obj = {
-              c: 'c',
-              b: 'b',
-              a: 'a',
-            }
-
-            let { a, b, c } = obj
-          `,
-          options: [
-            {
-              destructureOnly: true,
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: allow to use 'objectDeclarations'`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              c: 'c',
-              a: 'a',
-              b: 'b',
-            }
-
-            let { a, b, c } = obj
-          `,
-          code: dedent`
-            let obj = {
-              c: 'c',
-              a: 'a',
-              b: 'b',
-            }
-
-            let { c, b, a } = obj
-          `,
-          options: [
-            {
-              objectDeclarations: false,
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let obj = {
-              c: 'c',
-              a: 'a',
-              b: 'b',
-            }
-
-            let { a, b, c } = obj
-          `,
-          options: [
-            {
-              objectDeclarations: false,
-            },
-          ],
-        },
-      ],
-    })
-
-    describe(`${ruleName}: allow to use 'destructuredObjects'`, () => {
-      ruleTester.run(`${ruleName}: boolean 'destructuredObjects'`, rule, {
-        invalid: [
+    it.each([
+      'Styles$',
+      ['noMatch', 'Styles$'],
+      { pattern: 'STYLES$', flags: 'i' },
+      ['noMatch', { pattern: 'STYLES$', flags: 'i' }],
+    ])('ignores patterns matching %s', async ignorePattern => {
+      await valid({
+        code: dedent`
+          const buttonStyles = {
+            background: "red",
+            display: 'flex',
+            flexDirection: 'column',
+            width: "50px",
+            height: "50px",
+          }
+        `,
+        options: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            output: dedent`
-              let obj = {
-                a: 'a',
-                b: 'b',
-                c: 'c',
-              }
-
-              let { c, a, b } = obj
-            `,
-            code: dedent`
-              let obj = {
-                c: 'c',
-                b: 'b',
-                a: 'a',
-              }
-
-              let { c, a, b } = obj
-            `,
-            options: [
-              {
-                destructuredObjects: false,
-              },
-            ],
+            ignorePattern,
           },
         ],
-        valid: [
-          {
-            code: dedent`
-              let obj = {
-                a: 'a',
-                b: 'b',
-                c: 'c',
-              }
+      })
+    })
 
-              let { b, c, a } = obj
-            `,
-            options: [
-              {
-                destructuredObjects: false,
-              },
-            ],
+    it('sorts only destructured objects when destructureOnly is enabled', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            c: 'c',
+            b: 'b',
+            a: 'a',
+          }
+
+          let { a, b, c } = obj
+        `,
+        options: [
+          {
+            destructureOnly: true,
           },
         ],
       })
 
-      ruleTester.run(
-        `${ruleName}: object 'destructuredObjects': 'groups' attribute`,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            c: 'c',
+            b: 'b',
+            a: 'a',
+          }
+
+          let { a, b, c } = obj
+        `,
+        code: dedent`
+          let obj = {
+            c: 'c',
+            b: 'b',
+            a: 'a',
+          }
+
+          let { c, b, a } = obj
+        `,
+        options: [
+          {
+            destructureOnly: true,
+          },
+        ],
+      })
+    })
+
+    it('skips object declarations when objectDeclarations is disabled', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            c: 'c',
+            a: 'a',
+            b: 'b',
+          }
+
+          let { a, b, c } = obj
+        `,
+        options: [
+          {
+            objectDeclarations: false,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            c: 'c',
+            a: 'a',
+            b: 'b',
+          }
+
+          let { a, b, c } = obj
+        `,
+        code: dedent`
+          let obj = {
+            c: 'c',
+            a: 'a',
+            b: 'b',
+          }
+
+          let { c, b, a } = obj
+        `,
+        options: [
+          {
+            objectDeclarations: false,
+          },
+        ],
+      })
+    })
+
+    it('skips destructured objects when destructuredObjects is disabled', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            a: 'a',
+            b: 'b',
+            c: 'c',
+          }
+
+          let { b, c, a } = obj
+        `,
+        options: [
+          {
+            destructuredObjects: false,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: 'a',
+            b: 'b',
+            c: 'c',
+          }
+
+          let { c, a, b } = obj
+        `,
+        code: dedent`
+          let obj = {
+            c: 'c',
+            b: 'b',
+            a: 'a',
+          }
+
+          let { c, a, b } = obj
+        `,
+        options: [
+          {
+            destructuredObjects: false,
+          },
+        ],
+      })
+    })
+
+    it('applies groups configuration to destructured objects based on groups attribute', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'unknown',
+              rightGroup: 'top',
+              right: 'c',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: {
+              top: 'c',
+            },
+            destructuredObjects: { groups: true },
+            groups: ['top', 'unknown'],
+          },
+        ],
+        output: dedent`
+          let { c, a, b } = obj
+        `,
+        code: dedent`
+          let { a, c, b } = obj
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'top',
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: {
+              top: 'c',
+            },
+            destructuredObjects: { groups: false },
+            groups: ['top', 'unknown'],
+          },
+        ],
+        output: dedent`
+          let { a, b, c } = obj
+        `,
+        code: dedent`
+          let { a, c, b } = obj
+        `,
+      })
+    })
+
+    it('respects global settings configuration', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            ccc: 'ccc',
+            bb: 'bb',
+            a: 'a',
+          }
+        `,
+        settings: {
+          perfectionist: {
+            type: 'line-length',
+            order: 'desc',
+          },
+        },
+        options: [{}],
+      })
+    })
+
+    it('preserves comments with their associated properties', async () => {
+      await invalid({
+        output: dedent`
+          let obj = {
+            // Ignore this comment
+
+            // A3
+            /**
+              * A2
+              */
+            // A1
+            a,
+
+            // Ignore this comment
+
+            // B2
+            /**
+              * B1
+              */
+            b,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            // Ignore this comment
+
+            // B2
+            /**
+              * B1
+              */
+            b,
+
+            // Ignore this comment
+
+            // A3
+            /**
+              * A2
+              */
+            // A1
+            a,
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('respects partition comments when sorting', async () => {
+      await invalid({
+        output: dedent`
+          let obj = {
+            // Ignore this comment
+
+            // B2
+            /**
+              * B1
+              */
+            b,
+
+            // C2
+            // C1
+            c,
+
+            // Above a partition comment ignore me
+            // PartitionComment: 1
+            a,
+
+            /**
+              * D2
+              */
+            // D1
+            d,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            // Ignore this comment
+
+            // C2
+            // C1
+            c,
+
+            // B2
+            /**
+              * B1
+              */
+            b,
+
+            // Above a partition comment ignore me
+            // PartitionComment: 1
+            /**
+              * D2
+              */
+            // D1
+            d,
+
+            a,
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [
+          {
+            partitionByComment: 'PartitionComment:',
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('allows to disable sorting object in style prop in jsx', async () => {
+      let jsxRuleTester = createRuleTester({
+        languageOptions: {
+          parserOptions: {
+            ecmaFeatures: {
+              jsx: true,
+            },
+          },
+        },
+        name: 'sort-objects',
         rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    leftGroup: 'unknown',
-                    rightGroup: 'top',
-                    right: 'c',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: {
-                    top: 'c',
-                  },
-                  destructuredObjects: { groups: true },
-                  groups: ['top', 'unknown'],
-                },
-              ],
-              output: dedent`
-                let { c, a, b } = obj
-              `,
-              code: dedent`
-                let { a, c, b } = obj
-              `,
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'top',
-                    right: 'b',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedObjectsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: {
-                    top: 'c',
-                  },
-                  destructuredObjects: { groups: false },
-                  groups: ['top', 'unknown'],
-                },
-              ],
-              output: dedent`
-                let { a, b, c } = obj
-              `,
-              code: dedent`
-                let { a, c, b } = obj
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(`${ruleName}: works with settings`, rule, {
-      valid: [
-        {
-          code: dedent`
-            let obj = {
-              ccc: 'ccc',
-              bb: 'bb',
-              a: 'a',
-            }
-          `,
-          settings: {
-            perfectionist: {
-              type: 'line-length',
-              order: 'desc',
-            },
-          },
-          options: [{}],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe('handles complex comment cases', () => {
-      ruleTester.run(`keeps comments associated to their node`, rule, {
-        invalid: [
-          {
-            output: dedent`
-              let obj = {
-                // Ignore this comment
-
-                // A3
-                /**
-                  * A2
-                  */
-                // A1
-                a,
-
-                // Ignore this comment
-
-                // B2
-                /**
-                  * B1
-                  */
-                b,
-              }
-            `,
-            code: dedent`
-              let obj = {
-                // Ignore this comment
-
-                // B2
-                /**
-                  * B1
-                  */
-                b,
-
-                // Ignore this comment
-
-                // A3
-                /**
-                  * A2
-                  */
-                // A1
-                a,
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-          },
-        ],
-        valid: [],
       })
-
-      ruleTester.run(`handles partition comments`, rule, {
-        invalid: [
+      await jsxRuleTester.valid({
+        code: dedent`
+          let Element = () => (
+            <div
+              style={{
+                display: 'block',
+                margin: 0,
+                padding: 20,
+                background: 'orange',
+              }}
+            />
+          )
+        `,
+        options: [
           {
-            output: dedent`
-              let obj = {
-                // Ignore this comment
-
-                // B2
-                /**
-                  * B1
-                  */
-                b,
-
-                // C2
-                // C1
-                c,
-
-                // Above a partition comment ignore me
-                // PartitionComment: 1
-                a,
-
-                /**
-                  * D2
-                  */
-                // D1
-                d,
-              }
-            `,
-            code: dedent`
-              let obj = {
-                // Ignore this comment
-
-                // C2
-                // C1
-                c,
-
-                // B2
-                /**
-                  * B1
-                  */
-                b,
-
-                // Above a partition comment ignore me
-                // PartitionComment: 1
-                /**
-                  * D2
-                  */
-                // D1
-                d,
-
-                a,
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-              {
-                data: {
-                  right: 'a',
-                  left: 'd',
-                },
-                messageId: 'unexpectedObjectsOrder',
-              },
-            ],
-            options: [
-              {
-                partitionByComment: 'PartitionComment:',
-                type: 'alphabetical',
-              },
-            ],
+            styledComponents: false,
           },
         ],
-        valid: [],
       })
     })
 
-    let ruleTesterJSX = new RuleTester({
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    })
-    ruleTesterJSX.run(
-      'allows to disable sorting object is style prop in jsx',
-      rule,
-      {
-        valid: [
+    it('handles eslint-disable comments correctly', async () => {
+      await valid({
+        code: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            // eslint-disable-next-line
+            a = 'a',
+          }
+        `,
+      })
+
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              let Element = () => (
-                <div
-                  style={{
-                    display: 'block',
-                    margin: 0,
-                    padding: 20,
-                    background: 'orange',
-                  }}
-                />
-              )
-            `,
-            options: [
-              {
-                styledComponents: false,
-              },
-            ],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            // eslint-disable-next-line
+            a = 'a'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            // eslint-disable-next-line
+            a = 'a'
+          }
+        `,
+        options: [{}],
+      })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              // eslint-disable-next-line
-              a = 'a'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              // eslint-disable-next-line
-              a = 'a'
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              b: 'b',
-              c: 'c',
-              // eslint-disable-next-line
-              a: 'a',
-              d: 'd'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              d: 'd',
-              c: 'c',
-              // eslint-disable-next-line
-              a: 'a',
-              b: 'b'
-            }
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              b = a,
-              c = 'c',
-              // eslint-disable-next-line
-              a = 'a'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = a,
-              // eslint-disable-next-line
-              a = 'a'
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              a = 'a' // eslint-disable-line
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              a = 'a' // eslint-disable-line
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              /* eslint-disable-next-line */
-              a = 'a'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              /* eslint-disable-next-line */
-              a = 'a'
-            }
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              a = 'a' /* eslint-disable-line */
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              a = 'a' /* eslint-disable-line */
-            }
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let obj = {
-              a = 'a',
-              d = 'd',
-              /* eslint-disable */
-              c = 'c',
-              b = 'b',
-              // Shouldn't move
-              /* eslint-enable */
-              e = 'e'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              d = 'd',
-              e = 'e',
-              /* eslint-disable */
-              c = 'c',
-              b = 'b',
-              // Shouldn't move
-              /* eslint-enable */
-              a = 'a'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a = 'a'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a = 'a'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              a = 'a' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              a = 'a' // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a = 'a'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a = 'a'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              a = 'a' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          code: dedent`
-            let obj = {
-              c = 'c',
-              b = 'b',
-              a = 'a' /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let obj = {
-              a = 'a',
-              d = 'd',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c = 'c',
-              b = 'b',
-              // Shouldn't move
-              /* eslint-enable */
-              e = 'e'
-            }
-          `,
-          code: dedent`
-            let obj = {
-              d = 'd',
-              e = 'e',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c = 'c',
-              b = 'b',
-              // Shouldn't move
-              /* eslint-enable */
-              a = 'a'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedObjectsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let obj = {
-              b = 'b',
-              c = 'c',
-              // eslint-disable-next-line
-              a = 'a',
-            }
-          `,
-        },
-      ],
-    })
-
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              let Func = ({
-                b = () => 1,
-                a = b(),
-              }) => {
-                // ...
-              }
-            `,
-            options: [{}],
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedObjectsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          let obj = {
+            b: 'b',
+            c: 'c',
+            // eslint-disable-next-line
+            a: 'a',
+            d: 'd'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            d: 'd',
+            c: 'c',
+            // eslint-disable-next-line
+            a: 'a',
+            b: 'b'
+          }
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b = a,
+            c = 'c',
+            // eslint-disable-next-line
+            a = 'a'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = a,
+            // eslint-disable-next-line
+            a = 'a'
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            a = 'a' // eslint-disable-line
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            a = 'a' // eslint-disable-line
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            /* eslint-disable-next-line */
+            a = 'a'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            /* eslint-disable-next-line */
+            a = 'a'
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            a = 'a' /* eslint-disable-line */
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            a = 'a' /* eslint-disable-line */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          let obj = {
+            a = 'a',
+            d = 'd',
+            /* eslint-disable */
+            c = 'c',
+            b = 'b',
+            // Shouldn't move
+            /* eslint-enable */
+            e = 'e'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            d = 'd',
+            e = 'e',
+            /* eslint-disable */
+            c = 'c',
+            b = 'b',
+            // Shouldn't move
+            /* eslint-enable */
+            a = 'a'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable comments', async () => {
+      await invalid({
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            // eslint-disable-next-line rule-to-test/sort-objects
+            a = 'a'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            // eslint-disable-next-line rule-to-test/sort-objects
+            a = 'a'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            a = 'a' // eslint-disable-line rule-to-test/sort-objects
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            a = 'a' // eslint-disable-line rule-to-test/sort-objects
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            /* eslint-disable-next-line rule-to-test/sort-objects */
+            a = 'a'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            /* eslint-disable-next-line rule-to-test/sort-objects */
+            a = 'a'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            b = 'b',
+            c = 'c',
+            a = 'a' /* eslint-disable-line rule-to-test/sort-objects */
+          }
+        `,
+        code: dedent`
+          let obj = {
+            c = 'c',
+            b = 'b',
+            a = 'a' /* eslint-disable-line rule-to-test/sort-objects */
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          let obj = {
+            a = 'a',
+            d = 'd',
+            /* eslint-disable rule-to-test/sort-objects */
+            c = 'c',
+            b = 'b',
+            // Shouldn't move
+            /* eslint-enable */
+            e = 'e'
+          }
+        `,
+        code: dedent`
+          let obj = {
+            d = 'd',
+            e = 'e',
+            /* eslint-disable rule-to-test/sort-objects */
+            c = 'c',
+            b = 'b',
+            // Shouldn't move
+            /* eslint-enable */
+            a = 'a'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
   })
 })

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1,3381 +1,5513 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import { Alphabet } from '../../utils/alphabet'
 import rule from '../../rules/sort-sets'
 
-let ruleName = 'sort-sets'
+describe('sort-sets', () => {
+  let { invalid, valid } = createRuleTester({
+    parser: typescriptParser,
+    name: 'sort-sets',
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'a',
-                'c',
-                'b',
-                'd',
-                'e',
-                ...other,
-              ])
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              new Set([
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ])
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts spread elements`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...bbbb',
-                left: '...ccc',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ])
-          `,
-          code: dedent`
-            new Set([
-              ...aaa,
-              ...ccc,
-              ...bbbb,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set([
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores nullable array elements`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            output: dedent`
-              new Set(['a', 'b', 'c',, 'd'])
-            `,
-            code: dedent`
-              new Set(['b', 'a', 'c',, 'd'])
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              new Set(['a', 'b', 'c',, 'd'])
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allow to put spread elements to the end`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '...other',
-                  right: 'c',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            output: dedent`
-              new Set(['a', 'b', 'c', ...other])
-            `,
-            code: dedent`
-              new Set(['a', 'b', ...other, 'c'])
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            code: dedent`
-              new Set(['a', 'b', 'c', ...other])
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts array constructor`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set(new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ))
-          `,
-          code: dedent`
-            new Set(new Array(
-              'a',
-              'c',
-              'b',
-              'd',
-            ))
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set(new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ))
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows mixed sorting`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...d',
-                left: 'bbb',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set(new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ))
-          `,
-          code: dedent`
-            new Set(new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ))
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set(new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ))
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-    })
-
-    describe(`${ruleName}(${type}): partition by new line`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use new line as partition`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-                {
-                  data: {
-                    right: 'b',
-                    left: 'e',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  'a',
-                  'd',
-
-                  'c',
-
-                  'b',
-                  'e',
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'd',
-                  'a',
-
-                  'c',
-
-                  'e',
-                  'b',
-                ])
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByNewLine: true,
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritize partitions over group kind`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: '...d',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-                {
-                  data: {
-                    right: '...b',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  groupKind: 'spreads-first',
-                  partitionByNewLine: true,
-                },
-              ],
-              output: dedent`
-                new Set([
-                  ...d,
-                  'c',
-
-                  ...b,
-                  'a',
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'c',
-                  ...d,
-
-                  'a',
-                  ...b,
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}(${type}): partition comments`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bbb',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-                {
-                  data: {
-                    right: 'fff',
-                    left: 'gg',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  // Part: A
-                  // Not partition comment
-                  'bbb',
-                  'cc',
-                  'd',
-                  // Part: B
-                  'aaaa',
-                  'e',
-                  // Part: C
-                  // Not partition comment
-                  'fff',
-                  'gg',
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  // Part: A
-                  'cc',
-                  'd',
-                  // Not partition comment
-                  'bbb',
-                  // Part: B
-                  'aaaa',
-                  'e',
-                  // Part: C
-                  'gg',
-                  // Not partition comment
-                  'fff',
-                ])
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                new Set([
-                  // Comment
-                  'bb',
-                  // Other comment
-                  'a',
-                ])
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                new Set([
-                  /* Partition Comment */
-                  // Part: A
-                  'd',
-                  // Part: B
-                  'aaa',
-                  'bb',
-                  'c',
-                  /* Other */
-                  'e',
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  /* Partition Comment */
-                  // Part: A
-                  'd',
-                  // Part: B
-                  'aaa',
-                  'c',
-                  'bb',
-                  /* Other */
-                  'e',
-                ])
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}): allows to use regex`, rule, {
-        valid: [
-          {
-            code: dedent`
-              new Set([
-                'e',
-                'f',
-                // I am a partition comment because I don't have f o o
-                'a',
-                'b',
-              ])
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
+    it('preserves set structure when fixing sort order', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ])
+        `,
+        options: [options],
       })
 
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                new Set([
-                  /* Comment */
-                  'a',
-                  'b'
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'b',
-                  /* Comment */
-                  'a'
-                ])
-              `,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  new Set([
-                    'b',
-                    // Comment
-                    'a'
-                  ])
-                `,
-              },
-            ],
-            invalid: [],
+            messageId: 'unexpectedSetsOrder',
           },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['a', 'b'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  new Set([
-                    'c',
-                    // b
-                    'b',
-                    // a
-                    'a'
-                  ])
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  new Set([
-                    'b',
-                    // I am a partition comment because I don't have f o o
-                    'a'
-                  ])
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                new Set([
-                  // Comment
-                  'a',
-                  'b'
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'b',
-                  // Comment
-                  'a'
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  new Set([
-                    'b',
-                    /* Comment */
-                    'a'
-                  ])
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                code: dedent`
-                  new Set([
-                    'c',
-                    /* b */
-                    'b',
-                    /* a */
-                    'a'
-                  ])
-                `,
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['a', 'b'],
-                    },
-                  },
-                ],
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  new Set([
-                    'b',
-                    /* I am a partition comment because I don't have f o o */
-                    'a'
-                  ])
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'c',
+            'b',
+            'd',
+            'e',
+            ...other,
+          ])
+        `,
+        options: [options],
       })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              new Set([
-                '$a',
-                'b',
-                '$c',
-              ])
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              new Set([
-                'ab',
-                'a$c',
-              ])
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            new Set([
-              '你好',
-              '世界',
-              'a',
-              'A',
-              'b',
-              'B',
-            ])
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                a, b
-              ])
-            `,
-            code: dedent`
-              new Set([
-                b, a
-              ])
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                a, b,
-              ])
-            `,
-            code: dedent`
-              new Set([
-                b, a,
-              ])
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use predefined groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'spread',
-                  leftGroup: 'literal',
-                  right: '...b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSetsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['spread', 'literal'],
-                groupKind: 'mixed',
-              },
-            ],
-            output: dedent`
-              new Set([
-                ...b,
-                'a',
-                'c'
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'c',
-                ...b,
-                'a'
-              ])
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'literalElements',
-                    selector: 'literal',
-                  },
-                ],
-                groups: ['literalElements', 'unknown'],
-                groupKind: 'mixed',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'literalElements',
-                  leftGroup: 'unknown',
-                  left: '...b',
-                  right: 'a',
-                },
-                messageId: 'unexpectedSetsGroupOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                'a',
-                ...b,
-              ])
-            `,
-            code: dedent`
-              new Set([
-                ...b,
-                'a',
-              ])
-            `,
-          },
-        ],
-        valid: [],
+    it('sorts spread elements in sets', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ])
+        `,
+        options: [options],
       })
 
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'literalsStartingWithHello',
-                      selector: 'literal',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['literalsStartingWithHello', 'unknown'],
-                  groupKind: 'mixed',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'literalsStartingWithHello',
-                    right: 'helloLiteral',
-                    leftGroup: 'unknown',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedSetsGroupOrder',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  'helloLiteral',
-                  'a',
-                  'b',
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'a',
-                  'b',
-                  'helloLiteral',
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedLiteralsByLineLength',
-                    leftGroup: 'unknown',
-                    left: '...m',
-                    right: 'eee',
-                  },
-                  messageId: 'unexpectedSetsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedLiteralsByLineLength',
-                      selector: 'literal',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedLiteralsByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  groupKind: 'mixed',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  'dddd',
-                  'ccc',
-                  'eee',
-                  'bb',
-                  'ff',
-                  'a',
-                  'g',
-                  ...m,
-                  ...o,
-                  ...p,
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'a',
-                  'bb',
-                  'ccc',
-                  'dddd',
-                  ...m,
-                  'eee',
-                  'ff',
-                  'g',
-                  ...o,
-                  ...p,
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedSetsOrder',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  'fooBar',
-                  'fooZar',
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'fooZar',
-                  'fooBar',
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedLiterals',
-                      selector: 'literal',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedLiterals', 'unknown'],
-                  groupKind: 'mixed',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedLiterals',
-                    leftGroup: 'unknown',
-                    left: '...m',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedSetsGroupOrder',
-                },
-              ],
-              output: dedent`
-                new Set([
-                  'b',
-                  'a',
-                  'd',
-                  'e',
-                  'c',
-                  ...m,
-                ])
-              `,
-              code: dedent`
-                new Set([
-                  'b',
-                  'a',
-                  'd',
-                  'e',
-                  ...m,
-                  'c',
-                ])
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'literal',
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'spread',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: '...foo',
-                  left: 'a',
-                },
-                messageId: 'unexpectedSetsGroupOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                '...foo',
-                'cFoo',
-                'a',
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'a',
-                '...foo',
-                'cFoo',
-              ])
-            `,
+            data: {
+              right: '...bbbb',
+              left: '...ccc',
+            },
+            messageId: 'unexpectedSetsOrder',
           },
         ],
-        valid: [],
+        output: dedent`
+          new Set([
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            ...aaa,
+            ...ccc,
+            ...bbbb,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles sets with empty slots correctly', async () => {
+      await valid({
+        code: dedent`
+          new Set(['a', 'b', 'c',, 'd'])
+        `,
+        options: [options],
       })
 
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                new Set([
-                  'iHaveFooInMyName',
-                  'meTooIHaveFoo',
-                  'a',
-                  'b',
-                ])
-              `,
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
             },
-          ],
-          invalid: [],
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(['a', 'b', 'c',, 'd'])
+        `,
+        code: dedent`
+          new Set(['b', 'a', 'c',, 'd'])
+        `,
+        options: [options],
+      })
+    })
+
+    it('places spread elements after literals with literals-first option', async () => {
+      let literalsFirstOptions = [
+        {
+          ...options,
+          groupKind: 'literals-first',
         },
-      )
-    })
+      ]
 
-    describe(`${ruleName}(${type}): allows to use 'useConfigurationIf'`, () => {
-      for (let allNamesMatchPattern of [
-        'foo',
-        ['noMatch', 'foo'],
-        { pattern: 'FOO', flags: 'i' },
-        ['noMatch', { pattern: 'foo', flags: 'i' }],
-      ]) {
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use 'allNamesMatchPattern'`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    useConfigurationIf: {
-                      allNamesMatchPattern,
-                    },
-                  },
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: '^r$',
-                        groupName: 'r',
-                      },
-                      {
-                        elementNamePattern: '^g$',
-                        groupName: 'g',
-                      },
-                      {
-                        elementNamePattern: '^b$',
-                        groupName: 'b',
-                      },
-                    ],
-                    useConfigurationIf: {
-                      allNamesMatchPattern: '^r|g|b$',
-                    },
-                    groups: ['r', 'g', 'b'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      rightGroup: 'g',
-                      leftGroup: 'b',
-                      right: 'g',
-                      left: 'b',
-                    },
-                    messageId: 'unexpectedSetsGroupOrder',
-                  },
-                  {
-                    data: {
-                      rightGroup: 'r',
-                      leftGroup: 'g',
-                      right: 'r',
-                      left: 'g',
-                    },
-                    messageId: 'unexpectedSetsGroupOrder',
-                  },
-                ],
-                output: dedent`
-                  new Set([
-                    'r',
-                    'g',
-                    'b',
-                  ])
-                `,
-                code: dedent`
-                  new Set([
-                    'b',
-                    'g',
-                    'r',
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenSetsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedSetsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenSetsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  new Set([
-                    'a',
-
-
-                   'y',
-                  'z',
-
-                      'b'
-                  ])
-                `,
-                output: dedent`
-                  new Set([
-                    'a',
-                   'b',
-                  'y',
-                      'z'
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenSetsMembers',
-                  },
-                ],
-                output: dedent`
-                  new Set([
-                    'a', 
-
-                  'b',
-                  ])
-                `,
-                code: dedent`
-                  new Set([
-                    'a', 'b',
-                  ])
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenSetsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedSetsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId: 'missedSpacingBetweenSetsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  new Set([
-                    'a',
-
-                   'y',
-                  'z',
-
-                      'b',
-                  ])
-                `,
-                code: dedent`
-                  new Set([
-                    'a',
-
-
-                   'z',
-                  'y',
-                      'b',
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenSetsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenSetsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenSetsMembers',
-                  },
-                ],
-                output: dedent`
-                  new Set([
-                    'a',
-
-                    'b',
-
-                    'c',
-                    'd',
-
-
-                    'e'
-                  ])
-                `,
-                code: dedent`
-                  new Set([
-                    'a',
-                    'b',
-
-
-                    'c',
-
-                    'd',
-
-
-                    'e'
-                  ])
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'missedSpacingBetweenSetsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      new Set([
-                        a,
-
-
-                        b,
-                      ])
-                    `,
-                    code: dedent`
-                      new Set([
-                        a,
-                        b,
-                      ])
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId: 'extraSpacingBetweenSetsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      new Set([
-                        a,
-                        b,
-                      ])
-                    `,
-                    code: dedent`
-                      new Set([
-                        a,
-
-                        b,
-                      ])
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      new Set([
-                        a,
-
-                        b,
-                      ])
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      new Set([
-                        a,
-                        b,
-                      ])
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
+      await valid({
+        code: dedent`
+          new Set(['a', 'b', 'c', ...other])
+        `,
+        options: literalsFirstOptions,
       })
 
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '...other',
+              right: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(['a', 'b', 'c', ...other])
+        `,
+        code: dedent`
+          new Set(['a', 'b', ...other, 'c'])
+        `,
+        options: literalsFirstOptions,
+      })
+    })
+
+    it('sorts elements in Set with Array constructor', async () => {
+      await valid({
+        code: dedent`
+          new Set(new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ))
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ))
+        `,
+        code: dedent`
+          new Set(new Array(
+            'a',
+            'c',
+            'b',
+            'd',
+          ))
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts mixed literals and spread elements together with mixed grouping', async () => {
+      let mixedOptions = [
         {
-          invalid: [
+          ...options,
+          groupKind: 'mixed',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Set(new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ))
+        `,
+        options: mixedOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'bbb',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ))
+        `,
+        code: dedent`
+          new Set(new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ))
+        `,
+        options: mixedOptions,
+      })
+    })
+
+    it('sorts elements within newline-separated groups independently', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            'd',
+
+            'c',
+
+            'b',
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'd',
+            'a',
+
+            'c',
+
+            'e',
+            'b',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats each newline-separated section as independent partition', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...d,
+            'c',
+
+            ...b,
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            ...d,
+
+            'a',
+            ...b,
+          ])
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            // Part: A
+            // Not partition comment
+            'bbb',
+            'cc',
+            'd',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            // Not partition comment
+            'fff',
+            'gg',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            // Part: A
+            'cc',
+            'd',
+            // Not partition comment
+            'bbb',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            'gg',
+            // Not partition comment
+            'fff',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            // Comment
+            'bb',
+            // Other comment
+            'a',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      let multiplePatternOptions = [
+        {
+          ...options,
+          partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+        },
+      ]
+
+      await invalid({
+        output: dedent`
+          new Set([
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'bb',
+            'c',
+            /* Other */
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'c',
+            'bb',
+            /* Other */
+            'e',
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        options: multiplePatternOptions,
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'e',
+            'f',
+            // I am a partition comment because I don't have f o o
+            'a',
+            'b',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      let blockCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            block: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            // Comment
+            'a',
+            'b'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            // Comment
+            'a'
+          ])
+        `,
+        options: blockCommentsOnlyOptions,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Set([
+            'b',
+            /* Comment */
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          new Set([
+            'c',
+            /* b */
+            'b',
+            /* a */
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'b',
+            /* I am a partition comment because I don't have f o o */
+            'a'
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            '$a',
+            'b',
+            '$c',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'ab',
+            'a$c',
+          ])
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            '你好',
+            '世界',
+            'a',
+            'A',
+            'b',
+            'B',
+          ])
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts single-line sets correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            a, b
+          ])
+        `,
+        code: dedent`
+          new Set([
+            b, a
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles trailing commas in single-line sets', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            a, b,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            b, a,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'spread',
+              leftGroup: 'literal',
+              right: '...b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['spread', 'literal'],
+            groupKind: 'mixed',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...b,
+            'a',
+            'c'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            ...b,
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      let customGroupOptions = [
+        {
+          customGroups: [
             {
-              output: [
-                dedent`
-                  new Set([
-                    'a', // Comment after
-                    'b',
-
-                    'c'
-                  ])
-                `,
-                dedent`
-                  new Set([
-                    'a', // Comment after
-
-                    'b',
-                    'c'
-                  ])
-                `,
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'b|c',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedSetsGroupOrder',
-                },
-              ],
-              code: dedent`
-                new Set([
-                  'b',
-                  'a', // Comment after
-
-                  'c'
-                ])
-              `,
+              groupName: 'literalElements',
+              selector: 'literal',
             },
           ],
-          valid: [],
+          groups: ['literalElements', 'unknown'],
+          groupKind: 'mixed',
         },
-      )
+      ]
 
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
+      await invalid({
+        errors: [
           {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedSetsOrder',
-                  },
-                ],
-                output: dedent`
-                  new Set([
-                    'a',
-
-                    // Partition comment
-
-                    'b',
-                    'c',
-                  ])
-                `,
-                code: dedent`
-                  new Set([
-                    'a',
-
-                    // Partition comment
-
-                    'c',
-                    'b',
-                  ])
-                `,
-              },
-            ],
-            valid: [],
+            data: {
+              rightGroup: 'literalElements',
+              leftGroup: 'unknown',
+              left: '...b',
+              right: 'a',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
           },
-        )
-      }
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            ...b,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            ...b,
+            'a',
+          ])
+        `,
+        options: customGroupOptions,
+      })
     })
-  })
 
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        let customGroupOptions = [
           {
-            errors: [
+            customGroups: [
               {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSetsOrder',
+                groupName: 'literalsStartingWithHello',
+                selector: 'literal',
+                elementNamePattern,
               },
             ],
-            output: dedent`
-              new Set([
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'a',
-                'c',
-                'b',
-                'd',
-                'e',
-                ...other,
-              ])
-            `,
-            options: [options],
+            groups: ['literalsStartingWithHello', 'unknown'],
+            groupKind: 'mixed',
           },
-        ],
-        valid: [
-          {
-            code: dedent`
-              new Set([
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                ...other,
-              ])
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
+        ]
 
-    ruleTester.run(`${ruleName}(${type}): sorts spread elements`, rule, {
-      invalid: [
-        {
+        await invalid({
           errors: [
             {
               data: {
-                right: '...bbbb',
-                left: '...ccc',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ])
-          `,
-          code: dedent`
-            new Set([
-              ...aaa,
-              ...ccc,
-              ...bbbb,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set([
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores nullable array elements`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            output: dedent`
-              new Set(['a', 'b', 'c',, 'd'])
-            `,
-            code: dedent`
-              new Set(['b', 'a', 'c',, 'd'])
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              new Set(['a', 'b', 'c',, 'd'])
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allow to put spread elements to the end`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '...other',
-                  right: 'c',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            output: dedent`
-              new Set(['a', 'b', 'c', ...other])
-            `,
-            code: dedent`
-              new Set(['a', 'b', ...other, 'c'])
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            code: dedent`
-              new Set(['a', 'b', 'c', ...other])
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts array constructor`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set(new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ))
-          `,
-          code: dedent`
-            new Set(new Array(
-              'a',
-              'c',
-              'b',
-              'd',
-            ))
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set(new Array(
-              'a',
-              'b',
-              'c',
-              'd',
-            ))
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows mixed sorting`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...d',
-                left: 'bbb',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set(new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ))
-          `,
-          code: dedent`
-            new Set(new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ))
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set(new Array(
-              ...d,
-              'aaaa',
-              'bbb',
-              'cc',
-            ))
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts sets`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'a',
-              'b',
-              'c',
-              'd',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'a',
-              'c',
-              'b',
-              'd',
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set(
-              'a',
-              'b',
-              'c',
-              'd',
-            )
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not break the property list`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bbbb',
-                  left: 'ccc',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                'aaaaa',
-                'bbbb',
-                'ccc',
-                'dd',
-                'e',
-                ...other,
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'aaaaa',
-                'ccc',
-                'bbbb',
-                'dd',
-                'e',
-                ...other,
-              ])
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              new Set([
-                'aaaaa',
-                'bbbb',
-                'ccc',
-                'dd',
-                'e',
-                ...other,
-              ])
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts spread elements`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '...bbbb',
-                left: '...aaa',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              ...bbbb,
-              ...aaa,
-              ...ccc,
-            ])
-          `,
-          code: dedent`
-            new Set([
-              ...aaa,
-              ...bbbb,
-              ...ccc,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set([
-              ...bbbb,
-              ...aaa,
-              ...ccc,
-            ])
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): ignores nullable array elements`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              new Set(['a', 'b', 'c',, 'd'])
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allow to put spread elements to the end`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '...other',
-                  right: 'c',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            output: dedent`
-              new Set(['a', 'b', 'c', ...other])
-            `,
-            code: dedent`
-              new Set(['a', 'b', ...other, 'c'])
-            `,
-          },
-        ],
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                groupKind: 'literals-first',
-              },
-            ],
-            code: dedent`
-              new Set(['a', 'b', 'c', ...other])
-            `,
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): sorts array constructor`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set(new Array(
-              'aaaa',
-              'bbb',
-              'cc',
-              'd',
-            ))
-          `,
-          code: dedent`
-            new Set(new Array(
-              'aaaa',
-              'cc',
-              'bbb',
-              'd',
-            ))
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set(new Array(
-              'aaaa',
-              'bbb',
-              'cc',
-              'd',
-            ))
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): allows mixed sorting`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: '...d',
-                right: 'bbb',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set(new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ))
-          `,
-          code: dedent`
-            new Set(new Array(
-              'aaaa',
-              ...d,
-              'bbb',
-              'cc',
-            ))
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set(new Array(
-              'aaaa',
-              'bbb',
-              ...d,
-              'cc',
-            ))
-          `,
-          options: [
-            {
-              ...options,
-              groupKind: 'mixed',
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              new Set([
-                'bb',
-                'c',
-                'a',
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'a',
-                'bb',
-                'c',
-              ])
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              new Set([
-                'bb',
-                'a',
-                'c',
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'c',
-                'bb',
-                'a',
-              ])
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            new Set([
-              'b',
-              'c',
-              'a'
-            ])
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: '^a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: '^b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['b', 'a'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                rightGroup: 'b',
-                leftGroup: 'a',
-                right: 'ba',
-                left: 'aa',
+                rightGroup: 'literalsStartingWithHello',
+                right: 'helloLiteral',
+                leftGroup: 'unknown',
+                left: 'b',
               },
               messageId: 'unexpectedSetsGroupOrder',
             },
           ],
           output: dedent`
             new Set([
-              'ba',
-              'bb',
-              'ab',
-              'aa',
+              'helloLiteral',
+              'a',
+              'b',
             ])
           `,
           code: dedent`
             new Set([
-              'ab',
-              'aa',
-              'ba',
-              'bb',
+              'a',
+              'b',
+              'helloLiteral',
             ])
           `,
-        },
-      ],
-      valid: [],
-    })
+          options: customGroupOptions,
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
+    it('overrides sort type and order for specific groups', async () => {
+      let customSortOptions = [
         {
-          options: [
+          customGroups: [
             {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groupName: 'reversedLiteralsByLineLength',
+              selector: 'literal',
+              type: 'line-length',
+              order: 'desc',
             },
           ],
+          groups: ['reversedLiteralsByLineLength', 'unknown'],
+          type: 'alphabetical',
+          groupKind: 'mixed',
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedLiteralsByLineLength',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'eee',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'dddd',
+            'ccc',
+            'eee',
+            'bb',
+            'ff',
+            'a',
+            'g',
+            ...m,
+            ...o,
+            ...p,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'bb',
+            'ccc',
+            'dddd',
+            ...m,
+            'eee',
+            'ff',
+            'g',
+            ...o,
+            ...p,
+          ])
+        `,
+        options: customSortOptions,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      let fallbackSortOptions = [
+        {
+          customGroups: [
+            {
+              fallbackSort: {
+                type: 'alphabetical',
+                order: 'asc',
+              },
+              elementNamePattern: '^foo',
+              type: 'line-length',
+              groupName: 'foo',
+              order: 'desc',
+            },
+          ],
+          type: 'alphabetical',
+          groups: ['foo'],
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'fooBar',
+            'fooZar',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'fooZar',
+            'fooBar',
+          ])
+        `,
+        options: fallbackSortOptions,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      let unsortedGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'unsortedLiterals',
+              selector: 'literal',
+              type: 'unsorted',
+            },
+          ],
+          groups: ['unsortedLiterals', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedLiterals',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'c',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'a',
+            'd',
+            'e',
+            'c',
+            ...m,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a',
+            'd',
+            'e',
+            ...m,
+            'c',
+          ])
+        `,
+        options: unsortedGroupOptions,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      let anyOfOptions = [
+        {
+          customGroups: [
+            {
+              anyOf: [
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'literal',
+                },
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'spread',
+                },
+              ],
+              groupName: 'elementsIncludingFoo',
+            },
+          ],
+          groups: ['elementsIncludingFoo', 'unknown'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: '...foo',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            '...foo',
+            'cFoo',
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            '...foo',
+            'cFoo',
+          ])
+        `,
+        options: anyOfOptions,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'iHaveFooInMyName',
+            'meTooIHaveFoo',
+            'a',
+            'b',
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array of patterns', ['noMatch', 'foo']],
+      ['case-insensitive regex', { pattern: 'FOO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'foo', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_, allNamesMatchPattern) => {
+        let conditionalOptions = [
+          {
+            ...options,
+            useConfigurationIf: {
+              allNamesMatchPattern,
+            },
+          },
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^r$',
+                groupName: 'r',
+              },
+              {
+                elementNamePattern: '^g$',
+                groupName: 'g',
+              },
+              {
+                elementNamePattern: '^b$',
+                groupName: 'b',
+              },
+            ],
+            useConfigurationIf: {
+              allNamesMatchPattern: '^r|g|b$',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ]
+
+        await invalid({
           errors: [
             {
               data: {
-                right: 'a',
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
                 left: 'b',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'r',
+              'g',
+              'b',
+            ])
+          `,
+          code: dedent`
+            new Set([
+              'b',
+              'g',
+              'r',
+            ])
+          `,
+          options: conditionalOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        let newlinesOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+          ],
+          code: dedent`
+            new Set([
+              'a',
+
+
+             'y',
+            'z',
+
+                'b'
+            ])
+          `,
+          output: dedent`
+            new Set([
+              'a',
+             'b',
+            'y',
+                'z'
+            ])
+          `,
+          options: newlinesOptions,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      let inlineNewlineOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+            {
+              elementNamePattern: 'c',
+              groupName: 'c',
+            },
+            {
+              elementNamePattern: 'd',
+              groupName: 'd',
+            },
+            {
+              elementNamePattern: 'e',
+              groupName: 'e',
+            },
+          ],
+          groups: [
+            'a',
+            {
+              newlinesBetween: 'always',
+            },
+            'b',
+            {
+              newlinesBetween: 'always',
+            },
+            'c',
+            {
+              newlinesBetween: 'never',
+            },
+            'd',
+            {
+              newlinesBetween: 'ignore',
+            },
+            'e',
+          ],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+
+            'b',
+
+            'c',
+            'd',
+
+
+            'e'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'b',
+
+
+            'c',
+
+            'd',
+
+
+            'e'
+          ])
+        `,
+        options: inlineNewlineOptions,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let mixedNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenSetsMembers',
             },
           ],
           output: dedent`
             new Set([
-              'b',
+              a,
 
+
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          options: mixedNewlineOptions,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        let neverBetweenGroupsOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
               'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+          ],
+          output: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              a,
+
+              b,
+            ])
+          `,
+          options: neverBetweenGroupsOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let ignoreNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await valid({
+          code: dedent`
+            new Set([
+              a,
+
+              b,
+            ])
+          `,
+          options: ignoreNewlineOptions,
+        })
+
+        await valid({
+          code: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          options: ignoreNewlineOptions,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      let commentOptions = [
+        {
+          customGroups: [
+            {
+              elementNamePattern: 'b|c',
+              groupName: 'b|c',
+            },
+          ],
+          groups: ['unknown', 'b|c'],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+
+        output: dedent`
+          new Set([
+            'a', // Comment after
+
+            'b',
+            'c'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a', // Comment after
+
+            'c'
+          ])
+        `,
+        options: commentOptions,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        let partitionOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'a',
+
+              // Partition comment
+
+              'b',
+              'c',
+            ])
+          `,
+          code: dedent`
+            new Set([
+              'a',
+
+              // Partition comment
+
+              'c',
+              'b',
+            ])
+          `,
+          options: partitionOptions,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('preserves set structure when fixing sort order', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            ...other,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'c',
+            'b',
+            'd',
+            'e',
+            ...other,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts spread elements in sets', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...bbbb',
+              left: '...ccc',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...aaa,
+            ...bbbb,
+            ...ccc,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            ...aaa,
+            ...ccc,
+            ...bbbb,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles sets with empty slots correctly', async () => {
+      await valid({
+        code: dedent`
+          new Set(['a', 'b', 'c',, 'd'])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(['a', 'b', 'c',, 'd'])
+        `,
+        code: dedent`
+          new Set(['b', 'a', 'c',, 'd'])
+        `,
+        options: [options],
+      })
+    })
+
+    it('places spread elements after literals with literals-first option', async () => {
+      let literalsFirstOptions = [
+        {
+          ...options,
+          groupKind: 'literals-first',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Set(['a', 'b', 'c', ...other])
+        `,
+        options: literalsFirstOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '...other',
+              right: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(['a', 'b', 'c', ...other])
+        `,
+        code: dedent`
+          new Set(['a', 'b', ...other, 'c'])
+        `,
+        options: literalsFirstOptions,
+      })
+    })
+
+    it('sorts elements in Set with Array constructor', async () => {
+      await valid({
+        code: dedent`
+          new Set(new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ))
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(new Array(
+            'a',
+            'b',
+            'c',
+            'd',
+          ))
+        `,
+        code: dedent`
+          new Set(new Array(
+            'a',
+            'c',
+            'b',
+            'd',
+          ))
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts mixed literals and spread elements together with mixed grouping', async () => {
+      let mixedOptions = [
+        {
+          ...options,
+          groupKind: 'mixed',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Set(new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ))
+        `,
+        options: mixedOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'bbb',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(new Array(
+            ...d,
+            'aaaa',
+            'bbb',
+            'cc',
+          ))
+        `,
+        code: dedent`
+          new Set(new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ))
+        `,
+        options: mixedOptions,
+      })
+    })
+
+    it('sorts elements within newline-separated groups independently', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            'd',
+
+            'c',
+
+            'b',
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'd',
+            'a',
+
+            'c',
+
+            'e',
+            'b',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats each newline-separated section as independent partition', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...d,
+            'c',
+
+            ...b,
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            ...d,
+
+            'a',
+            ...b,
+          ])
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            // Part: A
+            // Not partition comment
+            'bbb',
+            'cc',
+            'd',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            // Not partition comment
+            'fff',
+            'gg',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            // Part: A
+            'cc',
+            'd',
+            // Not partition comment
+            'bbb',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            'gg',
+            // Not partition comment
+            'fff',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            // Comment
+            'bb',
+            // Other comment
+            'a',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      let multiplePatternOptions = [
+        {
+          ...options,
+          partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+        },
+      ]
+
+      await invalid({
+        output: dedent`
+          new Set([
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'bb',
+            'c',
+            /* Other */
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'c',
+            'bb',
+            /* Other */
+            'e',
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        options: multiplePatternOptions,
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'e',
+            'f',
+            // I am a partition comment because I don't have f o o
+            'a',
+            'b',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      let blockCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            block: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            // Comment
+            'a',
+            'b'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            // Comment
+            'a'
+          ])
+        `,
+        options: blockCommentsOnlyOptions,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Set([
+            'b',
+            /* Comment */
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          new Set([
+            'c',
+            /* b */
+            'b',
+            /* a */
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'b',
+            /* I am a partition comment because I don't have f o o */
+            'a'
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            '$a',
+            'b',
+            '$c',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'ab',
+            'a$c',
+          ])
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            '你好',
+            '世界',
+            'a',
+            'A',
+            'b',
+            'B',
+          ])
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts single-line sets correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            a, b
+          ])
+        `,
+        code: dedent`
+          new Set([
+            b, a
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles trailing commas in single-line sets', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            a, b,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            b, a,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'spread',
+              leftGroup: 'literal',
+              right: '...b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['spread', 'literal'],
+            groupKind: 'mixed',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...b,
+            'a',
+            'c'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            ...b,
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      let customGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'literalElements',
+              selector: 'literal',
+            },
+          ],
+          groups: ['literalElements', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literalElements',
+              leftGroup: 'unknown',
+              left: '...b',
+              right: 'a',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            ...b,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            ...b,
+            'a',
+          ])
+        `,
+        options: customGroupOptions,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        let customGroupOptions = [
+          {
+            customGroups: [
+              {
+                groupName: 'literalsStartingWithHello',
+                selector: 'literal',
+                elementNamePattern,
+              },
+            ],
+            groups: ['literalsStartingWithHello', 'unknown'],
+            groupKind: 'mixed',
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'literalsStartingWithHello',
+                right: 'helloLiteral',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'helloLiteral',
+              'a',
+              'b',
+            ])
+          `,
+          code: dedent`
+            new Set([
+              'a',
+              'b',
+              'helloLiteral',
+            ])
+          `,
+          options: customGroupOptions,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      let customSortOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'reversedLiteralsByLineLength',
+              selector: 'literal',
+              type: 'line-length',
+              order: 'desc',
+            },
+          ],
+          groups: ['reversedLiteralsByLineLength', 'unknown'],
+          type: 'alphabetical',
+          groupKind: 'mixed',
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedLiteralsByLineLength',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'eee',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'dddd',
+            'ccc',
+            'eee',
+            'bb',
+            'ff',
+            'a',
+            'g',
+            ...m,
+            ...o,
+            ...p,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'bb',
+            'ccc',
+            'dddd',
+            ...m,
+            'eee',
+            'ff',
+            'g',
+            ...o,
+            ...p,
+          ])
+        `,
+        options: customSortOptions,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      let fallbackSortOptions = [
+        {
+          customGroups: [
+            {
+              fallbackSort: {
+                type: 'alphabetical',
+                order: 'asc',
+              },
+              elementNamePattern: '^foo',
+              type: 'line-length',
+              groupName: 'foo',
+              order: 'desc',
+            },
+          ],
+          type: 'alphabetical',
+          groups: ['foo'],
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'fooBar',
+            'fooZar',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'fooZar',
+            'fooBar',
+          ])
+        `,
+        options: fallbackSortOptions,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      let unsortedGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'unsortedLiterals',
+              selector: 'literal',
+              type: 'unsorted',
+            },
+          ],
+          groups: ['unsortedLiterals', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedLiterals',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'c',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'a',
+            'd',
+            'e',
+            'c',
+            ...m,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a',
+            'd',
+            'e',
+            ...m,
+            'c',
+          ])
+        `,
+        options: unsortedGroupOptions,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      let anyOfOptions = [
+        {
+          customGroups: [
+            {
+              anyOf: [
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'literal',
+                },
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'spread',
+                },
+              ],
+              groupName: 'elementsIncludingFoo',
+            },
+          ],
+          groups: ['elementsIncludingFoo', 'unknown'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: '...foo',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            '...foo',
+            'cFoo',
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            '...foo',
+            'cFoo',
+          ])
+        `,
+        options: anyOfOptions,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'iHaveFooInMyName',
+            'meTooIHaveFoo',
+            'a',
+            'b',
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array of patterns', ['noMatch', 'foo']],
+      ['case-insensitive regex', { pattern: 'FOO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'foo', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_, allNamesMatchPattern) => {
+        let conditionalOptions = [
+          {
+            ...options,
+            useConfigurationIf: {
+              allNamesMatchPattern,
+            },
+          },
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^r$',
+                groupName: 'r',
+              },
+              {
+                elementNamePattern: '^g$',
+                groupName: 'g',
+              },
+              {
+                elementNamePattern: '^b$',
+                groupName: 'b',
+              },
+            ],
+            useConfigurationIf: {
+              allNamesMatchPattern: '^r|g|b$',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'r',
+              'g',
+              'b',
             ])
           `,
           code: dedent`
             new Set([
               'b',
-              'a',
+              'g',
+              'r',
             ])
           `,
+          options: conditionalOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        let newlinesOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+          ],
+          code: dedent`
+            new Set([
+              'a',
+
+
+             'y',
+            'z',
+
+                'b'
+            ])
+          `,
+          output: dedent`
+            new Set([
+              'a',
+             'b',
+            'y',
+                'z'
+            ])
+          `,
+          options: newlinesOptions,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      let inlineNewlineOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+            {
+              elementNamePattern: 'c',
+              groupName: 'c',
+            },
+            {
+              elementNamePattern: 'd',
+              groupName: 'd',
+            },
+            {
+              elementNamePattern: 'e',
+              groupName: 'e',
+            },
+          ],
+          groups: [
+            'a',
+            {
+              newlinesBetween: 'always',
+            },
+            'b',
+            {
+              newlinesBetween: 'always',
+            },
+            'c',
+            {
+              newlinesBetween: 'never',
+            },
+            'd',
+            {
+              newlinesBetween: 'ignore',
+            },
+            'e',
+          ],
+          newlinesBetween: 'always',
         },
-      ],
-      valid: [],
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+
+            'b',
+
+            'c',
+            'd',
+
+
+            'e'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'b',
+
+
+            'c',
+
+            'd',
+
+
+            'e'
+          ])
+        `,
+        options: inlineNewlineOptions,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let mixedNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenSetsMembers',
+            },
+          ],
+          output: dedent`
+            new Set([
+              a,
+
+
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          options: mixedNewlineOptions,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        let neverBetweenGroupsOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+          ],
+          output: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              a,
+
+              b,
+            ])
+          `,
+          options: neverBetweenGroupsOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let ignoreNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await valid({
+          code: dedent`
+            new Set([
+              a,
+
+              b,
+            ])
+          `,
+          options: ignoreNewlineOptions,
+        })
+
+        await valid({
+          code: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          options: ignoreNewlineOptions,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      let commentOptions = [
+        {
+          customGroups: [
+            {
+              elementNamePattern: 'b|c',
+              groupName: 'b|c',
+            },
+          ],
+          groups: ['unknown', 'b|c'],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+
+        output: dedent`
+          new Set([
+            'a', // Comment after
+
+            'b',
+            'c'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a', // Comment after
+
+            'c'
+          ])
+        `,
+        options: commentOptions,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        let partitionOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'a',
+
+              // Partition comment
+
+              'b',
+              'c',
+            ])
+          `,
+          code: dedent`
+            new Set([
+              'a',
+
+              // Partition comment
+
+              'c',
+              'b',
+            ])
+          `,
+          options: partitionOptions,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('preserves set structure when fixing sort order', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'aaaaa',
+            'bbbb',
+            'ccc',
+            'dd',
+            'e',
+            ...other,
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbbb',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'aaaaa',
+            'bbbb',
+            'ccc',
+            'dd',
+            'e',
+            ...other,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'aaaaa',
+            'ccc',
+            'bbbb',
+            'dd',
+            'e',
+            ...other,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts spread elements in sets', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            ...aaa,
+            ...bb,
+            ...c,
+          ])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...bb',
+              left: '...c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...aaa,
+            ...bb,
+            ...c,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            ...aaa,
+            ...c,
+            ...bb,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles sets with empty slots correctly', async () => {
+      await valid({
+        code: dedent`
+          new Set(['aaaa', 'bbb', 'cc',, 'd'])
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaaa',
+              left: 'bbb',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(['aaaa', 'bbb', 'cc',, 'd'])
+        `,
+        code: dedent`
+          new Set(['bbb', 'aaaa', 'cc',, 'd'])
+        `,
+        options: [options],
+      })
+    })
+
+    it('places spread elements after literals with literals-first option', async () => {
+      let literalsFirstOptions = [
+        {
+          ...options,
+          groupKind: 'literals-first',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Set(['a', 'b', 'c', ...other])
+        `,
+        options: literalsFirstOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '...other',
+              right: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(['a', 'b', 'c', ...other])
+        `,
+        code: dedent`
+          new Set(['a', 'b', ...other, 'c'])
+        `,
+        options: literalsFirstOptions,
+      })
+    })
+
+    it('sorts elements in Set with Array constructor', async () => {
+      await valid({
+        code: dedent`
+          new Set(new Array(
+            'aaaa',
+            'bbb',
+            'cc',
+            'd',
+          ))
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(new Array(
+            'aaaa',
+            'bbb',
+            'cc',
+            'd',
+          ))
+        `,
+        code: dedent`
+          new Set(new Array(
+            'aaaa',
+            'cc',
+            'bbb',
+            'd',
+          ))
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts mixed literals and spread elements together with mixed grouping', async () => {
+      let mixedOptions = [
+        {
+          ...options,
+          groupKind: 'mixed',
+        },
+      ]
+
+      await valid({
+        code: dedent`
+          new Set(new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ))
+        `,
+        options: mixedOptions,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: '...d',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set(new Array(
+            'aaaa',
+            'bbb',
+            ...d,
+            'cc',
+          ))
+        `,
+        code: dedent`
+          new Set(new Array(
+            'aaaa',
+            ...d,
+            'bbb',
+            'cc',
+          ))
+        `,
+        options: mixedOptions,
+      })
+    })
+
+    it('sorts elements within newline-separated groups independently', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aaaaa',
+              left: 'dd',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'bbbb',
+              left: 'e',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'aaaaa',
+            'dd',
+
+            'ccc',
+
+            'bbbb',
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'dd',
+            'aaaaa',
+
+            'ccc',
+
+            'e',
+            'bbbb',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats each newline-separated section as independent partition', async () => {
+      let partitionWithGroupOptions = [
+        {
+          ...options,
+          groupKind: 'spreads-first',
+          partitionByNewLine: true,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '...d',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: '...b',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...d,
+            'c',
+
+            ...b,
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            ...d,
+
+            'a',
+            ...b,
+          ])
+        `,
+        options: partitionWithGroupOptions,
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          partitionByComment: '^Part',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            // Part: A
+            // Not partition comment
+            'bbb',
+            'cc',
+            'd',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            // Not partition comment
+            'fff',
+            'gg',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            // Part: A
+            'cc',
+            'd',
+            // Not partition comment
+            'bbb',
+            // Part: B
+            'aaaa',
+            'e',
+            // Part: C
+            'gg',
+            // Not partition comment
+            'fff',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            // Comment
+            'bb',
+            // Other comment
+            'a',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      let multiplePatternOptions = [
+        {
+          ...options,
+          partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+        },
+      ]
+
+      await invalid({
+        output: dedent`
+          new Set([
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'bb',
+            'c',
+            /* Other */
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            /* Partition Comment */
+            // Part: A
+            'd',
+            // Part: B
+            'aaa',
+            'c',
+            'bb',
+            /* Other */
+            'e',
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        options: multiplePatternOptions,
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'e',
+            'f',
+            // I am a partition comment because I don't have f o o
+            'a',
+            'b',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      let blockCommentsOnlyOptions = [
+        {
+          ...options,
+          partitionByComment: {
+            block: true,
+          },
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            // Comment
+            'aa',
+            'b'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            // Comment
+            'aa'
+          ])
+        `,
+        options: blockCommentsOnlyOptions,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          new Set([
+            'b',
+            /* Comment */
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          new Set([
+            'c',
+            /* b */
+            'b',
+            /* a */
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'b',
+            /* I am a partition comment because I don't have f o o */
+            'a'
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            '$a',
+            'bb',
+            '$c',
+          ])
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'abc',
+            'a$c',
+          ])
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            '你好',
+            '世界',
+            'a',
+            'A',
+            'b',
+            'B',
+          ])
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts single-line sets correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            aa, b
+          ])
+        `,
+        code: dedent`
+          new Set([
+            b, aa
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles trailing commas in single-line sets', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            aa, b,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            b, aa,
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'spread',
+              leftGroup: 'literal',
+              right: '...b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['spread', 'literal'],
+            groupKind: 'mixed',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...b,
+            'c',
+            'a'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            ...b,
+            'a'
+          ])
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      let customGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'literalElements',
+              selector: 'literal',
+            },
+          ],
+          groups: ['literalElements', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literalElements',
+              leftGroup: 'unknown',
+              left: '...b',
+              right: 'a',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            ...b,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            ...b,
+            'a',
+          ])
+        `,
+        options: customGroupOptions,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        let customGroupOptions = [
+          {
+            customGroups: [
+              {
+                groupName: 'literalsStartingWithHello',
+                selector: 'literal',
+                elementNamePattern,
+              },
+            ],
+            groups: ['literalsStartingWithHello', 'unknown'],
+            groupKind: 'mixed',
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'literalsStartingWithHello',
+                right: 'helloLiteral',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'helloLiteral',
+              'a',
+              'b',
+            ])
+          `,
+          code: dedent`
+            new Set([
+              'a',
+              'b',
+              'helloLiteral',
+            ])
+          `,
+          options: customGroupOptions,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      let customSortOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'reversedLiteralsByLineLength',
+              selector: 'literal',
+              type: 'line-length',
+              order: 'desc',
+            },
+          ],
+          groups: ['reversedLiteralsByLineLength', 'unknown'],
+          type: 'alphabetical',
+          groupKind: 'mixed',
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedLiteralsByLineLength',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'eee',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'dddd',
+            'ccc',
+            'eee',
+            'bb',
+            'ff',
+            'a',
+            'g',
+            ...m,
+            ...o,
+            ...p,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'bb',
+            'ccc',
+            'dddd',
+            ...m,
+            'eee',
+            'ff',
+            'g',
+            ...o,
+            ...p,
+          ])
+        `,
+        options: customSortOptions,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      let fallbackSortOptions = [
+        {
+          customGroups: [
+            {
+              fallbackSort: {
+                type: 'alphabetical',
+                order: 'asc',
+              },
+              elementNamePattern: '^foo',
+              type: 'line-length',
+              groupName: 'foo',
+              order: 'desc',
+            },
+          ],
+          type: 'alphabetical',
+          groups: ['foo'],
+          order: 'asc',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'fooBar',
+            'fooZar',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'fooZar',
+            'fooBar',
+          ])
+        `,
+        options: fallbackSortOptions,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      let unsortedGroupOptions = [
+        {
+          customGroups: [
+            {
+              groupName: 'unsortedLiterals',
+              selector: 'literal',
+              type: 'unsorted',
+            },
+          ],
+          groups: ['unsortedLiterals', 'unknown'],
+          groupKind: 'mixed',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedLiterals',
+              leftGroup: 'unknown',
+              left: '...m',
+              right: 'c',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'a',
+            'd',
+            'e',
+            'c',
+            ...m,
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a',
+            'd',
+            'e',
+            ...m,
+            'c',
+          ])
+        `,
+        options: unsortedGroupOptions,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      let anyOfOptions = [
+        {
+          customGroups: [
+            {
+              anyOf: [
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'literal',
+                },
+                {
+                  elementNamePattern: 'foo|Foo',
+                  selector: 'spread',
+                },
+              ],
+              groupName: 'elementsIncludingFoo',
+            },
+          ],
+          groups: ['elementsIncludingFoo', 'unknown'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: '...foo',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            '...foo',
+            'cFoo',
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            '...foo',
+            'cFoo',
+          ])
+        `,
+        options: anyOfOptions,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'iHaveFooInMyName',
+            'meTooIHaveFoo',
+            'a',
+            'b',
+          ])
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'foo'],
+      ['array of patterns', ['noMatch', 'foo']],
+      ['case-insensitive regex', { pattern: 'FOO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'foo', flags: 'i' }]],
+    ])(
+      'applies configuration when all names match pattern - %s',
+      async (_, allNamesMatchPattern) => {
+        let conditionalOptions = [
+          {
+            ...options,
+            useConfigurationIf: {
+              allNamesMatchPattern,
+            },
+          },
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: '^r$',
+                groupName: 'r',
+              },
+              {
+                elementNamePattern: '^g$',
+                groupName: 'g',
+              },
+              {
+                elementNamePattern: '^b$',
+                groupName: 'b',
+              },
+            ],
+            useConfigurationIf: {
+              allNamesMatchPattern: '^r|g|b$',
+            },
+            groups: ['r', 'g', 'b'],
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'g',
+                leftGroup: 'b',
+                right: 'g',
+                left: 'b',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+            {
+              data: {
+                rightGroup: 'r',
+                leftGroup: 'g',
+                right: 'r',
+                left: 'g',
+              },
+              messageId: 'unexpectedSetsGroupOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'r',
+              'g',
+              'b',
+            ])
+          `,
+          code: dedent`
+            new Set([
+              'b',
+              'g',
+              'r',
+            ])
+          `,
+          options: conditionalOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        let newlinesOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+          ],
+          code: dedent`
+            new Set([
+              'aaaa',
+
+
+             'yy',
+            'z',
+
+                'bbb'
+            ])
+          `,
+          output: dedent`
+            new Set([
+              'aaaa',
+             'bbb',
+            'yy',
+                'z'
+            ])
+          `,
+          options: newlinesOptions,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      let inlineNewlineOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+            {
+              elementNamePattern: 'c',
+              groupName: 'c',
+            },
+            {
+              elementNamePattern: 'd',
+              groupName: 'd',
+            },
+            {
+              elementNamePattern: 'e',
+              groupName: 'e',
+            },
+          ],
+          groups: [
+            'a',
+            {
+              newlinesBetween: 'always',
+            },
+            'b',
+            {
+              newlinesBetween: 'always',
+            },
+            'c',
+            {
+              newlinesBetween: 'never',
+            },
+            'd',
+            {
+              newlinesBetween: 'ignore',
+            },
+            'e',
+          ],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+
+            'b',
+
+            'c',
+            'd',
+
+
+            'e'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'b',
+
+
+            'c',
+
+            'd',
+
+
+            'e'
+          ])
+        `,
+        options: inlineNewlineOptions,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let mixedNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenSetsMembers',
+            },
+          ],
+          output: dedent`
+            new Set([
+              a,
+
+
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          options: mixedNewlineOptions,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        let neverBetweenGroupsOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'never' },
+              'unusedGroup',
+              { newlinesBetween: 'never' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenSetsMembers',
+            },
+          ],
+          output: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              a,
+
+              b,
+            ])
+          `,
+          options: neverBetweenGroupsOptions,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        let ignoreNewlineOptions = [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { groupName: 'unusedGroup', elementNamePattern: 'X' },
+            ],
+            groups: [
+              'a',
+              'unusedGroup',
+              { newlinesBetween: groupNewlinesBetween },
+              'b',
+            ],
+            newlinesBetween: globalNewlinesBetween,
+          },
+        ]
+
+        await valid({
+          code: dedent`
+            new Set([
+              a,
+
+              b,
+            ])
+          `,
+          options: ignoreNewlineOptions,
+        })
+
+        await valid({
+          code: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          options: ignoreNewlineOptions,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      let commentOptions = [
+        {
+          customGroups: [
+            {
+              elementNamePattern: 'b|c',
+              groupName: 'b|c',
+            },
+          ],
+          groups: ['unknown', 'b|c'],
+          newlinesBetween: 'always',
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+
+        output: dedent`
+          new Set([
+            'a', // Comment after
+
+            'b',
+            'c'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a', // Comment after
+
+            'c'
+          ])
+        `,
+        options: commentOptions,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        let partitionOptions = [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaa',
+                groupName: 'a',
+              },
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween,
+          },
+        ]
+
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              'aaa',
+
+              // Partition comment
+
+              'bb',
+              'c',
+            ])
+          `,
+          code: dedent`
+            new Set([
+              'aaa',
+
+              // Partition comment
+
+              'c',
+              'bb',
+            ])
+          `,
+          options: partitionOptions,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts elements in sets', async () => {
+      await valid({
+        code: dedent`
+          new Set(
+            'a',
+            'b',
+            'c',
+            'd',
+          )
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            'b',
+            'c',
+            'd',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
+            'c',
+            'b',
+            'd',
+          ])
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('accepts unsorted sets', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'b',
+            'c',
+            'a'
+          ])
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces custom group ordering', async () => {
+      let customGroupOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: '^a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: '^b',
+              groupName: 'b',
+            },
+          ],
+          groups: ['b', 'a'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'b',
+              leftGroup: 'a',
+              right: 'ba',
+              left: 'aa',
+            },
+            messageId: 'unexpectedSetsGroupOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'ba',
+            'bb',
+            'ab',
+            'aa',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'ab',
+            'aa',
+            'ba',
+            'bb',
+          ])
+        `,
+        options: customGroupOptions,
+      })
+    })
+
+    it('adds required newlines between groups', async () => {
+      let newlineGroupOptions = [
+        {
+          ...options,
+          customGroups: [
+            {
+              elementNamePattern: 'a',
+              groupName: 'a',
+            },
+            {
+              elementNamePattern: 'b',
+              groupName: 'b',
+            },
+          ],
+          newlinesBetween: 'always',
+          groups: ['b', 'a'],
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenSetsMembers',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a',
+          ])
+        `,
+        options: newlineGroupOptions,
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
+    it('uses alphabetical ascending order by default', async () => {
+      await valid(
+        dedent`
+          new Set([
+            'a',
+            'b',
+            'c',
+            'd',
+          ])
+        `,
+      )
+
+      await valid({
+        code: dedent`
+          new Set([
+            'v1.png',
+            'v10.png',
+            'v12.png',
+            'v2.png',
+          ])
+        `,
+        options: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-              {
-                data: {
-                  right: 'c',
-                  left: 'd',
-                },
-                messageId: 'unexpectedSetsOrder',
-              },
-            ],
-            output: dedent`
-              new Set([
-                'a',
-                'b',
-                'c',
-                'd',
-              ])
-            `,
-            code: dedent`
-              new Set([
-                'b',
-                'a',
-                'd',
-                'c',
-              ])
-            `,
+            ignoreCase: false,
           },
         ],
-        valid: [
-          dedent`
-            new Set([
-              'a',
-              'b',
-              'c',
-              'd',
-            ])
-          `,
+      })
+
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              new Set([
-                'v1.png',
-                'v10.png',
-                'v12.png',
-                'v2.png',
-              ])
-            `,
-            options: [
-              {
-                ignoreCase: false,
-              },
-            ],
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedSetsOrder',
           },
         ],
-      },
-    )
+        output: dedent`
+          new Set([
+            'a',
+            'b',
+            'c',
+            'd',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'b',
+            'a',
+            'd',
+            'c',
+          ])
+        `,
+      })
+    })
 
-    ruleTester.run(
-      `${ruleName}: works consistently with an empty array or an array with one element`,
-      rule,
-      {
-        valid: ['new Set([])', "new Set(['a'])"],
-        invalid: [],
-      },
-    )
+    it('handles empty and single-element sets', async () => {
+      await valid('new Set([])')
+      await valid("new Set(['a'])")
+    })
 
-    ruleTester.run(`${ruleName}: ignores quotes of strings`, rule, {
-      valid: [
+    it('treats different quote styles as equivalent', async () => {
+      await valid(
         dedent`
           new Set(['a', "b", 'c'])
         `,
-      ],
-      invalid: [],
+      )
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              // eslint-disable-next-line
-              'a',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              // eslint-disable-next-line
-              'a',
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              // eslint-disable-next-line
-              'a',
-              'd'
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'd',
-              'c',
-              // eslint-disable-next-line
-              'a',
-              'b'
-            ])
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-            {
-              data: {
-                right: '...anotherArray',
-                left: 'a',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              ...anotherArray,
-              'b',
-              // eslint-disable-next-line
-              'a',
-              'c'
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              // eslint-disable-next-line
-              'a',
-              ...anotherArray
-            ])
-          `,
-          options: [
-            {
-              groupKind: 'mixed',
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              'a', // eslint-disable-line
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              'a', // eslint-disable-line
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              /* eslint-disable-next-line */
-              'a',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              /* eslint-disable-next-line */
-              'a',
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              'a', /* eslint-disable-line */
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              'a', /* eslint-disable-line */
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Set([
-              'a',
-              'd',
-              /* eslint-disable */
-              'c',
-              'b',
-              // Shouldn't move
-              /* eslint-enable */
-              'e',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'd',
-              'e',
-              /* eslint-disable */
-              'c',
-              'b',
-              // Shouldn't move
-              /* eslint-enable */
-              'a',
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              'a',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              'a',
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              'a', // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              'a', // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              'a',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              'a',
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          output: dedent`
-            new Set([
-              'b',
-              'c',
-              'a', /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'c',
-              'b',
-              'a', /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-            ])
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            new Set([
-              'a',
-              'd',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              'c',
-              'b',
-              // Shouldn't move
-              /* eslint-enable */
-              'e',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'd',
-              'e',
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              'c',
-              'b',
-              // Shouldn't move
-              /* eslint-enable */
-              'a',
-            ])
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            new Set([
-              'b',
-              'c',
-              // eslint-disable-next-line
-              'a',
-            ])
-          `,
-        },
-      ],
-    })
+    it('respects eslint-disable-next-line comments', async () => {
+      await valid({
+        code: dedent`
+          new Set([
+            'b',
+            'c',
+            // eslint-disable-next-line
+            'a',
+          ])
+        `,
+      })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              new Set([
-                'a',
-                'b',
-                'c',
-              ])
-            `,
-            options: [{}],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            // eslint-disable-next-line
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            // eslint-disable-next-line
+            'a',
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles eslint-disable with partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            // eslint-disable-next-line
+            'a',
+            'd'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'd',
+            'c',
+            // eslint-disable-next-line
+            'a',
+            'b'
+          ])
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('works with eslint-disable and mixed grouping', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: '...anotherArray',
+              left: 'a',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            ...anotherArray,
+            'b',
+            // eslint-disable-next-line
+            'a',
+            'c'
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            // eslint-disable-next-line
+            'a',
+            ...anotherArray
+          ])
+        `,
+        options: [
+          {
+            groupKind: 'mixed',
+          },
+        ],
+      })
+    })
+
+    it('handles inline eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            'a', // eslint-disable-line
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            'a', // eslint-disable-line
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block-style eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            /* eslint-disable-next-line */
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            /* eslint-disable-next-line */
+            'a',
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles inline block-style eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            'a', /* eslint-disable-line */
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            'a', /* eslint-disable-line */
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable/enable block regions', async () => {
+      await invalid({
+        output: dedent`
+          new Set([
+            'a',
+            'd',
+            /* eslint-disable */
+            'c',
+            'b',
+            // Shouldn't move
+            /* eslint-enable */
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'd',
+            'e',
+            /* eslint-disable */
+            'c',
+            'b',
+            // Shouldn't move
+            /* eslint-enable */
+            'a',
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            // eslint-disable-next-line rule-to-test/sort-sets
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            // eslint-disable-next-line rule-to-test/sort-sets
+            'a',
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles inline rule-specific eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            'a', // eslint-disable-line rule-to-test/sort-sets
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            'a', // eslint-disable-line rule-to-test/sort-sets
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block-style rule-specific eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            /* eslint-disable-next-line rule-to-test/sort-sets */
+            'a',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            /* eslint-disable-next-line rule-to-test/sort-sets */
+            'a',
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles inline block-style rule-specific eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'b',
+            'c',
+            'a', /* eslint-disable-line rule-to-test/sort-sets */
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'c',
+            'b',
+            'a', /* eslint-disable-line rule-to-test/sort-sets */
+          ])
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects rule-specific eslint-disable/enable regions', async () => {
+      await invalid({
+        output: dedent`
+          new Set([
+            'a',
+            'd',
+            /* eslint-disable rule-to-test/sort-sets */
+            'c',
+            'b',
+            // Shouldn't move
+            /* eslint-enable */
+            'e',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'd',
+            'e',
+            /* eslint-disable rule-to-test/sort-sets */
+            'c',
+            'b',
+            // Shouldn't move
+            /* eslint-enable */
+            'a',
+          ])
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
   })
 })

--- a/test/rules/sort-switch-case.test.ts
+++ b/test/rules/sort-switch-case.test.ts
@@ -1,2735 +1,3313 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-switch-case'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-switch-case'
+describe('sort-switch-case', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-switch-case',
+    parser: typescriptParser,
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with return statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                switch(<any> myFunc(a! + b?.c as any)) {
-                  case 'aaa':
-                    return 'a'
-                  case 'bb':
-                    return 'b'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                switch(<any> myFunc(a! + b?.c as any)) {
-                  case 'bb':
-                    return 'b'
-                  case 'aaa':
-                    return 'a'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-          {
-            output: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'aaa':
-                    return 'a'
-                  case 'bb':
-                    return 'b'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'bb':
-                    return 'b'
-                  case 'aaa':
-                    return 'a'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch(x) {
-              }
-            `,
-            options: [{}],
-          },
-          {
-            code: dedent`
-              switch(x) {
-                case "a":
-                  break;
-              }
-            `,
-            options: [{}],
-          },
-          {
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'aaa':
-                    return 'a'
-                  case 'bb':
-                    return 'b'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with break statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with block statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                    break
-                  }
-                  case 'bb': {
-                    height = 2
-                    break
-                  }
-                  case 'c': {
-                    height = 3
-                    break
-                  }
-                  default:
-                    height = NaN
-                    break
-                }
-                return size
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                    break
-                  }
-                  case 'c': {
-                    height = 3
-                    break
-                  }
-                  case 'bb': {
-                    height = 2
-                    break
-                  }
-                  default:
-                    height = NaN
-                    break
-                }
-                return size
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                  }
-                  case 'bb': {
-                    height = 2
-                  }
-                  case 'c': {
-                    height = 3
-                  }
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases without ending statements`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'b':
-                    let b
-                    break
-                  case 'a':
-                }
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'b':
-                    let b
-                    break
-                  case 'a':
-                    let a
-                }
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'b':
-                    let b
-                    break
-                  default:
-                }
-              }
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'b':
-                    let b
-                    break
-                  default:
-                    let x
-                }
-              }
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'b':
-                    let b
-                    break
-                  case 'c':
-                    let c
-                    break
-                  case 'a':
-                }
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'c':
-                    let c
-                    break
-                  case 'b':
-                    let b
-                    break
-                  case 'a':
-                }
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'b',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): works with grouped cases`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-          ],
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'ee':
-              case 'cccc':
-              case 'f':
-                return 'tertiary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'cccc',
-                left: 'ee',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'bbbbb',
-                left: 'f',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'cccc':
-              case 'ee':
-              case 'f':
-                return 'tertiary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
-          options: [options],
-        },
-      ],
+    it('not works if switch-case is not sortable', async () => {
+      await valid({
+        code: dedent`
+          switch(x) {
+          }
+        `,
+        options: [{}],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): works with grouped cases with default`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              switch (operationMode) {
-                case wwww:
-                  return null
-                case yy:
-                case z:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            code: dedent`
-              switch (operationMode) {
-                case yy:
-                case z:
-                  return null
-                case wwww:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'wwww',
-                  left: 'z',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (operationMode) {
-                case wwww:
-                  return null
-                case yy:
-                case z:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with single grouped case`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'AA',
-                  left: 'B',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case AA:
-                case B:
-                  const a = 1;
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case B:
-                case AA:
-                  const a = 1;
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (x) {
-                case AA:
-                case B:
-                  const a = 1;
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): works with complex cases`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (x) {
-                case DD:
-                case E:
-                  const b = () => {
-                    return 2
-                  }
-                  break
-                case CCC:
-                  break
-                case AAAAA:
-                case BBBB:
-                  const a = 1
-                  break
-                default:
-                  const c = 3
-              }
-            `,
-            dedent`
-              switch (x) {
-                case AAAAA:
-                case BBBB:
-                  const a = 1
-                  break
-                case CCC:
-                  break
-                case DD:
-                case E:
-                  const b = () => {
-                    return 2
-                  }
-                  break
-                default:
-                  const c = 3
-              }
-            `,
-          ],
-          errors: [
-            {
-              data: {
-                right: 'DD',
-                left: 'E',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'CCC',
-                left: 'DD',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'BBBB',
-                left: 'CCC',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'AAAAA',
-                left: 'BBBB',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          code: dedent`
-            switch (x) {
-              case E:
-              case DD:
-                const b = () => {
-                  return 2
-                }
-                break
-              case CCC:
-                break
-              case BBBB:
-              case AAAAA:
-                const a = 1
-                break
+    it('sorts switch cases with return statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
               default:
-                const c = 3
+                return 'x'
             }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            switch (x) {
-              case AAAAA:
-              case BBBB:
-                const a = 1
-                break
-              case CCC:
-                break
-              case DD:
-              case E:
-                const b = () => {
-                  return 2
-                }
-                break
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(<any> myFunc(a! + b?.c as any)) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
               default:
-                const c = 3
+                return 'x'
             }
-          `,
-          options: [options],
-        },
-      ],
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(<any> myFunc(a! + b?.c as any)) {
+              case 'bb':
+                return 'b'
+              case 'aaa':
+                return 'a'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(name) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'bb':
+                return 'b'
+              case 'aaa':
+                return 'a'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): works with groups with default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'default',
-                  right: 'B',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case 'AA':
-                case 'B':
-                default:
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case 'AA':
-                default:
-                case 'B':
-                  break;
-              }
-            `,
-            options: [options],
-          },
-          {
-            output: [
-              dedent`
-                switch (x) {
-                  case 'default':
-                  default:
-                    break;
-                  case 'somethingElse':
-                    break;
-                }
-              `,
-              dedent`
-                switch (x) {
-                  case 'somethingElse':
-                    break;
-                  case 'default':
-                  default:
-                    break;
-                }
-              `,
-            ],
-            errors: [
-              {
-                data: {
-                  right: 'default',
-                  left: 'default',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-              {
-                data: {
-                  right: 'somethingElse',
-                  left: 'default',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            code: dedent`
-              switch (x) {
-                default:
-                case 'default':
-                  break;
-                case 'somethingElse':
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (x) {
-                case 'AA':
-                case 'B':
-                default:
-                  const c = 3
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
+    it('sorts switch cases with break statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
+                break
+              case 'bb':
+                height = 2
+                break
+              case 'c':
+                height = 3
+                break
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        options: [options],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
+      await invalid({
+        output: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
+                break
+              case 'bb':
+                height = 2
+                break
+              case 'c':
+                height = 3
+                break
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
+                break
+              case 'c':
+                height = 3
+                break
+              case 'bb':
+                height = 2
+                break
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        errors: [
           {
-            code: dedent`
-              switch (x) {
-                case '_a':
-                case 'b':
-                case '_c':
-                  break;
-              }
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        options: [options],
+      })
+    })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            code: dedent`
-              switch (x) {
-                case 'ab':
-                case 'a_c':
-                  break;
+    it('sorts switch cases with block statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
               }
-            `,
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
+              case 'bb': {
+                height = 2
+              }
+              case 'c': {
+                height = 3
+              }
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+                break
+              }
+              case 'bb': {
+                height = 2
+                break
+              }
+              case 'c': {
+                height = 3
+                break
+              }
+              default:
+                height = NaN
+                break
+            }
+            return size
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+                break
+              }
+              case 'c': {
+                height = 3
+                break
+              }
+              case 'bb': {
+                height = 2
+                break
+              }
+              default:
+                height = NaN
+                break
+            }
+            return size
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        options: [options],
+      })
+    })
 
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            switch (x) {
-              case '你好':
-              case '世界':
-              case 'a':
-              case 'A':
+    it('sorts switch cases without ending statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
               case 'b':
-              case 'B':
-                break;
+                let b
+                break
+              case 'a':
             }
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
+          }
+        `,
+        options: [options],
+      })
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              case 'a':
+                let a
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              default:
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              default:
+                let x
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              case 'c':
+                let c
+                break
+              case 'a':
+            }
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'c':
+                let c
+                break
+              case 'b':
+                let b
+                break
+              case 'a':
+            }
+          }
+        `,
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case "a": break; case "b": break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case "b": break; case "a": break
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case "a": break; case "b": break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case "b": break; case "a": break;
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case "a": { break }; case "b": { break }
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case "b": { break } case "a": { break }
-              }
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case "a": { break }; case "b": { break }
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case "b": { break } case "a": { break };
-              }
-            `,
-            options: [options],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
           },
         ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: handles comments`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (value) {
-                case "a": // a
-                case "b": // b
-                  break;
-              }
-            `,
-          ],
-          code: dedent`
-            switch (value) {
-              case "b": // b
-              case "a": // a
-                break;
-            }
-          `,
-          errors: [
-            {
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: [
-            dedent`
-              switch (value) {
-                case "a": // a
-                default: // default
-                  break;
-              }
-            `,
-          ],
-          code: dedent`
-            switch (value) {
-              default: // default
-              case "a": // a
-                break;
-            }
-          `,
-          errors: [
-            {
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          output: [
-            dedent`
-              switch (value) {
-                case "z": { return; } // z
-                case      "x"
-                   : // x
-                case "y": // y
-                default    : // default
-                    let a;
-                case "b": // b
-                  return;
-                case "a": // A
-                  break;
-              }
-            `,
-            dedent`
-              switch (value) {
-                case "a": // A
-                  break;
-                case "z": { return; } // z
-                case      "x"
-                   : // x
-                case "y": // y
-                default    : // default
-                    let a;
-                case "b": // b
-                  return;
-              }
-            `,
-          ],
-          errors: [
-            {
-              data: {
-                left: 'default',
-                right: 'x',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'x',
-                left: 'y',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          code: dedent`
-            switch (value) {
-              case "z": { return; } // z
-              default    : // default
-              case "y": // y
-              case      "x"
-                 : // x
-                  let a;
-              case "b": // b
-                return;
-              case "a": // A
-                break;
-            }
-          `,
-          options: [{}],
-        },
-      ],
-      valid: [],
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: handles last case without break`, rule, {
-      valid: [
-        {
-          code: dedent`
-            switch(x) {
-              case "b": {
-                break
-              }
-              case "a": {
-                let a
-              }
-            }
-          `,
-          options: [{}],
-        },
-        {
-          code: dedent`
-            switch(x) {
-              default: {
-                break
-              }
-              case "a": {
-                let a
-              }
-            }
-          `,
-          options: [{}],
-        },
-        {
-          code: dedent`
-            switch(x) {
-              case "b":
-                break
-              case "a":
-                let a
-            }
-          `,
-          options: [{}],
-        },
-        {
-          code: dedent`
-            switch(x) {
-              default:
-                break;
-              case "a":
-                let a
-            }
-          `,
-          options: [{}],
-        },
-      ],
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: 'default',
-                right: 'a',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
+    it('works with grouped cases', async () => {
+      await valid({
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'ee':
+            case 'cccc':
+            case 'f':
+              return 'tertiary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'cccc',
+              left: 'ee',
             },
-          ],
-          output: dedent`
-            switch(x) {
-              case "a":
-                break;
-              default:
-                break;
-              case "a":
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'bbbbb',
+              left: 'f',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('works with grouped cases with default', async () => {
+      await valid({
+        code: dedent`
+          switch (operationMode) {
+            case wwww:
+              return null
+            case yy:
+            case z:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (operationMode) {
+            case wwww:
+              return null
+            case yy:
+            case z:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        code: dedent`
+          switch (operationMode) {
+            case yy:
+            case z:
+              return null
+            case wwww:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'wwww',
+              left: 'z',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('works with single grouped case', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case AA:
+            case B:
+              const a = 1;
+              break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case AA:
+            case B:
+              const a = 1;
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case B:
+            case AA:
+              const a = 1;
+              break;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with complex cases', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case AAAAA:
+            case BBBB:
+              const a = 1
+              break
+            case CCC:
+              break
+            case DD:
+            case E:
+              const b = () => {
+                return 2
+              }
+              break
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'DD',
+              left: 'E',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'CCC',
+              left: 'DD',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'BBBB',
+              left: 'CCC',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'AAAAA',
+              left: 'BBBB',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case AAAAA:
+            case BBBB:
+              const a = 1
+              break
+            case CCC:
+              break
+            case DD:
+            case E:
+              const b = () => {
+                return 2
+              }
+              break
+            default:
+              const c = 3
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case E:
+            case DD:
+              const b = () => {
+                return 2
+              }
+              break
+            case CCC:
+              break
+            case BBBB:
+            case AAAAA:
+              const a = 1
+              break
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with groups with default', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'AA':
+            case 'B':
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'B',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case 'AA':
+            case 'B':
+            default:
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case 'AA':
+            default:
+            case 'B':
+              break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'default',
+              left: 'default',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'somethingElse',
+              left: 'default',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case 'somethingElse':
+              break;
+            case 'default':
+            default:
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            default:
+            case 'default':
+              break;
+            case 'somethingElse':
+              break;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case '_a':
+            case 'b':
+            case '_c':
+              break;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'ab':
+            case 'a_c':
+              break;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case '你好':
+            case '世界':
+            case 'a':
+            case 'A':
+            case 'b':
+            case 'B':
+              break;
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": break; case "b": break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": break; case "a": break
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": break; case "b": break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": break; case "a": break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": { break }; case "b": { break }
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": { break } case "a": { break }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": { break }; case "b": { break }
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": { break } case "a": { break };
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles comments', async () => {
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case "a": // a
+            case "b": // b
+              break;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case "b": // b
+            case "a": // a
+              break;
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case "a": // a
+            default: // default
+              break;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            default: // default
+            case "a": // a
+              break;
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'x',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'x',
+              left: 'y',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (value) {
+            case "a": // A
+              break;
+            case "z": { return; } // z
+            case      "x"
+               : // x
+            case "y": // y
+            default    : // default
+                let a;
+            case "b": // b
+              return;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case "z": { return; } // z
+            default    : // default
+            case "y": // y
+            case      "x"
+               : // x
+                let a;
+            case "b": // b
+              return;
+            case "a": // A
+              break;
+          }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles last case without break', async () => {
+      await valid({
+        code: dedent`
+          switch(x) {
+            case "b": {
+              break
             }
-          `,
-          code: dedent`
-            switch(x) {
-              default:
-                break;
-              case "a":
-                break;
-              case "a":
+            case "a": {
+              let a
             }
-          `,
-          options: [{}],
-        },
-      ],
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            default: {
+              break
+            }
+            case "a": {
+              let a
+            }
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            case "b":
+              break
+            case "a":
+              let a
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            default:
+              break;
+            case "a":
+              let a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'a',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch(x) {
+            case "a":
+              break;
+            default:
+              break;
+            case "a":
+          }
+        `,
+        code: dedent`
+          switch(x) {
+            default:
+              break;
+            case "a":
+              break;
+            case "a":
+          }
+        `,
+        options: [{}],
+      })
     })
   })
 
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
+  describe('natural', () => {
     let options = {
-      ignoreCase: true,
       type: 'natural',
       order: 'asc',
     } as const
 
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with return statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'aaa':
-                    return 'a'
-                  case 'bb':
-                    return 'b'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'bb':
-                    return 'b'
-                  case 'aaa':
-                    return 'a'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'aaa':
-                    return 'a'
-                  case 'bb':
-                    return 'b'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with break statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with block statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                    break
-                  }
-                  case 'bb': {
-                    height = 2
-                    break
-                  }
-                  case 'c': {
-                    height = 3
-                    break
-                  }
-                  default:
-                    height = NaN
-                    break
-                }
-                return size
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                    break
-                  }
-                  case 'c': {
-                    height = 3
-                    break
-                  }
-                  case 'bb': {
-                    height = 2
-                    break
-                  }
-                  default:
-                    height = NaN
-                    break
-                }
-                return size
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                  }
-                  case 'bb': {
-                    height = 2
-                  }
-                  case 'c': {
-                    height = 3
-                  }
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): works with grouped cases`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-          ],
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'ee':
-              case 'cccc':
-              case 'f':
-                return 'tertiary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'x':
+    it('sorts switch cases with return statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
               default:
-                return 'unknown'
+                return 'x'
             }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'cccc',
-                left: 'ee',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'bbbbb',
-                left: 'f',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'cccc':
-              case 'ee':
-              case 'f':
-                return 'tertiary'
-              case 'x':
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(<any> myFunc(a! + b?.c as any)) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
               default:
-                return 'unknown'
+                return 'x'
             }
-          `,
-          options: [options],
-        },
-      ],
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(<any> myFunc(a! + b?.c as any)) {
+              case 'bb':
+                return 'b'
+              case 'aaa':
+                return 'a'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(name) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'bb':
+                return 'b'
+              case 'aaa':
+                return 'a'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): works with grouped cases with default`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              switch (operationMode) {
-                case wwww:
-                  return null
-                case yy:
-                case z:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            code: dedent`
-              switch (operationMode) {
-                case yy:
-                case z:
-                  return null
-                case wwww:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'wwww',
-                  left: 'z',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (operationMode) {
-                case wwww:
-                  return null
-                case yy:
-                case z:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with single grouped case`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'AA',
-                  left: 'B',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case AA:
-                case B:
-                  const a = 1;
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case B:
-                case AA:
-                  const a = 1;
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (x) {
-                case AA:
-                case B:
-                  const a = 1;
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): works with complex cases`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (x) {
-                case DD:
-                case E:
-                  const b = () => {
-                    return 2
-                  }
-                  break
-                case CCC:
-                  break
-                case AAAAA:
-                case BBBB:
-                  const a = 1
-                  break
-                default:
-                  const c = 3
-              }
-            `,
-            dedent`
-              switch (x) {
-                case AAAAA:
-                case BBBB:
-                  const a = 1
-                  break
-                case CCC:
-                  break
-                case DD:
-                case E:
-                  const b = () => {
-                    return 2
-                  }
-                  break
-                default:
-                  const c = 3
-              }
-            `,
-          ],
-          errors: [
-            {
-              data: {
-                right: 'DD',
-                left: 'E',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'CCC',
-                left: 'DD',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'BBBB',
-                left: 'CCC',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'AAAAA',
-                left: 'BBBB',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          code: dedent`
-            switch (x) {
-              case E:
-              case DD:
-                const b = () => {
-                  return 2
-                }
+    it('sorts switch cases with break statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
                 break
-              case CCC:
+              case 'bb':
+                height = 2
                 break
-              case BBBB:
-              case AAAAA:
-                const a = 1
+              case 'c':
+                height = 3
                 break
               default:
-                const c = 3
+                height = NaN
             }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            switch (x) {
-              case AAAAA:
-              case BBBB:
-                const a = 1
+            return size
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
                 break
-              case CCC:
+              case 'bb':
+                height = 2
                 break
-              case DD:
-              case E:
-                const b = () => {
-                  return 2
-                }
+              case 'c':
+                height = 3
                 break
               default:
-                const c = 3
+                height = NaN
             }
-          `,
-          options: [options],
-        },
-      ],
+            return size
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
+                break
+              case 'c':
+                height = 3
+                break
+              case 'bb':
+                height = 2
+                break
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): works with groups with default`,
-      rule,
-      {
-        invalid: [
+    it('sorts switch cases with block statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+              }
+              case 'bb': {
+                height = 2
+              }
+              case 'c': {
+                height = 3
+              }
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+                break
+              }
+              case 'bb': {
+                height = 2
+                break
+              }
+              case 'c': {
+                height = 3
+                break
+              }
+              default:
+                height = NaN
+                break
+            }
+            return size
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+                break
+              }
+              case 'c': {
+                height = 3
+                break
+              }
+              case 'bb': {
+                height = 2
+                break
+              }
+              default:
+                height = NaN
+                break
+            }
+            return size
+          }
+        `,
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  left: 'default',
-                  right: 'B',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case 'AA':
-                case 'B':
-                default:
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case 'AA':
-                default:
-                case 'B':
-                  break;
-              }
-            `,
-            options: [options],
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
           },
         ],
-        valid: [
+        options: [options],
+      })
+    })
+
+    it('sorts switch cases without ending statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              case 'a':
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              case 'a':
+                let a
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              default:
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              default:
+                let x
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              case 'c':
+                let c
+                break
+              case 'a':
+            }
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'c':
+                let c
+                break
+              case 'b':
+                let b
+                break
+              case 'a':
+            }
+          }
+        `,
+        errors: [
           {
-            code: dedent`
-              switch (x) {
-                case 'AA':
-                case 'B':
-                default:
-                  const c = 3
-              }
-            `,
-            options: [options],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
           },
         ],
-      },
-    )
+        options: [options],
+      })
+    })
+
+    it('works with grouped cases', async () => {
+      await valid({
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'ee':
+            case 'cccc':
+            case 'f':
+              return 'tertiary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'cccc',
+              left: 'ee',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'bbbbb',
+              left: 'f',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('works with grouped cases with default', async () => {
+      await valid({
+        code: dedent`
+          switch (operationMode) {
+            case wwww:
+              return null
+            case yy:
+            case z:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (operationMode) {
+            case wwww:
+              return null
+            case yy:
+            case z:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        code: dedent`
+          switch (operationMode) {
+            case yy:
+            case z:
+              return null
+            case wwww:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'wwww',
+              left: 'z',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('works with single grouped case', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case AA:
+            case B:
+              const a = 1;
+              break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case AA:
+            case B:
+              const a = 1;
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case B:
+            case AA:
+              const a = 1;
+              break;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with complex cases', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case AAAAA:
+            case BBBB:
+              const a = 1
+              break
+            case CCC:
+              break
+            case DD:
+            case E:
+              const b = () => {
+                return 2
+              }
+              break
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'DD',
+              left: 'E',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'CCC',
+              left: 'DD',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'BBBB',
+              left: 'CCC',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'AAAAA',
+              left: 'BBBB',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case AAAAA:
+            case BBBB:
+              const a = 1
+              break
+            case CCC:
+              break
+            case DD:
+            case E:
+              const b = () => {
+                return 2
+              }
+              break
+            default:
+              const c = 3
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case E:
+            case DD:
+              const b = () => {
+                return 2
+              }
+              break
+            case CCC:
+              break
+            case BBBB:
+            case AAAAA:
+              const a = 1
+              break
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with groups with default', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'AA':
+            case 'B':
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'B',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case 'AA':
+            case 'B':
+            default:
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case 'AA':
+            default:
+            case 'B':
+              break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'default',
+              left: 'default',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'somethingElse',
+              left: 'default',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case 'somethingElse':
+              break;
+            case 'default':
+            default:
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            default:
+            case 'default':
+              break;
+            case 'somethingElse':
+              break;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case '_a':
+            case 'b':
+            case '_c':
+              break;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'ab':
+            case 'a_c':
+              break;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case '你好':
+            case '世界':
+            case 'a':
+            case 'A':
+            case 'b':
+            case 'B':
+              break;
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": break; case "b": break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": break; case "a": break
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": break; case "b": break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": break; case "a": break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": { break }; case "b": { break }
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": { break } case "a": { break }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "a": { break }; case "b": { break }
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": { break } case "a": { break };
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles comments', async () => {
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case "a": // a
+            case "b": // b
+              break;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case "b": // b
+            case "a": // a
+              break;
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case "a": // a
+            default: // default
+              break;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            default: // default
+            case "a": // a
+              break;
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'x',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'x',
+              left: 'y',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (value) {
+            case "a": // A
+              break;
+            case "z": { return; } // z
+            case      "x"
+               : // x
+            case "y": // y
+            default    : // default
+                let a;
+            case "b": // b
+              return;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case "z": { return; } // z
+            default    : // default
+            case "y": // y
+            case      "x"
+               : // x
+                let a;
+            case "b": // b
+              return;
+            case "a": // A
+              break;
+          }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles last case without break', async () => {
+      await valid({
+        code: dedent`
+          switch(x) {
+            case "b": {
+              break
+            }
+            case "a": {
+              let a
+            }
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            default: {
+              break
+            }
+            case "a": {
+              let a
+            }
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            case "b":
+              break
+            case "a":
+              let a
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            default:
+              break;
+            case "a":
+              let a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'a',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch(x) {
+            case "a":
+              break;
+            default:
+              break;
+            case "a":
+          }
+        `,
+        code: dedent`
+          switch(x) {
+            default:
+              break;
+            case "a":
+              break;
+            case "a":
+          }
+        `,
+        options: [{}],
+      })
+    })
   })
 
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
 
+    it('sorts switch cases with return statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(<any> myFunc(a! + b?.c as any)) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(<any> myFunc(a! + b?.c as any)) {
+              case 'bb':
+                return 'b'
+              case 'aaa':
+                return 'a'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(name) {
+              case 'aaa':
+                return 'a'
+              case 'bb':
+                return 'b'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'bb':
+                return 'b'
+              case 'aaa':
+                return 'a'
+              case 'c':
+                return 'c'
+              default:
+                return 'x'
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('sorts switch cases with break statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
+                break
+              case 'bb':
+                height = 2
+                break
+              case 'c':
+                height = 3
+                break
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
+                break
+              case 'bb':
+                height = 2
+                break
+              case 'c':
+                height = 3
+                break
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa':
+                height = 1
+                break
+              case 'c':
+                height = 3
+                break
+              case 'bb':
+                height = 2
+                break
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('sorts switch cases with block statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+              }
+              case 'bb': {
+                height = 2
+              }
+              case 'c': {
+                height = 3
+              }
+              default:
+                height = NaN
+            }
+            return size
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+                break
+              }
+              case 'bb': {
+                height = 2
+                break
+              }
+              case 'c': {
+                height = 3
+                break
+              }
+              default:
+                height = NaN
+                break
+            }
+            return size
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            let size
+            switch(name) {
+              case 'aaa': {
+                height = 1
+                break
+              }
+              case 'c': {
+                height = 3
+                break
+              }
+              case 'bb': {
+                height = 2
+                break
+              }
+              default:
+                height = NaN
+                break
+            }
+            return size
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('sorts switch cases without ending statements', async () => {
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              case 'a':
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              case 'a':
+                let a
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              default:
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'b':
+                let b
+                break
+              default:
+                let x
+            }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          function func(name) {
+            switch(name) {
+              case 'bb':
+                let b
+                break
+              case 'c':
+                let c
+                break
+              case 'aaa':
+            }
+          }
+        `,
+        code: dedent`
+          function func(name) {
+            switch(name) {
+              case 'c':
+                let c
+                break
+              case 'bb':
+                let b
+                break
+              case 'aaa':
+            }
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('works with grouped cases', async () => {
+      await valid({
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'ee':
+            case 'cccc':
+            case 'f':
+              return 'tertiary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'cccc',
+              left: 'ee',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'bbbbb',
+              left: 'f',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('works with grouped cases with default', async () => {
+      await valid({
+        code: dedent`
+          switch (operationMode) {
+            case wwww:
+              return null
+            case yy:
+            case z:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (operationMode) {
+            case wwww:
+              return null
+            case yy:
+            case z:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        code: dedent`
+          switch (operationMode) {
+            case yy:
+            case z:
+              return null
+            case wwww:
+              return null
+            case xxx:
+            default:
+              return null
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'wwww',
+              left: 'z',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('works with single grouped case', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case AA:
+            case B:
+              const a = 1;
+              break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case AA:
+            case B:
+              const a = 1;
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case B:
+            case AA:
+              const a = 1;
+              break;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with complex cases', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case AAAAA:
+            case BBBB:
+              const a = 1
+              break
+            case CCC:
+              break
+            case DD:
+            case E:
+              const b = () => {
+                return 2
+              }
+              break
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'DD',
+              left: 'E',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'CCC',
+              left: 'DD',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'BBBB',
+              left: 'CCC',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'AAAAA',
+              left: 'BBBB',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case AAAAA:
+            case BBBB:
+              const a = 1
+              break
+            case CCC:
+              break
+            case DD:
+            case E:
+              const b = () => {
+                return 2
+              }
+              break
+            default:
+              const c = 3
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case E:
+            case DD:
+              const b = () => {
+                return 2
+              }
+              break
+            case CCC:
+              break
+            case BBBB:
+            case AAAAA:
+              const a = 1
+              break
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with groups with default', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'AA':
+            case 'B':
+            default:
+              const c = 3
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'B',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case 'AA':
+            case 'B':
+            default:
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case 'AA':
+            default:
+            case 'B':
+              break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'default',
+              left: 'default',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'somethingElse',
+              left: 'default',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case 'somethingElse':
+              break;
+            case 'default':
+            default:
+              break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            default:
+            case 'default':
+              break;
+            case 'somethingElse':
+              break;
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('allows to trim special characters', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case '_aa':
+            case 'bb':
+            case '_c':
+              break;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+      })
+    })
+
+    it('allows to remove special characters', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'abcd':
+            case 'a_c':
+              break;
+          }
+        `,
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+      })
+    })
+
+    it('allows to use locale', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case '你好':
+            case '世界':
+            case 'a':
+            case 'A':
+            case 'b':
+            case 'B':
+              break;
+          }
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline elements correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "aa": break; case "b": break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": break; case "aa": break
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "aa": break; case "b": break;
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": break; case "aa": break;
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "aa": { break }; case "b": { break }
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": { break } case "aa": { break }
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (x) {
+            case "aa": { break }; case "b": { break }
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case "b": { break } case "aa": { break };
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles comments', async () => {
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case "a": // a
+            case "b": // b
+              break;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case "b": // b
+            case "a": // a
+              break;
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case "a": // a
+            default: // default
+              break;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            default: // default
+            case "a": // a
+              break;
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'x',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'x',
+              left: 'y',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch (value) {
+            case "a": // A
+              break;
+            case "z": { return; } // z
+            case      "x"
+               : // x
+            case "y": // y
+            default    : // default
+                let a;
+            case "b": // b
+              return;
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case "z": { return; } // z
+            default    : // default
+            case "y": // y
+            case      "x"
+               : // x
+                let a;
+            case "b": // b
+              return;
+            case "a": // A
+              break;
+          }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles last case without break', async () => {
+      await valid({
+        code: dedent`
+          switch(x) {
+            case "b": {
+              break
+            }
+            case "a": {
+              let a
+            }
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            default: {
+              break
+            }
+            case "a": {
+              let a
+            }
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            case "b":
+              break
+            case "a":
+              let a
+          }
+        `,
+        options: [{}],
+      })
+
+      await valid({
+        code: dedent`
+          switch(x) {
+            default:
+              break;
+            case "a":
+              let a
+          }
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'a',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        output: dedent`
+          switch(x) {
+            case "a":
+              break;
+            default:
+              break;
+            case "a":
+          }
+        `,
+        code: dedent`
+          switch(x) {
+            default:
+              break;
+            case "a":
+              break;
+            case "a":
+          }
+        `,
+        options: [{}],
+      })
+    })
+  })
+
+  describe('custom', () => {
     let alphabet = Alphabet.generateRecommendedAlphabet()
       .sortByLocaleCompare('en-US')
       .getCharacters()
+
     let options = {
       type: 'custom',
       order: 'asc',
       alphabet,
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): works with grouped cases`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-          ],
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'ee':
-              case 'cccc':
-              case 'f':
-                return 'tertiary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'cccc',
-                left: 'ee',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
+    it('works with grouped cases', async () => {
+      await valid({
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'cccc':
+            case 'ee':
+            case 'f':
+              return 'tertiary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case 'aaaaaa':
+              return 'primary'
+            case 'ee':
+            case 'cccc':
+            case 'f':
+              return 'tertiary'
+            case 'bbbbb':
+            case 'ddd':
+              return 'secondary'
+            case 'x':
+            default:
+              return 'unknown'
+          }
+        `,
+        errors: [
+          {
+            data: {
+              right: 'cccc',
+              left: 'ee',
             },
-            {
-              data: {
-                right: 'bbbbb',
-                left: 'f',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+          {
+            data: {
+              right: 'bbbbb',
+              left: 'f',
             },
-          ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'cccc':
-              case 'ee':
-              case 'f':
-                return 'tertiary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with return statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'aaa':
-                    return 'a'
-                  case 'bb':
-                    return 'b'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'bb':
-                    return 'b'
-                  case 'aaa':
-                    return 'a'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'aaa',
-                  left: 'bb',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                switch(name) {
-                  case 'aaa':
-                    return 'a'
-                  case 'bb':
-                    return 'b'
-                  case 'c':
-                    return 'c'
-                  default:
-                    return 'x'
-                }
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with break statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa':
-                    height = 1
-                    break
-                  case 'bb':
-                    height = 2
-                    break
-                  case 'c':
-                    height = 3
-                    break
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts switch cases with block statements`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                    break
-                  }
-                  case 'bb': {
-                    height = 2
-                    break
-                  }
-                  case 'c': {
-                    height = 3
-                    break
-                  }
-                  default:
-                    height = NaN
-                    break
-                }
-                return size
-              }
-            `,
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                    break
-                  }
-                  case 'c': {
-                    height = 3
-                    break
-                  }
-                  case 'bb': {
-                    height = 2
-                    break
-                  }
-                  default:
-                    height = NaN
-                    break
-                }
-                return size
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              function func(name) {
-                let size
-                switch(name) {
-                  case 'aaa': {
-                    height = 1
-                  }
-                  case 'bb': {
-                    height = 2
-                  }
-                  case 'c': {
-                    height = 3
-                  }
-                  default:
-                    height = NaN
-                }
-                return size
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): works with grouped cases`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-            dedent`
-              switch (value) {
-                case 'aaaaaa':
-                  return 'primary'
-                case 'bbbbb':
-                case 'ddd':
-                  return 'secondary'
-                case 'cccc':
-                case 'ee':
-                case 'f':
-                  return 'tertiary'
-                case 'x':
-                default:
-                  return 'unknown'
-              }
-            `,
-          ],
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'ee':
-              case 'cccc':
-              case 'f':
-                return 'tertiary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
-          errors: [
-            {
-              data: {
-                right: 'cccc',
-                left: 'ee',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'bbbbb',
-                left: 'f',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            switch (value) {
-              case 'aaaaaa':
-                return 'primary'
-              case 'bbbbb':
-              case 'ddd':
-                return 'secondary'
-              case 'cccc':
-              case 'ee':
-              case 'f':
-                return 'tertiary'
-              case 'x':
-              default:
-                return 'unknown'
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with grouped cases with default`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              switch (operationMode) {
-                case wwww:
-                  return null
-                case yy:
-                case z:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            code: dedent`
-              switch (operationMode) {
-                case yy:
-                case z:
-                  return null
-                case wwww:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'wwww',
-                  left: 'z',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (operationMode) {
-                case wwww:
-                  return null
-                case yy:
-                case z:
-                  return null
-                case xxx:
-                default:
-                  return null
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with single grouped case`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'AA',
-                  left: 'B',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case AA:
-                case B:
-                  const a = 1;
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case B:
-                case AA:
-                  const a = 1;
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (x) {
-                case AA:
-                case B:
-                  const a = 1;
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): works with complex cases`, rule, {
-      invalid: [
-        {
-          output: [
-            dedent`
-              switch (x) {
-                case DD:
-                case E:
-                  const b = () => {
-                    return 2
-                  }
-                  break
-                case CCC:
-                  break
-                case AAAAA:
-                case BBBB:
-                  const a = 1
-                  break
-                default:
-                  const c = 3
-              }
-            `,
-            dedent`
-              switch (x) {
-                case AAAAA:
-                case BBBB:
-                  const a = 1
-                  break
-                case CCC:
-                  break
-                case DD:
-                case E:
-                  const b = () => {
-                    return 2
-                  }
-                  break
-                default:
-                  const c = 3
-              }
-            `,
-          ],
-          errors: [
-            {
-              data: {
-                right: 'DD',
-                left: 'E',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'CCC',
-                left: 'DD',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'BBBB',
-                left: 'CCC',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-            {
-              data: {
-                right: 'AAAAA',
-                left: 'BBBB',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
-            },
-          ],
-          code: dedent`
-            switch (x) {
-              case E:
-              case DD:
-                const b = () => {
-                  return 2
-                }
-                break
-              case CCC:
-                break
-              case BBBB:
-              case AAAAA:
-                const a = 1
-                break
-              default:
-                const c = 3
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            switch (x) {
-              case AAAAA:
-              case BBBB:
-                const a = 1
-                break
-              case CCC:
-                break
-              case DD:
-              case E:
-                const b = () => {
-                  return 2
-                }
-                break
-              default:
-                const c = 3
-            }
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with groups with default`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: 'default',
-                  right: 'B',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            output: dedent`
-              switch (x) {
-                case 'AA':
-                case 'B':
-                default:
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case 'AA':
-                default:
-                case 'B':
-                  break;
-              }
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              switch (x) {
-                case 'AA':
-                case 'B':
-                default:
-                  const c = 3
-              }
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              switch (x) {
-                case 'bb':
-                  break;
-                case 'c':
-                  break;
-                case 'a':
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case 'a':
-                  break;
-                case 'bb':
-                  break;
-                case 'c':
-                  break;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-          },
-          {
-            output: dedent`
-              switch (x) {
-                case 'bb':
-                  break;
-                case 'a':
-                  break;
-                case 'c':
-                  break;
-              }
-            `,
-            code: dedent`
-              switch (x) {
-                case 'c':
-                  break;
-                case 'bb':
-                  break;
-                case 'a':
-                  break;
-              }
-            `,
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
+  describe('unsorted', () => {
     let options = {
       type: 'unsorted',
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            switch (x) {
-              case 'b':
-                break;
-              case 'c':
-                break;
-              case 'a':
-                break;
-            }
-          `,
-          options: [options],
-        },
-        {
-          code: dedent`
-            switch (x) {
-              case 'b':
-              case 'c':
-              case 'a':
-                break;
-            }
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+    it('does not enforce sorting', async () => {
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'b':
+              break;
+            case 'c':
+              break;
+            case 'a':
+              break;
+          }
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          switch (x) {
+            case 'b':
+            case 'c':
+            case 'a':
+              break;
+          }
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(`${ruleName}: not works if discriminant is true`, rule, {
-      valid: [
-        dedent`
+    it('not works if discriminant is true', async () => {
+      await valid({
+        code: dedent`
           switch (true) {
             case name === 'bb':
               return 'b'
@@ -2741,126 +3319,94 @@ describe(ruleName, () => {
               return 'x'
           }
         `,
-      ],
-      invalid: [],
+      })
     })
 
-    ruleTester.run(`${ruleName}: default should be last`, rule, {
-      invalid: [
-        {
-          output: dedent`
-            switch (value) {
-              case 'aa':
-                return true
-              case 'b':
-                return true
-              default:
-                return false
-            }
-          `,
-          code: dedent`
-            switch (value) {
-              case 'aa':
-                return true
-              default:
-                return false
-              case 'b':
-                return true
-            }
-          `,
-          errors: [
-            {
-              data: {
-                left: 'default',
-                right: 'b',
-              },
-              messageId: 'unexpectedSwitchCaseOrder',
+    it('default should be last', async () => {
+      await invalid({
+        output: dedent`
+          switch (value) {
+            case 'aa':
+              return true
+            case 'b':
+              return true
+            default:
+              return false
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case 'aa':
+              return true
+            default:
+              return false
+            case 'b':
+              return true
+          }
+        `,
+        errors: [
+          {
+            data: {
+              left: 'default',
+              right: 'b',
             },
-          ],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedSwitchCaseOrder',
+          },
+        ],
+      })
     })
 
-    ruleTester.run(
-      `${ruleName}: handles default case and default clause`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              switch (variable) {
-                case 'add':
-                  break
-                case 'default':
-                  break
-                case 'remove':
-                  break
-                default:
-                  break
-                }
-            `,
-            code: dedent`
-              switch (variable) {
-                case 'default':
-                  break
-                case 'add':
-                  break
-                case 'remove':
-                  break
-                default:
-                  break
-                }
-            `,
-            errors: [
-              {
-                data: {
-                  left: 'default',
-                  right: 'add',
-                },
-                messageId: 'unexpectedSwitchCaseOrder',
-              },
-            ],
-          },
-        ],
-        valid: [
-          dedent`
-            switch (variable) {
-              case 'add':
-                break
-              case 'default':
-                break
-              case 'remove':
-                break
-              default:
-                break
-              }
-          `,
-        ],
-      },
-    )
+    it('handles default case and default clause', async () => {
+      await valid({
+        code: dedent`
+          switch (variable) {
+            case 'add':
+              break
+            case 'default':
+              break
+            case 'remove':
+              break
+            default:
+              break
+            }
+        `,
+      })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+      await invalid({
+        output: dedent`
+          switch (variable) {
+            case 'add':
+              break
+            case 'default':
+              break
+            case 'remove':
+              break
+            default:
+              break
+            }
+        `,
+        code: dedent`
+          switch (variable) {
+            case 'default':
+              break
+            case 'add':
+              break
+            case 'remove':
+              break
+            default:
+              break
+            }
+        `,
+        errors: [
           {
-            code: dedent`
-              switch (variable) {
-                case 'a':
-                case 'b':
-                  break
-                case 'c':
-                default:
-                  break
-                }
-            `,
-            options: [{}],
+            data: {
+              left: 'default',
+              right: 'add',
+            },
+            messageId: 'unexpectedSwitchCaseOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+      })
+    })
   })
 })

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -1,2163 +1,4544 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-union-types'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-union-types'
+describe('sort-union-types', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-union-types',
+    parser: typescriptParser,
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}: sorts union types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "'bbb'",
-                left: "'cc'",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+    it('sorts union types', async () => {
+      await valid({
+        code: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'bbb'",
+              left: "'cc'",
             },
-          ],
-          output: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          code: dedent`
-            type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        code: dedent`
+          type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts keyword union types`, rule, {
-      invalid: [
-        {
+    it('sorts keyword union types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'string',
+              right: 'any',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              left: 'unknown',
+              right: 'null',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              left: 'undefined',
+              right: 'never',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'bigint',
+              left: 'void',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Value =
+            | any
+            | bigint
+            | boolean
+            | never
+            | null
+            | number
+            | string
+            | undefined
+            | unknown
+            | void
+        `,
+        code: dedent`
+          type Value =
+            | boolean
+            | number
+            | string
+            | any
+            | unknown
+            | null
+            | undefined
+            | never
+            | void
+            | bigint
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with generics', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'aa'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: "Omit<T, 'aa' | 'b'>",
+        code: "Omit<T, 'b' | 'aa'>",
+        options: [options],
+      })
+    })
+
+    it('sorts type references', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: 'type Type = aaa | bb | c',
+        code: 'type Type = c | bb | aaa',
+        options: [options],
+      })
+    })
+
+    it('sorts unions with objects', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ name: 'aa', status: 'success' }",
+              left: "{ name: 'b', status: 'success' }",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | { name: 'aa', status: 'success' }
+            | { name: 'b', status: 'success' }
+        `,
+        code: dedent`
+          type Type =
+            | { name: 'b', status: 'success' }
+            | { name: 'aa', status: 'success' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts unions with parentheses', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '( value: () => void, ) => D | E',
+              left: 'A',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            x:
+              | ((
+                  value: () => void,
+                ) => D | E)
+              | A
+              | B[]
+          }
+        `,
+        code: dedent`
+          type Type = {
+            x:
+              | A
+              | ((
+                  value: () => void,
+                ) => D | E)
+              | B[]
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves inline comments at the end of union', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '3',
+              left: '4',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: '100',
+              left: '5',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Step = 1 | 100 | 2 | 3 | 4 | 5; // Comment
+        `,
+        code: dedent`
+          type Step = 1 | 2 | 4 | 3 | 5 | 100; // Comment
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts unions by groups', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            | A
+            | intrinsic
+            | SomeClass['name']
+            | string[]
+            | any
+            | bigint
+            | boolean
+            | number
+            | this
+            | unknown
+            | keyof { a: string; b: number }
+            | keyof A
+            | typeof B
+            | 'aaa'
+            | \`\${A}\`
+            | 1
+            | (new () => SomeClass)
+            | (import('path'))
+            | (A extends B ? C : D)
+            | { [P in keyof T]: T[P] }
+            | { name: 'a' }
+            | [A, B, C]
+            | (A & B)
+            | (A | B)
+            | null
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: "{ name: 'a' }",
+              rightGroup: 'keyword',
+              leftGroup: 'object',
+              right: 'boolean',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'keyword',
+              rightGroup: 'named',
+              left: 'boolean',
+              right: 'A',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'operator',
+              rightGroup: 'keyword',
+              left: 'keyof A',
+              right: 'bigint',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'nullish',
+              left: 'null',
+              right: '1',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'intersection',
+              leftGroup: 'union',
+              right: 'A & B',
+              left: 'A | B',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type =
+            | A
+            | any
+            | bigint
+            | boolean
+            | keyof A
+            | typeof B
+            | 'aaa'
+            | 1
+            | (import('path'))
+            | (A extends B ? C : D)
+            | { name: 'a' }
+            | [A, B, C]
+            | (A & B)
+            | (A | B)
+            | null
+        `,
+        code: dedent`
+          type Type =
+            | any
+            | { name: 'a' }
+            | boolean
+            | A
+            | keyof A
+            | bigint
+            | typeof B
+            | 'aaa'
+            | (import('path'))
+            | null
+            | 1
+            | (A extends B ? C : D)
+            | [A, B, C]
+            | (A | B)
+            | (A & B)
+        `,
+      })
+    })
+
+    it('sorts within partitions when separated by newlines', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            A |
+            D |
+
+            C |
+
+            B |
+            E
+        `,
+        code: dedent`
+          type Type =
+            D |
+            A |
+
+            C |
+
+            E |
+            B
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            // Not partition comment
+            BBB |
+            CC |
+            D |
+            // Part: B
+            AAA |
+            E |
+            // Part: C
+            // Not partition comment
+            FFF |
+            GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            CC |
+            D |
+            // Not partition comment
+            BBB |
+            // Part: B
+            AAA |
+            E |
+            // Part: C
+            GG |
+            // Not partition comment
+            FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            | BBB
+            | CC
+            // Not partition comment
+            | D
+            // Part: B
+            | AAA
+            | E
+            // Part: C
+            | FFF
+            // Not partition comment
+            | GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            | CC
+            | D
+            // Not partition comment
+            | BBB
+            // Part: B
+            | AAA
+            | E
+            // Part: C
+            | GG
+            // Not partition comment
+            | FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            // Comment
+            BB |
+            // Other comment
+            A
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D |
+            // Part: B
+            AAA |
+            BB |
+            C |
+            /* Other */
+            E
+        `,
+        code: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D |
+            // Part: B
+            AAA |
+            C |
+            BB |
+            /* Other */
+            E
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            E |
+            F |
+            // I am a partition comment because I don't have f o o
+            A |
+            B
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            /* Comment */
+            A |
+            B
+        `,
+        code: dedent`
+          type Type =
+            B |
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C |
+            // B
+            B |
+            // A
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            // I am a partition comment because I don't have f o o
+            A
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            // Comment
+            A |
+            B
+        `,
+        code: dedent`
+          type Type =
+            B |
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C |
+            /* B */
+            B |
+            /* A */
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            /* I am a partition comment because I don't have f o o */
+            A
+        `,
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          type T =
+            _A |
+            B |
+            _C
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type T =
+            AB |
+            A_C
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            你好 |
+            世界 |
+            a |
+            A |
+            b |
+            B
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                left: 'string',
-                right: 'any',
+                left: '() => null',
+                right: 'Y',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
               },
               messageId: 'unexpectedUnionTypesOrder',
             },
             {
               data: {
-                left: 'unknown',
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['function', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              (() => null)
+
+
+             | Y
+            | Z
+
+                | B
+          `,
+          output: dedent`
+            type T =
+              (() => null)
+             | B
+            | Y
+                | Z
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ a: string }',
+              left: '() => void',
+            },
+            messageId: 'missedSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              left: '{ a: string }',
+              right: 'A',
+            },
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              right: '[A]',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'function',
+              { newlinesBetween: 'always' },
+              'object',
+              { newlinesBetween: 'always' },
+              'named',
+              { newlinesBetween: 'never' },
+              'tuple',
+              { newlinesBetween: 'ignore' },
+              'nullish',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            (() => void) |
+
+            { a: string } |
+
+            A |
+            [A] |
+
+
+            null
+        `,
+        code: dedent`
+          type Type =
+            (() => void) |
+            { a: string } |
+
+
+            A |
+
+            [A] |
+
+
+            null
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
                 right: 'null',
+                left: 'A',
               },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-            {
-              data: {
-                left: 'undefined',
-                right: 'never',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-            {
-              data: {
-                right: 'bigint',
-                left: 'void',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'missedSpacingBetweenUnionTypes',
             },
           ],
           output: dedent`
-            type Value =
-              | any
-              | bigint
-              | boolean
-              | never
-              | null
-              | number
-              | string
-              | undefined
-              | unknown
-              | void
+            type T =
+              A |
+
+
+              null
           `,
           code: dedent`
-            type Value =
-              | boolean
-              | number
-              | string
-              | any
-              | unknown
-              | null
-              | undefined
-              | never
-              | void
-              | bigint
+            type T =
+              A |
+              null
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}: works with generics`, rule, {
-      invalid: [
-        {
-          errors: [
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
             {
-              data: {
-                right: "'aa'",
-                left: "'b'",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+              ...options,
+              groups: [
+                'named',
+                { newlinesBetween: 'never' },
+                'tuple',
+                { newlinesBetween: 'never' },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
-          output: "Omit<T, 'aa' | 'b'>",
-          code: "Omit<T, 'b' | 'aa'>",
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
           errors: [
             {
               data: {
-                right: 'bb',
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A |
+              null
+          `,
+          code: dedent`
+            type T =
+              A |
+
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A |
+
+              null
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A |
+              null
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'named',
+              right: "'a'",
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['literal', 'named'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type T =
+            | 'a' // Comment after
+
+            | B
+            | C
+        `,
+        code: dedent`
+          type T =
+            | B
+            | 'a' // Comment after
+
+            | C
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
                 left: 'c',
               },
               messageId: 'unexpectedUnionTypesOrder',
             },
-            {
-              data: {
-                right: 'aaa',
-                left: 'bb',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: 'type Type = aaa | bb | c',
-          code: 'type Type = c | bb | aaa',
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ name: 'aa', status: 'success' }",
-                left: "{ name: 'b', status: 'success' }",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
           ],
           output: dedent`
             type Type =
-              | { name: 'aa', status: 'success' }
-              | { name: 'b', status: 'success' }
+              | a
+
+              // Partition comment
+
+              | b
+              | c
           `,
           code: dedent`
             type Type =
-              | { name: 'b', status: 'success' }
-              | { name: 'aa', status: 'success' }
+              | a
+
+              // Partition comment
+
+              | c
+              | b
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it('sorts single-line union types correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | A | B
+        `,
+        code: dedent`
+          type T =
+            | B | A
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            A | B
+        `,
+        code: dedent`
+          type T =
+            B | A
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts unions with parentheses`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '( value: () => void, ) => D | E',
-                left: 'A',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+    it('applies custom groups based on element selectors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'namedElements',
+              leftGroup: 'unknown',
+              left: 'null',
+              right: 'a',
             },
-          ],
-          output: dedent`
-            type Type = {
-              x:
-                | ((
-                    value: () => void,
-                  ) => D | E)
-                | A
-                | B[]
-            }
-          `,
-          code: dedent`
-            type Type = {
-              x:
-                | A
-                | ((
-                    value: () => void,
-                  ) => D | E)
-                | B[]
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'namedElements',
+                selector: 'named',
+              },
+            ],
+            groups: ['namedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
+            | null
+        `,
+        code: dedent`
+          type T =
+            | null
+            | a
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts unions with comment at the end`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '3',
-                left: '4',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-            {
-              data: {
-                right: '100',
-                left: '5',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Step = 1 | 100 | 2 | 3 | 4 | 5; // Comment
-          `,
-          code: dedent`
-            type Step = 1 | 2 | 4 | 3 | 5 | 100; // Comment
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts unions using groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: "{ name: 'a' }",
-                rightGroup: 'keyword',
-                leftGroup: 'object',
-                right: 'boolean',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'keyword',
-                rightGroup: 'named',
-                left: 'boolean',
-                right: 'A',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'operator',
-                rightGroup: 'keyword',
-                left: 'keyof A',
-                right: 'bigint',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'literal',
-                leftGroup: 'nullish',
-                left: 'null',
-                right: '1',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'intersection',
-                leftGroup: 'union',
-                right: 'A & B',
-                left: 'A | B',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-          ],
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
           options: [
             {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
+              customGroups: [
+                {
+                  groupName: 'namedStartingWithHello',
+                  elementNamePattern,
+                  selector: 'named',
+                },
               ],
+              groups: ['namedStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'namedStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloNamed',
+                left: 'undefined',
+              },
+              messageId: 'unexpectedUnionTypesGroupOrder',
             },
           ],
           output: dedent`
             type Type =
-              | A
-              | any
-              | bigint
-              | boolean
-              | keyof A
-              | typeof B
-              | 'aaa'
-              | 1
-              | (import('path'))
-              | (A extends B ? C : D)
-              | { name: 'a' }
-              | [A, B, C]
-              | (A & B)
-              | (A | B)
+              | helloNamed
               | null
+              | undefined
           `,
           code: dedent`
             type Type =
-              | any
-              | { name: 'a' }
-              | boolean
-              | A
-              | keyof A
-              | bigint
-              | typeof B
-              | 'aaa'
-              | (import('path'))
               | null
-              | 1
-              | (A extends B ? C : D)
-              | [A, B, C]
-              | (A | B)
-              | (A & B)
+              | undefined
+              | helloNamed
           `,
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              | A
-              | intrinsic
-              | SomeClass['name']
-              | string[]
-              | any
-              | bigint
-              | boolean
-              | number
-              | this
-              | unknown
-              | keyof { a: string; b: number }
-              | keyof A
-              | typeof B
-              | 'aaa'
-              | \`\${A}\`
-              | 1
-              | (new () => SomeClass)
-              | (import('path'))
-              | (A extends B ? C : D)
-              | { [P in keyof T]: T[P] }
-              | { name: 'a' }
-              | [A, B, C]
-              | (A & B)
-              | (A | B)
-              | null
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
-              ],
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'D',
-                },
-                messageId: 'unexpectedUnionTypesOrder',
-              },
-              {
-                data: {
-                  right: 'B',
-                  left: 'E',
-                },
-                messageId: 'unexpectedUnionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type Type =
-                A |
-                D |
-
-                C |
-
-                B |
-                E
-            `,
-            code: dedent`
-              type Type =
-                D |
-                A |
-
-                C |
-
-                E |
-                B
-            `,
-            options: [
-              {
-                partitionByNewLine: true,
-                type: 'alphabetical',
-              },
-            ],
-          },
-        ],
-        valid: [],
+        })
       },
     )
 
-    describe('partition comments', () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'BBB',
-                    left: 'D',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'FFF',
-                    left: 'GG',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  // Part: A
-                  // Not partition comment
-                  BBB |
-                  CC |
-                  D |
-                  // Part: B
-                  AAA |
-                  E |
-                  // Part: C
-                  // Not partition comment
-                  FFF |
-                  GG
-              `,
-              code: dedent`
-                type T =
-                  // Part: A
-                  CC |
-                  D |
-                  // Not partition comment
-                  BBB |
-                  // Part: B
-                  AAA |
-                  E |
-                  // Part: C
-                  GG |
-                  // Not partition comment
-                  FFF
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'BBB',
-                    left: 'D',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'FFF',
-                    left: 'GG',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  // Part: A
-                  | BBB
-                  | CC
-                  // Not partition comment
-                  | D
-                  // Part: B
-                  | AAA
-                  | E
-                  // Part: C
-                  | FFF
-                  // Not partition comment
-                  | GG
-              `,
-              code: dedent`
-                type T =
-                  // Part: A
-                  | CC
-                  | D
-                  // Not partition comment
-                  | BBB
-                  // Part: B
-                  | AAA
-                  | E
-                  // Part: C
-                  | GG
-                  // Not partition comment
-                  | FFF
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                type T =
-                  // Comment
-                  BB |
-                  // Other comment
-                  A
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                type T =
-                  /* Partition Comment */
-                  // Part: A
-                  D |
-                  // Part: B
-                  AAA |
-                  BB |
-                  C |
-                  /* Other */
-                  E
-              `,
-              code: dedent`
-                type T =
-                  /* Partition Comment */
-                  // Part: A
-                  D |
-                  // Part: B
-                  AAA |
-                  C |
-                  BB |
-                  /* Other */
-                  E
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'BB',
-                    left: 'C',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use regex for partition comments`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                type T =
-                  E |
-                  F |
-                  // I am a partition comment because I don't have f o o
-                  A |
-                  B
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['^(?!.*foo).*$'],
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                type Type =
-                  /* Comment */
-                  A |
-                  B
-              `,
-              code: dedent`
-                type Type =
-                  B |
-                  /* Comment */
-                  A
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
           {
-            valid: [
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedNamedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: "'m'",
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
               {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B |
-                    // Comment
-                    A
-                `,
+                groupName: 'reversedNamedByLineLength',
+                type: 'line-length',
+                selector: 'named',
+                order: 'desc',
               },
             ],
-            invalid: [],
+            groups: ['reversedNamedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
           },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['A', 'B'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    C |
-                    // B
-                    B |
-                    // A
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B |
-                    // I am a partition comment because I don't have f o o
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'A',
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                type Type =
-                  // Comment
-                  A |
-                  B
-              `,
-              code: dedent`
-                type Type =
-                  B |
-                  // Comment
-                  A
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B |
-                    /* Comment */
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['A', 'B'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    C |
-                    /* B */
-                    B |
-                    /* A */
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  type Type =
-                    B |
-                    /* I am a partition comment because I don't have f o o */
-                    A
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
+        ],
+        output: dedent`
+          type T =
+            | dddd
+            | ccc
+            | eee
+            | bb
+            | ff
+            | a
+            | g
+            | 'm'
+            | 'o'
+            | 'p'
+        `,
+        code: dedent`
+          type T =
+            | a
+            | bb
+            | ccc
+            | dddd
+            | 'm'
+            | eee
+            | ff
+            | g
+            | 'o'
+            | 'p'
+        `,
       })
     })
 
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
           {
-            options: [
+            customGroups: [
               {
-                ...options,
-                specialCharacters: 'trim',
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
               },
             ],
-            code: dedent`
-              type T =
-                _A |
-                B |
-                _C
-            `,
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
           },
         ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
+        errors: [
           {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              type T =
-                AB |
-                A_C
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type T =
-              你好 |
-              世界 |
-              a |
-              A |
-              b |
-              B
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      left: '() => null',
-                      right: 'Y',
-                    },
-                    messageId: 'extraSpacingBetweenUnionTypes',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'Z',
-                    },
-                    messageId: 'unexpectedUnionTypesOrder',
-                  },
-                  {
-                    data: {
-                      right: 'B',
-                      left: 'Z',
-                    },
-                    messageId: 'extraSpacingBetweenUnionTypes',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['function', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  type T =
-                    (() => null)
-
-
-                   | Y
-                  | Z
-
-                      | B
-                `,
-                output: dedent`
-                  type T =
-                    (() => null)
-                   | B
-                  | Y
-                      | Z
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenUnionTypes',
-                  },
-                ],
-                output: dedent`
-                  type Type =
-                    | a | 
-
-                  b
-                `,
-                code: dedent`
-                  type Type =
-                    | a | b
-                `,
-              },
-              {
-                errors: [
-                  {
-                    data: {
-                      left: '() => null',
-                      right: 'Z',
-                    },
-                    messageId: 'extraSpacingBetweenUnionTypes',
-                  },
-                  {
-                    data: {
-                      right: 'Y',
-                      left: 'Z',
-                    },
-                    messageId: 'unexpectedUnionTypesOrder',
-                  },
-                  {
-                    data: {
-                      right: '"A"',
-                      left: 'Y',
-                    },
-                    messageId: 'missedSpacingBetweenUnionTypes',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: ['function', 'unknown', 'literal'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  type T =
-                    (() => null)
-
-                   | Y
-                  | Z
-
-                      | "A"
-                `,
-                code: dedent`
-                  type T =
-                    (() => null)
-
-
-                   | Z
-                  | Y
-                      | "A"
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: '{ a: string }',
-                      left: '() => void',
-                    },
-                    messageId: 'missedSpacingBetweenUnionTypes',
-                  },
-                  {
-                    data: {
-                      left: '{ a: string }',
-                      right: 'A',
-                    },
-                    messageId: 'extraSpacingBetweenUnionTypes',
-                  },
-                  {
-                    data: {
-                      right: '[A]',
-                      left: 'A',
-                    },
-                    messageId: 'extraSpacingBetweenUnionTypes',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'function',
-                      { newlinesBetween: 'always' },
-                      'object',
-                      { newlinesBetween: 'always' },
-                      'named',
-                      { newlinesBetween: 'never' },
-                      'tuple',
-                      { newlinesBetween: 'ignore' },
-                      'nullish',
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                output: dedent`
-                  type Type =
-                    (() => void) |
-
-                    { a: string } |
-
-                    A |
-                    [A] |
-
-
-                    null
-                `,
-                code: dedent`
-                  type Type =
-                    (() => void) |
-                    { a: string } |
-
-
-                    A |
-
-                    [A] |
-
-
-                    null
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          'tuple',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'null',
-                          left: 'A',
-                        },
-                        messageId: 'missedSpacingBetweenUnionTypes',
-                      },
-                    ],
-                    output: dedent`
-                      type T =
-                        A |
-
-
-                        null
-                    `,
-                    code: dedent`
-                      type T =
-                        A |
-                        null
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          { newlinesBetween: 'never' },
-                          'tuple',
-                          { newlinesBetween: 'never' },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'null',
-                          left: 'A',
-                        },
-                        messageId: 'extraSpacingBetweenUnionTypes',
-                      },
-                    ],
-                    output: dedent`
-                      type T =
-                        A |
-                        null
-                    `,
-                    code: dedent`
-                      type T =
-                        A |
-
-                        null
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          'tuple',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      type T =
-                        A |
-
-                        null
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'named',
-                          'tuple',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'nullish',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      type T =
-                        A |
-                        null
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              output: [
-                dedent`
-                  type T =
-                    | 'a' // Comment after
-                    | B
-
-                    | C
-                `,
-                dedent`
-                  type T =
-                    | 'a' // Comment after
-
-                    | B
-                    | C
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'literal',
-                    leftGroup: 'named',
-                    right: "'a'",
-                    left: 'B',
-                  },
-                  messageId: 'unexpectedUnionTypesGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  groups: ['literal', 'named'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              code: dedent`
-                type T =
-                  | B
-                  | 'a' // Comment after
-
-                  | C
-              `,
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
             },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedUnionTypesOrder',
-                  },
-                ],
-                output: dedent`
-                  type Type =
-                    | a
-
-                    // Partition comment
-
-                    | b
-                    | c
-                `,
-                code: dedent`
-                  type Type =
-                    | a
-
-                    // Partition comment
-
-                    | c
-                    | b
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedUnionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type T =
-                | A | B
-            `,
-            code: dedent`
-              type T =
-                | B | A
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'A',
-                  left: 'B',
-                },
-                messageId: 'unexpectedUnionTypesOrder',
-              },
-            ],
-            output: dedent`
-              type T =
-                A | B
-            `,
-            code: dedent`
-              type T =
-                B | A
-            `,
-            options: [options],
+            messageId: 'unexpectedUnionTypesOrder',
           },
         ],
-        valid: [],
-      },
-    )
+        output: dedent`
+          type T =
+            | fooBar
+            | fooZar
+        `,
+        code: dedent`
+          type T =
+            | fooZar
+            | fooBar
+        `,
+      })
+    })
 
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector`, rule, {
-        invalid: [
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
           {
-            errors: [
+            customGroups: [
               {
-                data: {
-                  rightGroup: 'namedElements',
-                  leftGroup: 'unknown',
-                  left: 'null',
-                  right: 'a',
-                },
-                messageId: 'unexpectedUnionTypesGroupOrder',
+                groupName: 'unsortedNamed',
+                selector: 'named',
+                type: 'unsorted',
               },
             ],
-            options: [
+            groups: ['unsortedNamed', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedNamed',
+              leftGroup: 'unknown',
+              left: "'m'",
+              right: 'c',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | b
+            | a
+            | d
+            | e
+            | c
+            | 'm'
+        `,
+        code: dedent`
+          type T =
+            | b
+            | a
+            | d
+            | e
+            | 'm'
+            | c
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
               {
-                customGroups: [
+                anyOf: [
                   {
-                    groupName: 'namedElements',
+                    elementNamePattern: 'foo|Foo',
                     selector: 'named',
                   },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'literal',
+                  },
                 ],
-                groups: ['namedElements', 'unknown'],
+                groupName: 'elementsIncludingFoo',
               },
             ],
-            output: dedent`
-              type T =
-                | a
-                | null
-            `,
-            code: dedent`
-              type T =
-                | null
-                | a
-            `,
+            groups: ['elementsIncludingFoo', 'unknown'],
+            newlinesBetween: 'always',
           },
         ],
-        valid: [],
-      })
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'foo'",
+              left: 'null',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | 'foo'
+            | cFoo
 
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
+            | null
+        `,
+        code: dedent`
+          type T =
+            | null
+            | 'foo'
+            | cFoo
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type T =
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines within groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
             {
-              options: [
+              customGroups: [
                 {
-                  customGroups: [
-                    {
-                      groupName: 'namedStartingWithHello',
-                      elementNamePattern,
-                      selector: 'named',
-                    },
-                  ],
-                  groups: ['namedStartingWithHello', 'unknown'],
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
                 },
               ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'namedStartingWithHello',
-                    leftGroup: 'unknown',
-                    right: 'helloNamed',
-                    left: 'undefined',
-                  },
-                  messageId: 'unexpectedUnionTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type Type =
-                  | helloNamed
-                  | null
-                  | undefined
-              `,
-              code: dedent`
-                type Type =
-                  | null
-                  | undefined
-                  | helloNamed
-              `,
+              groups: ['group1'],
             },
           ],
-          valid: [],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              | a
+
+              | b
+          `,
+          code: dedent`
+            type T =
+              | a
+              | b
+          `,
         })
-      }
+      },
+    )
 
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
             {
-              errors: [
+              customGroups: [
                 {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedNamedByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'eee',
-                    left: "'m'",
-                  },
-                  messageId: 'unexpectedUnionTypesGroupOrder',
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
                 },
               ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedNamedByLineLength',
-                      type: 'line-length',
-                      selector: 'named',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedNamedByLineLength', 'unknown'],
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                type T =
-                  | dddd
-                  | ccc
-                  | eee
-                  | bb
-                  | ff
-                  | a
-                  | g
-                  | 'm'
-                  | 'o'
-                  | 'p'
-              `,
-              code: dedent`
-                type T =
-                  | a
-                  | bb
-                  | ccc
-                  | dddd
-                  | 'm'
-                  | eee
-                  | ff
-                  | g
-                  | 'o'
-                  | 'p'
-              `,
+              type: 'alphabetical',
+              groups: ['group1'],
             },
           ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
+          errors: [
             {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedUnionTypesOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  | fooBar
-                  | fooZar
-              `,
-              code: dedent`
-                type T =
-                  | fooZar
-                  | fooBar
-              `,
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
             },
           ],
-          valid: [],
-        },
-      )
+          output: dedent`
+            type T =
+              | a
+              | b
+          `,
+          code: dedent`
+            type T =
+              | a
 
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedNamed',
-                      selector: 'named',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedNamed', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedNamed',
-                    leftGroup: 'unknown',
-                    left: "'m'",
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedUnionTypesGroupOrder',
-                },
-              ],
-              output: dedent`
-                type T =
-                  | b
-                  | a
-                  | d
-                  | e
-                  | c
-                  | 'm'
-              `,
-              code: dedent`
-                type T =
-                  | b
-                  | a
-                  | d
-                  | e
-                  | 'm'
-                  | c
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'named',
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'literal',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-                newlinesBetween: 'always',
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: "'foo'",
-                  left: 'null',
-                },
-                messageId: 'unexpectedUnionTypesGroupOrder',
-              },
-            ],
-            output: dedent`
-              type T =
-                | 'foo'
-                | cFoo
-
-                | null
-            `,
-            code: dedent`
-              type T =
-                | null
-                | 'foo'
-                | cFoo
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                type T =
-                  iHaveFooInMyName
-                  meTooIHaveFoo
-                  a
-                  b
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe('newlinesInside', () => {
-      for (let newlinesInside of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'group1',
-                        selector: 'named',
-                        newlinesInside,
-                      },
-                    ],
-                    groups: ['group1'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'missedSpacingBetweenUnionTypes',
-                  },
-                ],
-                output: dedent`
-                  type T =
-                    | a
-
-                    | b
-                `,
-                code: dedent`
-                  type T =
-                    | a
-                    | b
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesInside of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}: allows to use newlinesInside: "${newlinesInside}"`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    customGroups: [
-                      {
-                        groupName: 'group1',
-                        selector: 'named',
-                        newlinesInside,
-                      },
-                    ],
-                    type: 'alphabetical',
-                    groups: ['group1'],
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenUnionTypes',
-                  },
-                ],
-                output: dedent`
-                  type T =
-                    | a
-                    | b
-                `,
-                code: dedent`
-                  type T =
-                    | a
-
-                    | b
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
+              | b
+          `,
+        })
+      },
+    )
   })
 
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
+  describe('natural', () => {
     let options = {
-      ignoreCase: true,
       type: 'natural',
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}: sorts union types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "'bbb'",
-                left: "'cc'",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+    it('sorts union types', async () => {
+      await valid({
+        code: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'bbb'",
+              left: "'cc'",
             },
-          ],
-          output: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          code: dedent`
-            type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          options: [options],
-        },
-      ],
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        code: dedent`
+          type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts keyword union types`, rule, {
-      invalid: [
-        {
+    it('sorts keyword union types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'string',
+              right: 'any',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              left: 'unknown',
+              right: 'null',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              left: 'undefined',
+              right: 'never',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'bigint',
+              left: 'void',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Value =
+            | any
+            | bigint
+            | boolean
+            | never
+            | null
+            | number
+            | string
+            | undefined
+            | unknown
+            | void
+        `,
+        code: dedent`
+          type Value =
+            | boolean
+            | number
+            | string
+            | any
+            | unknown
+            | null
+            | undefined
+            | never
+            | void
+            | bigint
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with generics', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'aa'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: "Omit<T, 'aa' | 'b'>",
+        code: "Omit<T, 'b' | 'aa'>",
+        options: [options],
+      })
+    })
+
+    it('sorts type references', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: 'type Type = aaa | bb | c',
+        code: 'type Type = c | bb | aaa',
+        options: [options],
+      })
+    })
+
+    it('sorts unions with objects', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ name: 'aa', status: 'success' }",
+              left: "{ name: 'b', status: 'success' }",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | { name: 'aa', status: 'success' }
+            | { name: 'b', status: 'success' }
+        `,
+        code: dedent`
+          type Type =
+            | { name: 'b', status: 'success' }
+            | { name: 'aa', status: 'success' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts unions with parentheses', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '( value: () => void, ) => D | E',
+              left: 'A',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            x:
+              | ((
+                  value: () => void,
+                ) => D | E)
+              | A
+              | B[]
+          }
+        `,
+        code: dedent`
+          type Type = {
+            x:
+              | A
+              | ((
+                  value: () => void,
+                ) => D | E)
+              | B[]
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves inline comments at the end of union', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '100',
+              right: '2',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: '3',
+              left: '4',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Step = 1 | 2 | 3 | 4 | 5 | 100; // Comment
+        `,
+        code: dedent`
+          type Step = 1 | 100 | 2 | 4 | 3 | 5; // Comment
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts unions by groups', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            | A
+            | intrinsic
+            | SomeClass['name']
+            | string[]
+            | any
+            | bigint
+            | boolean
+            | number
+            | this
+            | unknown
+            | keyof A
+            | keyof { a: string; b: number }
+            | typeof B
+            | 1
+            | 'aaa'
+            | \`\${A}\`
+            | (new () => SomeClass)
+            | (import('path'))
+            | (A extends B ? C : D)
+            | { [P in keyof T]: T[P] }
+            | { name: 'a' }
+            | [A, B, C]
+            | (A & B)
+            | (A | B)
+            | null
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: "{ name: 'a' }",
+              rightGroup: 'keyword',
+              leftGroup: 'object',
+              right: 'boolean',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'keyword',
+              rightGroup: 'named',
+              left: 'boolean',
+              right: 'A',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'operator',
+              rightGroup: 'keyword',
+              left: 'keyof A',
+              right: 'bigint',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'nullish',
+              left: 'null',
+              right: '1',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'intersection',
+              leftGroup: 'union',
+              right: 'A & B',
+              left: 'A | B',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type =
+            | A
+            | any
+            | bigint
+            | boolean
+            | keyof A
+            | typeof B
+            | 1
+            | 'aaa'
+            | (import('path'))
+            | (A extends B ? C : D)
+            | { name: 'a' }
+            | [A, B, C]
+            | (A & B)
+            | (A | B)
+            | null
+        `,
+        code: dedent`
+          type Type =
+            | any
+            | { name: 'a' }
+            | boolean
+            | A
+            | keyof A
+            | bigint
+            | typeof B
+            | 'aaa'
+            | (import('path'))
+            | null
+            | 1
+            | (A extends B ? C : D)
+            | [A, B, C]
+            | (A | B)
+            | (A & B)
+        `,
+      })
+    })
+
+    it('sorts within partitions when separated by newlines', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            A |
+            D |
+
+            C |
+
+            B |
+            E
+        `,
+        code: dedent`
+          type Type =
+            D |
+            A |
+
+            C |
+
+            E |
+            B
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            // Not partition comment
+            BBB |
+            CC |
+            D |
+            // Part: B
+            AAA |
+            E |
+            // Part: C
+            // Not partition comment
+            FFF |
+            GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            CC |
+            D |
+            // Not partition comment
+            BBB |
+            // Part: B
+            AAA |
+            E |
+            // Part: C
+            GG |
+            // Not partition comment
+            FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            | BBB
+            | CC
+            // Not partition comment
+            | D
+            // Part: B
+            | AAA
+            | E
+            // Part: C
+            | FFF
+            // Not partition comment
+            | GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            | CC
+            | D
+            // Not partition comment
+            | BBB
+            // Part: B
+            | AAA
+            | E
+            // Part: C
+            | GG
+            // Not partition comment
+            | FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            // Comment
+            BB |
+            // Other comment
+            A
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D |
+            // Part: B
+            AAA |
+            BB |
+            C |
+            /* Other */
+            E
+        `,
+        code: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D |
+            // Part: B
+            AAA |
+            C |
+            BB |
+            /* Other */
+            E
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            E |
+            F |
+            // I am a partition comment because I don't have f o o
+            A |
+            B
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            /* Comment */
+            A |
+            B
+        `,
+        code: dedent`
+          type Type =
+            B |
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C |
+            // B
+            B |
+            // A
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            // I am a partition comment because I don't have f o o
+            A
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            // Comment
+            A |
+            B
+        `,
+        code: dedent`
+          type Type =
+            B |
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C |
+            /* B */
+            B |
+            /* A */
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            /* I am a partition comment because I don't have f o o */
+            A
+        `,
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          type T =
+            _A |
+            B |
+            _C
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type T =
+            AB |
+            A_C
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            你好 |
+            世界 |
+            a |
+            A |
+            b |
+            B
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
           errors: [
             {
               data: {
-                left: 'string',
-                right: 'any',
+                left: '() => null',
+                right: 'Y',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+            {
+              data: {
+                right: 'B',
+                left: 'Z',
               },
               messageId: 'unexpectedUnionTypesOrder',
             },
             {
               data: {
-                left: 'unknown',
+                right: 'B',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              groups: ['function', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              (() => null)
+
+
+             | Y
+            | Z
+
+                | B
+          `,
+          output: dedent`
+            type T =
+              (() => null)
+             | B
+            | Y
+                | Z
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ a: string }',
+              left: '() => void',
+            },
+            messageId: 'missedSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              left: '{ a: string }',
+              right: 'A',
+            },
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              right: '[A]',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'function',
+              { newlinesBetween: 'always' },
+              'object',
+              { newlinesBetween: 'always' },
+              'named',
+              { newlinesBetween: 'never' },
+              'tuple',
+              { newlinesBetween: 'ignore' },
+              'nullish',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            (() => void) |
+
+            { a: string } |
+
+            A |
+            [A] |
+
+
+            null
+        `,
+        code: dedent`
+          type Type =
+            (() => void) |
+            { a: string } |
+
+
+            A |
+
+            [A] |
+
+
+            null
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
                 right: 'null',
+                left: 'A',
               },
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'missedSpacingBetweenUnionTypes',
             },
+          ],
+          output: dedent`
+            type T =
+              A |
+
+
+              null
+          `,
+          code: dedent`
+            type T =
+              A |
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                { newlinesBetween: 'never' },
+                'tuple',
+                { newlinesBetween: 'never' },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
             {
               data: {
-                left: 'undefined',
-                right: 'never',
+                right: 'null',
+                left: 'A',
               },
-              messageId: 'unexpectedUnionTypesOrder',
+              messageId: 'extraSpacingBetweenUnionTypes',
             },
+          ],
+          output: dedent`
+            type T =
+              A |
+              null
+          `,
+          code: dedent`
+            type T =
+              A |
+
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A |
+
+              null
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A |
+              null
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'named',
+              right: "'a'",
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['literal', 'named'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type T =
+            | 'a' // Comment after
+
+            | B
+            | C
+        `,
+        code: dedent`
+          type T =
+            | B
+            | 'a' // Comment after
+
+            | C
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
             {
               data: {
-                right: 'bigint',
-                left: 'void',
+                right: 'b',
+                left: 'c',
               },
               messageId: 'unexpectedUnionTypesOrder',
             },
           ],
           output: dedent`
-            type Value =
-              | any
-              | bigint
-              | boolean
-              | never
-              | null
-              | number
-              | string
-              | undefined
-              | unknown
-              | void
+            type Type =
+              | a
+
+              // Partition comment
+
+              | b
+              | c
           `,
           code: dedent`
-            type Value =
-              | boolean
-              | number
-              | string
-              | any
-              | unknown
-              | null
-              | undefined
-              | never
-              | void
-              | bigint
+            type Type =
+              | a
+
+              // Partition comment
+
+              | c
+              | b
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it('sorts single-line union types correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | A | B
+        `,
+        code: dedent`
+          type T =
+            | B | A
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            A | B
+        `,
+        code: dedent`
+          type T =
+            B | A
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: works with generics`, rule, {
-      invalid: [
-        {
+    it('applies custom groups based on element selectors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'namedElements',
+              leftGroup: 'unknown',
+              left: 'null',
+              right: 'a',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'namedElements',
+                selector: 'named',
+              },
+            ],
+            groups: ['namedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
+            | null
+        `,
+        code: dedent`
+          type T =
+            | null
+            | a
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'namedStartingWithHello',
+                  elementNamePattern,
+                  selector: 'named',
+                },
+              ],
+              groups: ['namedStartingWithHello', 'unknown'],
+            },
+          ],
           errors: [
             {
               data: {
-                right: "'aa'",
-                left: "'b'",
+                rightGroup: 'namedStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloNamed',
+                left: 'undefined',
+              },
+              messageId: 'unexpectedUnionTypesGroupOrder',
+            },
+          ],
+          output: dedent`
+            type Type =
+              | helloNamed
+              | null
+              | undefined
+          `,
+          code: dedent`
+            type Type =
+              | null
+              | undefined
+              | helloNamed
+          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedNamedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: "'m'",
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedNamedByLineLength',
+                type: 'line-length',
+                selector: 'named',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedNamedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type T =
+            | dddd
+            | ccc
+            | eee
+            | bb
+            | ff
+            | a
+            | g
+            | 'm'
+            | 'o'
+            | 'p'
+        `,
+        code: dedent`
+          type T =
+            | a
+            | bb
+            | ccc
+            | dddd
+            | 'm'
+            | eee
+            | ff
+            | g
+            | 'o'
+            | 'p'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | fooBar
+            | fooZar
+        `,
+        code: dedent`
+          type T =
+            | fooZar
+            | fooBar
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedNamed',
+                selector: 'named',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedNamed', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedNamed',
+              leftGroup: 'unknown',
+              left: "'m'",
+              right: 'c',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | b
+            | a
+            | d
+            | e
+            | c
+            | 'm'
+        `,
+        code: dedent`
+          type T =
+            | b
+            | a
+            | d
+            | e
+            | 'm'
+            | c
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'named',
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'literal',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'foo'",
+              left: 'null',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | 'foo'
+            | cFoo
+
+            | null
+        `,
+        code: dedent`
+          type T =
+            | null
+            | 'foo'
+            | cFoo
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type T =
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines within groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              | a
+
+              | b
+          `,
+          code: dedent`
+            type T =
+              | a
+              | b
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              | a
+              | b
+          `,
+          code: dedent`
+            type T =
+              | a
+
+              | b
+          `,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts union types', async () => {
+      await valid({
+        code: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'bbb'",
+              left: "'cc'",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        code: dedent`
+          type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts keyword union types', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'unknown',
+              left: 'any',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'undefined',
+              left: 'null',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'bigint',
+              left: 'void',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Value =
+            | undefined
+            | boolean
+            | unknown
+            | number
+            | string
+            | bigint
+            | never
+            | null
+            | void
+            | any
+        `,
+        code: dedent`
+          type Value =
+            | boolean
+            | number
+            | string
+            | any
+            | unknown
+            | null
+            | undefined
+            | never
+            | void
+            | bigint
+        `,
+        options: [options],
+      })
+    })
+
+    it('works with generics', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'aa'",
+              left: "'b'",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: "Omit<T, 'aa' | 'b'>",
+        code: "Omit<T, 'b' | 'aa'>",
+        options: [options],
+      })
+    })
+
+    it('sorts type references', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'aaa',
+              left: 'bb',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: 'type Type = aaa | bb | c',
+        code: 'type Type = c | bb | aaa',
+        options: [options],
+      })
+    })
+
+    it('sorts unions with objects', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "{ name: 'aa', status: 'success' }",
+              left: "{ name: 'b', status: 'success' }",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | { name: 'aa', status: 'success' }
+            | { name: 'b', status: 'success' }
+        `,
+        code: dedent`
+          type Type =
+            | { name: 'b', status: 'success' }
+            | { name: 'aa', status: 'success' }
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts unions with parentheses', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '( value: () => void, ) => D | E',
+              left: 'A',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            x:
+              | ((
+                  value: () => void,
+                ) => D | E)
+              | B[]
+              | A
+          }
+        `,
+        code: dedent`
+          type Type = {
+            x:
+              | A
+              | ((
+                  value: () => void,
+                ) => D | E)
+              | B[]
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('preserves inline comments at the end of union', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '100',
+              left: '1',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Step = 100 | 1 | 2 | 4 | 3 | 5; // Comment
+        `,
+        code: dedent`
+          type Step = 1 | 100 | 2 | 4 | 3 | 5; // Comment
+        `,
+        options: [options],
+      })
+    })
+
+    it('sorts unions by groups', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            | SomeClass['name']
+            | intrinsic
+            | string[]
+            | A
+            | boolean
+            | unknown
+            | bigint
+            | number
+            | this
+            | any
+            | keyof { a: string; b: number }
+            | typeof B
+            | keyof A
+            | \`\${A}\`
+            | 'aaa'
+            | 1
+            | (new () => SomeClass)
+            | (import('path'))
+            | (A extends B ? C : D)
+            | { [P in keyof T]: T[P] }
+            | { name: 'a' }
+            | [A, B, C]
+            | (A & B)
+            | (A | B)
+            | null
+        `,
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: "{ name: 'a' }",
+              rightGroup: 'keyword',
+              leftGroup: 'object',
+              right: 'boolean',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'keyword',
+              rightGroup: 'named',
+              left: 'boolean',
+              right: 'A',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              leftGroup: 'operator',
+              rightGroup: 'keyword',
+              left: 'keyof A',
+              right: 'bigint',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'nullish',
+              left: 'null',
+              right: '1',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+          {
+            data: {
+              rightGroup: 'intersection',
+              leftGroup: 'union',
+              right: 'A & B',
+              left: 'A | B',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'named',
+              'keyword',
+              'operator',
+              'literal',
+              'function',
+              'import',
+              'conditional',
+              'object',
+              'tuple',
+              'intersection',
+              'union',
+              'nullish',
+            ],
+          },
+        ],
+        output: dedent`
+          type Type =
+            | A
+            | boolean
+            | bigint
+            | any
+            | typeof B
+            | keyof A
+            | 'aaa'
+            | 1
+            | (import('path'))
+            | (A extends B ? C : D)
+            | { name: 'a' }
+            | [A, B, C]
+            | (A & B)
+            | (A | B)
+            | null
+        `,
+        code: dedent`
+          type Type =
+            | any
+            | { name: 'a' }
+            | boolean
+            | A
+            | keyof A
+            | bigint
+            | typeof B
+            | 'aaa'
+            | (import('path'))
+            | null
+            | 1
+            | (A extends B ? C : D)
+            | [A, B, C]
+            | (A | B)
+            | (A & B)
+        `,
+      })
+    })
+
+    it('sorts within partitions when separated by newlines', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'E',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            A |
+            D |
+
+            C |
+
+            B |
+            E
+        `,
+        code: dedent`
+          type Type =
+            D |
+            A |
+
+            C |
+
+            E |
+            B
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('creates partitions based on matching comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            // Not partition comment
+            BBB |
+            CC |
+            D |
+            // Part: B
+            AAA |
+            E |
+            // Part: C
+            // Not partition comment
+            FFF |
+            GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            CC |
+            D |
+            // Not partition comment
+            BBB |
+            // Part: B
+            AAA |
+            E |
+            // Part: C
+            GG |
+            // Not partition comment
+            FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'BBB',
+              left: 'D',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'FFF',
+              left: 'GG',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            // Part: A
+            | BBB
+            | CC
+            // Not partition comment
+            | D
+            // Part: B
+            | AAA
+            | E
+            // Part: C
+            | FFF
+            // Not partition comment
+            | GG
+        `,
+        code: dedent`
+          type T =
+            // Part: A
+            | CC
+            | D
+            // Not partition comment
+            | BBB
+            // Part: B
+            | AAA
+            | E
+            // Part: C
+            | GG
+            // Not partition comment
+            | FFF
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats every comment as partition boundary when set to true', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            // Comment
+            BB |
+            // Other comment
+            A
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D |
+            // Part: B
+            AAA |
+            BB |
+            C |
+            /* Other */
+            E
+        `,
+        code: dedent`
+          type T =
+            /* Partition Comment */
+            // Part: A
+            D |
+            // Part: B
+            AAA |
+            C |
+            BB |
+            /* Other */
+            E
+        `,
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            E |
+            F |
+            // I am a partition comment because I don't have f o o
+            A |
+            B
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            /* Comment */
+            AA |
+            B
+        `,
+        code: dedent`
+          type Type =
+            B |
+            /* Comment */
+            AA
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            // Comment
+            A
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C |
+            // B
+            B |
+            // A
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            // I am a partition comment because I don't have f o o
+            A
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are specified', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          type Type =
+            // Comment
+            AA |
+            B
+        `,
+        code: dedent`
+          type Type =
+            B |
+            // Comment
+            AA
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            /* Comment */
+            A
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['A', 'B'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            C |
+            /* B */
+            B |
+            /* A */
+            A
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comments', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          type Type =
+            B |
+            /* I am a partition comment because I don't have f o o */
+            A
+        `,
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          type T =
+            _A |
+            BB |
+            _C
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          type T =
+            ABC |
+            A_C
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          type T =
+            你好 |
+            世界 |
+            a |
+            A |
+            b |
+            B
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: '() => null',
+                right: 'YY',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+            {
+              data: {
+                right: 'BBB',
+                left: 'Z',
               },
               messageId: 'unexpectedUnionTypesOrder',
             },
+            {
+              data: {
+                right: 'BBB',
+                left: 'Z',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
           ],
-          output: "Omit<T, 'aa' | 'b'>",
-          code: "Omit<T, 'b' | 'aa'>",
-          options: [options],
-        },
-      ],
-      valid: [],
+          options: [
+            {
+              ...options,
+              groups: ['function', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              (() => null)
+
+
+             | YY
+            | Z
+
+                | BBB
+          `,
+          output: dedent`
+            type T =
+              (() => null)
+             | BBB
+            | YY
+                | Z
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ a: string }',
+              left: '() => void',
+            },
+            messageId: 'missedSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              left: '{ a: string }',
+              right: 'A',
+            },
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              right: '[A]',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: [
+              'function',
+              { newlinesBetween: 'always' },
+              'object',
+              { newlinesBetween: 'always' },
+              'named',
+              { newlinesBetween: 'never' },
+              'tuple',
+              { newlinesBetween: 'ignore' },
+              'nullish',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            (() => void) |
+
+            { a: string } |
+
+            A |
+            [A] |
+
+
+            null
+        `,
+        code: dedent`
+          type Type =
+            (() => void) |
+            { a: string } |
+
+
+            A |
+
+            [A] |
+
+
+            null
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'missedSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A |
+
+
+              null
+          `,
+          code: dedent`
+            type T =
+              A |
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                { newlinesBetween: 'never' },
+                'tuple',
+                { newlinesBetween: 'never' },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'null',
+                left: 'A',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              A |
+              null
+          `,
+          code: dedent`
+            type T =
+              A |
+
+              null
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A |
+
+              null
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              groups: [
+                'named',
+                'tuple',
+                { newlinesBetween: groupNewlinesBetween },
+                'nullish',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            type T =
+              A |
+              null
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'literal',
+              leftGroup: 'named',
+              right: "'a'",
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            groups: ['literal', 'named'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type T =
+            | 'a' // Comment after
+
+            | B
+            | C
+        `,
+        code: dedent`
+          type T =
+            | B
+            | 'a' // Comment after
+
+            | C
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
           errors: [
             {
               data: {
@@ -2166,1284 +4547,1034 @@ describe(ruleName, () => {
               },
               messageId: 'unexpectedUnionTypesOrder',
             },
-            {
-              data: {
-                right: 'aaa',
-                left: 'bb',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: 'type Type = aaa | bb | c',
-          code: 'type Type = c | bb | aaa',
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ name: 'aa', status: 'success' }",
-                left: "{ name: 'b', status: 'success' }",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
           ],
           output: dedent`
             type Type =
-              | { name: 'aa', status: 'success' }
-              | { name: 'b', status: 'success' }
+              | a
+
+              // Partition comment
+
+              | bb
+              | c
           `,
           code: dedent`
             type Type =
-              | { name: 'b', status: 'success' }
-              | { name: 'aa', status: 'success' }
+              | a
+
+              // Partition comment
+
+              | c
+              | bb
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it('sorts single-line union types correctly', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | AA | B
+        `,
+        code: dedent`
+          type T =
+            | B | AA
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'AA',
+              left: 'B',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            AA | B
+        `,
+        code: dedent`
+          type T =
+            B | AA
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts unions with parentheses`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '( value: () => void, ) => D | E',
-                left: 'A',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+    it('applies custom groups based on element selectors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'namedElements',
+              leftGroup: 'unknown',
+              left: 'null',
+              right: 'a',
             },
-          ],
-          output: dedent`
-            type Type = {
-              x:
-                | ((
-                    value: () => void,
-                  ) => D | E)
-                | A
-                | B[]
-            }
-          `,
-          code: dedent`
-            type Type = {
-              x:
-                | A
-                | ((
-                    value: () => void,
-                  ) => D | E)
-                | B[]
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'namedElements',
+                selector: 'named',
+              },
+            ],
+            groups: ['namedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
+            | null
+        `,
+        code: dedent`
+          type T =
+            | null
+            | a
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}: sorts unions with comment at the end`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '3',
-                left: '4',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Step = 1 | 2 | 3 | 4 | 5 | 100; // Comment
-          `,
-          code: dedent`
-            type Step = 1 | 2 | 4 | 3 | 5 | 100; // Comment
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts unions using groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: "{ name: 'a' }",
-                rightGroup: 'keyword',
-                leftGroup: 'object',
-                right: 'boolean',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'keyword',
-                rightGroup: 'named',
-                left: 'boolean',
-                right: 'A',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'operator',
-                rightGroup: 'keyword',
-                left: 'keyof A',
-                right: 'bigint',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'literal',
-                leftGroup: 'nullish',
-                left: 'null',
-                right: '1',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'intersection',
-                leftGroup: 'union',
-                right: 'A & B',
-                left: 'A | B',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-          ],
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
           options: [
             {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
+              customGroups: [
+                {
+                  groupName: 'namedStartingWithHello',
+                  elementNamePattern,
+                  selector: 'named',
+                },
               ],
+              groups: ['namedStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'namedStartingWithHello',
+                leftGroup: 'unknown',
+                right: 'helloNamed',
+                left: 'undefined',
+              },
+              messageId: 'unexpectedUnionTypesGroupOrder',
             },
           ],
           output: dedent`
             type Type =
-              | A
-              | any
-              | bigint
-              | boolean
-              | keyof A
-              | typeof B
-              | 1
-              | 'aaa'
-              | (import('path'))
-              | (A extends B ? C : D)
-              | { name: 'a' }
-              | [A, B, C]
-              | (A & B)
-              | (A | B)
+              | helloNamed
               | null
+              | undefined
           `,
           code: dedent`
             type Type =
-              | any
-              | { name: 'a' }
-              | boolean
-              | A
-              | keyof A
-              | bigint
-              | typeof B
-              | 'aaa'
-              | (import('path'))
               | null
-              | 1
-              | (A extends B ? C : D)
-              | [A, B, C]
-              | (A | B)
-              | (A & B)
+              | undefined
+              | helloNamed
           `,
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              | A
-              | SomeClass['name']
-              | string[]
-              | any
-              | bigint
-              | boolean
-              | keyof A
-              | typeof B
-              | 1
-              | 'aaa'
-              | (new () => SomeClass)
-              | (import('path'))
-              | (A extends B ? C : D)
-              | { [P in keyof T]: T[P] }
-              | { name: 'a' }
-              | [A, B, C]
-              | (A & B)
-              | (A | B)
-              | null
-          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedNamedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: "'m'",
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedNamedByLineLength',
+                type: 'line-length',
+                selector: 'named',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedNamedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          type T =
+            | dddd
+            | ccc
+            | eee
+            | bb
+            | ff
+            | a
+            | g
+            | 'm'
+            | 'o'
+            | 'p'
+        `,
+        code: dedent`
+          type T =
+            | a
+            | bb
+            | ccc
+            | dddd
+            | 'm'
+            | eee
+            | ff
+            | g
+            | 'o'
+            | 'p'
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | fooBar
+            | fooZar
+        `,
+        code: dedent`
+          type T =
+            | fooZar
+            | fooBar
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedNamed',
+                selector: 'named',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedNamed', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedNamed',
+              leftGroup: 'unknown',
+              left: "'m'",
+              right: 'c',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | b
+            | a
+            | d
+            | e
+            | c
+            | 'm'
+        `,
+        code: dedent`
+          type T =
+            | b
+            | a
+            | d
+            | e
+            | 'm'
+            | c
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'named',
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'literal',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: "'foo'",
+              left: 'null',
+            },
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            | 'foo'
+            | cFoo
+
+            | null
+        `,
+        code: dedent`
+          type T =
+            | null
+            | 'foo'
+            | cFoo
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          type T =
+            iHaveFooInMyName
+            meTooIHaveFoo
+            a
+            b
+        `,
+      })
+    })
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines within groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
           options: [
             {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
               ],
+              groups: ['group1'],
             },
           ],
-        },
-      ],
-    })
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              | a
+
+              | b
+          `,
+          code: dedent`
+            type T =
+              | a
+              | b
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines within groups when newlinesInside is %s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'group1',
+                  selector: 'named',
+                  newlinesInside,
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['group1'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenUnionTypes',
+            },
+          ],
+          output: dedent`
+            type T =
+              | a
+              | b
+          `,
+          code: dedent`
+            type T =
+              | a
+
+              | b
+          `,
+        })
+      },
+    )
   })
 
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
+  describe('custom', () => {
     let alphabet = Alphabet.generateRecommendedAlphabet()
       .sortByLocaleCompare('en-US')
       .getCharacters()
+
     let options = {
       type: 'custom',
       order: 'asc',
       alphabet,
     } as const
 
-    ruleTester.run(`${ruleName}(${type}: sorts union types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "'bbb'",
-                left: "'cc'",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          code: dedent`
-            type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
+    it('sorts union types', async () => {
+      await valid({
+        code: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        options: [options],
+      })
 
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}: sorts union types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "'bbb'",
-                left: "'cc'",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          code: dedent`
-            type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(`${ruleName}: sorts keyword union types`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'unknown',
-                left: 'any',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-            {
-              data: {
-                right: 'undefined',
-                left: 'null',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-            {
-              data: {
-                right: 'bigint',
-                left: 'void',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Value =
-              | undefined
-              | boolean
-              | unknown
-              | number
-              | string
-              | bigint
-              | never
-              | null
-              | void
-              | any
-          `,
-          code: dedent`
-            type Value =
-              | boolean
-              | number
-              | string
-              | any
-              | unknown
-              | null
-              | undefined
-              | never
-              | void
-              | bigint
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with generics`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "'aa'",
-                left: "'b'",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: "Omit<T, 'aa' | 'b'>",
-          code: "Omit<T, 'b' | 'aa'>",
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-            {
-              data: {
-                right: 'aaa',
-                left: 'bb',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: 'type Type = aaa | bb | c',
-          code: 'type Type = c | bb | aaa',
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: works with type references`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "{ name: 'aa', status: 'success' }",
-                left: "{ name: 'b', status: 'success' }",
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type =
-              | { name: 'aa', status: 'success' }
-              | { name: 'b', status: 'success' }
-          `,
-          code: dedent`
-            type Type =
-              | { name: 'b', status: 'success' }
-              | { name: 'aa', status: 'success' }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts unions with parentheses`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '( value: () => void, ) => D | E',
-                left: 'A',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Type = {
-              x:
-                | ((
-                    value: () => void,
-                  ) => D | E)
-                | B[]
-                | A
-            }
-          `,
-          code: dedent`
-            type Type = {
-              x:
-                | A
-                | ((
-                    value: () => void,
-                  ) => D | E)
-                | B[]
-            }
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts unions with comment at the end`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: '100',
-                left: '5',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
-            },
-          ],
-          output: dedent`
-            type Step = 100 | 1 | 2 | 4 | 3 | 5; // Comment
-          `,
-          code: dedent`
-            type Step = 1 | 2 | 4 | 3 | 5 | 100; // Comment
-          `,
-          options: [options],
-        },
-      ],
-      valid: [],
-    })
-
-    ruleTester.run(`${ruleName}: sorts intersections using groups`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                left: "{ name: 'a' }",
-                rightGroup: 'keyword',
-                leftGroup: 'object',
-                right: 'boolean',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'keyword',
-                rightGroup: 'named',
-                left: 'boolean',
-                right: 'A',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                leftGroup: 'operator',
-                rightGroup: 'keyword',
-                left: 'keyof A',
-                right: 'bigint',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'literal',
-                leftGroup: 'nullish',
-                left: 'null',
-                right: '1',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-            {
-              data: {
-                rightGroup: 'intersection',
-                leftGroup: 'union',
-                right: 'A & B',
-                left: 'A | B',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
-              ],
-            },
-          ],
-          output: dedent`
-            type Type =
-              | A
-              | boolean
-              | bigint
-              | any
-              | typeof B
-              | keyof A
-              | 'aaa'
-              | 1
-              | (import('path'))
-              | (A extends B ? C : D)
-              | { name: 'a' }
-              | [A, B, C]
-              | (A & B)
-              | (A | B)
-              | null
-          `,
-          code: dedent`
-            type Type =
-              | any
-              | { name: 'a' }
-              | boolean
-              | A
-              | keyof A
-              | bigint
-              | typeof B
-              | 'aaa'
-              | (import('path'))
-              | null
-              | 1
-              | (A extends B ? C : D)
-              | [A, B, C]
-              | (A | B)
-              | (A & B)
-          `,
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              | SomeClass['name']
-              | string[]
-              | A
-              | boolean
-              | bigint
-              | any
-              | typeof B
-              | keyof A
-              | 'aaa'
-              | 1
-              | (new () => SomeClass)
-              | (import('path'))
-              | (A extends B ? C : D)
-              | { [P in keyof T]: T[P] }
-              | { name: 'a' }
-              | [A, B, C]
-              | (A & B)
-              | (A | B)
-              | null
-          `,
-          options: [
-            {
-              ...options,
-              groups: [
-                'named',
-                'keyword',
-                'operator',
-                'literal',
-                'function',
-                'import',
-                'conditional',
-                'object',
-                'tuple',
-                'intersection',
-                'union',
-                'nullish',
-              ],
-            },
-          ],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
+      await invalid({
+        errors: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'A',
-                },
-                messageId: 'unexpectedUnionTypesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              type T =
-                | BB
-                | C
-                | A
-            `,
-            code: dedent`
-              type T =
-                | A
-                | BB
-                | C
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'BB',
-                  left: 'C',
-                },
-                messageId: 'unexpectedUnionTypesOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              type T =
-                | BB
-                | A
-                | C
-
-            `,
-            code: dedent`
-              type T =
-                | C
-                | BB
-                | A
-            `,
+            data: {
+              right: "'bbb'",
+              left: "'cc'",
+            },
+            messageId: 'unexpectedUnionTypesOrder',
           },
         ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: validating group configuration`, () => {
-    ruleTester.run(`${ruleName}: allows predefined groups`, rule, {
-      valid: [
-        {
-          options: [
-            {
-              groups: [
-                'intersection',
-                'conditional',
-                'function',
-                'operator',
-                'keyword',
-                'literal',
-                'nullish',
-                'unknown',
-                'import',
-                'object',
-                'named',
-                'tuple',
-                'union',
-              ],
-            },
-          ],
-          code: dedent`
-            type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
-          `,
-        },
-      ],
-      invalid: [],
+        output: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+        code: dedent`
+          type Type = 'aaaa' | 'cc' | 'bbb' | 'd'
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
+  describe('unsorted', () => {
     let options = {
       type: 'unsorted',
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              | B
-              | C
-              | A
-          `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+    it('accepts any order with unsorted type', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            | B
+            | C
+            | A
+        `,
+        options: [options],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces grouping`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                leftGroup: 'literal',
-                rightGroup: 'named',
-                left: "'aa'",
-                right: 'ba',
-              },
-              messageId: 'unexpectedUnionTypesGroupOrder',
+    it('enforces group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'literal',
+              rightGroup: 'named',
+              left: "'aa'",
+              right: 'ba',
             },
-          ],
-          output: dedent`
-            type Type =
-              | ba
-              | bb
-              | 'ab'
-              | 'aa'
-          `,
-          code: dedent`
-            type Type =
-              | 'ab'
-              | 'aa'
-              | ba
-              | bb
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['named', 'literal'],
-            },
-          ],
-        },
-      ],
-      valid: [],
+            messageId: 'unexpectedUnionTypesGroupOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | ba
+            | bb
+            | 'ab'
+            | 'aa'
+        `,
+        code: dedent`
+          type Type =
+            | 'ab'
+            | 'aa'
+            | ba
+            | bb
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['named', 'literal'],
+          },
+        ],
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: "'a'",
-                left: 'b',
-              },
-              messageId: 'missedSpacingBetweenUnionTypes',
+    it('adds newlines between groups when configured', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: "'a'",
+              left: 'b',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['named', 'literal'],
-              newlinesBetween: 'always',
-            },
-          ],
-          output: dedent`
-            type Type =
-              | b
+            messageId: 'missedSpacingBetweenUnionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['named', 'literal'],
+            newlinesBetween: 'always',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | b
 
-              | 'a'
-          `,
-          code: dedent`
-            type Type =
-              | b
-              | 'a'
-          `,
-        },
-      ],
-      valid: [],
+            | 'a'
+        `,
+        code: dedent`
+          type Type =
+            | b
+            | 'a'
+        `,
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    ruleTester.run(
-      `${ruleName}: sets alphabetical asc sorting as default`,
-      rule,
-      {
-        invalid: [
+    it('accepts predefined group configurations', async () => {
+      await valid({
+        options: [
           {
-            errors: [
-              {
-                data: {
-                  right: 'NumberBase.BASE_10',
-                  left: 'NumberBase.BASE_2',
-                },
-                messageId: 'unexpectedUnionTypesOrder',
-              },
+            groups: [
+              'intersection',
+              'conditional',
+              'function',
+              'operator',
+              'keyword',
+              'literal',
+              'nullish',
+              'unknown',
+              'import',
+              'object',
+              'named',
+              'tuple',
+              'union',
             ],
-            output: dedent`
-              type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
-            `,
-            code: dedent`
-              type SupportedNumberBase = NumberBase.BASE_2 | NumberBase.BASE_10 | NumberBase.BASE_16
-            `,
           },
         ],
-        valid: [
-          dedent`
-            type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
-          `,
-          {
-            code: dedent`
-              type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
-            `,
-            options: [{}],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(`${ruleName}: should ignore whitespaces`, rule, {
-      valid: [
-        {
-          code: dedent`
-            type T =
-            { a: string } |
-            {  b: string }
-          `,
-          options: [{}],
-        },
-      ],
-      invalid: [],
+        code: dedent`
+          type Type = 'aaaa' | 'bbb' | 'cc' | 'd'
+        `,
+      })
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+    it('sorts alphabetically in ascending order by default', async () => {
+      await valid(
+        dedent`
+          type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
+        `,
+      )
+
+      await valid({
+        code: dedent`
+          type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'NumberBase.BASE_10',
+              left: 'NumberBase.BASE_2',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              // eslint-disable-next-line
-              | A
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              // eslint-disable-next-line
-              | A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'C',
-                left: 'D',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type SupportedNumberBase = NumberBase.BASE_10 | NumberBase.BASE_16 | NumberBase.BASE_2
+        `,
+        code: dedent`
+          type SupportedNumberBase = NumberBase.BASE_2 | NumberBase.BASE_10 | NumberBase.BASE_16
+        `,
+      })
+    })
+
+    it('ignores whitespace differences when comparing', async () => {
+      await valid({
+        code: dedent`
+          type T =
+          { a: string } |
+          {  b: string }
+        `,
+        options: [{}],
+      })
+    })
+
+    it('preserves elements disabled with eslint-disable-next-line', async () => {
+      await valid({
+        code: dedent`
+          type Type =
+            | B
+            | C
+            // eslint-disable-next-line
+            | A
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'A',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            // eslint-disable-next-line
+            | A
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            // eslint-disable-next-line
+            | A
+        `,
+        options: [{}],
+      })
+    })
+
+    it('partitions by eslint-disable comments when configured', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'C',
+              left: 'D',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              // eslint-disable-next-line
-              | A
-              | D
-          `,
-          code: dedent`
-            type T =
-              D
-              | C
-              // eslint-disable-next-line
-              | A
-              | B
-          `,
-          options: [
-            {
-              partitionByComment: true,
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            // eslint-disable-next-line
+            | A
+            | D
+        `,
+        code: dedent`
+          type T =
+            D
+            | C
+            // eslint-disable-next-line
+            | A
+            | B
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('preserves elements with inline eslint-disable-line', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              | A // eslint-disable-line
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              | A // eslint-disable-line
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            | A // eslint-disable-line
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            | A // eslint-disable-line
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              /* eslint-disable-next-line */
-              | A
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              /* eslint-disable-next-line */
-              | A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            /* eslint-disable-next-line */
+            | A
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            /* eslint-disable-next-line */
+            | A
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              | A /* eslint-disable-line */
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              | A /* eslint-disable-line */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type =
-              A
-              | D
-              /* eslint-disable */
-              | C
-              | B
-              // Shouldn't move
-              /* eslint-enable */
-              | E
-          `,
-          code: dedent`
-            type Type =
-              D
-              | E
-              /* eslint-disable */
-              | C
-              | B
-              // Shouldn't move
-              /* eslint-enable */
-              | A
-          `,
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            | A /* eslint-disable-line */
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            | A /* eslint-disable-line */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable/enable regions', async () => {
+      await invalid({
+        output: dedent`
+          type Type =
+            A
+            | D
+            /* eslint-disable */
+            | C
+            | B
+            // Shouldn't move
+            /* eslint-enable */
+            | E
+        `,
+        code: dedent`
+          type Type =
+            D
+            | E
+            /* eslint-disable */
+            | C
+            | B
+            // Shouldn't move
+            /* eslint-enable */
+            | A
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
             },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              | A
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              | A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            // eslint-disable-next-line rule-to-test/sort-union-types
+            | A
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            // eslint-disable-next-line rule-to-test/sort-union-types
+            | A
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              | A // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              | A // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            | A // eslint-disable-line rule-to-test/sort-union-types
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            | A // eslint-disable-line rule-to-test/sort-union-types
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific block eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              | A
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              | A
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            /* eslint-disable-next-line rule-to-test/sort-union-types */
+            | A
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            /* eslint-disable-next-line rule-to-test/sort-union-types */
+            | A
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            type T =
-              B
-              | C
-              | A /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          code: dedent`
-            type T =
-              C
-              | B
-              | A /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            type Type =
-              A
-              | D
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              | C
-              | B
-              // Shouldn't move
-              /* eslint-enable */
-              | E
-          `,
-          code: dedent`
-            type Type =
-              D
-              | E
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              | C
-              | B
-              // Shouldn't move
-              /* eslint-enable */
-              | A
-          `,
-          errors: [
-            {
-              data: {
-                right: 'A',
-                left: 'B',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type T =
+            B
+            | C
+            | A /* eslint-disable-line rule-to-test/sort-union-types */
+        `,
+        code: dedent`
+          type T =
+            C
+            | B
+            | A /* eslint-disable-line rule-to-test/sort-union-types */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects rule-specific eslint-disable/enable regions', async () => {
+      await invalid({
+        output: dedent`
+          type Type =
+            A
+            | D
+            /* eslint-disable rule-to-test/sort-union-types */
+            | C
+            | B
+            // Shouldn't move
+            /* eslint-enable */
+            | E
+        `,
+        code: dedent`
+          type Type =
+            D
+            | E
+            /* eslint-disable rule-to-test/sort-union-types */
+            | C
+            | B
+            // Shouldn't move
+            /* eslint-enable */
+            | A
+        `,
+        errors: [
+          {
+            data: {
+              right: 'A',
+              left: 'B',
             },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            type Type =
-              | B
-              | C
-              // eslint-disable-next-line
-              | A
-          `,
-        },
-      ],
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        options: [{}],
+      })
     })
   })
 })

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -1,2702 +1,1492 @@
-import type { Rule } from 'eslint'
-
-import { RuleTester } from '@typescript-eslint/rule-tester'
-import { RuleTester as EslintRuleTester } from 'eslint'
-import { afterAll, describe, expect, it } from 'vitest'
+import { createRuleTester } from 'eslint-vitest-rule-tester'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, expect, it } from 'vitest'
 import dedent from 'dedent'
 
 import { validateRuleJsonSchema } from '../utils/validate-rule-json-schema'
 import rule from '../../rules/sort-variable-declarations'
 import { Alphabet } from '../../utils/alphabet'
 
-let ruleName = 'sort-variable-declarations'
+describe('sort-variable-declarations', () => {
+  let { invalid, valid } = createRuleTester({
+    name: 'sort-variable-declarations',
+    parser: typescriptParser,
+    rule,
+  })
 
-describe(ruleName, () => {
-  RuleTester.describeSkip = describe.skip
-  RuleTester.afterAll = afterAll
-  RuleTester.describe = describe
-  RuleTester.itOnly = it.only
-  RuleTester.itSkip = it.skip
-  RuleTester.it = it
-
-  let ruleTester = new RuleTester()
-  let eslintRuleTester = new EslintRuleTester()
-
-  describe(`${ruleName}: sorting by alphabetical order`, () => {
-    let type = 'alphabetical-order'
-
+  describe('alphabetical', () => {
     let options = {
       type: 'alphabetical',
-      ignoreCase: true,
       order: 'asc',
     } as const
 
-    ruleTester.run(`${ruleName}(${type}): sorts variables declarations`, rule, {
-      invalid: [
-        {
+    it('sorts variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const aaa, bb, c
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedVariableDeclarationsOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        output: dedent`
+          const aaa, bb, c
+        `,
+        code: dedent`
+          const bb, aaa, c
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles array and object destructuring in variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const [c] = C, { bb } = B, aaa
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ bb }',
+              left: 'aaa',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              left: '{ bb }',
+              right: '[c]',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const [c] = C, { bb } = B, aaa
+        `,
+        code: dedent`
+          const aaa, { bb } = B, [c] = C
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles dependencies between variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const bb = 1,
+                aaa = bb + 2,
+                c = aaa + 3
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = 1,
+              b = a + 2,
+              c = b + 3,
+              d = [a, b, c];
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          var x = 10,
+              y = x * 2,
+              z = y + 5 - x;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          const arr = [1, 2, 3],
+                sum = arr.reduce((acc, val) => acc + val, 0),
+                avg = sum / arr.length;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          const getValue = () => 1,
+                value = getValue(),
+                result = value + 2;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let position = editor.state.selection.$anchor,
+          depth = position.depth;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedVariableDeclarationsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          const a,
+                b,
+                c;
+        `,
+        code: dedent`
+          const b,
+                a,
+                c;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'bb',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const bb = 1,
+                aaa = bb + 2,
+                c = aaa + 3;
+        `,
+        code: dedent`
+          const aaa = bb + 2,
+                bb = 1,
+                c = aaa + 3;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let a = 1,
+              b = a + 2,
+              c = b + 3;
+        `,
+        code: dedent`
+          let b = a + 2,
+              a = 1,
+              c = b + 3;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'y',
+              right: 'x',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          var x = 10,
+              y = x * 2,
+              z = y + 5;
+        `,
+        code: dedent`
+          var y = x * 2,
+              x = 10,
+              z = y + 5;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'sum',
+              right: 'arr',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const arr = [1, 2, 3],
+                sum = arr.reduce((acc, val) => acc + val, 0),
+                avg = sum / arr.length;
+        `,
+        code: dedent`
+          const sum = arr.reduce((acc, val) => acc + val, 0),
+                arr = [1, 2, 3],
+                avg = sum / arr.length;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'value',
+              right: 'getValue',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const getValue = () => 1,
+                value = getValue(),
+                result = value + 2;
+        `,
+        code: dedent`
+          const value = getValue(),
+                getValue = () => 1,
+                result = value + 2;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const c = 10,
+                a = c,
+                b = 10;
+        `,
+        code: dedent`
+          const a = c,
+                b = 10,
+                c = 10;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = () => 1,
+          a = b();
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = function() { return 1 },
+          a = b();
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = () => 1,
+          a = a.map(b);
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object properties', async () => {
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = {x: b};
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = {[b]: 0};
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects chained member expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = b.x;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = new Subject(),
+          a = b.asObservable();
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chaining dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = b?.x;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects non-null assertion dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = b!;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects unary expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = true,
+          a = !b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects spread element dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = {b = 'b',};
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = [1]
+          a = [b = 'b',];
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = b ? 1 : 0;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = x ? b : 0;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = x ? 0 : b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in type assertions', async () => {
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = b as any;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = <any>b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literals', async () => {
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = \`\${b}\`
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores dependencies inside function bodies', async () => {
+      await valid({
+        code: dedent`
+          let a = () => b,
+          b = 1;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = function() { return b },
+          b = 1;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = () => {return b},
+          b = 1;
+        `,
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'variablesStartingWithA',
+                elementNamePattern: 'a',
+              },
+              {
+                groupName: 'variablesStartingWithB',
+                elementNamePattern: 'b',
+              },
+            ],
+            groups: ['variablesStartingWithA', 'variablesStartingWithB'],
+          },
+        ],
+        code: dedent`
+          let
+            b,
+            a = b,
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+        output: dedent`
+          let
+            a = 0,
+            // Part: 1
+            b = a,
+        `,
+        code: dedent`
+          let
+            b = a,
+            // Part: 1
+            a = 0,
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over newline partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          let
+            a = 0,
+
+            b = a,
+        `,
+        code: dedent`
+          let
+            b = a,
+
+            a = 0,
+        `,
+      })
+    })
+
+    it('sorts within newline-separated partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            a = 'A',
+            d = 'D',
+
+            c = 'C',
+
+            b = 'B',
+            e = 'E'
+        `,
+        code: dedent`
+          const
+            d = 'D',
+            a = 'A',
+
+            c = 'C',
+
+            e = 'E',
+            b = 'B'
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('sorts within comment-defined partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            // Part: A
+            // Not partition comment
+            bbb = 'BBB',
+            cc = 'CC',
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            e = 'E',
+            // Part: C
+            // Not partition comment
+            fff = 'FFF',
+            gg = 'GG'
+        `,
+        code: dedent`
+          const
+            // Part: A
+            cc = 'CC',
+            d = 'D',
+            // Not partition comment
+            bbb = 'BBB',
+            // Part: B
+            aaa = 'AAA',
+            e = 'E',
+            // Part: C
+            gg = 'GG',
+            // Not partition comment
+            fff = 'FFF'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition boundaries', async () => {
+      await valid({
+        code: dedent`
+          const
+            // Comment
+            bb = 'bb',
+            // Other comment
+            a = 'a'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          const
+            /* Partition Comment */
+            // Part: A
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            bb = 'BB',
+            c = 'C',
+            /* Other */
+            e = 'E'
+        `,
+        code: dedent`
+          const
+            /* Partition Comment */
+            // Part: A
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            c = 'C',
+            bb = 'BB',
+            /* Other */
+            e = 'E'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          const
+            e = 'e',
+            f = 'f',
+            // I am a partition comment because I don't have f o o
+            a = 'a',
+            b = 'b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are partition boundaries', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          const
+            /* Comment */
+            a: 'a',
+            b: 'b',
+        `,
+        code: dedent`
+          const
+            b: 'b',
+            /* Comment */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            // Comment
+            a: 'a',
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            c: 'c',
+            // b
+            b: 'b',
+            // a
+            a: 'a',
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            // I am a partition comment because I don't have f o o
+            a: 'a',
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are partition boundaries', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          const
+            // Comment
+            a: 'a',
+            b: 'b',
+        `,
+        code: dedent`
+          const
+            b: 'b',
+            // Comment
+            a: 'a',
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            /* Comment */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            c: 'c',
+            /* b */
+            b: 'b',
+            /* a */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            /* I am a partition comment because I don't have f o o */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          const
+            _a = 'a',
+            b = 'b',
+            _c = 'c'
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          const
+            ab = 'ab',
+            a_c = 'ac'
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          const
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline variable declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            a = 'a', b = 'b'
+        `,
+        code: dedent`
+          const
+            b = 'b', a = 'a'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            a = 'a', b = 'b',
+        `,
+        code: dedent`
+          const
+            b = 'b', a = 'a',
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces predefined group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'uninitialized',
+              rightGroup: 'initialized',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['initialized', 'uninitialized'],
+          },
+        ],
+        output: dedent`
+          let
+            b ='b',
+            a,
+        `,
+        code: dedent`
+          let
+            a,
+            b ='b',
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'uninitializedElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'uninitializedElements',
+                selector: 'uninitialized',
+              },
+            ],
+            groups: ['uninitializedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          let
+            a,
+            b = 'b',
+        `,
+        code: dedent`
+          let
+            b = 'b',
+            a,
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'uninitializedStartingWithHello',
+                  selector: 'uninitialized',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['uninitializedStartingWithHello', 'unknown'],
+            },
+          ],
           errors: [
             {
-              messageId: 'unexpectedVariableDeclarationsOrder',
-              data: { right: 'aaa', left: 'bb' },
+              data: {
+                rightGroup: 'uninitializedStartingWithHello',
+                right: 'helloUninitialized',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedVariableDeclarationsGroupOrder',
             },
           ],
           output: dedent`
-            const aaa, bb, c
+            let
+              helloUninitialized,
+              a,
+              b,
           `,
-          code: dedent`
-            const bb, aaa, c
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            const aaa, bb, c
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with array and object declarations`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '{ bb }',
-                  left: 'aaa',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-              {
-                data: {
-                  left: '{ bb }',
-                  right: '[c]',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            output: dedent`
-              const [c] = C, { bb } = B, aaa
-            `,
-            code: dedent`
-              const aaa, { bb } = B, [c] = C
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              const [c] = C, { bb } = B, aaa
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    describe(`${ruleName}(${type}): detects dependencies`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): does not sort properties if the right value depends on the left value`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                  data: { right: 'a', left: 'b' },
-                },
-              ],
-              output: dedent`
-                const a,
-                      b,
-                      c;
-              `,
-              code: dedent`
-                const b,
-                      a,
-                      c;
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'aaa',
-                    right: 'bb',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                const bb = 1,
-                      aaa = bb + 2,
-                      c = aaa + 3;
-              `,
-              code: dedent`
-                const aaa = bb + 2,
-                      bb = 1,
-                      c = aaa + 3;
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'a',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                let a = 1,
-                    b = a + 2,
-                    c = b + 3;
-              `,
-              code: dedent`
-                let b = a + 2,
-                    a = 1,
-                    c = b + 3;
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'y',
-                    right: 'x',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                var x = 10,
-                    y = x * 2,
-                    z = y + 5;
-              `,
-              code: dedent`
-                var y = x * 2,
-                    x = 10,
-                    z = y + 5;
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'sum',
-                    right: 'arr',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                const arr = [1, 2, 3],
-                      sum = arr.reduce((acc, val) => acc + val, 0),
-                      avg = sum / arr.length;
-              `,
-              code: dedent`
-                const sum = arr.reduce((acc, val) => acc + val, 0),
-                      arr = [1, 2, 3],
-                      avg = sum / arr.length;
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'value',
-                    right: 'getValue',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                const getValue = () => 1,
-                      value = getValue(),
-                      result = value + 2;
-              `,
-              code: dedent`
-                const value = getValue(),
-                      getValue = () => 1,
-                      result = value + 2;
-              `,
-              options: [options],
-            },
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'a',
-                    right: 'c',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              output: dedent`
-                const c = 10,
-                      a = c,
-                      b = 10;
-              `,
-              code: dedent`
-                const a = c,
-                      b = 10,
-                      c = 10;
-              `,
-              options: [options],
-            },
-          ],
-          valid: [
-            {
-              code: dedent`
-                const bb = 1,
-                      aaa = bb + 2,
-                      c = aaa + 3
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let a = 1,
-                    b = a + 2,
-                    c = b + 3,
-                    d = [a, b, c];
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                var x = 10,
-                    y = x * 2,
-                    z = y + 5 - x;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                const arr = [1, 2, 3],
-                      sum = arr.reduce((acc, val) => acc + val, 0),
-                      avg = sum / arr.length;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                const getValue = () => 1,
-                      value = getValue(),
-                      result = value + 2;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let position = editor.state.selection.$anchor,
-                depth = position.depth;
-              `,
-              options: [options],
-            },
-          ],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects function expression dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = () => 1,
-                a = b();
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let b = function() { return 1 },
-                a = b();
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let b = () => 1,
-                a = a.map(b);
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in objects`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = 1,
-                a = {x: b};
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let b = 1,
-                a = {[b]: 0};
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects chained dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = {x: 1},
-                a = b.x;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let b = new Subject(),
-                a = b.asObservable();
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects optional chained dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = {x: 1},
-                a = b?.x;
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects non-null asserted dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = 1,
-                a = b!;
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}) detects unary dependencies`, rule, {
-        valid: [
-          {
-            code: dedent`
-              let b = true,
-              a = !b;
-            `,
-            options: [options],
-          },
-        ],
-        invalid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects spread elements dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = {x: 1},
-                a = {b = 'b',};
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let b = [1]
-                a = [b = 'b',];
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in conditional expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = 0,
-                a = b ? 1 : 0;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let b = 0,
-                a = x ? b : 0;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let b = 0,
-                a = x ? 0 : b;
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in 'as' expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = 'b',
-                a = b as any;
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in type assertion expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = 'b',
-                a = <any>b;
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) detects dependencies in template literal expressions`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let b = 'b',
-                a = \`\${b}\`
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}) ignores function body dependencies`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                let a = () => b,
-                b = 1;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let a = function() { return b },
-                b = 1;
-              `,
-              options: [options],
-            },
-            {
-              code: dedent`
-                let a = () => {return b},
-                b = 1;
-              `,
-              options: [options],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over group configuration`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  ...options,
-                  customGroups: [
-                    {
-                      groupName: 'variablesStartingWithA',
-                      elementNamePattern: 'a',
-                    },
-                    {
-                      groupName: 'variablesStartingWithB',
-                      elementNamePattern: 'b',
-                    },
-                  ],
-                  groups: ['variablesStartingWithA', 'variablesStartingWithB'],
-                },
-              ],
-              code: dedent`
-                let
-                  b,
-                  a = b,
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByComment`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'a',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-              output: dedent`
-                let
-                  a = 0,
-                  // Part: 1
-                  b = a,
-              `,
-              code: dedent`
-                let
-                  b = a,
-                  // Part: 1
-                  a = 0,
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): prioritizes dependencies over partitionByNewLine`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    nodeDependentOnRight: 'b',
-                    right: 'a',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByNewLine: true,
-                },
-              ],
-              output: dedent`
-                let
-                  a = 0,
-
-                  b = a,
-              `,
-              code: dedent`
-                let
-                  b = a,
-
-                  a = 0,
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use new line as partition`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'd',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-              {
-                data: {
-                  right: 'b',
-                  left: 'e',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            output: dedent`
-              const
-                a = 'A',
-                d = 'D',
-
-                c = 'C',
-
-                b = 'B',
-                e = 'E'
-            `,
-            code: dedent`
-              const
-                d = 'D',
-                a = 'A',
-
-                c = 'C',
-
-                e = 'E',
-                b = 'B'
-            `,
-            options: [
-              {
-                partitionByNewLine: true,
-                type: 'alphabetical',
-              },
-            ],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}(${type}): partition comments`, () => {
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bbb',
-                    left: 'd',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-                {
-                  data: {
-                    right: 'fff',
-                    left: 'gg',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-              ],
-              output: dedent`
-                const
-                  // Part: A
-                  // Not partition comment
-                  bbb = 'BBB',
-                  cc = 'CC',
-                  d = 'D',
-                  // Part: B
-                  aaa = 'AAA',
-                  e = 'E',
-                  // Part: C
-                  // Not partition comment
-                  fff = 'FFF',
-                  gg = 'GG'
-              `,
-              code: dedent`
-                const
-                  // Part: A
-                  cc = 'CC',
-                  d = 'D',
-                  // Not partition comment
-                  bbb = 'BBB',
-                  // Part: B
-                  aaa = 'AAA',
-                  e = 'E',
-                  // Part: C
-                  gg = 'GG',
-                  // Not partition comment
-                  fff = 'FFF'
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: '^Part',
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use all comments as parts`,
-        rule,
-        {
-          valid: [
-            {
-              code: dedent`
-                const
-                  // Comment
-                  bb = 'bb',
-                  // Other comment
-                  a = 'a'
-              `,
-              options: [
-                {
-                  ...options,
-                  partitionByComment: true,
-                },
-              ],
-            },
-          ],
-          invalid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}(${type}): allows to use multiple partition comments`,
-        rule,
-        {
-          invalid: [
-            {
-              output: dedent`
-                const
-                  /* Partition Comment */
-                  // Part: A
-                  d = 'D',
-                  // Part: B
-                  aaa = 'AAA',
-                  bb = 'BB',
-                  c = 'C',
-                  /* Other */
-                  e = 'E'
-              `,
-              code: dedent`
-                const
-                  /* Partition Comment */
-                  // Part: A
-                  d = 'D',
-                  // Part: B
-                  aaa = 'AAA',
-                  c = 'C',
-                  bb = 'BB',
-                  /* Other */
-                  e = 'E'
-              `,
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'c',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: ['Partition Comment', 'Part:', 'Other'],
-                },
-              ],
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}(${type}): allows to use regex`, rule, {
-        valid: [
-          {
-            code: dedent`
-              const
-                e = 'e',
-                f = 'f',
-                // I am a partition comment because I don't have f o o
-                a = 'a',
-                b = 'b'
-            `,
-            options: [
-              {
-                ...options,
-                partitionByComment: ['^(?!.*foo).*$'],
-              },
-            ],
-          },
-        ],
-        invalid: [],
-      })
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.line"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores block comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    line: true,
-                  },
-                },
-              ],
-              output: dedent`
-                const
-                  /* Comment */
-                  a: 'a',
-                  b: 'b',
-              `,
-              code: dedent`
-                const
-                  b: 'b',
-                  /* Comment */
-                  a: 'a',
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  const
-                    b: 'b',
-                    // Comment
-                    a: 'a',
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['a', 'b'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  const
-                    c: 'c',
-                    // b
-                    b: 'b',
-                    // a
-                    a: 'a',
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      line: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  const
-                    b: 'b',
-                    // I am a partition comment because I don't have f o o
-                    a: 'a',
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-
-      describe(`${ruleName}(${type}): allows to use "partitionByComment.block"`, () => {
-        ruleTester.run(`${ruleName}(${type}): ignores line comments`, rule, {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-              ],
-              options: [
-                {
-                  ...options,
-                  partitionByComment: {
-                    block: true,
-                  },
-                },
-              ],
-              output: dedent`
-                const
-                  // Comment
-                  a: 'a',
-                  b: 'b',
-              `,
-              code: dedent`
-                const
-                  b: 'b',
-                  // Comment
-                  a: 'a',
-              `,
-            },
-          ],
-          valid: [],
-        })
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use all comments as parts`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: true,
-                    },
-                  },
-                ],
-                code: dedent`
-                  const
-                    b: 'b',
-                    /* Comment */
-                    a: 'a',
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use multiple partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['a', 'b'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  const
-                    c: 'c',
-                    /* b */
-                    b: 'b',
-                    /* a */
-                    a: 'a',
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-
-        ruleTester.run(
-          `${ruleName}(${type}): allows to use regex for partition comments`,
-          rule,
-          {
-            valid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    partitionByComment: {
-                      block: ['^(?!.*foo).*$'],
-                    },
-                  },
-                ],
-                code: dedent`
-                  const
-                    b: 'b',
-                    /* I am a partition comment because I don't have f o o */
-                    a: 'a',
-                `,
-              },
-            ],
-            invalid: [],
-          },
-        )
-      })
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to trim special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'trim',
-              },
-            ],
-            code: dedent`
-              const
-                _a = 'a',
-                b = 'b',
-                _c = 'c'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to remove special characters`,
-      rule,
-      {
-        valid: [
-          {
-            options: [
-              {
-                ...options,
-                specialCharacters: 'remove',
-              },
-            ],
-            code: dedent`
-              const
-                ab = 'ab',
-                a_c = 'ac'
-            `,
-          },
-        ],
-        invalid: [],
-      },
-    )
-
-    ruleTester.run(`${ruleName}(${type}): allows to use locale`, rule, {
-      valid: [
-        {
-          code: dedent`
-            const
-              你好 = '你好',
-              世界 = '世界',
-              a = 'a',
-              A = 'A',
-              b = 'b',
-              B = 'B'
-          `,
-          options: [{ ...options, locales: 'zh-CN' }],
-        },
-      ],
-      invalid: [],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): sorts inline elements correctly`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            output: dedent`
-              const
-                a = 'a', b = 'b'
-            `,
-            code: dedent`
-              const
-                b = 'b', a = 'a'
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            output: dedent`
-              const
-                a = 'a', b = 'b',
-            `,
-            code: dedent`
-              const
-                b = 'b', a = 'a',
-            `,
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): allows to use predefined groups`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  leftGroup: 'uninitialized',
-                  rightGroup: 'initialized',
-                  right: 'b',
-                  left: 'a',
-                },
-                messageId: 'unexpectedVariableDeclarationsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                groups: ['initialized', 'uninitialized'],
-              },
-            ],
-            output: dedent`
-              let
-                b ='b',
-                a,
-            `,
-            code: dedent`
-              let
-                a,
-                b ='b',
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-
-    describe(`${ruleName}: custom groups`, () => {
-      ruleTester.run(`${ruleName}: filters on selector`, rule, {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  rightGroup: 'uninitializedElements',
-                  leftGroup: 'unknown',
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedVariableDeclarationsGroupOrder',
-              },
-            ],
-            options: [
-              {
-                customGroups: [
-                  {
-                    groupName: 'uninitializedElements',
-                    selector: 'uninitialized',
-                  },
-                ],
-                groups: ['uninitializedElements', 'unknown'],
-              },
-            ],
-            output: dedent`
-              let
-                a,
-                b = 'b',
-            `,
-            code: dedent`
-              let
-                b = 'b',
-                a,
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      for (let elementNamePattern of [
-        'hello',
-        ['noMatch', 'hello'],
-        { pattern: 'HELLO', flags: 'i' },
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ]) {
-        ruleTester.run(`${ruleName}: filters on elementNamePattern`, rule, {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'uninitializedStartingWithHello',
-                      selector: 'uninitialized',
-                      elementNamePattern,
-                    },
-                  ],
-                  groups: ['uninitializedStartingWithHello', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'uninitializedStartingWithHello',
-                    right: 'helloUninitialized',
-                    leftGroup: 'unknown',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsGroupOrder',
-                },
-              ],
-              output: dedent`
-                let
-                  helloUninitialized,
-                  a,
-                  b,
-              `,
-              code: dedent`
-                let
-                  a,
-                  b,
-                  helloUninitialized,
-              `,
-            },
-          ],
-          valid: [],
-        })
-      }
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'type' and 'order'`,
-        rule,
-        {
-          invalid: [
-            {
-              errors: [
-                {
-                  data: {
-                    right: 'bb',
-                    left: 'a',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-                {
-                  data: {
-                    right: 'ccc',
-                    left: 'bb',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-                {
-                  data: {
-                    right: 'dddd',
-                    left: 'ccc',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-                {
-                  data: {
-                    rightGroup: 'reversedUninitializedByLineLength',
-                    leftGroup: 'unknown',
-                    right: 'eee',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsGroupOrder',
-                },
-              ],
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'reversedUninitializedByLineLength',
-                      selector: 'uninitialized',
-                      type: 'line-length',
-                      order: 'desc',
-                    },
-                  ],
-                  groups: ['reversedUninitializedByLineLength', 'unknown'],
-                  type: 'alphabetical',
-
-                  order: 'asc',
-                },
-              ],
-              output: dedent`
-                let
-                  dddd,
-                  ccc,
-                  eee,
-                  bb,
-                  ff,
-                  a,
-                  g,
-                  m = 'm',
-                  o = 'o',
-                  p = 'p',
-              `,
-              code: dedent`
-                let
-                  a,
-                  bb,
-                  ccc,
-                  dddd,
-                  m = 'm',
-                  eee,
-                  ff,
-                  g,
-                  o = 'o',
-                  p = 'p',
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: sort custom groups by overriding 'fallbackSort'`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      fallbackSort: {
-                        type: 'alphabetical',
-                        order: 'asc',
-                      },
-                      elementNamePattern: '^foo',
-                      type: 'line-length',
-                      groupName: 'foo',
-                      order: 'desc',
-                    },
-                  ],
-                  type: 'alphabetical',
-                  groups: ['foo'],
-                  order: 'asc',
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    right: 'fooBar',
-                    left: 'fooZar',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsOrder',
-                },
-              ],
-              output: dedent`
-                let
-                  fooBar,
-                  fooZar,
-              `,
-              code: dedent`
-                let
-                  fooZar,
-                  fooBar,
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(
-        `${ruleName}: does not sort custom groups with 'unsorted' type`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      groupName: 'unsortedUninitialized',
-                      selector: 'uninitialized',
-                      type: 'unsorted',
-                    },
-                  ],
-                  groups: ['unsortedUninitialized', 'unknown'],
-                },
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unsortedUninitialized',
-                    leftGroup: 'unknown',
-                    right: 'c',
-                    left: 'm',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsGroupOrder',
-                },
-              ],
-              output: dedent`
-                let
-                  b,
-                  a,
-                  d,
-                  e,
-                  c,
-                  m = 'm',
-              `,
-              code: dedent`
-                let
-                  b,
-                  a,
-                  d,
-                  e,
-                  m = 'm',
-                  c,
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      ruleTester.run(`${ruleName}: sort custom group blocks`, rule, {
-        invalid: [
-          {
-            options: [
-              {
-                customGroups: [
-                  {
-                    anyOf: [
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'uninitialized',
-                      },
-                      {
-                        elementNamePattern: 'foo|Foo',
-                        selector: 'initialized',
-                      },
-                    ],
-                    groupName: 'elementsIncludingFoo',
-                  },
-                ],
-                groups: ['elementsIncludingFoo', 'unknown'],
-              },
-            ],
-            errors: [
-              {
-                data: {
-                  rightGroup: 'elementsIncludingFoo',
-                  leftGroup: 'unknown',
-                  right: 'cFoo',
-                  left: 'a',
-                },
-                messageId: 'unexpectedVariableDeclarationsGroupOrder',
-              },
-            ],
-            output: dedent`
-              let
-                cFoo,
-                foo = 'foo',
-                a,
-            `,
-            code: dedent`
-              let
-                a,
-                cFoo,
-                foo = 'foo',
-            `,
-          },
-        ],
-        valid: [],
-      })
-
-      ruleTester.run(
-        `${ruleName}: allows to use regex for element names in custom groups`,
-        rule,
-        {
-          valid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: '^(?!.*Foo).*$',
-                      groupName: 'elementsWithoutFoo',
-                    },
-                  ],
-                  groups: ['unknown', 'elementsWithoutFoo'],
-                  type: 'alphabetical',
-                },
-              ],
-              code: dedent`
-                let
-                  iHaveFooInMyName,
-                  meTooIHaveFoo,
-                  a,
-                  b,
-              `,
-            },
-          ],
-          invalid: [],
-        },
-      )
-    })
-
-    describe(`${ruleName}: newlinesBetween`, () => {
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): removes newlines when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedVariableDeclarationsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'z',
-                    },
-                    messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    newlinesBetween,
-                  },
-                ],
-                code: dedent`
-                  let
-                    a,
-
-
-                   y,
-                  z,
-
-                      b,
-                `,
-                output: dedent`
-                  let
-                    a,
-                   b,
-                  y,
-                      z,
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      for (let newlinesBetween of ['always', 1] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): keeps one newline when "${newlinesBetween}"`,
-          rule,
-          {
-            invalid: [
-              {
-                errors: [
-                  {
-                    data: {
-                      right: 'z',
-                      left: 'a',
-                    },
-                    messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'y',
-                      left: 'z',
-                    },
-                    messageId: 'unexpectedVariableDeclarationsOrder',
-                  },
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'y',
-                    },
-                    messageId:
-                      'missedSpacingBetweenVariableDeclarationsMembers',
-                  },
-                ],
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                      {
-                        elementNamePattern: 'b',
-                        groupName: 'b',
-                      },
-                    ],
-                    groups: ['a', 'unknown', 'b'],
-                    newlinesBetween,
-                  },
-                ],
-                output: dedent`
-                  let
-                    a,
-
-                   y,
-                  z,
-
-                      b,
-                `,
-                code: dedent`
-                  let
-                    a,
-
-
-                   z,
-                  y,
-                      b,
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-
-      describe(`${ruleName}(${type}): "newlinesBetween" inside groups`, () => {
-        ruleTester.run(
-          `${ruleName}(${type}): handles "newlinesBetween" between consecutive groups`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    groups: [
-                      'a',
-                      { newlinesBetween: 'always' },
-                      'b',
-                      { newlinesBetween: 'always' },
-                      'c',
-                      { newlinesBetween: 'never' },
-                      'd',
-                      { newlinesBetween: 'ignore' },
-                      'e',
-                    ],
-                    customGroups: [
-                      { elementNamePattern: 'a', groupName: 'a' },
-                      { elementNamePattern: 'b', groupName: 'b' },
-                      { elementNamePattern: 'c', groupName: 'c' },
-                      { elementNamePattern: 'd', groupName: 'd' },
-                      { elementNamePattern: 'e', groupName: 'e' },
-                    ],
-                    newlinesBetween: 'always',
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'a',
-                    },
-                    messageId:
-                      'missedSpacingBetweenVariableDeclarationsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'c',
-                      left: 'b',
-                    },
-                    messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-                  },
-                  {
-                    data: {
-                      right: 'd',
-                      left: 'c',
-                    },
-                    messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-                  },
-                ],
-                output: dedent`
-                  let
-                    a,
-
-                    b,
-
-                    c,
-                    d,
-
-
-                    e
-                `,
-                code: dedent`
-                  let
-                    a,
-                    b,
-
-
-                    c,
-
-                    d,
-
-
-                    e
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-
-        describe(`${ruleName}(${type}): "newlinesBetween" between non-consecutive groups`, () => {
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            [2, 'never'],
-            [2, 0],
-            [2, 'ignore'],
-            ['never', 2],
-            [0, 2],
-            ['ignore', 2],
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces newlines if the global option is ${globalNewlinesBetween} and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId:
-                          'missedSpacingBetweenVariableDeclarationsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      let
-                        a,
-
-
-                        b,
-                    `,
-                    code: dedent`
-                      let
-                        a,
-                        b,
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let globalNewlinesBetween of [
-            'always',
-            2,
-            'ignore',
-            'never',
-            0,
-          ] as const) {
-            ruleTester.run(
-              `${ruleName}(${type}): enforces no newline if the global option is "${globalNewlinesBetween}" and "newlinesBetween: never" exists between all groups`,
-              rule,
-              {
-                invalid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        groups: [
-                          'a',
-                          { newlinesBetween: 'never' },
-                          'unusedGroup',
-                          { newlinesBetween: 'never' },
-                          'b',
-                          { newlinesBetween: 'always' },
-                          'c',
-                        ],
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { elementNamePattern: 'c', groupName: 'c' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    errors: [
-                      {
-                        data: {
-                          right: 'b',
-                          left: 'a',
-                        },
-                        messageId:
-                          'extraSpacingBetweenVariableDeclarationsMembers',
-                      },
-                    ],
-                    output: dedent`
-                      let
-                        a,
-                        b,
-                    `,
-                    code: dedent`
-                      let
-                        a,
-
-                        b,
-                    `,
-                  },
-                ],
-                valid: [],
-              },
-            )
-          }
-
-          for (let [globalNewlinesBetween, groupNewlinesBetween] of [
-            ['ignore', 'never'] as const,
-            ['ignore', 0] as const,
-            ['never', 'ignore'] as const,
-            [0, 'ignore'] as const,
-          ]) {
-            ruleTester.run(
-              `${ruleName}(${type}): does not enforce a newline if the global option is "${globalNewlinesBetween}" and the group option is "${groupNewlinesBetween}"`,
-              rule,
-              {
-                valid: [
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      let
-                        a,
-
-                        b,
-                    `,
-                  },
-                  {
-                    options: [
-                      {
-                        ...options,
-                        customGroups: [
-                          { elementNamePattern: 'a', groupName: 'a' },
-                          { elementNamePattern: 'b', groupName: 'b' },
-                          { groupName: 'unusedGroup', elementNamePattern: 'X' },
-                        ],
-                        groups: [
-                          'a',
-                          'unusedGroup',
-                          { newlinesBetween: groupNewlinesBetween },
-                          'b',
-                        ],
-                        newlinesBetween: globalNewlinesBetween,
-                      },
-                    ],
-                    code: dedent`
-                      let
-                        a,
-                        b,
-                    `,
-                  },
-                ],
-                invalid: [],
-              },
-            )
-          }
-        })
-      })
-
-      ruleTester.run(
-        `${ruleName}(${type}): handles newlines and comment after fixes`,
-        rule,
-        {
-          invalid: [
-            {
-              options: [
-                {
-                  customGroups: [
-                    {
-                      elementNamePattern: 'b|c',
-                      groupName: 'b|c',
-                    },
-                  ],
-                  groups: ['unknown', 'b|c'],
-                  newlinesBetween: 'always',
-                },
-              ],
-              output: [
-                dedent`
-                  let
-                    a, // Comment after
-                    b,
-
-                    c
-                `,
-                dedent`
-                  let
-                    a, // Comment after
-
-                    b,
-                    c
-                `,
-              ],
-              errors: [
-                {
-                  data: {
-                    rightGroup: 'unknown',
-                    leftGroup: 'b|c',
-                    right: 'a',
-                    left: 'b',
-                  },
-                  messageId: 'unexpectedVariableDeclarationsGroupOrder',
-                },
-              ],
-              code: dedent`
-                let
-                  b,
-                  a, // Comment after
-
-                  c
-              `,
-            },
-          ],
-          valid: [],
-        },
-      )
-
-      for (let newlinesBetween of ['never', 0] as const) {
-        ruleTester.run(
-          `${ruleName}(${type}): ignores newline fixes between different partitions (${newlinesBetween})`,
-          rule,
-          {
-            invalid: [
-              {
-                options: [
-                  {
-                    ...options,
-                    customGroups: [
-                      {
-                        elementNamePattern: 'a',
-                        groupName: 'a',
-                      },
-                    ],
-                    groups: ['a', 'unknown'],
-                    partitionByComment: true,
-                    newlinesBetween,
-                  },
-                ],
-                errors: [
-                  {
-                    data: {
-                      right: 'b',
-                      left: 'c',
-                    },
-                    messageId: 'unexpectedVariableDeclarationsOrder',
-                  },
-                ],
-                output: dedent`
-                  let
-                    a,
-
-                    // Partition comment
-
-                    b,
-                    c
-                `,
-                code: dedent`
-                  let
-                    a,
-
-                    // Partition comment
-
-                    c,
-                    b
-                `,
-              },
-            ],
-            valid: [],
-          },
-        )
-      }
-    })
-  })
-
-  describe(`${ruleName}: sorting by natural order`, () => {
-    let type = 'natural-order'
-
-    let options = {
-      ignoreCase: true,
-      type: 'natural',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts variables declarations`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              messageId: 'unexpectedVariableDeclarationsOrder',
-              data: { right: 'aaa', left: 'bb' },
-            },
-          ],
-          output: dedent`
-            const aaa, bb, c
-          `,
-          code: dedent`
-            const bb, aaa, c
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            const aaa, bb, c
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with array and object declarations`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  left: '{ bb }',
-                  right: '[c]',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            output: dedent`
-              const [c] = C, aaa, { bb } = B
-            `,
-            code: dedent`
-              const aaa, { bb } = B, [c] = C
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              const [c] = C, aaa, { bb } = B
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): does not sort properties if the right value depends on the left value`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'a',
-                  left: 'b',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            output: dedent`
-              const a,
-                    b,
-                    c;
-            `,
-            code: dedent`
-              const b,
-                    a,
-                    c;
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'aaa',
-                  right: 'bb',
-                },
-                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              const bb = 1,
-                    aaa = bb + 2,
-                    c = aaa + 3;
-            `,
-            code: dedent`
-              const aaa = bb + 2,
-                    bb = 1,
-                    c = aaa + 3;
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'b',
-                  right: 'a',
-                },
-                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              let a = 1,
-                  b = a + 2,
-                  c = b + 3;
-            `,
-            code: dedent`
-              let b = a + 2,
-                  a = 1,
-                  c = b + 3;
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'y',
-                  right: 'x',
-                },
-                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              var x = 10,
-                  y = x * 2,
-                  z = y + 5;
-            `,
-            code: dedent`
-              var y = x * 2,
-                  x = 10,
-                  z = y + 5;
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'sum',
-                  right: 'arr',
-                },
-                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              const arr = [1, 2, 3],
-                    sum = arr.reduce((acc, val) => acc + val, 0),
-                    avg = sum / arr.length;
-            `,
-            code: dedent`
-              const sum = arr.reduce((acc, val) => acc + val, 0),
-                    arr = [1, 2, 3],
-                    avg = sum / arr.length;
-            `,
-            options: [options],
-          },
-          {
-            errors: [
-              {
-                data: {
-                  nodeDependentOnRight: 'value',
-                  right: 'getValue',
-                },
-                messageId: 'unexpectedVariableDeclarationsDependencyOrder',
-              },
-            ],
-            output: dedent`
-              const getValue = () => 1,
-                    value = getValue(),
-                    result = value + 2;
-            `,
-            code: dedent`
-              const value = getValue(),
-                    getValue = () => 1,
-                    result = value + 2;
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              const bb = 1,
-                    aaa = bb + 2,
-                    c = aaa + 3
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              let a = 1,
-                  b = a + 2,
-                  c = b + 3,
-                  d = [a, b, c];
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              var x = 10,
-                  y = x * 2,
-                  z = y + 5 - x;
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              const arr = [1, 2, 3],
-                    sum = arr.reduce((acc, val) => acc + val, 0),
-                    avg = sum / arr.length;
-            `,
-            options: [options],
-          },
-          {
-            code: dedent`
-              const getValue = () => 1,
-                    value = getValue(),
-                    result = value + 2;
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): detects and ignores circular dependencies`,
-      rule,
-      {
-        invalid: [
-          {
-            output: dedent`
-              const a,
-                    b = f + 1,
-                    c,
-                    d = b + 1,
-                    e,
-                    f = d + 1
-            `,
-            code: dedent`
-              const a,
-                    c,
-                    b = f + 1,
-                    d = b + 1,
-                    e,
-                    f = d + 1
-            `,
-            errors: [
-              {
-                messageId: 'unexpectedVariableDeclarationsOrder',
-                data: { right: 'b', left: 'c' },
-              },
-            ],
-            options: [options],
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: sorts by custom alphabet`, () => {
-    let type = 'custom'
-
-    let alphabet = Alphabet.generateRecommendedAlphabet()
-      .sortByLocaleCompare('en-US')
-      .getCharacters()
-    let options = {
-      type: 'custom',
-      order: 'asc',
-      alphabet,
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts variables declarations`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              messageId: 'unexpectedVariableDeclarationsOrder',
-              data: { right: 'aaa', left: 'bb' },
-            },
-          ],
-          output: dedent`
-            const aaa, bb, c
-          `,
-          code: dedent`
-            const bb, aaa, c
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            const aaa, bb, c
-          `,
-          options: [options],
-        },
-      ],
-    })
-  })
-
-  describe(`${ruleName}: sorting by line length`, () => {
-    let type = 'line-length-order'
-
-    let options = {
-      type: 'line-length',
-      order: 'desc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): sorts variables declarations`, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              messageId: 'unexpectedVariableDeclarationsOrder',
-              data: { right: 'aaa', left: 'bb' },
-            },
-          ],
-          output: dedent`
-            const aaa, bb, c
-          `,
-          code: dedent`
-            const bb, aaa, c
-          `,
-          options: [options],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            const aaa, bb, c
-          `,
-          options: [options],
-        },
-      ],
-    })
-
-    ruleTester.run(
-      `${ruleName}(${type}): works with array and object declarations`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: '{ bb }',
-                  left: 'aaa',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            output: dedent`
-              const { bb } = B, [c] = C, aaa
-            `,
-            code: dedent`
-              const aaa, { bb } = B, [c] = C
-            `,
-            options: [options],
-          },
-        ],
-        valid: [
-          {
-            code: dedent`
-              const { bb } = B, [c] = C, aaa
-            `,
-            options: [options],
-          },
-        ],
-      },
-    )
-
-    ruleTester.run(
-      `${ruleName}(${type}): handles "fallbackSort" option`,
-      rule,
-      {
-        invalid: [
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'a',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                },
-              },
-            ],
-            output: dedent`
-              let
-                bb,
-                c,
-                a,
-            `,
-            code: dedent`
-              let
-                a,
-                bb,
-                c,
-            `,
-          },
-          {
-            errors: [
-              {
-                data: {
-                  right: 'bb',
-                  left: 'c',
-                },
-                messageId: 'unexpectedVariableDeclarationsOrder',
-              },
-            ],
-            options: [
-              {
-                ...options,
-                fallbackSort: {
-                  type: 'alphabetical',
-                  order: 'asc',
-                },
-              },
-            ],
-            output: dedent`
-              let
-                bb,
-                a,
-                c,
-            `,
-            code: dedent`
-              let
-                c,
-                bb,
-                a,
-            `,
-          },
-        ],
-        valid: [],
-      },
-    )
-  })
-
-  describe(`${ruleName}: unsorted type`, () => {
-    let type = 'unsorted'
-
-    let options = {
-      type: 'unsorted',
-      order: 'asc',
-    } as const
-
-    ruleTester.run(`${ruleName}(${type}): does not enforce sorting`, rule, {
-      valid: [
-        {
           code: dedent`
             let
-              b,
-              c,
               a,
+              b,
+              helloUninitialized,
           `,
-          options: [options],
-        },
-      ],
-      invalid: [],
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedUninitializedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedUninitializedByLineLength',
+                selector: 'uninitialized',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedUninitializedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          let
+            dddd,
+            ccc,
+            eee,
+            bb,
+            ff,
+            a,
+            g,
+            m = 'm',
+            o = 'o',
+            p = 'p',
+        `,
+        code: dedent`
+          let
+            a,
+            bb,
+            ccc,
+            dddd,
+            m = 'm',
+            eee,
+            ff,
+            g,
+            o = 'o',
+            p = 'p',
+        `,
+      })
     })
 
-    ruleTester.run(`${ruleName}(${type}): enforces newlines between`, rule, {
-      invalid: [
-        {
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            fooBar,
+            fooZar,
+        `,
+        code: dedent`
+          let
+            fooZar,
+            fooBar,
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedUninitialized',
+                selector: 'uninitialized',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedUninitialized', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedUninitialized',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            a,
+            d,
+            e,
+            c,
+            m = 'm',
+        `,
+        code: dedent`
+          let
+            b,
+            a,
+            d,
+            e,
+            m = 'm',
+            c,
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'uninitialized',
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'initialized',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            cFoo,
+            foo = 'foo',
+            a,
+        `,
+        code: dedent`
+          let
+            a,
+            cFoo,
+            foo = 'foo',
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          let
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+
+
+             y,
+            z,
+
+                b,
+          `,
+          output: dedent`
+            let
+              a,
+             b,
+            y,
+                z,
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+            {
+              data: {
+                right: 'y',
+                left: 'z',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'y',
+              },
+              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
           options: [
             {
               ...options,
@@ -2710,437 +1500,4566 @@ describe(ruleName, () => {
                   groupName: 'b',
                 },
               ],
-              newlinesBetween: 'always',
-              groups: ['b', 'a'],
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            let
+              a,
+
+             y,
+            z,
+
+                b,
+          `,
+          code: dedent`
+            let
+              a,
+
+
+             z,
+            y,
+                b,
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        output: dedent`
+          let
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e
+        `,
+        code: dedent`
+          let
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
             },
           ],
           errors: [
             {
               data: {
-                right: 'a',
-                left: 'b',
+                right: 'b',
+                left: 'a',
               },
               messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
             },
           ],
           output: dedent`
             let
-              b,
-
               a,
+
+
+              b,
           `,
           code: dedent`
             let
-              b,
               a,
+              b,
           `,
-        },
-      ],
-      valid: [],
-    })
+        })
+      },
+    )
 
-    ruleTester.run(`${ruleName}(${type}): enforces dependency sorting`, rule, {
-      invalid: [
-        {
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
           errors: [
             {
               data: {
-                nodeDependentOnRight: 'a',
                 right: 'b',
+                left: 'a',
               },
-              messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
             },
           ],
           output: dedent`
             let
-              b = 1,
-              a = b,
+              a,
+              b,
           `,
           code: dedent`
             let
-              a = b,
-              b = 1,
+              a,
+
+              b,
           `,
-          options: [options],
-        },
-      ],
-      valid: [],
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+
+              b,
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+              b,
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            a, // Comment after
+
+            b,
+            c
+        `,
+        code: dedent`
+          let
+            b,
+            a, // Comment after
+
+            c
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let
+              a,
+
+              // Partition comment
+
+              b,
+              c
+          `,
+          code: dedent`
+            let
+              a,
+
+              // Partition comment
+
+              c,
+              b
+          `,
+        })
+      },
+    )
+  })
+
+  describe('natural', () => {
+    let options = {
+      type: 'natural',
+      order: 'asc',
+    } as const
+
+    it('sorts variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const aaa, bb, c
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedVariableDeclarationsOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        output: dedent`
+          const aaa, bb, c
+        `,
+        code: dedent`
+          const bb, aaa, c
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles array and object destructuring in variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const [c] = C, aaa, { bb } = B
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '{ bb }',
+              right: '[c]',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const [c] = C, aaa, { bb } = B
+        `,
+        code: dedent`
+          const aaa, { bb } = B, [c] = C
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles dependencies between variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const bb = 1,
+                aaa = bb + 2,
+                c = aaa + 3
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = 1,
+              b = a + 2,
+              c = b + 3,
+              d = [a, b, c];
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          var x = 10,
+              y = x * 2,
+              z = y + 5 - x;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          const arr = [1, 2, 3],
+                sum = arr.reduce((acc, val) => acc + val, 0),
+                avg = sum / arr.length;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          const getValue = () => 1,
+                value = getValue(),
+                result = value + 2;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let position = editor.state.selection.$anchor,
+          depth = position.depth;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedVariableDeclarationsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          const a,
+                b,
+                c;
+        `,
+        code: dedent`
+          const b,
+                a,
+                c;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'bb',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const bb = 1,
+                aaa = bb + 2,
+                c = aaa + 3;
+        `,
+        code: dedent`
+          const aaa = bb + 2,
+                bb = 1,
+                c = aaa + 3;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let a = 1,
+              b = a + 2,
+              c = b + 3;
+        `,
+        code: dedent`
+          let b = a + 2,
+              a = 1,
+              c = b + 3;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'y',
+              right: 'x',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          var x = 10,
+              y = x * 2,
+              z = y + 5;
+        `,
+        code: dedent`
+          var y = x * 2,
+              x = 10,
+              z = y + 5;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'sum',
+              right: 'arr',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const arr = [1, 2, 3],
+                sum = arr.reduce((acc, val) => acc + val, 0),
+                avg = sum / arr.length;
+        `,
+        code: dedent`
+          const sum = arr.reduce((acc, val) => acc + val, 0),
+                arr = [1, 2, 3],
+                avg = sum / arr.length;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'value',
+              right: 'getValue',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const getValue = () => 1,
+                value = getValue(),
+                result = value + 2;
+        `,
+        code: dedent`
+          const value = getValue(),
+                getValue = () => 1,
+                result = value + 2;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const c = 10,
+                a = c,
+                b = 10;
+        `,
+        code: dedent`
+          const a = c,
+                b = 10,
+                c = 10;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = () => 1,
+          a = b();
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = function() { return 1 },
+          a = b();
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = () => 1,
+          a = a.map(b);
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object properties', async () => {
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = {x: b};
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = {[b]: 0};
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects chained member expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = b.x;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = new Subject(),
+          a = b.asObservable();
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chaining dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = b?.x;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects non-null assertion dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = b!;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects unary expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = true,
+          a = !b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects spread element dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = {b = 'b',};
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = [1]
+          a = [b = 'b',];
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = b ? 1 : 0;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = x ? b : 0;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = x ? 0 : b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in type assertions', async () => {
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = b as any;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = <any>b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literals', async () => {
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = \`\${b}\`
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores dependencies inside function bodies', async () => {
+      await valid({
+        code: dedent`
+          let a = () => b,
+          b = 1;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = function() { return b },
+          b = 1;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = () => {return b},
+          b = 1;
+        `,
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'variablesStartingWithA',
+                elementNamePattern: 'a',
+              },
+              {
+                groupName: 'variablesStartingWithB',
+                elementNamePattern: 'b',
+              },
+            ],
+            groups: ['variablesStartingWithA', 'variablesStartingWithB'],
+          },
+        ],
+        code: dedent`
+          let
+            b,
+            a = b,
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+        output: dedent`
+          let
+            a = 0,
+            // Part: 1
+            b = a,
+        `,
+        code: dedent`
+          let
+            b = a,
+            // Part: 1
+            a = 0,
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over newline partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          let
+            a = 0,
+
+            b = a,
+        `,
+        code: dedent`
+          let
+            b = a,
+
+            a = 0,
+        `,
+      })
+    })
+
+    it('sorts within newline-separated partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            a = 'A',
+            d = 'D',
+
+            c = 'C',
+
+            b = 'B',
+            e = 'E'
+        `,
+        code: dedent`
+          const
+            d = 'D',
+            a = 'A',
+
+            c = 'C',
+
+            e = 'E',
+            b = 'B'
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('sorts within comment-defined partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            // Part: A
+            // Not partition comment
+            bbb = 'BBB',
+            cc = 'CC',
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            e = 'E',
+            // Part: C
+            // Not partition comment
+            fff = 'FFF',
+            gg = 'GG'
+        `,
+        code: dedent`
+          const
+            // Part: A
+            cc = 'CC',
+            d = 'D',
+            // Not partition comment
+            bbb = 'BBB',
+            // Part: B
+            aaa = 'AAA',
+            e = 'E',
+            // Part: C
+            gg = 'GG',
+            // Not partition comment
+            fff = 'FFF'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition boundaries', async () => {
+      await valid({
+        code: dedent`
+          const
+            // Comment
+            bb = 'bb',
+            // Other comment
+            a = 'a'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          const
+            /* Partition Comment */
+            // Part: A
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            bb = 'BB',
+            c = 'C',
+            /* Other */
+            e = 'E'
+        `,
+        code: dedent`
+          const
+            /* Partition Comment */
+            // Part: A
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            c = 'C',
+            bb = 'BB',
+            /* Other */
+            e = 'E'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          const
+            e = 'e',
+            f = 'f',
+            // I am a partition comment because I don't have f o o
+            a = 'a',
+            b = 'b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are partition boundaries', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          const
+            /* Comment */
+            a: 'a',
+            b: 'b',
+        `,
+        code: dedent`
+          const
+            b: 'b',
+            /* Comment */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            // Comment
+            a: 'a',
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            c: 'c',
+            // b
+            b: 'b',
+            // a
+            a: 'a',
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            // I am a partition comment because I don't have f o o
+            a: 'a',
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are partition boundaries', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          const
+            // Comment
+            a: 'a',
+            b: 'b',
+        `,
+        code: dedent`
+          const
+            b: 'b',
+            // Comment
+            a: 'a',
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            /* Comment */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            c: 'c',
+            /* b */
+            b: 'b',
+            /* a */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            /* I am a partition comment because I don't have f o o */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          const
+            _a = 'a',
+            b = 'b',
+            _c = 'c'
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          const
+            ab = 'ab',
+            a_c = 'ac'
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          const
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline variable declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            a = 'a', b = 'b'
+        `,
+        code: dedent`
+          const
+            b = 'b', a = 'a'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            a = 'a', b = 'b',
+        `,
+        code: dedent`
+          const
+            b = 'b', a = 'a',
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces predefined group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'uninitialized',
+              rightGroup: 'initialized',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['initialized', 'uninitialized'],
+          },
+        ],
+        output: dedent`
+          let
+            b ='b',
+            a,
+        `,
+        code: dedent`
+          let
+            a,
+            b ='b',
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'uninitializedElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'uninitializedElements',
+                selector: 'uninitialized',
+              },
+            ],
+            groups: ['uninitializedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          let
+            a,
+            b = 'b',
+        `,
+        code: dedent`
+          let
+            b = 'b',
+            a,
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'uninitializedStartingWithHello',
+                  selector: 'uninitialized',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['uninitializedStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'uninitializedStartingWithHello',
+                right: 'helloUninitialized',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedVariableDeclarationsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let
+              helloUninitialized,
+              a,
+              b,
+          `,
+          code: dedent`
+            let
+              a,
+              b,
+              helloUninitialized,
+          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedUninitializedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedUninitializedByLineLength',
+                selector: 'uninitialized',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedUninitializedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          let
+            dddd,
+            ccc,
+            eee,
+            bb,
+            ff,
+            a,
+            g,
+            m = 'm',
+            o = 'o',
+            p = 'p',
+        `,
+        code: dedent`
+          let
+            a,
+            bb,
+            ccc,
+            dddd,
+            m = 'm',
+            eee,
+            ff,
+            g,
+            o = 'o',
+            p = 'p',
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            fooBar,
+            fooZar,
+        `,
+        code: dedent`
+          let
+            fooZar,
+            fooBar,
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedUninitialized',
+                selector: 'uninitialized',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedUninitialized', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedUninitialized',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            a,
+            d,
+            e,
+            c,
+            m = 'm',
+        `,
+        code: dedent`
+          let
+            b,
+            a,
+            d,
+            e,
+            m = 'm',
+            c,
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'uninitialized',
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'initialized',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            cFoo,
+            foo = 'foo',
+            a,
+        `,
+        code: dedent`
+          let
+            a,
+            cFoo,
+            foo = 'foo',
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          let
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+
+
+             y,
+            z,
+
+                b,
+          `,
+          output: dedent`
+            let
+              a,
+             b,
+            y,
+                z,
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'z',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+            {
+              data: {
+                right: 'y',
+                left: 'z',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+            {
+              data: {
+                right: 'b',
+                left: 'y',
+              },
+              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+                {
+                  elementNamePattern: 'b',
+                  groupName: 'b',
+                },
+              ],
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            let
+              a,
+
+             y,
+            z,
+
+                b,
+          `,
+          code: dedent`
+            let
+              a,
+
+
+             z,
+            y,
+                b,
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        output: dedent`
+          let
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e
+        `,
+        code: dedent`
+          let
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          output: dedent`
+            let
+              a,
+
+
+              b,
+          `,
+          code: dedent`
+            let
+              a,
+              b,
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          output: dedent`
+            let
+              a,
+              b,
+          `,
+          code: dedent`
+            let
+              a,
+
+              b,
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+
+              b,
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+              b,
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            a, // Comment after
+
+            b,
+            c
+        `,
+        code: dedent`
+          let
+            b,
+            a, // Comment after
+
+            c
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'a',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'c',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let
+              a,
+
+              // Partition comment
+
+              b,
+              c
+          `,
+          code: dedent`
+            let
+              a,
+
+              // Partition comment
+
+              c,
+              b
+          `,
+        })
+      },
+    )
+  })
+
+  describe('line-length', () => {
+    let options = {
+      type: 'line-length',
+      order: 'desc',
+    } as const
+
+    it('sorts variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const aaa, bb, c
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedVariableDeclarationsOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        output: dedent`
+          const aaa, bb, c
+        `,
+        code: dedent`
+          const bb, aaa, c
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles array and object destructuring in variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const { bb } = B, [c] = C, aaa
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: '{ bb }',
+              left: 'aaa',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const { bb } = B, [c] = C, aaa
+        `,
+        code: dedent`
+          const aaa, { bb } = B, [c] = C
+        `,
+        options: [options],
+      })
+    })
+
+    it('handles dependencies between variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const bb = 1,
+                aaa = bb + 2,
+                c = aaa + 3
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = 1,
+              b = a + 2,
+              c = b + 3,
+              d = [a, b, c];
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          var x = 10,
+              y = x * 2,
+              z = y + 5 - x;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          const arr = [1, 2, 3],
+                sum = arr.reduce((acc, val) => acc + val, 0),
+                avg = sum / arr.length;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          const getValue = () => 1,
+                value = getValue(),
+                result = value + 2;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let position = editor.state.selection.$anchor,
+          depth = position.depth;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedVariableDeclarationsOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        output: dedent`
+          const aaa,
+                bb,
+                c;
+        `,
+        code: dedent`
+          const bb,
+                aaa,
+                c;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'bb',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const bb = 1,
+                aaa = bb + 2,
+                c = aaa + 3;
+        `,
+        code: dedent`
+          const aaa = bb + 2,
+                bb = 1,
+                c = aaa + 3;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let a = 1,
+              b = a + 2,
+              c = b + 3;
+        `,
+        code: dedent`
+          let b = a + 2,
+              a = 1,
+              c = b + 3;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'y',
+              right: 'x',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          var x = 10,
+              y = x * 2,
+              z = y + 5;
+        `,
+        code: dedent`
+          var y = x * 2,
+              x = 10,
+              z = y + 5;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'sum',
+              right: 'arr',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const arr = [1, 2, 3],
+                sum = arr.reduce((acc, val) => acc + val, 0),
+                avg = sum / arr.length;
+        `,
+        code: dedent`
+          const sum = arr.reduce((acc, val) => acc + val, 0),
+                arr = [1, 2, 3],
+                avg = sum / arr.length;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'value',
+              right: 'getValue',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const getValue = () => 1,
+                value = getValue(),
+                result = value + 2;
+        `,
+        code: dedent`
+          const value = getValue(),
+                getValue = () => 1,
+                result = value + 2;
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'aaa',
+              right: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          const c = 10,
+                aaa = c,
+                bb = 10;
+        `,
+        code: dedent`
+          const aaa = c,
+                bb = 10,
+                c = 10;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects function expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = () => 1,
+          a = b();
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = function() { return 1 },
+          a = b();
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = () => 1,
+          a = a.map(b);
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in object properties', async () => {
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = {x: b};
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = {[b]: 0};
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects chained member expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = b.x;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = new Subject(),
+          a = b.asObservable();
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects optional chaining dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = b?.x;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects non-null assertion dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = 1,
+          a = b!;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects unary expression dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = true,
+          a = !b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects spread element dependencies', async () => {
+      await valid({
+        code: dedent`
+          let b = {x: 1},
+          a = {b = 'b',};
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = [1]
+          a = [b = 'b',];
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in conditional expressions', async () => {
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = b ? 1 : 0;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = x ? b : 0;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 0,
+          a = x ? 0 : b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in type assertions', async () => {
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = b as any;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = <any>b;
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in template literals', async () => {
+      await valid({
+        code: dedent`
+          let b = 'b',
+          a = \`\${b}\`
+        `,
+        options: [options],
+      })
+    })
+
+    it('ignores dependencies inside function bodies', async () => {
+      await valid({
+        code: dedent`
+          let a = () => b,
+          b = 1;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = function() { return b },
+          b = 1;
+        `,
+        options: [options],
+      })
+
+      await valid({
+        code: dedent`
+          let a = () => {return b},
+          b = 1;
+        `,
+        options: [options],
+      })
+    })
+
+    it('prioritizes dependencies over group configuration', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                groupName: 'variablesStartingWithA',
+                elementNamePattern: 'a',
+              },
+              {
+                groupName: 'variablesStartingWithB',
+                elementNamePattern: 'b',
+              },
+            ],
+            groups: ['variablesStartingWithA', 'variablesStartingWithB'],
+          },
+        ],
+        code: dedent`
+          let
+            b,
+            a = b,
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over partition comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+        output: dedent`
+          let
+            a = 0,
+            // Part: 1
+            b = a,
+        `,
+        code: dedent`
+          let
+            b = a,
+            // Part: 1
+            a = 0,
+        `,
+      })
+    })
+
+    it('prioritizes dependencies over newline partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'b',
+              right: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByNewLine: true,
+          },
+        ],
+        output: dedent`
+          let
+            a = 0,
+
+            b = a,
+        `,
+        code: dedent`
+          let
+            b = a,
+
+            a = 0,
+        `,
+      })
+    })
+
+    it('sorts within newline-separated partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'd',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'e',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            a = 'A',
+            d = 'D',
+
+            c = 'C',
+
+            b = 'B',
+            e = 'E'
+        `,
+        code: dedent`
+          const
+            d = 'D',
+            a = 'A',
+
+            c = 'C',
+
+            e = 'E',
+            b = 'B'
+        `,
+        options: [
+          {
+            partitionByNewLine: true,
+            type: 'alphabetical',
+          },
+        ],
+      })
+    })
+
+    it('sorts within comment-defined partitions', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'd',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'fff',
+              left: 'gg',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            // Part: A
+            // Not partition comment
+            bbb = 'BBB',
+            cc = 'CC',
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            e = 'E',
+            // Part: C
+            // Not partition comment
+            fff = 'FFF',
+            gg = 'GG'
+        `,
+        code: dedent`
+          const
+            // Part: A
+            cc = 'CC',
+            d = 'D',
+            // Not partition comment
+            bbb = 'BBB',
+            // Part: B
+            aaa = 'AAA',
+            e = 'E',
+            // Part: C
+            gg = 'GG',
+            // Not partition comment
+            fff = 'FFF'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: '^Part',
+          },
+        ],
+      })
+    })
+
+    it('treats all comments as partition boundaries', async () => {
+      await valid({
+        code: dedent`
+          const
+            // Comment
+            bb = 'bb',
+            // Other comment
+            a = 'a'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('supports multiple partition comment patterns', async () => {
+      await invalid({
+        output: dedent`
+          const
+            /* Partition Comment */
+            // Part: A
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            bb = 'BB',
+            c = 'C',
+            /* Other */
+            e = 'E'
+        `,
+        code: dedent`
+          const
+            /* Partition Comment */
+            // Part: A
+            d = 'D',
+            // Part: B
+            aaa = 'AAA',
+            c = 'C',
+            bb = 'BB',
+            /* Other */
+            e = 'E'
+        `,
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: ['Partition Comment', 'Part:', 'Other'],
+          },
+        ],
+      })
+    })
+
+    it('supports regex patterns for partition comments', async () => {
+      await valid({
+        code: dedent`
+          const
+            e = 'e',
+            f = 'f',
+            // I am a partition comment because I don't have f o o
+            a = 'a',
+            b = 'b'
+        `,
+        options: [
+          {
+            ...options,
+            partitionByComment: ['^(?!.*foo).*$'],
+          },
+        ],
+      })
+    })
+
+    it('ignores block comments when line comments are partition boundaries', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        output: dedent`
+          const
+            /* Comment */
+            aa: 'a',
+            b: 'b',
+        `,
+        code: dedent`
+          const
+            b: 'b',
+            /* Comment */
+            aa: 'a',
+        `,
+      })
+    })
+
+    it('uses line comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: true,
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            // Comment
+            a: 'a',
+        `,
+      })
+    })
+
+    it('matches specific line comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            c: 'c',
+            // b
+            b: 'b',
+            // a
+            a: 'a',
+        `,
+      })
+    })
+
+    it('supports regex patterns for line comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              line: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            // I am a partition comment because I don't have f o o
+            a: 'a',
+        `,
+      })
+    })
+
+    it('ignores line comments when block comments are partition boundaries', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        output: dedent`
+          const
+            // Comment
+            aa: 'a',
+            b: 'b',
+        `,
+        code: dedent`
+          const
+            b: 'b',
+            // Comment
+            aa: 'a',
+        `,
+      })
+    })
+
+    it('uses block comments as partition boundaries', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: true,
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            /* Comment */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('matches specific block comment patterns', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['a', 'b'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            c: 'c',
+            /* b */
+            b: 'b',
+            /* a */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('supports regex patterns for block comment partitions', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            partitionByComment: {
+              block: ['^(?!.*foo).*$'],
+            },
+          },
+        ],
+        code: dedent`
+          const
+            b: 'b',
+            /* I am a partition comment because I don't have f o o */
+            a: 'a',
+        `,
+      })
+    })
+
+    it('ignores special characters at start when trimming', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'trim',
+          },
+        ],
+        code: dedent`
+          const
+            _a = 'a',
+            bb = 'b',
+            _c = 'c'
+        `,
+      })
+    })
+
+    it('ignores special characters completely when removing', async () => {
+      await valid({
+        options: [
+          {
+            ...options,
+            specialCharacters: 'remove',
+          },
+        ],
+        code: dedent`
+          const
+            abc = 'ab',
+            a_c = 'ac'
+        `,
+      })
+    })
+
+    it('sorts elements according to locale-specific rules', async () => {
+      await valid({
+        code: dedent`
+          const
+            你好 = '你好',
+            世界 = '世界',
+            a = 'a',
+            A = 'A',
+            b = 'b',
+            B = 'B'
+        `,
+        options: [{ ...options, locales: 'zh-CN' }],
+      })
+    })
+
+    it('sorts inline variable declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            aa = 'a', b = 'b'
+        `,
+        code: dedent`
+          const
+            b = 'b', aa = 'a'
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'aa',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          const
+            aa = 'a', b = 'b',
+        `,
+        code: dedent`
+          const
+            b = 'b', aa = 'a',
+        `,
+        options: [options],
+      })
+    })
+
+    it('enforces predefined group ordering', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'uninitialized',
+              rightGroup: 'initialized',
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['initialized', 'uninitialized'],
+          },
+        ],
+        output: dedent`
+          let
+            b ='b',
+            a,
+        `,
+        code: dedent`
+          let
+            a,
+            b ='b',
+        `,
+      })
+    })
+
+    it('applies custom groups based on element selectors', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'uninitializedElements',
+              leftGroup: 'unknown',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'uninitializedElements',
+                selector: 'uninitialized',
+              },
+            ],
+            groups: ['uninitializedElements', 'unknown'],
+          },
+        ],
+        output: dedent`
+          let
+            a,
+            b = 'b',
+        `,
+        code: dedent`
+          let
+            b = 'b',
+            a,
+        `,
+      })
+    })
+
+    it.each([
+      ['string pattern', 'hello'],
+      ['array of patterns', ['noMatch', 'hello']],
+      ['case-insensitive regex', { pattern: 'HELLO', flags: 'i' }],
+      ['regex in array', ['noMatch', { pattern: 'HELLO', flags: 'i' }]],
+    ])(
+      'groups elements by name pattern - %s',
+      async (_, elementNamePattern) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'uninitializedStartingWithHello',
+                  selector: 'uninitialized',
+                  elementNamePattern,
+                },
+              ],
+              groups: ['uninitializedStartingWithHello', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'uninitializedStartingWithHello',
+                right: 'helloUninitialized',
+                leftGroup: 'unknown',
+                left: 'b',
+              },
+              messageId: 'unexpectedVariableDeclarationsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let
+              helloUninitialized,
+              a,
+              b,
+          `,
+          code: dedent`
+            let
+              a,
+              b,
+              helloUninitialized,
+          `,
+        })
+      },
+    )
+
+    it('overrides sort type and order for specific groups', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'ccc',
+              left: 'bb',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'dddd',
+              left: 'ccc',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              rightGroup: 'reversedUninitializedByLineLength',
+              leftGroup: 'unknown',
+              right: 'eee',
+              left: 'm',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'reversedUninitializedByLineLength',
+                selector: 'uninitialized',
+                type: 'line-length',
+                order: 'desc',
+              },
+            ],
+            groups: ['reversedUninitializedByLineLength', 'unknown'],
+            type: 'alphabetical',
+            order: 'asc',
+          },
+        ],
+        output: dedent`
+          let
+            dddd,
+            ccc,
+            eee,
+            bb,
+            ff,
+            a,
+            g,
+            m = 'm',
+            o = 'o',
+            p = 'p',
+        `,
+        code: dedent`
+          let
+            a,
+            bb,
+            ccc,
+            dddd,
+            m = 'm',
+            eee,
+            ff,
+            g,
+            o = 'o',
+            p = 'p',
+        `,
+      })
+    })
+
+    it('applies fallback sort when primary sort results in tie', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                fallbackSort: {
+                  type: 'alphabetical',
+                  order: 'asc',
+                },
+                elementNamePattern: '^foo',
+                type: 'line-length',
+                groupName: 'foo',
+                order: 'desc',
+              },
+            ],
+            type: 'alphabetical',
+            groups: ['foo'],
+            order: 'asc',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'fooBar',
+              left: 'fooZar',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            fooBar,
+            fooZar,
+        `,
+        code: dedent`
+          let
+            fooZar,
+            fooBar,
+        `,
+      })
+    })
+
+    it('preserves original order for unsorted groups', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'unsortedUninitialized',
+                selector: 'uninitialized',
+                type: 'unsorted',
+              },
+            ],
+            groups: ['unsortedUninitialized', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unsortedUninitialized',
+              leftGroup: 'unknown',
+              right: 'c',
+              left: 'm',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            a,
+            d,
+            e,
+            c,
+            m = 'm',
+        `,
+        code: dedent`
+          let
+            b,
+            a,
+            d,
+            e,
+            m = 'm',
+            c,
+        `,
+      })
+    })
+
+    it('combines multiple selectors with anyOf', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                anyOf: [
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'uninitialized',
+                  },
+                  {
+                    elementNamePattern: 'foo|Foo',
+                    selector: 'initialized',
+                  },
+                ],
+                groupName: 'elementsIncludingFoo',
+              },
+            ],
+            groups: ['elementsIncludingFoo', 'unknown'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'elementsIncludingFoo',
+              leftGroup: 'unknown',
+              right: 'cFoo',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            cFoo,
+            foo = 'foo',
+            a,
+        `,
+        code: dedent`
+          let
+            a,
+            cFoo,
+            foo = 'foo',
+        `,
+      })
+    })
+
+    it('supports negative regex patterns in custom groups', async () => {
+      await valid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '^(?!.*Foo).*$',
+                groupName: 'elementsWithoutFoo',
+              },
+            ],
+            groups: ['unknown', 'elementsWithoutFoo'],
+            type: 'alphabetical',
+          },
+        ],
+        code: dedent`
+          let
+            iHaveFooInMyName,
+            meTooIHaveFoo,
+            a,
+            b,
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'removes newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'yy',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'z',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              newlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              aaaa,
+
+
+             yy,
+            z,
+
+                bbb,
+          `,
+          output: dedent`
+            let
+              aaaa,
+             bbb,
+            yy,
+                z,
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['always', 'always' as const],
+      ['1', 1 as const],
+    ])(
+      'adds newlines between groups when newlinesBetween is %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                left: 'aaaa',
+                right: 'z',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+            {
+              data: {
+                right: 'yy',
+                left: 'z',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+            {
+              data: {
+                right: 'bbb',
+                left: 'yy',
+              },
+              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaaa',
+                  groupName: 'a',
+                },
+                {
+                  elementNamePattern: 'bbb',
+                  groupName: 'b',
+                },
+              ],
+              groups: ['a', 'unknown', 'b'],
+              newlinesBetween,
+            },
+          ],
+          output: dedent`
+            let
+              aaaa,
+
+             yy,
+            z,
+
+                bbb,
+          `,
+          code: dedent`
+            let
+              aaaa,
+
+
+             z,
+            yy,
+                bbb,
+          `,
+        })
+      },
+    )
+
+    it('applies inline newline settings between specific groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              { elementNamePattern: 'a', groupName: 'a' },
+              { elementNamePattern: 'b', groupName: 'b' },
+              { elementNamePattern: 'c', groupName: 'c' },
+              { elementNamePattern: 'd', groupName: 'd' },
+              { elementNamePattern: 'e', groupName: 'e' },
+            ],
+            groups: [
+              'a',
+              { newlinesBetween: 'always' },
+              'b',
+              { newlinesBetween: 'always' },
+              'c',
+              { newlinesBetween: 'never' },
+              'd',
+              { newlinesBetween: 'ignore' },
+              'e',
+            ],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        output: dedent`
+          let
+            a,
+
+            b,
+
+            c,
+            d,
+
+
+            e
+        `,
+        code: dedent`
+          let
+            a,
+            b,
+
+
+            c,
+
+            d,
+
+
+            e
+        `,
+      })
+    })
+
+    it.each([
+      [2, 'never' as const],
+      [2, 0 as const],
+      [2, 'ignore' as const],
+      ['never' as const, 2],
+      [0 as const, 2],
+      ['ignore' as const, 2],
+    ])(
+      'enforces 2 newlines when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          output: dedent`
+            let
+              a,
+
+
+              b,
+          `,
+          code: dedent`
+            let
+              a,
+              b,
+          `,
+        })
+      },
+    )
+
+    it.each([
+      'always' as const,
+      2 as const,
+      'ignore' as const,
+      'never' as const,
+      0 as const,
+    ])(
+      'removes newlines when "never" overrides global %s between specific groups',
+      async globalNewlinesBetween => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { elementNamePattern: 'c', groupName: 'c' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                { newlinesBetween: 'never' },
+                'unusedGroup',
+                { newlinesBetween: 'never' },
+                'b',
+                { newlinesBetween: 'always' },
+                'c',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            },
+          ],
+          output: dedent`
+            let
+              a,
+              b,
+          `,
+          code: dedent`
+            let
+              a,
+
+              b,
+          `,
+        })
+      },
+    )
+
+    it.each([
+      ['ignore' as const, 'never' as const],
+      ['ignore' as const, 0 as const],
+      ['never' as const, 'ignore' as const],
+      [0 as const, 'ignore' as const],
+    ])(
+      'accepts any spacing when global is %s and group is %s',
+      async (globalNewlinesBetween, groupNewlinesBetween) => {
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+
+              b,
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                { elementNamePattern: 'a', groupName: 'a' },
+                { elementNamePattern: 'b', groupName: 'b' },
+                { groupName: 'unusedGroup', elementNamePattern: 'X' },
+              ],
+              groups: [
+                'a',
+                'unusedGroup',
+                { newlinesBetween: groupNewlinesBetween },
+                'b',
+              ],
+              newlinesBetween: globalNewlinesBetween,
+            },
+          ],
+          code: dedent`
+            let
+              a,
+              b,
+          `,
+        })
+      },
+    )
+
+    it('preserves inline comments when reordering elements', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: 'b|c',
+                groupName: 'b|c',
+              },
+            ],
+            groups: ['unknown', 'b|c'],
+            newlinesBetween: 'always',
+          },
+        ],
+        errors: [
+          {
+            data: {
+              rightGroup: 'unknown',
+              leftGroup: 'b|c',
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsGroupOrder',
+          },
+        ],
+        output: dedent`
+          let
+            a, // Comment after
+
+            b,
+            c
+        `,
+        code: dedent`
+          let
+            b,
+            a, // Comment after
+
+            c
+        `,
+      })
+    })
+
+    it.each([
+      ['never', 'never' as const],
+      ['0', 0 as const],
+    ])(
+      'preserves partition boundaries regardless of newlinesBetween %s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  elementNamePattern: 'aaa',
+                  groupName: 'a',
+                },
+              ],
+              groups: ['a', 'unknown'],
+              partitionByComment: true,
+              newlinesBetween,
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'bb',
+                left: 'c',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let
+              aaa,
+
+              // Partition comment
+
+              bb,
+              c
+          `,
+          code: dedent`
+            let
+              aaa,
+
+              // Partition comment
+
+              c,
+              bb
+          `,
+        })
+      },
+    )
+  })
+
+  describe('custom', () => {
+    let alphabet = Alphabet.generateRecommendedAlphabet()
+      .sortByLocaleCompare('en-US')
+      .getCharacters()
+
+    let options = {
+      type: 'custom',
+      order: 'asc',
+      alphabet,
+    } as const
+
+    it('sorts variable declarations', async () => {
+      await valid({
+        code: dedent`
+          const aaa, bb, c
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedVariableDeclarationsOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        output: dedent`
+          const aaa, bb, c
+        `,
+        code: dedent`
+          const bb, aaa, c
+        `,
+        options: [options],
+      })
     })
   })
 
-  describe(`${ruleName}: misc`, () => {
+  describe('unsorted', () => {
+    let options = {
+      type: 'unsorted',
+      order: 'asc',
+    } as const
+
+    it('does not require specific order without sorting', async () => {
+      await valid({
+        code: dedent`
+          let
+            b,
+            c,
+            a,
+        `,
+        options: [options],
+      })
+    })
+
+    it('adds required newlines between groups', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            newlinesBetween: 'always',
+            groups: ['b', 'a'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+
+            a,
+        `,
+        code: dedent`
+          let
+            b,
+            a,
+        `,
+      })
+    })
+
+    it('enforces dependency order between declarations', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              nodeDependentOnRight: 'a',
+              right: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsDependencyOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b = 1,
+            a = b,
+        `,
+        code: dedent`
+          let
+            a = b,
+            b = 1,
+        `,
+        options: [options],
+      })
+    })
+  })
+
+  describe('misc', () => {
     it('validates the JSON schema', async () => {
       await expect(
         validateRuleJsonSchema(rule.meta.schema),
       ).resolves.not.toThrow()
     })
 
-    let eslintDisableRuleTesterName = `${ruleName}: supports 'eslint-disable' for individual nodes`
-    ruleTester.run(eslintDisableRuleTesterName, rule, {
-      invalid: [
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              // eslint-disable-next-line
-              a
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              // eslint-disable-next-line
-              a
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'd',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              // eslint-disable-next-line
-              a,
-              d
-          `,
-          code: dedent`
-            let
-              d,
-              c,
-              // eslint-disable-next-line
-              a,
-              b
-          `,
-          options: [
-            {
-              partitionByComment: true,
-            },
-          ],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b = a,
-              c,
-              // eslint-disable-next-line
-              a
-          `,
-          code: dedent`
-            let
-              c,
-              b = a,
-              // eslint-disable-next-line
-              a
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              a // eslint-disable-line
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              a // eslint-disable-line
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              /* eslint-disable-next-line */
-              a
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              /* eslint-disable-next-line */
-              a
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              a /* eslint-disable-line */
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              a /* eslint-disable-line */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let
-              a,
-              d,
-              /* eslint-disable */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              e
-          `,
-          code: dedent`
-            let
-              d,
-              e,
-              /* eslint-disable */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              a
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              // eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName}
-              a
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              a // eslint-disable-line @rule-tester/${eslintDisableRuleTesterName}
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              /* eslint-disable-next-line @rule-tester/${eslintDisableRuleTesterName} */
-              a
-          `,
-          options: [{}],
-        },
-        {
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          output: dedent`
-            let
-              b,
-              c,
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          code: dedent`
-            let
-              c,
-              b,
-              a /* eslint-disable-line @rule-tester/${eslintDisableRuleTesterName} */
-          `,
-          options: [{}],
-        },
-        {
-          output: dedent`
-            let
-              a,
-              d,
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              e
-          `,
-          code: dedent`
-            let
-              d,
-              e,
-              /* eslint-disable @rule-tester/${eslintDisableRuleTesterName} */
-              c,
-              b,
-              // Shouldn't move
-              /* eslint-enable */
-              a
-          `,
-          errors: [
-            {
-              data: {
-                right: 'a',
-                left: 'b',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-          ],
-          options: [{}],
-        },
-      ],
-      valid: [
-        {
-          code: dedent`
-            let
-              b,
-              c,
-              // eslint-disable-next-line
-              a
-          `,
-        },
-      ],
-    })
+    it('ignores variables with eslint-disable-next-line comments', async () => {
+      await valid({
+        code: dedent`
+          let
+            b,
+            c,
+            // eslint-disable-next-line
+            a
+        `,
+      })
 
-    eslintRuleTester.run(
-      `${ruleName}: handles non typescript-eslint parser`,
-      rule as unknown as Rule.RuleModule,
-      {
-        valid: [
+      await invalid({
+        errors: [
           {
-            code: dedent`
-              const b = 1,
-                    a = b + 2,
-                    c = a + 3;
-            `,
-            options: [{}],
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
           },
         ],
-        invalid: [],
-      },
-    )
+        output: dedent`
+          let
+            b,
+            c,
+            // eslint-disable-next-line
+            a
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            // eslint-disable-next-line
+            a
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles partitioned comments with eslint-disable', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'd',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            // eslint-disable-next-line
+            a,
+            d
+        `,
+        code: dedent`
+          let
+            d,
+            c,
+            // eslint-disable-next-line
+            a,
+            b
+        `,
+        options: [
+          {
+            partitionByComment: true,
+          },
+        ],
+      })
+    })
+
+    it('handles dependencies with eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b = a,
+            c,
+            // eslint-disable-next-line
+            a
+        `,
+        code: dedent`
+          let
+            c,
+            b = a,
+            // eslint-disable-next-line
+            a
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles inline eslint-disable-line comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            a // eslint-disable-line
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            a // eslint-disable-line
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles block eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            /* eslint-disable-next-line */
+            a
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            /* eslint-disable-next-line */
+            a
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            a /* eslint-disable-line */
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            a /* eslint-disable-line */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects eslint-disable/enable block boundaries', async () => {
+      await invalid({
+        output: dedent`
+          let
+            a,
+            d,
+            /* eslint-disable */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            e
+        `,
+        code: dedent`
+          let
+            d,
+            e,
+            /* eslint-disable */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            a
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            // eslint-disable-next-line rule-to-test/sort-variable-declarations
+            a
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            // eslint-disable-next-line rule-to-test/sort-variable-declarations
+            a
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            a // eslint-disable-line rule-to-test/sort-variable-declarations
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            a // eslint-disable-line rule-to-test/sort-variable-declarations
+        `,
+        options: [{}],
+      })
+    })
+
+    it('handles rule-specific block eslint-disable comments', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            /* eslint-disable-next-line rule-to-test/sort-variable-declarations */
+            a
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            /* eslint-disable-next-line rule-to-test/sort-variable-declarations */
+            a
+        `,
+        options: [{}],
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            b,
+            c,
+            a /* eslint-disable-line rule-to-test/sort-variable-declarations */
+        `,
+        code: dedent`
+          let
+            c,
+            b,
+            a /* eslint-disable-line rule-to-test/sort-variable-declarations */
+        `,
+        options: [{}],
+      })
+    })
+
+    it('respects rule-specific eslint-disable/enable blocks', async () => {
+      await invalid({
+        output: dedent`
+          let
+            a,
+            d,
+            /* eslint-disable rule-to-test/sort-variable-declarations */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            e
+        `,
+        code: dedent`
+          let
+            d,
+            e,
+            /* eslint-disable rule-to-test/sort-variable-declarations */
+            c,
+            b,
+            // Shouldn't move
+            /* eslint-enable */
+            a
+        `,
+        errors: [
+          {
+            data: {
+              right: 'a',
+              left: 'b',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        options: [{}],
+      })
+    })
   })
 })


### PR DESCRIPTION
### Description

I think we should switch to the [ESLint Vitest Rule Tester](https://github.com/antfu/eslint-vitest-rule-tester).

What are the benefits we will get:

1. The test code will become visually cleaner and nicer.
2. It will become more convenient to group tests using `it`, `describe`.
3. It will be possible to use hooks (`beforeEach`, `beforeAll`, `afterEach`, `afterAll`).
4. Easier to debug. When a test crashes, you can see at once which one has crashed.
5. You can run a separate `it.only` test or skip the `it.skip` test.
6. It becomes possible to use new Vitest features, such as snapshots.
7. I am a big fan of Wallaby. And it doesn't work well with ESLint Rule Tester, but it works perfectly with Vitest.

Current progress:

- [x] [sort-array-includes](https://perfectionist.dev/rules/sort-array-includes)
- [x] [sort-classes](https://perfectionist.dev/rules/sort-classes)
- [x] [sort-decorators](https://perfectionist.dev/rules/sort-decorators)
- [x] [sort-enums](https://perfectionist.dev/rules/sort-enums)
- [x] [sort-heritage-clauses](https://perfectionist.dev/rules/sort-heritage-clauses)
- [x] [sort-imports](https://perfectionist.dev/rules/sort-imports)
- [x] [sort-exports](https://perfectionist.dev/rules/sort-exports)
- [x] [sort-interfaces](https://perfectionist.dev/rules/sort-interfaces)
- [x] [sort-intersection-types](https://perfectionist.dev/rules/sort-intersection-types)
- [x] [sort-jsx-props](https://perfectionist.dev/rules/sort-jsx-props)
- [x] [sort-maps](https://perfectionist.dev/rules/sort-maps)
- [x] [sort-modules](https://perfectionist.dev/rules/sort-modules)
- [x] [sort-named-exports](https://perfectionist.dev/rules/sort-named-exports)
- [x] [sort-named-imports](https://perfectionist.dev/rules/sort-named-imports)
- [x] [sort-object-types](https://perfectionist.dev/rules/sort-object-types)
- [x] [sort-objects](https://perfectionist.dev/rules/sort-objects)
- [x] [sort-sets](https://perfectionist.dev/rules/sort-sets)
- [x] [sort-switch-case](https://perfectionist.dev/rules/sort-switch-case)
- [x] [sort-union-types](https://perfectionist.dev/rules/sort-union-types)
- [x] [sort-variable-declarations](https://perfectionist.dev/rules/sort-variable-declarations)

### Additional context

Additionally, I plan to improve the test descriptions.

But all existing tests will remain available, nothing will be removed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to enhance testing capabilities.

* **Tests**
  * Improved type assertions in tests for better type compatibility verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->