### PR TITLE
feat(sort-enums)!: replace `forceNumericSort` and update default `sortByValue` option

### DIFF
--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -176,7 +176,7 @@ Controls whether sorting should be done using the enum's values or names.
 
 - `true` — Use enum values.
 - `false` — Use enum names.
-- `ifNumericEnum` — Use enum values only if the enum is numeric.
+- `'ifNumericEnum'` — Use enum values only if the enum is numeric.
 
 When this setting is `true`, numeric enums will have their values sorted numerically regardless of the `type` setting.
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -176,17 +176,9 @@ Controls whether sorting should be done using the enum's values or names.
 
 - `true` — Use enum values.
 - `false` — Use enum names.
+- `ifNumericEnum` — Use enum values only if the enum is numeric.
 
 When this setting is `true`, numeric enums will have their values sorted numerically regardless of the `type` setting.
-
-### forceNumericSort
-
-<sub>default: `false`</sub>
-
-Controls whether numeric enums should always be sorted numerically, regardless of the `type` and `sortByValue` settings.
-
-- `true` — Use enum values.
-- `false` — Use enum names.
 
 ### partitionByComment
 
@@ -361,7 +353,6 @@ Custom groups have a higher priority than any predefined group.
                   partitionByNewLine: false,
                   newlinesBetween: 'ignore',
                   sortByValue: false,
-                  forceNumericSort: false,
                   groups: [],
                   customGroups: [],
                 },
@@ -393,7 +384,6 @@ Custom groups have a higher priority than any predefined group.
                 partitionByNewLine: false,
                 newlinesBetween: 'ignore',
                 sortByValue: false,
-                forceNumericSort: false,
                 groups: [],
                 customGroups: [],
               },

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -170,7 +170,7 @@ Specifies the sorting locales. Refer To [String.prototype.localeCompare() - loca
 
 ### sortByValue
 
-<sub>default: `false`</sub>
+<sub>default: `'ifNumericEnum'`</sub>
 
 Controls whether sorting should be done using the enum's values or names.
 
@@ -352,7 +352,7 @@ Custom groups have a higher priority than any predefined group.
                   partitionByComment: false,
                   partitionByNewLine: false,
                   newlinesBetween: 'ignore',
-                  sortByValue: false,
+                  sortByValue: "ifNumericEnum",
                   groups: [],
                   customGroups: [],
                 },
@@ -383,7 +383,7 @@ Custom groups have a higher priority than any predefined group.
                 partitionByComment: false,
                 partitionByNewLine: false,
                 newlinesBetween: 'ignore',
-                sortByValue: false,
+                sortByValue: "ifNumericEnum",
                 groups: [],
                 customGroups: [],
               },

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -174,8 +174,8 @@ Specifies the sorting locales. Refer To [String.prototype.localeCompare() - loca
 
 Controls whether sorting should be done using the enum's values or names.
 
-- `true` — Use enum values.
-- `false` — Use enum names.
+- `'always'` — Use enum values.
+- `'never'` — Use enum names.
 - `'ifNumericEnum'` — Use enum values only if the enum is numeric.
 
 When this setting is `true`, numeric enums will have their values sorted numerically regardless of the `type` setting.

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -261,16 +261,9 @@ export default createEslintRule<Options, MessageId>({
         properties: {
           ...commonJsonSchemas,
           sortByValue: {
-            oneOf: [
-              {
-                type: 'boolean',
-              },
-              {
-                enum: ['ifNumericEnum'],
-                type: 'string',
-              },
-            ],
             description: 'Specifies whether to sort enums by value.',
+            enum: ['always', 'ifNumericEnum', 'never'],
+            type: 'string',
           },
           customGroups: buildCustomGroupsArrayJsonSchema({
             singleCustomGroupJsonSchema,
@@ -355,10 +348,10 @@ function computeNodeValueGetter({
         return null
       }
       break
-    case false:
-      return null
-    case true:
+    case 'always':
       break
+    case 'never':
+      return null
     /* v8 ignore next 2 */
     default:
       throw new UnreachableCaseError(options.sortByValue)
@@ -426,7 +419,7 @@ function computeOptionType({
   if (!isNumericEnum) {
     return options.type
   }
-  if (!options.sortByValue) {
+  if (options.sortByValue === 'never') {
     return options.type
   }
   return 'natural'

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -202,9 +202,7 @@ export default createEslintRule<Options, MessageId>({
       let nodes = formattedMembers.flat()
 
       let isNumericEnum = nodes.every(
-        sortingNode =>
-          sortingNode.numericValue !== null &&
-          !Number.isNaN(sortingNode.numericValue),
+        sortingNode => sortingNode.numericValue !== null,
       )
 
       let nodeValueGetter = computeNodeValueGetter({
@@ -306,9 +304,12 @@ function getBinaryExpressionNumberValue(
   leftExpression: TSESTree.PrivateIdentifier | TSESTree.Expression,
   rightExpression: TSESTree.Expression,
   operator: string,
-): number {
+): number | null {
   let left = getExpressionNumberValue(leftExpression)
   let right = getExpressionNumberValue(rightExpression)
+  if (left === null || right === null) {
+    return null
+  }
   switch (operator) {
     case '**':
       return left ** right
@@ -334,11 +335,11 @@ function getBinaryExpressionNumberValue(
       return left ^ right
     /* v8 ignore next 2 - Unsure if we can reach it */
     default:
-      return Number.NaN
+      return null
   }
 }
 
-function getExpressionNumberValue(expression: TSESTree.Node): number {
+function getExpressionNumberValue(expression: TSESTree.Node): number | null {
   switch (expression.type) {
     case 'BinaryExpression':
       return getBinaryExpressionNumberValue(
@@ -352,11 +353,9 @@ function getExpressionNumberValue(expression: TSESTree.Node): number {
         expression.operator,
       )
     case 'Literal':
-      return typeof expression.value === 'number'
-        ? expression.value
-        : Number.NaN
+      return typeof expression.value === 'number' ? expression.value : null
     default:
-      return Number.NaN
+      return null
   }
 }
 
@@ -377,6 +376,27 @@ function computeNodeValueGetter({
     : null
 }
 
+function getUnaryExpressionNumberValue(
+  argumentExpression: TSESTree.Expression,
+  operator: string,
+): number | null {
+  let argument = getExpressionNumberValue(argumentExpression)
+  if (argument === null) {
+    return null
+  }
+  switch (operator) {
+    case '+':
+      return argument
+    case '-':
+      return -argument
+    case '~':
+      return ~argument
+    /* v8 ignore next 2 - Unsure if we can reach it */
+    default:
+      return null
+  }
+}
+
 function computeOptionType({
   isNumericEnum,
   options,
@@ -394,22 +414,4 @@ function computeOptionType({
   return isNumericEnum && (options.forceNumericSort || options.sortByValue)
     ? 'natural'
     : options.type
-}
-
-function getUnaryExpressionNumberValue(
-  argumentExpression: TSESTree.Expression,
-  operator: string,
-): number {
-  let argument = getExpressionNumberValue(argumentExpression)
-  switch (operator) {
-    case '+':
-      return argument
-    case '-':
-      return -argument
-    case '~':
-      return ~argument
-    /* v8 ignore next 2 - Unsure if we can reach it */
-    default:
-      return Number.NaN
-  }
 }

--- a/rules/sort-enums.ts
+++ b/rules/sort-enums.ts
@@ -56,12 +56,12 @@ interface SortEnumsSortingNode
 
 let defaultOptions: Required<Options[number]> = {
   fallbackSort: { type: 'unsorted' },
+  sortByValue: 'ifNumericEnum',
   partitionByComment: false,
   partitionByNewLine: false,
   specialCharacters: 'keep',
   newlinesBetween: 'ignore',
   type: 'alphabetical',
-  sortByValue: false,
   ignoreCase: true,
   locales: 'en-US',
   customGroups: [],

--- a/rules/sort-enums/types.ts
+++ b/rules/sort-enums/types.ts
@@ -26,6 +26,14 @@ export type Options = Partial<
     customGroups: CustomGroupsOption<SingleCustomGroup>
 
     /**
+     * Whether to sort enum members by their values instead of names. When true,
+     * compares enum values; when false, compares enum member names.
+     *
+     * @default ifNumericEnum
+     */
+    sortByValue: 'ifNumericEnum' | 'always' | 'never'
+
+    /**
      * Partition enum members by comment delimiters. Members separated by
      * specific comments are sorted independently.
      */
@@ -36,14 +44,6 @@ export type Options = Partial<
      * members.
      */
     newlinesBetween: NewlinesBetweenOption
-
-    /**
-     * Whether to sort enum members by their values instead of names. When true,
-     * compares enum values; when false, compares enum member names.
-     *
-     * @default ifNumericEnum
-     */
-    sortByValue: 'ifNumericEnum' | boolean
 
     /**
      * Defines the order and grouping of enum members. Members are sorted within

--- a/rules/sort-enums/types.ts
+++ b/rules/sort-enums/types.ts
@@ -41,7 +41,7 @@ export type Options = Partial<
      * Whether to sort enum members by their values instead of names. When true,
      * compares enum values; when false, compares enum member names.
      *
-     * @default false
+     * @default ifNumericEnum
      */
     sortByValue: 'ifNumericEnum' | boolean
 

--- a/rules/sort-enums/types.ts
+++ b/rules/sort-enums/types.ts
@@ -38,6 +38,14 @@ export type Options = Partial<
     newlinesBetween: NewlinesBetweenOption
 
     /**
+     * Whether to sort enum members by their values instead of names. When true,
+     * compares enum values; when false, compares enum member names.
+     *
+     * @default false
+     */
+    sortByValue: 'ifNumericEnum' | boolean
+
+    /**
      * Defines the order and grouping of enum members. Members are sorted within
      * their groups and groups are ordered as specified.
      */
@@ -48,22 +56,6 @@ export type Options = Partial<
      * separated by empty lines are sorted independently.
      */
     partitionByNewLine: boolean
-
-    /**
-     * Forces numeric enums to be sorted by their value. When true, numeric
-     * enums are always sorted by value regardless of the main sort type.
-     *
-     * @default false
-     */
-    forceNumericSort: boolean
-
-    /**
-     * Whether to sort enum members by their values instead of names. When true,
-     * compares enum values; when false, compares enum member names.
-     *
-     * @default false
-     */
-    sortByValue: boolean
   } & CommonOptions
 >[]
 

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1571,6 +1571,24 @@ describe('sort-enums', () => {
         })
       },
     )
+
+    it('does not sort by value for a numeric enum if sortByValue is false', async () => {
+      await valid({
+        code: dedent`
+          enum Enum {
+            A = 3,
+            B = 1,
+            C = 2,
+          }
+        `,
+        options: [
+          {
+            ...options,
+            sortByValue: false,
+          },
+        ],
+      })
+    })
   })
 
   describe('natural', () => {
@@ -5045,10 +5063,10 @@ describe('sort-enums', () => {
       await valid({
         code: dedent`
           enum NumberBase {
-            BASE_10 = 10,
-            BASE_16 = 16,
             BASE_2 = 2,
-            BASE_8 = 8
+            BASE_8 = 8,
+            BASE_10 = 10,
+            BASE_16 = 16
           }
         `,
         options: [{}],

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -4847,7 +4847,7 @@ describe('sort-enums', () => {
         `,
         options: [
           {
-            forceNumericSort: true,
+            sortByValue: 'ifNumericEnum',
           },
         ],
       })
@@ -4863,7 +4863,7 @@ describe('sort-enums', () => {
         `,
         options: [
           {
-            forceNumericSort: true,
+            sortByValue: 'ifNumericEnum',
           },
         ],
       })
@@ -4879,7 +4879,7 @@ describe('sort-enums', () => {
         `,
         options: [
           {
-            forceNumericSort: true,
+            sortByValue: 'ifNumericEnum',
           },
         ],
       })
@@ -4895,7 +4895,7 @@ describe('sort-enums', () => {
         `,
         options: [
           {
-            forceNumericSort: true,
+            sortByValue: 'ifNumericEnum',
           },
         ],
       })
@@ -4921,7 +4921,7 @@ describe('sort-enums', () => {
         `,
         options: [
           {
-            forceNumericSort: true,
+            sortByValue: 'ifNumericEnum',
           },
         ],
       })
@@ -4937,7 +4937,7 @@ describe('sort-enums', () => {
         `,
         options: [
           {
-            forceNumericSort: true,
+            sortByValue: 'ifNumericEnum',
           },
         ],
       })
@@ -4988,7 +4988,7 @@ describe('sort-enums', () => {
     )
 
     it.each(['alphabetical', 'line-length', 'natural'])(
-      'forces numeric sorting when forceNumericSort is enabled (type: %s)',
+      'forces numeric sorting when sortByValue is ifNumericEnum (type: %s)',
       async type => {
         await invalid({
           errors: [
@@ -5023,7 +5023,7 @@ describe('sort-enums', () => {
           `,
           options: [
             {
-              forceNumericSort: true,
+              sortByValue: 'ifNumericEnum',
               type,
             },
           ],

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -4925,6 +4925,22 @@ describe('sort-enums', () => {
           },
         ],
       })
+
+      await valid({
+        code: dedent`
+          enum Enum {
+              A = 1,
+              B = A,
+              C = -A,
+              D = 2,
+            }
+        `,
+        options: [
+          {
+            forceNumericSort: true,
+          },
+        ],
+      })
     })
 
     it.each(['alphabetical', 'line-length', 'natural'])(

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -649,7 +649,7 @@ describe('sort-enums', () => {
         options: [
           {
             ...options,
-            sortByValue: true,
+            sortByValue: 'always',
           },
         ],
       })
@@ -1572,7 +1572,7 @@ describe('sort-enums', () => {
       },
     )
 
-    it('does not sort by value for a numeric enum if sortByValue is false', async () => {
+    it('does not sort by value for a numeric enum if sortByValue is "never"', async () => {
       await valid({
         code: dedent`
           enum Enum {
@@ -1584,7 +1584,7 @@ describe('sort-enums', () => {
         options: [
           {
             ...options,
-            sortByValue: false,
+            sortByValue: 'never',
           },
         ],
       })
@@ -2226,7 +2226,7 @@ describe('sort-enums', () => {
         options: [
           {
             ...options,
-            sortByValue: true,
+            sortByValue: 'always',
           },
         ],
       })
@@ -3729,7 +3729,7 @@ describe('sort-enums', () => {
         options: [
           {
             ...options,
-            sortByValue: true,
+            sortByValue: 'always',
           },
         ],
       })
@@ -4997,7 +4997,7 @@ describe('sort-enums', () => {
           `,
           options: [
             {
-              sortByValue: true,
+              sortByValue: 'always',
               type,
             },
           ],


### PR DESCRIPTION
- Resolves https://github.com/azat-io/eslint-plugin-perfectionist/issues/564

# Description

This PR addresses 3 points of the `sort-enums` rule.

## `forceNumericSort` replacement

There are 2 options used to control sorting by value today:
- `sortByValue: boolean`.
  - If `true`, will always sort by value.
- `forceNumericSort: boolean`.
  - If `true`, will sort by value if the enum is numeric.   

Those two options can be simply merged into:
`sortByValue: boolean | "ifNumericEnum"`.

## Incorrect `NaN` detection

When detecting if an enum value is a number, we ignore the fact that expressions such as `NaN | 42` result in `42`.

The case happens in enums such as

```ts
enum Enum {
  A = 1,
  B = 2,
  C = A << 2 // A is considered as NaN, so the result will be considered as 0, but it should be 4 in reality if we could parse that A is 1
}
```

## Sort numeric enums with `natural` sort by default

- Request from https://github.com/azat-io/eslint-plugin-perfectionist/issues/564

# What is the purpose of this pull request?

- [x] New Feature