### PR TITLE
feat(sort-object)!: drop deprecated `destructureOnly` option

### DIFF
--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -299,14 +299,6 @@ Specifies whether this rule should be applied to styled-components like librarie
 - `true` — Apply the rule to styled-components.
 - `false` — Disable the rule for styled-components.
 
-### [DEPRECATED] destructureOnly
-
-<sub>default: `false`</sub>
-
-Use the [objectDeclarations](#objectdeclarations) and [destructuredObjects](#destructuredobjects) options instead.
-
-Restricts sorting to objects that are part of a destructuring pattern. When set to `true`, the rule will apply sorting exclusively to destructured objects, leaving other object declarations unchanged.
-
 ### objectDeclarations
 
 <sub>default: `true`</sub>

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -72,7 +72,6 @@ let defaultOptions: Required<Options[number]> = {
   destructuredObjects: true,
   objectDeclarations: true,
   styledComponents: true,
-  destructureOnly: false,
   useConfigurationIf: {},
   type: 'alphabetical',
   ignorePattern: [],
@@ -115,7 +114,7 @@ export default createEslintRule<Options, MessageId>({
         if (!options.destructuredObjects) {
           return
         }
-      } else if (options.destructureOnly || !options.objectDeclarations) {
+      } else if (!options.objectDeclarations) {
         return
       }
 
@@ -429,11 +428,6 @@ export default createEslintRule<Options, MessageId>({
               callingFunctionNamePattern: regexJsonSchema,
             },
           }),
-          destructureOnly: {
-            description:
-              '[DEPRECATED] Controls whether to sort only destructured objects.',
-            type: 'boolean',
-          },
           objectDeclarations: {
             description: 'Controls whether to sort object declarations.',
             type: 'boolean',

--- a/rules/sort-objects/types.ts
+++ b/rules/sort-objects/types.ts
@@ -110,12 +110,6 @@ export type Options = Partial<
      * @default true
      */
     styledComponents: boolean
-
-    /**
-     * @deprecated For {@link `destructuredObjects`} and
-     *   {@link `objectDeclarations`}. Will be removed in v5.0.0.
-     */
-    destructureOnly: boolean
   } & CommonOptions
 >[]
 

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -8979,67 +8979,6 @@ describe('sort-objects', () => {
       })
     })
 
-    it('sorts only destructured objects when destructureOnly is enabled', async () => {
-      await valid({
-        code: dedent`
-          let obj = {
-            c: 'c',
-            b: 'b',
-            a: 'a',
-          }
-
-          let { a, b, c } = obj
-        `,
-        options: [
-          {
-            destructureOnly: true,
-          },
-        ],
-      })
-
-      await invalid({
-        errors: [
-          {
-            data: {
-              right: 'b',
-              left: 'c',
-            },
-            messageId: 'unexpectedObjectsOrder',
-          },
-          {
-            data: {
-              right: 'a',
-              left: 'b',
-            },
-            messageId: 'unexpectedObjectsOrder',
-          },
-        ],
-        output: dedent`
-          let obj = {
-            c: 'c',
-            b: 'b',
-            a: 'a',
-          }
-
-          let { a, b, c } = obj
-        `,
-        code: dedent`
-          let obj = {
-            c: 'c',
-            b: 'b',
-            a: 'a',
-          }
-
-          let { c, b, a } = obj
-        `,
-        options: [
-          {
-            destructureOnly: true,
-          },
-        ],
-      })
-    })
-
     it('skips object declarations when objectDeclarations is disabled', async () => {
       await valid({
         code: dedent`


### PR DESCRIPTION
## Description

In favor of `objectDeclarations` and `destructuredObjects`.

Ideally, I think that those two settings should be `useConfigurationIf` options.

## What is the purpose of this pull request?

- [x] Other