### PR TITLE
fix(sort-objects): fix complex call expressions being ignored in `callingFunctionNamePattern`

### DIFF
--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -99,6 +99,7 @@ export default createEslintRule<Options, MessageId>({
       let objectParent = getObjectParent({
         onlyFirstParent: true,
         node: nodeObject,
+        sourceCode,
       })
       let matchedContextOptions = getMatchingContextOptions({
         nodeNames: nodeObject.properties
@@ -146,6 +147,7 @@ export default createEslintRule<Options, MessageId>({
       let objectParentForIgnorePattern = getObjectParent({
         onlyFirstParent: false,
         node: nodeObject,
+        sourceCode,
       })
       if (
         objectParentForIgnorePattern?.name &&
@@ -538,15 +540,20 @@ function getVariableParentName({
 
 function getObjectParent({
   onlyFirstParent,
+  sourceCode,
   node,
 }: {
   node: TSESTree.ObjectExpression | TSESTree.ObjectPattern
+  sourceCode: TSESLint.SourceCode
   onlyFirstParent: boolean
 }): {
   type: 'VariableDeclarator' | 'CallExpression'
   name: string
 } | null {
-  let variableParentName = getVariableParentName({ onlyFirstParent, node })
+  let variableParentName = getVariableParentName({
+    onlyFirstParent,
+    node,
+  })
   if (variableParentName) {
     return {
       type: 'VariableDeclarator',
@@ -555,6 +562,7 @@ function getObjectParent({
   }
   let callParentName = getCallExpressionParentName({
     onlyFirstParent,
+    sourceCode,
     node,
   })
   if (callParentName) {
@@ -590,9 +598,11 @@ function isStyledComponents(styledNode: TSESTree.Node): boolean {
 
 function getCallExpressionParentName({
   onlyFirstParent,
+  sourceCode,
   node,
 }: {
   node: TSESTree.ObjectExpression | TSESTree.ObjectPattern
+  sourceCode: TSESLint.SourceCode
   onlyFirstParent: boolean
 }): string | null {
   let callParent = getFirstNodeParentWithType({
@@ -604,7 +614,7 @@ function getCallExpressionParentName({
     return null
   }
 
-  return callParent.callee.type === 'Identifier' ? callParent.callee.name : null
+  return sourceCode.getText(callParent.callee)
 }
 
 function getNodeName({

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -40,6 +40,7 @@ import { sortNodesByDependencies } from '../utils/sort-nodes-by-dependencies'
 import { getEslintDisabledLines } from '../utils/get-eslint-disabled-lines'
 import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { doesCustomGroupMatch } from '../utils/does-custom-group-match'
+import { UnreachableCaseError } from '../utils/unreachable-case-error'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { reportAllErrors } from '../utils/report-all-errors'
@@ -520,13 +521,16 @@ function getVariableParentName({
     return null
   }
   let parentId
-  if (variableParent.type === 'VariableDeclarator') {
-    parentId = variableParent.id
-  } else if ('key' in variableParent) {
-    parentId = variableParent.key
-    /* v8 ignore next 3 - Unsure if we can reach it */
-  } else {
-    return null
+  switch (variableParent.type) {
+    case TSESTree.AST_NODE_TYPES.VariableDeclarator:
+      parentId = variableParent.id
+      break
+    case TSESTree.AST_NODE_TYPES.Property:
+      parentId = variableParent.key
+      break
+    /* v8 ignore next 2 */
+    default:
+      throw new UnreachableCaseError(variableParent)
   }
 
   return parentId.type === 'Identifier' ? parentId.name : null

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -2325,6 +2325,21 @@ describe('sort-objects', () => {
           })
         `,
       })
+
+      await valid({
+        options: [
+          {
+            ...options,
+            useConfigurationIf: {
+              callingFunctionNamePattern: '^Schema.index$',
+            },
+            type: 'unsorted',
+          },
+        ],
+        code: dedent`
+          Schema.index({ b: 1, a: 1 });
+        `,
+      })
     })
 
     it('filters custom groups by selector and modifiers', async () => {


### PR DESCRIPTION
- Fixes #562.

### Description

In `sort-objects`, `useConfigurationIf.callingFunctionNamePattern` doesn't work with calls such as `a.b`.

### What is the purpose of this pull request?

- [x] Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved object parent detection and name resolution for calls, enabling reliable matching of complex callees (e.g., Schema.index) in callingFunctionNamePattern.
  - Broader support for callee shapes increases accuracy of conditional configuration application.

- Bug Fixes
  - Eliminated silent fallbacks with stricter handling of unexpected AST shapes, improving rule robustness.

- Tests
  - Added coverage for conditional configuration when matching Schema.index, ensuring valid behavior under callingFunctionNamePattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->