### PR TITLE
fix(594): fix destructured assignments dependencies not detected

### DIFF
--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -246,37 +246,37 @@ function extractDependencies(init: TSESTree.Expression): string[] {
     }
 
     if (nodeValue.type === 'Property') {
-      traverseNode(nodeValue.key)
-      traverseNode(nodeValue.value)
+      checkNode(nodeValue.key)
+      checkNode(nodeValue.value)
     }
 
     if (nodeValue.type === 'ConditionalExpression') {
-      traverseNode(nodeValue.test)
-      traverseNode(nodeValue.consequent)
-      traverseNode(nodeValue.alternate)
+      checkNode(nodeValue.test)
+      checkNode(nodeValue.consequent)
+      checkNode(nodeValue.alternate)
     }
 
     if (
       'expression' in nodeValue &&
       typeof nodeValue.expression !== 'boolean'
     ) {
-      traverseNode(nodeValue.expression)
+      checkNode(nodeValue.expression)
     }
 
     if ('object' in nodeValue) {
-      traverseNode(nodeValue.object)
+      checkNode(nodeValue.object)
     }
 
     if ('callee' in nodeValue) {
-      traverseNode(nodeValue.callee)
+      checkNode(nodeValue.callee)
     }
 
     if ('left' in nodeValue) {
-      traverseNode(nodeValue.left)
+      checkNode(nodeValue.left)
     }
 
     if ('right' in nodeValue) {
-      traverseNode(nodeValue.right as TSESTree.Node)
+      checkNode(nodeValue.right as TSESTree.Node)
     }
 
     if ('elements' in nodeValue) {
@@ -285,37 +285,33 @@ function extractDependencies(init: TSESTree.Expression): string[] {
       )
 
       for (let element of elements) {
-        traverseNode(element)
+        checkNode(element)
       }
     }
 
     if ('argument' in nodeValue && nodeValue.argument) {
-      traverseNode(nodeValue.argument)
+      checkNode(nodeValue.argument)
     }
 
     if ('arguments' in nodeValue) {
       for (let argument of nodeValue.arguments) {
-        traverseNode(argument)
+        checkNode(argument)
       }
     }
 
     if ('properties' in nodeValue) {
       for (let property of nodeValue.properties) {
-        traverseNode(property)
+        checkNode(property)
       }
     }
 
     if ('expressions' in nodeValue) {
       for (let nodeExpression of nodeValue.expressions) {
-        traverseNode(nodeExpression)
+        checkNode(nodeExpression)
       }
     }
   }
 
-  function traverseNode(nodeValue: TSESTree.Node): void {
-    checkNode(nodeValue)
-  }
-
-  traverseNode(init)
+  checkNode(init)
   return dependencies
 }

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -96,9 +96,9 @@ export default createEslintRule<Options, MessageId>({
 
           let selector: Selector
 
-          let dependencies: string[] = []
+          let dependencies: string[] = extractDependencies(declaration.id)
           if (declaration.init) {
-            dependencies = extractDependencies(declaration.init)
+            dependencies.push(...extractDependencies(declaration.init))
             selector = 'initialized'
           } else {
             selector = 'uninitialized'

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -458,6 +458,18 @@ describe('sort-variable-declarations', () => {
       })
     })
 
+    it('detects dependencies in destructured assignments', async () => {
+      await valid({
+        code: dedent`
+          let a = "a",
+            [{
+              b = a,
+            }] = {}
+        `,
+        options: [options],
+      })
+    })
+
     it('ignores dependencies inside function bodies', async () => {
       await valid({
         code: dedent`
@@ -2304,6 +2316,18 @@ describe('sort-variable-declarations', () => {
       })
     })
 
+    it('detects dependencies in destructured assignments', async () => {
+      await valid({
+        code: dedent`
+          let a = "a",
+            [{
+              b = a,
+            }] = {}
+        `,
+        options: [options],
+      })
+    })
+
     it('ignores dependencies inside function bodies', async () => {
       await valid({
         code: dedent`
@@ -4145,6 +4169,18 @@ describe('sort-variable-declarations', () => {
         code: dedent`
           let b = 'b',
           a = \`\${b}\`
+        `,
+        options: [options],
+      })
+    })
+
+    it('detects dependencies in destructured assignments', async () => {
+      await valid({
+        code: dedent`
+          let a = "a",
+            [{
+              b = a,
+            }] = {}
         `,
         options: [options],
       })


### PR DESCRIPTION
- Fix #594

### Description

Simply fix the bug !

> [!CAUTION]
> Merging toward **main**.
> - The merge afterward toward `next` shouldn't cause conflicts.
> - We can release a new minor version for V4 if needed.

### Estimated bug severity: minor

It's probably not a common variable declaration style.

### What is the purpose of this pull request?

- [x] Bug fix
