### PR TITLE
feat(sort-imports)!: drop deprecated `tsconfigRootDir` support

### DIFF
--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -282,18 +282,6 @@ This option is only available when the type is set to `'line-length'`.
 
 If this option is not set, the rule will not search for a `tsconfig.json` file.
 
-### [DEPRECATED] tsconfigRootDir
-
-<sub>default: `undefined`</sub>
-
-Use the [tsconfig](#tsconfig) option with the `rootDir` attribute.
-
-Specifies the  directory of the root `tsconfig.json` file (ex: `.`). This is used in [`groups`](#groups) for:
-- Marking aliased imports as `internal`.
-- Marking imports matching [tsconfig paths](https://www.typescriptlang.org/tsconfig/#paths) as `tsconfig-path`.
-
-If this option is not set, the rule will not search for a `tsconfig.json` file.
-
 ### groups
 
 <sub>
@@ -335,7 +323,7 @@ The list of selectors is sorted from most to least important:
 - `'side-effect-style'` — Side effect style imports.
 - `'side-effect'` — Side effect imports.
 - `'style'` — Styles.
-- `'tsconfig-path'` — `tsconfig` [paths](https://www.typescriptlang.org/tsconfig/#paths) alias imports. Requires [`tsconfigRootDir`](#tsconfigrootdir) to be set.
+- `'tsconfig-path'` — `tsconfig` [paths](https://www.typescriptlang.org/tsconfig/#paths) alias imports. Requires [`tsconfig.rootDir`](#tsconfig) to be set.
 - `'index'` — Main file from the current directory.
 - `'sibling'` — Modules from the same directory.
 - `'parent'` — Modules from the parent directory.

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -69,10 +69,8 @@ export type MessageId =
   | 'missedCommentAboveImport'
   | 'unexpectedImportsOrder'
 
-let defaultOptions: Required<
-  Omit<Options[0], 'tsconfigRootDir' | 'maxLineLength' | 'tsconfig'>
-> &
-  Pick<Options[0], 'tsconfigRootDir' | 'maxLineLength' | 'tsconfig'> = {
+let defaultOptions: Required<Omit<Options[0], 'maxLineLength' | 'tsconfig'>> &
+  Pick<Options[0], 'maxLineLength' | 'tsconfig'> = {
   groups: [
     'type-import',
     ['value-builtin', 'value-external'],
@@ -125,8 +123,7 @@ export default createEslintRule<Options, MessageId>({
     validateNewlinesAndPartitionConfiguration(options)
     validateSideEffectsConfiguration(options)
 
-    let tsconfigRootDirectory =
-      options.tsconfig?.rootDir ?? options.tsconfigRootDir
+    let tsconfigRootDirectory = options.tsconfig?.rootDir
     let tsConfigOutput = tsconfigRootDirectory
       ? readClosestTsConfigByPath({
           tsconfigFilename: options.tsconfig?.filename ?? 'tsconfig.json',
@@ -497,10 +494,6 @@ export default createEslintRule<Options, MessageId>({
             enum: ['node', 'bun'],
             type: 'string',
           },
-          tsconfigRootDir: {
-            description: 'Specifies the tsConfig root directory.',
-            type: 'string',
-          },
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
           newlinesBetween: newlinesBetweenJsonSchema,
@@ -579,7 +572,7 @@ function computeGroupExceptUnknown({
 }: {
   options: Omit<
     Required<Options[0]>,
-    'tsconfigRootDir' | 'maxLineLength' | 'customGroups' | 'tsconfig'
+    'maxLineLength' | 'customGroups' | 'tsconfig'
   >
   customGroups: DeprecatedCustomGroupsOption | CustomGroupsOption | undefined
   selectors?: Selector[]

--- a/rules/sort-imports/types.ts
+++ b/rules/sort-imports/types.ts
@@ -78,12 +78,6 @@ export type Options = Partial<{
   newlinesBetween: NewlinesBetweenOption
 
   /**
-   * @deprecated Since v4.14.0. Will be removed in v5.0.0. Use
-   *   {@link tsconfig.rootDir} instead.
-   */
-  tsconfigRootDir: undefined | string
-
-  /**
    * Maximum line length for imports. When exceeded, import names are used for
    * sorting instead of the entire line.
    */

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -2553,7 +2553,7 @@ describe('sort-imports', () => {
                 'tsconfig-path',
               ],
             ],
-            tsconfigRootDir: '.',
+            tsconfig: { rootDir: '.' },
           },
         ],
         output: dedent`
@@ -6375,7 +6375,7 @@ describe('sort-imports', () => {
                 'tsconfig-path',
               ],
             ],
-            tsconfigRootDir: '.',
+            tsconfig: { rootDir: '.' },
           },
         ],
         output: dedent`
@@ -10138,7 +10138,7 @@ describe('sort-imports', () => {
                 'tsconfig-path',
               ],
             ],
-            tsconfigRootDir: '.',
+            tsconfig: { rootDir: '.' },
           },
         ],
         output: dedent`
@@ -12027,7 +12027,7 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['internal', 'unknown'],
-            tsconfigRootDir: '.',
+            tsconfig: { rootDir: '.' },
           },
         ],
         before: () => {
@@ -12051,7 +12051,7 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['external', 'unknown'],
-            tsconfigRootDir: '.',
+            tsconfig: { rootDir: '.' },
           },
         ],
         code: dedent`
@@ -12075,7 +12075,7 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['external', 'unknown'],
-            tsconfigRootDir: '.',
+            tsconfig: { rootDir: '.' },
           },
         ],
         before: () => {
@@ -12105,7 +12105,7 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['external', 'unknown'],
-            tsconfigRootDir: '.',
+            tsconfig: { rootDir: '.' },
           },
         ],
         code: dedent`


### PR DESCRIPTION
## Description

The `tsconfigRootDir` option has been replaced with the `tsconfig` object option, which also includes an optional `filename` attribute.

## What is the purpose of this pull request?

- [x] Other