### PR TITLE
feat!: drop deprecated `newlinesBetween: 'always'` and `newlinesBetween: 'never'` support

### DIFF
--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1300,10 +1300,7 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         let newlinesOptions = [
@@ -1382,8 +1379,8 @@ describe('sort-array-includes', () => {
               groupName: 'b',
             },
           ],
-          newlinesBetween: 'always' as const,
           groups: ['a', 'unknown', 'b'],
+          newlinesBetween: 1,
         },
       ]
 
@@ -1464,15 +1461,15 @@ describe('sort-array-includes', () => {
           groups: [
             'a',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'b',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'c',
             {
-              newlinesBetween: 'never',
+              newlinesBetween: 0,
             },
             'd',
             {
@@ -1480,7 +1477,7 @@ describe('sort-array-includes', () => {
             },
             'e',
           ],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -1540,12 +1537,10 @@ describe('sort-array-includes', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1596,16 +1591,10 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
-        let neverBetweenGroupsOptions = [
+        let noNewlineBetweenGroupsOptions = [
           {
             ...options,
             customGroups: [
@@ -1616,11 +1605,11 @@ describe('sort-array-includes', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -1650,16 +1639,14 @@ describe('sort-array-includes', () => {
               b,
             ].includes(value)
           `,
-          options: neverBetweenGroupsOptions,
+          options: noNewlineBetweenGroupsOptions,
         })
       },
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1714,7 +1701,7 @@ describe('sort-array-includes', () => {
             },
           ],
           groups: ['unknown', 'b|c'],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -1751,10 +1738,7 @@ describe('sort-array-includes', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         let partitionOptions = [
@@ -3096,10 +3080,7 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         let newlinesOptions = [
@@ -3178,8 +3159,8 @@ describe('sort-array-includes', () => {
               groupName: 'b',
             },
           ],
-          newlinesBetween: 'always' as const,
           groups: ['a', 'unknown', 'b'],
+          newlinesBetween: 1,
         },
       ]
 
@@ -3260,15 +3241,15 @@ describe('sort-array-includes', () => {
           groups: [
             'a',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'b',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'c',
             {
-              newlinesBetween: 'never',
+              newlinesBetween: 0,
             },
             'd',
             {
@@ -3276,7 +3257,7 @@ describe('sort-array-includes', () => {
             },
             'e',
           ],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -3336,12 +3317,10 @@ describe('sort-array-includes', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -3392,16 +3371,10 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
-        let neverBetweenGroupsOptions = [
+        let noNewlineBetweenGroupsOptions = [
           {
             ...options,
             customGroups: [
@@ -3412,11 +3385,11 @@ describe('sort-array-includes', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -3446,16 +3419,14 @@ describe('sort-array-includes', () => {
               b,
             ].includes(value)
           `,
-          options: neverBetweenGroupsOptions,
+          options: noNewlineBetweenGroupsOptions,
         })
       },
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -3510,7 +3481,7 @@ describe('sort-array-includes', () => {
             },
           ],
           groups: ['unknown', 'b|c'],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -3547,10 +3518,7 @@ describe('sort-array-includes', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         let partitionOptions = [
@@ -4873,10 +4841,7 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         let newlinesOptions = [
@@ -4955,8 +4920,8 @@ describe('sort-array-includes', () => {
               groupName: 'b',
             },
           ],
-          newlinesBetween: 'always' as const,
           groups: ['aa', 'unknown', 'b'],
+          newlinesBetween: 1,
         },
       ]
 
@@ -5037,15 +5002,15 @@ describe('sort-array-includes', () => {
           groups: [
             'a',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'b',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'c',
             {
-              newlinesBetween: 'never',
+              newlinesBetween: 0,
             },
             'd',
             {
@@ -5053,7 +5018,7 @@ describe('sort-array-includes', () => {
             },
             'e',
           ],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -5113,12 +5078,10 @@ describe('sort-array-includes', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -5169,16 +5132,10 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
-        let neverBetweenGroupsOptions = [
+        let noNewlineBetweenGroupsOptions = [
           {
             ...options,
             customGroups: [
@@ -5189,11 +5146,11 @@ describe('sort-array-includes', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -5223,16 +5180,14 @@ describe('sort-array-includes', () => {
               b,
             ].includes(value)
           `,
-          options: neverBetweenGroupsOptions,
+          options: noNewlineBetweenGroupsOptions,
         })
       },
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -5287,7 +5242,7 @@ describe('sort-array-includes', () => {
             },
           ],
           groups: ['unknown', 'b|c'],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -5324,10 +5279,7 @@ describe('sort-array-includes', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         let partitionOptions = [
@@ -5521,7 +5473,7 @@ describe('sort-array-includes', () => {
               groupName: 'b',
             },
           ],
-          newlinesBetween: 'always' as const,
+          newlinesBetween: 1,
           groups: ['b', 'a'],
         },
       ]

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1300,70 +1300,67 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        let newlinesOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      let newlinesOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenArrayIncludesMembers',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          code: dedent`
-            [
-              'a',
+          groups: ['a', 'unknown'],
+          newlinesBetween: 0,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        code: dedent`
+          [
+            'a',
 
 
-             'y',
-            'z',
+           'y',
+          'z',
 
-                'b'
-            ].includes(value)
-          `,
-          output: dedent`
-            [
-              'a',
-             'b',
-            'y',
-                'z'
-            ].includes(value)
-          `,
-          options: newlinesOptions,
-        })
-      },
-    )
+              'b'
+          ].includes(value)
+        `,
+        output: dedent`
+          [
+            'a',
+           'b',
+          'y',
+              'z'
+          ].includes(value)
+        `,
+        options: newlinesOptions,
+      })
+    })
 
     it('adds newlines between multiple groups', async () => {
       let multiGroupOptions = [
@@ -1738,58 +1735,55 @@ describe('sort-array-includes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        let partitionOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            partitionByComment: true,
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          output: dedent`
-            [
-              'a',
+          groups: ['a', 'unknown'],
+          partitionByComment: true,
+          newlinesBetween: 0,
+        },
+      ]
 
-              // Partition comment
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
 
-              'b',
-              'c',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'a',
+            // Partition comment
 
-              // Partition comment
+            'b',
+            'c',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
 
-              'c',
-              'b',
-            ].includes(value)
-          `,
-          options: partitionOptions,
-        })
-      },
-    )
+            // Partition comment
+
+            'c',
+            'b',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -3080,70 +3074,67 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        let newlinesOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      let newlinesOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenArrayIncludesMembers',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          code: dedent`
-            [
-              'a',
+          groups: ['a', 'unknown'],
+          newlinesBetween: 0,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        code: dedent`
+          [
+            'a',
 
 
-             'y',
-            'z',
+           'y',
+          'z',
 
-                'b'
-            ].includes(value)
-          `,
-          output: dedent`
-            [
-              'a',
-             'b',
-            'y',
-                'z'
-            ].includes(value)
-          `,
-          options: newlinesOptions,
-        })
-      },
-    )
+              'b'
+          ].includes(value)
+        `,
+        output: dedent`
+          [
+            'a',
+           'b',
+          'y',
+              'z'
+          ].includes(value)
+        `,
+        options: newlinesOptions,
+      })
+    })
 
     it('adds newlines between multiple groups', async () => {
       let multiGroupOptions = [
@@ -3518,58 +3509,55 @@ describe('sort-array-includes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        let partitionOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            partitionByComment: true,
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          output: dedent`
-            [
-              'a',
+          groups: ['a', 'unknown'],
+          partitionByComment: true,
+          newlinesBetween: 0,
+        },
+      ]
 
-              // Partition comment
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'a',
 
-              'b',
-              'c',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'a',
+            // Partition comment
 
-              // Partition comment
+            'b',
+            'c',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'a',
 
-              'c',
-              'b',
-            ].includes(value)
-          `,
-          options: partitionOptions,
-        })
-      },
-    )
+            // Partition comment
+
+            'c',
+            'b',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4841,70 +4829,67 @@ describe('sort-array-includes', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        let newlinesOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'aa',
-                groupName: 'aa',
-              },
-            ],
-            groups: ['aa', 'unknown'],
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      let newlinesOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
-              },
-              messageId: 'extraSpacingBetweenArrayIncludesMembers',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenArrayIncludesMembers',
+              elementNamePattern: 'aa',
+              groupName: 'aa',
             },
           ],
-          code: dedent`
-            [
-              'aaaa',
+          groups: ['aa', 'unknown'],
+          newlinesBetween: 0,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenArrayIncludesMembers',
+          },
+        ],
+        code: dedent`
+          [
+            'aaaa',
 
 
-             'yy',
-            'z',
+           'yy',
+          'z',
 
-                'bbb'
-            ].includes(value)
-          `,
-          output: dedent`
-            [
-              'aaaa',
-             'bbb',
-            'yy',
-                'z'
-            ].includes(value)
-          `,
-          options: newlinesOptions,
-        })
-      },
-    )
+              'bbb'
+          ].includes(value)
+        `,
+        output: dedent`
+          [
+            'aaaa',
+           'bbb',
+          'yy',
+              'z'
+          ].includes(value)
+        `,
+        options: newlinesOptions,
+      })
+    })
 
     it('adds newlines between multiple groups', async () => {
       let multiGroupOptions = [
@@ -5279,58 +5264,55 @@ describe('sort-array-includes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        let partitionOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            partitionByComment: true,
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'bb',
-                left: 'c',
-              },
-              messageId: 'unexpectedArrayIncludesOrder',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          output: dedent`
-            [
-              'aaa',
+          groups: ['a', 'unknown'],
+          partitionByComment: true,
+          newlinesBetween: 0,
+        },
+      ]
 
-              // Partition comment
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedArrayIncludesOrder',
+          },
+        ],
+        output: dedent`
+          [
+            'aaa',
 
-              'bb',
-              'c',
-            ].includes(value)
-          `,
-          code: dedent`
-            [
-              'aaa',
+            // Partition comment
 
-              // Partition comment
+            'bb',
+            'c',
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            'aaa',
 
-              'c',
-              'bb',
-            ].includes(value)
-          `,
-          options: partitionOptions,
-        })
-      },
-    )
+            // Partition comment
+
+            'c',
+            'bb',
+          ].includes(value)
+        `,
+        options: partitionOptions,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4179,8 +4179,6 @@ describe('sort-classes', () => {
 
     it.each([
       ['ignore', 0],
-      ['ignore', 0],
-      [0, 'ignore'],
       [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
@@ -8831,8 +8829,6 @@ describe('sort-classes', () => {
 
     it.each([
       ['ignore', 0],
-      ['ignore', 0],
-      [0, 'ignore'],
       [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
@@ -13417,8 +13413,6 @@ describe('sort-classes', () => {
 
     it.each([
       ['ignore', 0],
-      ['ignore', 0],
-      [0, 'ignore'],
       [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -3891,62 +3891,59 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_name, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenClassMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedClassesOrder',
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenClassMembers',
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            class Class {
-              a = () => null
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        code: dedent`
+          class Class {
+            a = () => null
 
 
-             y = "y"
-            z = "z"
+           y = "y"
+          z = "z"
 
-                b = "b"
-            }
-          `,
-          output: dedent`
-            class Class {
-              a = () => null
-             b = "b"
-            y = "y"
-                z = "z"
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b = "b"
+          }
+        `,
+        output: dedent`
+          class Class {
+            a = () => null
+           b = "b"
+          y = "y"
+              z = "z"
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it.each([
       ['1', 1],
@@ -4281,56 +4278,53 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_name, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedClassesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            class Class {
-              a
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              b
-              c
-            }
-          `,
-          code: dedent`
-            class Class {
-              a
+            b
+            c
+          }
+        `,
+        code: dedent`
+          class Class {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              c
-              b
-            }
-          `,
-        })
-      },
-    )
+            c
+            b
+          }
+        `,
+      })
+    })
 
     it('sorts inline non-abstract methods correctly', async () => {
       await invalid({
@@ -8549,62 +8543,59 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_name, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenClassMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedClassesOrder',
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenClassMembers',
+            messageId: 'unexpectedClassesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            class Class {
-              a = () => null
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        code: dedent`
+          class Class {
+            a = () => null
 
 
-             y = "y"
-            z = "z"
+           y = "y"
+          z = "z"
 
-                b = "b"
-            }
-          `,
-          output: dedent`
-            class Class {
-              a = () => null
-             b = "b"
-            y = "y"
-                z = "z"
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b = "b"
+          }
+        `,
+        output: dedent`
+          class Class {
+            a = () => null
+           b = "b"
+          y = "y"
+              z = "z"
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it.each([
       ['1', 1],
@@ -8939,56 +8930,53 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_name, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedClassesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            class Class {
-              a
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              b
-              c
-            }
-          `,
-          code: dedent`
-            class Class {
-              a
+            b
+            c
+          }
+        `,
+        code: dedent`
+          class Class {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              c
-              b
-            }
-          `,
-        })
-      },
-    )
+            c
+            b
+          }
+        `,
+      })
+    })
 
     it('sorts inline non-abstract methods correctly', async () => {
       await invalid({
@@ -13148,55 +13136,52 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_name, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenClassMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'z',
-                left: 'y',
-              },
-              messageId: 'extraSpacingBetweenClassMembers',
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'z',
+              left: 'y',
             },
-          ],
-          code: dedent`
-            class Class {
-              a = () => null
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        code: dedent`
+          class Class {
+            a = () => null
 
 
-             b = "b"
-            y = "y"
+           b = "b"
+          y = "y"
 
-                z = "z"
-            }
-          `,
-          output: dedent`
-            class Class {
-              a = () => null
-             b = "b"
-            y = "y"
-                z = "z"
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              z = "z"
+          }
+        `,
+        output: dedent`
+          class Class {
+            a = () => null
+           b = "b"
+          y = "y"
+              z = "z"
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it.each([
       ['1', 1],
@@ -13531,56 +13516,53 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_name, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaa',
-                  groupName: 'aaa',
-                },
-              ],
-              groups: ['aaa', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaa',
+                groupName: 'aaa',
               },
-              messageId: 'unexpectedClassesOrder',
+            ],
+            groups: ['aaa', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            class Class {
-              aaa
+            messageId: 'unexpectedClassesOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            aaa
 
-              // Partition comment
+            // Partition comment
 
-              bb
-              c
-            }
-          `,
-          code: dedent`
-            class Class {
-              aaa
+            bb
+            c
+          }
+        `,
+        code: dedent`
+          class Class {
+            aaa
 
-              // Partition comment
+            // Partition comment
 
-              c
-              bb
-            }
-          `,
-        })
-      },
-    )
+            c
+            bb
+          }
+        `,
+      })
+    })
 
     it('sorts inline non-abstract methods correctly', async () => {
       await invalid({
@@ -14758,107 +14740,101 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_name, newlinesInside) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'c',
-                left: 'b',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'c',
+              left: 'b',
+            },
+            messageId: 'missedSpacingBetweenClassMembers',
+          },
+          {
+            data: {
+              right: 'd',
+              left: 'c',
+            },
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'methodsWithNewlinesInside',
+                selector: 'method',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenClassMembers',
-            },
-            {
-              data: {
-                right: 'd',
-                left: 'c',
+            ],
+            groups: ['unknown', 'methodsWithNewlinesInside'],
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
+            b() {}
+
+            c() {}
+
+            d() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            a
+            b() {}
+            c() {}
+
+
+            d() {}
+          }
+        `,
+      })
+    })
+
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'methodsWithoutNewlinesInside',
+                selector: 'method',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenClassMembers',
+            ],
+            groups: ['unknown', 'methodsWithoutNewlinesInside'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'd',
+              left: 'c',
             },
-          ],
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'methodsWithNewlinesInside',
-                  selector: 'method',
-                  newlinesInside,
-                },
-              ],
-              groups: ['unknown', 'methodsWithNewlinesInside'],
-            },
-          ],
-          output: dedent`
-            class Class {
-              a
-              b() {}
+            messageId: 'extraSpacingBetweenClassMembers',
+          },
+        ],
+        output: dedent`
+          class Class {
+            a
 
-              c() {}
+            c() {}
+            d() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            a
 
-              d() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              a
-              b() {}
-              c() {}
+            c() {}
 
-
-              d() {}
-            }
-          `,
-        })
-      },
-    )
-
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_name, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'methodsWithoutNewlinesInside',
-                  selector: 'method',
-                  newlinesInside,
-                },
-              ],
-              groups: ['unknown', 'methodsWithoutNewlinesInside'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'd',
-                left: 'c',
-              },
-              messageId: 'extraSpacingBetweenClassMembers',
-            },
-          ],
-          output: dedent`
-            class Class {
-              a
-
-              c() {}
-              d() {}
-            }
-          `,
-          code: dedent`
-            class Class {
-              a
-
-              c() {}
-
-              d() {}
-            }
-          `,
-        })
-      },
-    )
+            d() {}
+          }
+        `,
+      })
+    })
 
     it.each([
       ['1', 1],

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -3891,10 +3891,7 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
         await invalid({
@@ -3952,11 +3949,9 @@ describe('sort-classes', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
       'enforces no newline between overload signatures when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
@@ -4016,16 +4011,16 @@ describe('sort-classes', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4082,13 +4077,11 @@ describe('sort-classes', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -4136,8 +4129,8 @@ describe('sort-classes', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'enforces no newline if the global option is %s and "newlinesBetween: never" exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and "newlinesBetween: 0" exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4151,11 +4144,11 @@ describe('sort-classes', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4188,10 +4181,10 @@ describe('sort-classes', () => {
     )
 
     it.each([
-      ['ignore', 'never'] as const,
-      ['ignore', 0] as const,
-      ['never', 'ignore'] as const,
-      [0, 'ignore'] as const,
+      ['ignore', 0],
+      ['ignore', 0],
+      [0, 'ignore'],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4282,16 +4275,13 @@ describe('sort-classes', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
         await invalid({
@@ -8559,10 +8549,7 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
         await invalid({
@@ -8620,11 +8607,9 @@ describe('sort-classes', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
       'enforces no newline between overload signatures when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
@@ -8684,16 +8669,16 @@ describe('sort-classes', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -8750,13 +8735,11 @@ describe('sort-classes', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -8804,8 +8787,8 @@ describe('sort-classes', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'enforces no newline if the global option is %s and "newlinesBetween: never" exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and "newlinesBetween: 0" exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -8819,11 +8802,11 @@ describe('sort-classes', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -8856,10 +8839,10 @@ describe('sort-classes', () => {
     )
 
     it.each([
-      ['ignore', 'never'] as const,
-      ['ignore', 0] as const,
-      ['never', 'ignore'] as const,
-      [0, 'ignore'] as const,
+      ['ignore', 0],
+      ['ignore', 0],
+      [0, 'ignore'],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -8950,16 +8933,13 @@ describe('sort-classes', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
         await invalid({
@@ -13168,10 +13148,7 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
         await invalid({
@@ -13222,11 +13199,9 @@ describe('sort-classes', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
       'enforces no newline between overload signatures when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
@@ -13286,16 +13261,16 @@ describe('sort-classes', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -13352,13 +13327,11 @@ describe('sort-classes', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -13406,8 +13379,8 @@ describe('sort-classes', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'enforces no newline if the global option is %s and "newlinesBetween: never" exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and "newlinesBetween: 0" exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -13421,11 +13394,11 @@ describe('sort-classes', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -13458,10 +13431,10 @@ describe('sort-classes', () => {
     )
 
     it.each([
-      ['ignore', 'never'] as const,
-      ['ignore', 0] as const,
-      ['never', 'ignore'] as const,
-      [0, 'ignore'] as const,
+      ['ignore', 0],
+      ['ignore', 0],
+      [0, 'ignore'],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -13552,16 +13525,13 @@ describe('sort-classes', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_name, newlinesBetween) => {
         await invalid({
@@ -13985,7 +13955,7 @@ describe('sort-classes', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],
@@ -14788,113 +14758,111 @@ describe('sort-classes', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])('allows to use newlinesInside: %s', async (_name, newlinesInside) => {
-      await invalid({
-        errors: [
-          {
-            data: {
-              right: 'c',
-              left: 'b',
-            },
-            messageId: 'missedSpacingBetweenClassMembers',
-          },
-          {
-            data: {
-              right: 'd',
-              left: 'c',
-            },
-            messageId: 'extraSpacingBetweenClassMembers',
-          },
-        ],
-        options: [
-          {
-            customGroups: [
-              {
-                groupName: 'methodsWithNewlinesInside',
-                selector: 'method',
-                newlinesInside,
+    it.each([['1', 1]])(
+      'allows to use newlinesInside: %s',
+      async (_name, newlinesInside) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: 'c',
+                left: 'b',
               },
-            ],
-            groups: ['unknown', 'methodsWithNewlinesInside'],
-          },
-        ],
-        output: dedent`
-          class Class {
-            a
-            b() {}
-
-            c() {}
-
-            d() {}
-          }
-        `,
-        code: dedent`
-          class Class {
-            a
-            b() {}
-            c() {}
-
-
-            d() {}
-          }
-        `,
-      })
-    })
-
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])('allows to use newlinesInside: %s', async (_name, newlinesInside) => {
-      await invalid({
-        options: [
-          {
-            customGroups: [
-              {
-                groupName: 'methodsWithoutNewlinesInside',
-                selector: 'method',
-                newlinesInside,
-              },
-            ],
-            groups: ['unknown', 'methodsWithoutNewlinesInside'],
-          },
-        ],
-        errors: [
-          {
-            data: {
-              right: 'd',
-              left: 'c',
+              messageId: 'missedSpacingBetweenClassMembers',
             },
-            messageId: 'extraSpacingBetweenClassMembers',
-          },
-        ],
-        output: dedent`
-          class Class {
-            a
+            {
+              data: {
+                right: 'd',
+                left: 'c',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'methodsWithNewlinesInside',
+                  selector: 'method',
+                  newlinesInside,
+                },
+              ],
+              groups: ['unknown', 'methodsWithNewlinesInside'],
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+              b() {}
 
-            c() {}
-            d() {}
-          }
-        `,
-        code: dedent`
-          class Class {
-            a
+              c() {}
 
-            c() {}
+              d() {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              a
+              b() {}
+              c() {}
 
-            d() {}
-          }
-        `,
-      })
-    })
+
+              d() {}
+            }
+          `,
+        })
+      },
+    )
+
+    it.each([['0', 0]])(
+      'allows to use newlinesInside: %s',
+      async (_name, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  groupName: 'methodsWithoutNewlinesInside',
+                  selector: 'method',
+                  newlinesInside,
+                },
+              ],
+              groups: ['unknown', 'methodsWithoutNewlinesInside'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'd',
+                left: 'c',
+              },
+              messageId: 'extraSpacingBetweenClassMembers',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+
+              c() {}
+              d() {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              a
+
+              c() {}
+
+              d() {}
+            }
+          `,
+        })
+      },
+    )
 
     it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['0', 0],
     ])(
       'enforces no newline between overload signatures when newlinesInside is %s',
       async (_name, newlinesInside) => {

--- a/test/rules/sort-decorators.test.ts
+++ b/test/rules/sort-decorators.test.ts
@@ -849,10 +849,7 @@ describe('sort-decorators', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -913,10 +910,7 @@ describe('sort-decorators', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -996,16 +990,16 @@ describe('sort-decorators', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1060,12 +1054,10 @@ describe('sort-decorators', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1112,14 +1104,8 @@ describe('sort-decorators', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1133,11 +1119,11 @@ describe('sort-decorators', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1168,10 +1154,8 @@ describe('sort-decorators', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1239,7 +1223,7 @@ describe('sort-decorators', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1270,10 +1254,7 @@ describe('sort-decorators', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1322,10 +1303,7 @@ describe('sort-decorators', () => {
       },
     )
 
-    it.each([
-      ['always', 'always'],
-      ['1', 1],
-    ] as const)(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1365,10 +1343,7 @@ describe('sort-decorators', () => {
       },
     )
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({

--- a/test/rules/sort-decorators.test.ts
+++ b/test/rules/sort-decorators.test.ts
@@ -849,132 +849,126 @@ describe('sort-decorators', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenDecorators',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedDecoratorsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenDecorators',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenDecorators',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+            @a
+
+
+           @y
+          @z
+
+              @b
+          class Class {}
+        `,
+        output: dedent`
+            @a
+           @b
+          @y
+              @z
+          class Class {}
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+            messageId: 'extraSpacingBetweenDecorators',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedDecoratorsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenDecorators',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedDecoratorsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenDecorators',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-              @a
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+            @a
+
+           @y
+          @z
+
+              @b
+          class Class {}
+        `,
+        code: dedent`
+            @a
 
 
-             @y
-            @z
-
-                @b
-            class Class {}
-          `,
-          output: dedent`
-              @a
-             @b
-            @y
-                @z
-            class Class {}
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenDecorators',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedDecoratorsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenDecorators',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-              @a
-
-             @y
-            @z
-
-                @b
-            class Class {}
-          `,
-          code: dedent`
-              @a
-
-
-             @z
-            @y
-                @b
-            class Class {}
-          `,
-        })
-      },
-    )
+           @z
+          @y
+              @b
+          class Class {}
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -1254,135 +1248,126 @@ describe('sort-decorators', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedDecoratorsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            @a
+            messageId: 'unexpectedDecoratorsOrder',
+          },
+        ],
+        output: dedent`
+          @a
 
-            // Partition comment
+          // Partition comment
 
-            @b
-            @c
-            class Class {}
-          `,
-          code: dedent`
-            @a
+          @b
+          @c
+          class Class {}
+        `,
+        code: dedent`
+          @a
 
-            // Partition comment
+          // Partition comment
 
-            @c
-            @b
-            class Class {}
-          `,
-        })
-      },
-    )
+          @c
+          @b
+          class Class {}
+        `,
+      })
+    })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  elementNamePattern: '.*',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '.*',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenDecorators',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            @a
+            messageId: 'missedSpacingBetweenDecorators',
+          },
+        ],
+        output: dedent`
+          @a
 
-            @b
-            class Class {}
-          `,
-          code: dedent`
-            @a
-            @b
-            class Class {}
-          `,
-        })
-      },
-    )
+          @b
+          class Class {}
+        `,
+        code: dedent`
+          @a
+          @b
+          class Class {}
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  elementNamePattern: '.*',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '.*',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenDecorators',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            @a
-            @b
-            class Class {}
-          `,
-          code: dedent`
-            @a
+            messageId: 'extraSpacingBetweenDecorators',
+          },
+        ],
+        output: dedent`
+          @a
+          @b
+          class Class {}
+        `,
+        code: dedent`
+          @a
 
-            @b
-            class Class {}
-          `,
-        })
-      },
-    )
+          @b
+          class Class {}
+        `,
+      })
+    })
 
     it('sorts within newline-separated partitions', async () => {
       await invalid({

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1104,10 +1104,7 @@ describe('sort-enums', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1170,10 +1167,7 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces single newline between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1271,15 +1265,15 @@ describe('sort-enums', () => {
             groups: [
               'a',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'b',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'c',
               {
-                newlinesBetween: 'never',
+                newlinesBetween: 0,
               },
               'd',
               {
@@ -1287,7 +1281,7 @@ describe('sort-enums', () => {
               },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1344,12 +1338,10 @@ describe('sort-enums', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines between non-consecutive groups when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1398,14 +1390,8 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when never is set between all groups (global: %s)',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 is set between all groups (global: %s)',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1419,11 +1405,11 @@ describe('sort-enums', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1456,10 +1442,8 @@ describe('sort-enums', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'allows any spacing when both options allow flexibility (global: %s, group: %s)',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1518,10 +1502,7 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween setting (%s)',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2663,10 +2644,7 @@ describe('sort-enums', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2729,10 +2707,7 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces single newline between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2830,15 +2805,15 @@ describe('sort-enums', () => {
             groups: [
               'a',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'b',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'c',
               {
-                newlinesBetween: 'never',
+                newlinesBetween: 0,
               },
               'd',
               {
@@ -2846,7 +2821,7 @@ describe('sort-enums', () => {
               },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2903,12 +2878,10 @@ describe('sort-enums', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines between non-consecutive groups when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2957,14 +2930,8 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when never is set between all groups (global: %s)',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 is set between all groups (global: %s)',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2978,11 +2945,11 @@ describe('sort-enums', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -3015,10 +2982,8 @@ describe('sort-enums', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'allows any spacing when both options allow flexibility (global: %s, group: %s)',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -3077,10 +3042,7 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween setting (%s)',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4166,10 +4128,7 @@ describe('sort-enums', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4232,10 +4191,7 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces single newline between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4333,15 +4289,15 @@ describe('sort-enums', () => {
             groups: [
               'a',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'b',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'c',
               {
-                newlinesBetween: 'never',
+                newlinesBetween: 0,
               },
               'd',
               {
@@ -4349,7 +4305,7 @@ describe('sort-enums', () => {
               },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4406,12 +4362,10 @@ describe('sort-enums', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines between non-consecutive groups when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4460,14 +4414,8 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when never is set between all groups (global: %s)',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 is set between all groups (global: %s)',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4481,11 +4429,11 @@ describe('sort-enums', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4518,10 +4466,8 @@ describe('sort-enums', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'allows any spacing when both options allow flexibility (global: %s, group: %s)',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4580,10 +4526,7 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween setting (%s)',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4772,7 +4715,7 @@ describe('sort-enums', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1104,136 +1104,130 @@ describe('sort-enums', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'Y',
-                left: 'A',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'Y',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenEnumsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            A = null,
+
+
+           Y = null,
+          Z = null,
+
+              B = null,
+          }
+        `,
+        output: dedent`
+          enum Enum {
+            A = null,
+           B = null,
+          Y = null,
+              Z = null,
+          }
+        `,
+      })
+    })
+
+    it('enforces single newline between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'Z',
+              left: 'A',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'Y',
+              left: 'Z',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Y',
+            },
+            messageId: 'missedSpacingBetweenEnumsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'a',
               },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
+              {
+                elementNamePattern: 'B',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenEnumsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'A',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            enum Enum {
-              A = null,
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = null,
+
+           Y = null,
+          Z = null,
+
+              B = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
 
 
-             Y = null,
-            Z = null,
-
-                B = null,
-            }
-          `,
-          output: dedent`
-            enum Enum {
-              A = null,
-             B = null,
-            Y = null,
-                Z = null,
-            }
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'enforces single newline between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'Z',
-                left: 'A',
-              },
-              messageId: 'extraSpacingBetweenEnumsMembers',
-            },
-            {
-              data: {
-                right: 'Y',
-                left: 'Z',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'B',
-                left: 'Y',
-              },
-              messageId: 'missedSpacingBetweenEnumsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'A',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'B',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              A = null,
-
-             Y = null,
-            Z = null,
-
-                B = null,
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              A = null,
-
-
-             Z = null,
-            Y = null,
-                B = null,
-            }
-          `,
-        })
-      },
-    )
+           Z = null,
+          Y = null,
+              B = null,
+          }
+        `,
+      })
+    })
 
     it('applies newlinesBetween rules between consecutive groups', async () => {
       await invalid({
@@ -1502,56 +1496,53 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween setting (%s)',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'A',
-                  groupName: 'A',
-                },
-              ],
-              groups: ['A', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
+    it('preserves partition boundaries regardless of newlinesBetween setting (0)', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'A',
               },
-              messageId: 'unexpectedEnumsOrder',
+            ],
+            groups: ['A', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              A = 'A',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = 'A',
 
-              // Partition comment
+            // Partition comment
 
-              B = 'B',
-              C = 'C',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              A = 'A',
+            B = 'B',
+            C = 'C',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = 'A',
 
-              // Partition comment
+            // Partition comment
 
-              C = 'C',
-              B = 'B',
-            }
-          `,
-        })
-      },
-    )
+            C = 'C',
+            B = 'B',
+          }
+        `,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -2644,136 +2635,130 @@ describe('sort-enums', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'Y',
-                left: 'A',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'Y',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenEnumsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            A = null,
+
+
+           Y = null,
+          Z = null,
+
+              B = null,
+          }
+        `,
+        output: dedent`
+          enum Enum {
+            A = null,
+           B = null,
+          Y = null,
+              Z = null,
+          }
+        `,
+      })
+    })
+
+    it('enforces single newline between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'Z',
+              left: 'A',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'Y',
+              left: 'Z',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Y',
+            },
+            messageId: 'missedSpacingBetweenEnumsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'a',
               },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
+              {
+                elementNamePattern: 'B',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenEnumsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'A',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            enum Enum {
-              A = null,
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = null,
+
+           Y = null,
+          Z = null,
+
+              B = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = null,
 
 
-             Y = null,
-            Z = null,
-
-                B = null,
-            }
-          `,
-          output: dedent`
-            enum Enum {
-              A = null,
-             B = null,
-            Y = null,
-                Z = null,
-            }
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'enforces single newline between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'Z',
-                left: 'A',
-              },
-              messageId: 'extraSpacingBetweenEnumsMembers',
-            },
-            {
-              data: {
-                right: 'Y',
-                left: 'Z',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'B',
-                left: 'Y',
-              },
-              messageId: 'missedSpacingBetweenEnumsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'A',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'B',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              A = null,
-
-             Y = null,
-            Z = null,
-
-                B = null,
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              A = null,
-
-
-             Z = null,
-            Y = null,
-                B = null,
-            }
-          `,
-        })
-      },
-    )
+           Z = null,
+          Y = null,
+              B = null,
+          }
+        `,
+      })
+    })
 
     it('applies newlinesBetween rules between consecutive groups', async () => {
       await invalid({
@@ -3042,56 +3027,53 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween setting (%s)',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'A',
-                  groupName: 'A',
-                },
-              ],
-              groups: ['A', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'C',
+    it('preserves partition boundaries regardless of newlinesBetween setting (0)', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'A',
+                groupName: 'A',
               },
-              messageId: 'unexpectedEnumsOrder',
+            ],
+            groups: ['A', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              A = 'A',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = 'A',
 
-              // Partition comment
+            // Partition comment
 
-              B = 'B',
-              C = 'C',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              A = 'A',
+            B = 'B',
+            C = 'C',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            A = 'A',
 
-              // Partition comment
+            // Partition comment
 
-              C = 'C',
-              B = 'B',
-            }
-          `,
-        })
-      },
-    )
+            C = 'C',
+            B = 'B',
+          }
+        `,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4128,136 +4110,130 @@ describe('sort-enums', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'AAAA',
-                right: 'YY',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAAA',
+              right: 'YY',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'Z',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'Z',
+            },
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'AAAA',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenEnumsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          enum Enum {
+            AAAA = null,
+
+
+           YY = null,
+          Z = null,
+
+              BBB = null,
+          }
+        `,
+        output: dedent`
+          enum Enum {
+            AAAA = null,
+           BBB = null,
+          YY = null,
+              Z = null,
+          }
+        `,
+      })
+    })
+
+    it('enforces single newline between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAAA',
+              right: 'Z',
             },
-            {
-              data: {
-                right: 'BBB',
-                left: 'Z',
+            messageId: 'extraSpacingBetweenEnumsMembers',
+          },
+          {
+            data: {
+              right: 'YY',
+              left: 'Z',
+            },
+            messageId: 'unexpectedEnumsOrder',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'YY',
+            },
+            messageId: 'missedSpacingBetweenEnumsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'AAAA',
+                groupName: 'a',
               },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'BBB',
-                left: 'Z',
+              {
+                elementNamePattern: 'BBB',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenEnumsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'AAAA',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            enum Enum {
-              AAAA = null,
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            AAAA = null,
+
+           YY = null,
+          Z = null,
+
+              BBB = null,
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            AAAA = null,
 
 
-             YY = null,
-            Z = null,
-
-                BBB = null,
-            }
-          `,
-          output: dedent`
-            enum Enum {
-              AAAA = null,
-             BBB = null,
-            YY = null,
-                Z = null,
-            }
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'enforces single newline between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'AAAA',
-                right: 'Z',
-              },
-              messageId: 'extraSpacingBetweenEnumsMembers',
-            },
-            {
-              data: {
-                right: 'YY',
-                left: 'Z',
-              },
-              messageId: 'unexpectedEnumsOrder',
-            },
-            {
-              data: {
-                right: 'BBB',
-                left: 'YY',
-              },
-              messageId: 'missedSpacingBetweenEnumsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'AAAA',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'BBB',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            enum Enum {
-              AAAA = null,
-
-             YY = null,
-            Z = null,
-
-                BBB = null,
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              AAAA = null,
-
-
-             Z = null,
-            YY = null,
-                BBB = null,
-            }
-          `,
-        })
-      },
-    )
+           Z = null,
+          YY = null,
+              BBB = null,
+          }
+        `,
+      })
+    })
 
     it('applies newlinesBetween rules between consecutive groups', async () => {
       await invalid({
@@ -4526,56 +4502,53 @@ describe('sort-enums', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween setting (%s)',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'AAA',
-                  groupName: 'AAA',
-                },
-              ],
-              groups: ['AAA', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'BB',
-                left: 'C',
+    it('preserves partition boundaries regardless of newlinesBetween setting (0)', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'AAA',
+                groupName: 'AAA',
               },
-              messageId: 'unexpectedEnumsOrder',
+            ],
+            groups: ['AAA', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'BB',
+              left: 'C',
             },
-          ],
-          output: dedent`
-            enum Enum {
-              AAA = 'AAA',
+            messageId: 'unexpectedEnumsOrder',
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            AAA = 'AAA',
 
-              // Partition comment
+            // Partition comment
 
-              BB = 'BB',
-              C = 'C',
-            }
-          `,
-          code: dedent`
-            enum Enum {
-              AAA = 'AAA',
+            BB = 'BB',
+            C = 'C',
+          }
+        `,
+        code: dedent`
+          enum Enum {
+            AAA = 'AAA',
 
-              // Partition comment
+            // Partition comment
 
-              C = 'C',
-              BB = 'BB',
-            }
-          `,
-        })
-      },
-    )
+            C = 'C',
+            BB = 'BB',
+          }
+        `,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-export-attributes.test.ts
+++ b/test/rules/sort-export-attributes.test.ts
@@ -154,14 +154,14 @@ describe('sort-export-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
             ...options,
             customGroups: [{ elementNamePattern: '^t', groupName: 't' }],
-            newlinesBetween: 'always',
             groups: ['t', 'unknown'],
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -429,14 +429,14 @@ describe('sort-export-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
             ...options,
             customGroups: [{ elementNamePattern: '^t', groupName: 't' }],
-            newlinesBetween: 'always',
             groups: ['t', 'unknown'],
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -704,14 +704,14 @@ describe('sort-export-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
             ...options,
             customGroups: [{ elementNamePattern: '^t', groupName: 't' }],
-            newlinesBetween: 'always',
             groups: ['t', 'unknown'],
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -911,7 +911,7 @@ describe('sort-export-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
@@ -920,7 +920,7 @@ describe('sort-export-attributes', () => {
               { elementNamePattern: '^b', groupName: 'b' },
               { elementNamePattern: '^a', groupName: 'a' },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -836,10 +836,7 @@ describe('sort-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -928,15 +925,15 @@ describe('sort-exports', () => {
             groups: [
               'a',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'b',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'c',
               {
-                newlinesBetween: 'never',
+                newlinesBetween: 0,
               },
               'd',
               {
@@ -944,7 +941,7 @@ describe('sort-exports', () => {
               },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -997,12 +994,10 @@ describe('sort-exports', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1047,14 +1042,8 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1068,11 +1057,11 @@ describe('sort-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1101,10 +1090,8 @@ describe('sort-exports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1159,10 +1146,7 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1444,11 +1428,11 @@ describe('sort-exports', () => {
               'value-export',
               {
                 commentAbove: 'Type exports',
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               ['type-export'],
             ],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
         output: dedent`
@@ -2301,10 +2285,7 @@ describe('sort-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2393,15 +2374,15 @@ describe('sort-exports', () => {
             groups: [
               'a',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'b',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'c',
               {
-                newlinesBetween: 'never',
+                newlinesBetween: 0,
               },
               'd',
               {
@@ -2409,7 +2390,7 @@ describe('sort-exports', () => {
               },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2462,12 +2443,10 @@ describe('sort-exports', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2512,14 +2491,8 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2533,11 +2506,11 @@ describe('sort-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2566,10 +2539,8 @@ describe('sort-exports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2625,12 +2596,10 @@ describe('sort-exports', () => {
     )
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2675,14 +2644,8 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2696,11 +2659,11 @@ describe('sort-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2729,10 +2692,8 @@ describe('sort-exports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2787,10 +2748,7 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3072,11 +3030,11 @@ describe('sort-exports', () => {
               'value-export',
               {
                 commentAbove: 'Type exports',
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               ['type-export'],
             ],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
         output: dedent`
@@ -3922,10 +3880,7 @@ describe('sort-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4007,15 +3962,15 @@ describe('sort-exports', () => {
             groups: [
               'a',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'b',
               {
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               'c',
               {
-                newlinesBetween: 'never',
+                newlinesBetween: 0,
               },
               'd',
               {
@@ -4023,7 +3978,7 @@ describe('sort-exports', () => {
               },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4076,12 +4031,10 @@ describe('sort-exports', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4126,14 +4079,8 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4147,11 +4094,11 @@ describe('sort-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4180,10 +4127,8 @@ describe('sort-exports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4239,12 +4184,10 @@ describe('sort-exports', () => {
     )
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces newlines if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4289,14 +4232,8 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'enforces no newline if the global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline if the global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4310,11 +4247,11 @@ describe('sort-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4343,10 +4280,8 @@ describe('sort-exports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'does not enforce a newline if the global option is %s and the group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4401,10 +4336,7 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4686,11 +4618,11 @@ describe('sort-exports', () => {
               'value-export',
               {
                 commentAbove: 'Type exports',
-                newlinesBetween: 'always',
+                newlinesBetween: 1,
               },
               ['type-export'],
             ],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
         output: dedent`
@@ -4808,7 +4740,7 @@ describe('sort-exports', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -836,64 +836,61 @@ describe('sort-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenExports',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenExports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-              export { a } from 'a'
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+            export { a } from 'a'
 
 
-             export { y } from 'y'
-            export { z } from 'z'
+           export { y } from 'y'
+          export { z } from 'z'
 
-                export { b } from 'b'
-          `,
-          output: dedent`
-              export { a } from 'a'
-             export { b } from 'b'
-            export { y } from 'y'
-                export { z } from 'z'
-          `,
-        })
-      },
-    )
+              export { b } from 'b'
+        `,
+        output: dedent`
+            export { a } from 'a'
+           export { b } from 'b'
+          export { y } from 'y'
+              export { z } from 'z'
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -1146,52 +1143,49 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedExportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            export { a } from 'a'
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from 'a'
 
-            // Partition comment
+          // Partition comment
 
-            export { b } from 'b'
-            export { c } from 'c'
-          `,
-          code: dedent`
-            export { a } from 'a'
+          export { b } from 'b'
+          export { c } from 'c'
+        `,
+        code: dedent`
+          export { a } from 'a'
 
-            // Partition comment
+          // Partition comment
 
-            export { c } from 'c'
-            export { b } from 'b'
-          `,
-        })
-      },
-    )
+          export { c } from 'c'
+          export { b } from 'b'
+        `,
+      })
+    })
 
     it('reports missing comments', async () => {
       await invalid({
@@ -2285,64 +2279,61 @@ describe('sort-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedExportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenExports',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedExportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenExports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-              export { a } from 'a'
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+            export { a } from 'a'
 
 
-             export { y } from 'y'
-            export { z } from 'z'
+           export { y } from 'y'
+          export { z } from 'z'
 
-                export { b } from 'b'
-          `,
-          output: dedent`
-              export { a } from 'a'
-             export { b } from 'b'
-            export { y } from 'y'
-                export { z } from 'z'
-          `,
-        })
-      },
-    )
+              export { b } from 'b'
+        `,
+        output: dedent`
+            export { a } from 'a'
+           export { b } from 'b'
+          export { y } from 'y'
+              export { z } from 'z'
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -2748,52 +2739,49 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedExportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            export { a } from 'a'
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from 'a'
 
-            // Partition comment
+          // Partition comment
 
-            export { b } from 'b'
-            export { c } from 'c'
-          `,
-          code: dedent`
-            export { a } from 'a'
+          export { b } from 'b'
+          export { c } from 'c'
+        `,
+        code: dedent`
+          export { a } from 'a'
 
-            // Partition comment
+          // Partition comment
 
-            export { c } from 'c'
-            export { b } from 'b'
-          `,
-        })
-      },
-    )
+          export { c } from 'c'
+          export { b } from 'b'
+        `,
+      })
+    })
 
     it('reports missing comments', async () => {
       await invalid({
@@ -3880,57 +3868,54 @@ describe('sort-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenExports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenExports',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenExports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-              export { a } from 'a'
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+            export { a } from 'a'
 
 
-             export { y } from 'y'
-            export { z } from 'z'
+           export { y } from 'y'
+          export { z } from 'z'
 
-                export { b } from 'b'
-          `,
-          output: dedent`
-              export { a } from 'a'
-             export { y } from 'y'
-            export { z } from 'z'
-                export { b } from 'b'
-          `,
-        })
-      },
-    )
+              export { b } from 'b'
+        `,
+        output: dedent`
+            export { a } from 'a'
+           export { y } from 'y'
+          export { z } from 'z'
+              export { b } from 'b'
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -4336,52 +4321,49 @@ describe('sort-exports', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'aaaa',
-                },
-              ],
-              groups: ['aaaa', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bbb',
-                left: 'cc',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'aaaa',
               },
-              messageId: 'unexpectedExportsOrder',
+            ],
+            groups: ['aaaa', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bbb',
+              left: 'cc',
             },
-          ],
-          output: dedent`
-            export { a } from 'aaaa'
+            messageId: 'unexpectedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export { a } from 'aaaa'
 
-            // Partition comment
+          // Partition comment
 
-            export { b } from 'bbb'
-            export { c } from 'cc'
-          `,
-          code: dedent`
-            export { a } from 'aaaa'
+          export { b } from 'bbb'
+          export { c } from 'cc'
+        `,
+        code: dedent`
+          export { a } from 'aaaa'
 
-            // Partition comment
+          // Partition comment
 
-            export { c } from 'cc'
-            export { b } from 'bbb'
-          `,
-        })
-      },
-    )
+          export { c } from 'cc'
+          export { b } from 'bbb'
+        `,
+      })
+    })
 
     it('reports missing comments', async () => {
       await invalid({

--- a/test/rules/sort-heritage-clauses.test.ts
+++ b/test/rules/sort-heritage-clauses.test.ts
@@ -507,136 +507,130 @@ describe('sort-heritage-clauses', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenHeritageClauses',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedHeritageClausesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenHeritageClauses',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenHeritageClauses',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          class Class implements
+              a,
+
+
+             y,
+            z,
+
+                b
+          {}
+        `,
+        output: dedent`
+          class Class implements
+              a,
+             b,
+            y,
+                z
+          {}
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+            messageId: 'extraSpacingBetweenHeritageClauses',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedHeritageClausesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenHeritageClauses',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedHeritageClausesOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenHeritageClauses',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            class Class implements
-                a,
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          class Class implements
+              a,
+
+             y,
+            z,
+
+                b
+          {}
+        `,
+        code: dedent`
+          class Class implements
+              a,
 
 
-               y,
-              z,
-
-                  b
-            {}
-          `,
-          output: dedent`
-            class Class implements
-                a,
-               b,
-              y,
-                  z
-            {}
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenHeritageClauses',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedHeritageClausesOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenHeritageClauses',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            class Class implements
-                a,
-
-               y,
-              z,
-
-                  b
-            {}
-          `,
-          code: dedent`
-            class Class implements
-                a,
-
-
-               z,
-              y,
-                  b
-            {}
-          `,
-        })
-      },
-    )
+             z,
+            y,
+                b
+          {}
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -927,141 +921,132 @@ describe('sort-heritage-clauses', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedHeritageClausesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            class Class implements
-              a,
+            messageId: 'unexpectedHeritageClausesOrder',
+          },
+        ],
+        output: dedent`
+          class Class implements
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c
-            {}
-          `,
-          code: dedent`
-            class Class implements
-              a,
+            b,
+            c
+          {}
+        `,
+        code: dedent`
+          class Class implements
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b
-            {}
-          `,
-        })
-      },
-    )
+            c,
+            b
+          {}
+        `,
+      })
+    })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  elementNamePattern: '.*',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '.*',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenHeritageClauses',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            class Class implements
-              a,
+            messageId: 'missedSpacingBetweenHeritageClauses',
+          },
+        ],
+        output: dedent`
+          class Class implements
+            a,
 
-              b
-            {}
-          `,
-          code: dedent`
-            class Class implements
-              a,
-              b
-            {}
-          `,
-        })
-      },
-    )
+            b
+          {}
+        `,
+        code: dedent`
+          class Class implements
+            a,
+            b
+          {}
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  elementNamePattern: '.*',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                elementNamePattern: '.*',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenHeritageClauses',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            class Class implements
-              a,
-              b
-            {}
-          `,
-          code: dedent`
-            class Class implements
-              a,
+            messageId: 'extraSpacingBetweenHeritageClauses',
+          },
+        ],
+        output: dedent`
+          class Class implements
+            a,
+            b
+          {}
+        `,
+        code: dedent`
+          class Class implements
+            a,
 
-              b
-            {}
-          `,
-        })
-      },
-    )
+            b
+          {}
+        `,
+      })
+    })
 
     it('sorts within newline-separated partitions', async () => {
       await invalid({

--- a/test/rules/sort-heritage-clauses.test.ts
+++ b/test/rules/sort-heritage-clauses.test.ts
@@ -507,10 +507,7 @@ describe('sort-heritage-clauses', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -573,10 +570,7 @@ describe('sort-heritage-clauses', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -658,16 +652,16 @@ describe('sort-heritage-clauses', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -724,12 +718,10 @@ describe('sort-heritage-clauses', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -778,14 +770,8 @@ describe('sort-heritage-clauses', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -799,11 +785,11 @@ describe('sort-heritage-clauses', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -836,10 +822,8 @@ describe('sort-heritage-clauses', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -910,7 +894,7 @@ describe('sort-heritage-clauses', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -943,10 +927,7 @@ describe('sort-heritage-clauses', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -997,10 +978,7 @@ describe('sort-heritage-clauses', () => {
       },
     )
 
-    it.each([
-      ['always', 'always'],
-      ['1', 1],
-    ] as const)(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1042,10 +1020,7 @@ describe('sort-heritage-clauses', () => {
       },
     )
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({

--- a/test/rules/sort-import-attributes.test.ts
+++ b/test/rules/sort-import-attributes.test.ts
@@ -154,14 +154,14 @@ describe('sort-import-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
             ...options,
             customGroups: [{ elementNamePattern: '^t', groupName: 't' }],
-            newlinesBetween: 'always',
             groups: ['t', 'unknown'],
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -429,14 +429,14 @@ describe('sort-import-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
             ...options,
             customGroups: [{ elementNamePattern: '^t', groupName: 't' }],
-            newlinesBetween: 'always',
             groups: ['t', 'unknown'],
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -704,14 +704,14 @@ describe('sort-import-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
             ...options,
             customGroups: [{ elementNamePattern: '^t', groupName: 't' }],
-            newlinesBetween: 'always',
             groups: ['t', 'unknown'],
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -911,7 +911,7 @@ describe('sort-import-attributes', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
@@ -920,7 +920,7 @@ describe('sort-import-attributes', () => {
               { elementNamePattern: '^b', groupName: 'b' },
               { elementNamePattern: '^a', groupName: 'a' },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -251,7 +251,7 @@ describe('sort-imports', () => {
         options: [
           {
             ...options,
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })
@@ -307,7 +307,7 @@ describe('sort-imports', () => {
         options: [
           {
             ...options,
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })
@@ -741,7 +741,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['builtin', 'external', 'unknown'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
             environment: 'bun',
           },
         ],
@@ -767,7 +767,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['builtin', 'external', 'unknown'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
             environment: 'bun',
           },
         ],
@@ -1377,74 +1377,64 @@ describe('sort-imports', () => {
       })
     })
 
+    it.each([['removes newlines with 0 option', 0]])(
+      '%s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: '~/y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenImports',
+            },
+            {
+              data: {
+                right: '~/b',
+                left: '~/z',
+              },
+              messageId: 'unexpectedImportsOrder',
+            },
+            {
+              data: {
+                right: '~/b',
+                left: '~/z',
+              },
+              messageId: 'extraSpacingBetweenImports',
+            },
+          ],
+          code: dedent`
+              import { A } from 'a'
+
+
+             import y from '~/y'
+            import z from '~/z'
+
+                import b from '~/b'
+          `,
+          output: dedent`
+              import { A } from 'a'
+             import b from '~/b'
+            import y from '~/y'
+                import z from '~/z'
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
     it.each([
-      ['removes newlines with never option', 'never'],
-      ['removes newlines with 0 option', 0],
-    ])('%s', async (_description, newlinesBetween) => {
-      await invalid({
-        errors: [
-          {
-            data: {
-              right: '~/y',
-              left: 'a',
-            },
-            messageId: 'extraSpacingBetweenImports',
-          },
-          {
-            data: {
-              right: '~/b',
-              left: '~/z',
-            },
-            messageId: 'unexpectedImportsOrder',
-          },
-          {
-            data: {
-              right: '~/b',
-              left: '~/z',
-            },
-            messageId: 'extraSpacingBetweenImports',
-          },
-        ],
-        code: dedent`
-            import { A } from 'a'
-
-
-           import y from '~/y'
-          import z from '~/z'
-
-              import b from '~/b'
-        `,
-        output: dedent`
-            import { A } from 'a'
-           import b from '~/b'
-          import y from '~/y'
-              import z from '~/z'
-        `,
-        options: [
-          {
-            ...options,
-            newlinesBetween,
-          },
-        ],
-      })
-    })
-
-    it.each([
-      [
-        'enforces spacing when global option is 2 and group option is never',
-        2,
-        'never',
-      ],
       ['enforces spacing when global option is 2 and group option is 0', 2, 0],
       [
         'enforces spacing when global option is 2 and group option is ignore',
         2,
         'ignore',
-      ],
-      [
-        'enforces spacing when global option is never and group option is 2',
-        'never',
-        2,
       ],
       ['enforces spacing when global option is 0 and group option is 2', 0, 2],
       [
@@ -1507,23 +1497,19 @@ describe('sort-imports', () => {
 
     it.each([
       [
-        'removes spacing when never option exists between groups regardless of global setting always',
-        'always',
+        'removes spacing when 0 option exists between groups regardless of global setting 1',
+        1,
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting 2',
+        'removes spacing when 0 option exists between groups regardless of global setting 2',
         2,
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting ignore',
+        'removes spacing when 0 option exists between groups regardless of global setting ignore',
         'ignore',
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting never',
-        'never',
-      ],
-      [
-        'removes spacing when never option exists between groups regardless of global setting 0',
+        'removes spacing when 0 option exists between groups regardless of global setting 0',
         0,
       ],
     ])('%s', async (_description, globalNewlinesBetween) => {
@@ -1551,11 +1537,11 @@ describe('sort-imports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -1584,19 +1570,9 @@ describe('sort-imports', () => {
 
     it.each([
       [
-        'preserves existing spacing when ignore and never options are combined',
-        'ignore',
-        'never',
-      ],
-      [
         'preserves existing spacing when ignore and 0 options are combined',
         'ignore',
         0,
-      ],
-      [
-        'preserves existing spacing when never and ignore options are combined',
-        'never',
-        'ignore',
       ],
       [
         'preserves existing spacing when 0 and ignore options are combined',
@@ -1703,17 +1679,13 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['unknown', 'external'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
     it.each([
-      [
-        'ignores newline fixes between different partitions with never option',
-        'never',
-      ],
       ['ignores newline fixes between different partitions with 0 option', 0],
     ])('%s', async (_description, newlinesBetween) => {
       await invalid({
@@ -2933,52 +2905,45 @@ describe('sort-imports', () => {
       })
     })
 
-    it.each([
-      [
-        'adds spacing inside custom groups when always option is used',
-        'always',
-      ],
-      ['adds spacing inside custom groups when 1 option is used', 1],
-    ])('%s', async (_description, newlinesInside) => {
-      await invalid({
-        options: [
-          {
-            customGroups: [
-              {
-                selector: 'external',
-                groupName: 'group1',
-                newlinesInside,
-              },
-            ],
-            groups: ['group1'],
-          },
-        ],
-        errors: [
-          {
-            data: {
-              right: 'b',
-              left: 'a',
+    it.each([['adds spacing inside custom groups when 1 option is used', 1]])(
+      '%s',
+      async (_description, newlinesInside) => {
+        await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  selector: 'external',
+                  groupName: 'group1',
+                  newlinesInside,
+                },
+              ],
+              groups: ['group1'],
             },
-            messageId: 'missedSpacingBetweenImports',
-          },
-        ],
-        output: dedent`
-          import a from 'a'
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'missedSpacingBetweenImports',
+            },
+          ],
+          output: dedent`
+            import a from 'a'
 
-          import b from 'b'
-        `,
-        code: dedent`
-          import a from 'a'
-          import b from 'b'
-        `,
-      })
-    })
+            import b from 'b'
+          `,
+          code: dedent`
+            import a from 'a'
+            import b from 'b'
+          `,
+        })
+      },
+    )
 
     it.each([
-      [
-        'removes spacing inside custom groups when never option is used',
-        'never',
-      ],
       ['removes spacing inside custom groups when 0 option is used', 0],
     ])('%s', async (_description, newlinesInside) => {
       await invalid({
@@ -3351,7 +3316,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['external', 'internal'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -3645,21 +3610,6 @@ describe('sort-imports', () => {
           // external
           import b from '~/b'; // Comment after b
         `,
-        options: [
-          {
-            ...options,
-            groups: [
-              { commentAbove: 'external' },
-              'external',
-              {
-                commentAbove: 'internal or sibling',
-                newlinesBetween: 'always',
-              },
-              ['internal', 'sibling'],
-            ],
-            newlinesBetween: 'never',
-          },
-        ],
         output: dedent`
           #!/usr/bin/node
           // Some disclaimer
@@ -3674,6 +3624,21 @@ describe('sort-imports', () => {
           // Comment above b
           import b from '~/b'; // Comment after b
         `,
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              {
+                commentAbove: 'internal or sibling',
+                newlinesBetween: 1,
+              },
+              ['internal', 'sibling'],
+            ],
+            newlinesBetween: 0,
+          },
+        ],
       })
     })
   })
@@ -3887,7 +3852,7 @@ describe('sort-imports', () => {
         options: [
           {
             ...options,
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })
@@ -3943,7 +3908,7 @@ describe('sort-imports', () => {
         options: [
           {
             ...options,
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })
@@ -4384,7 +4349,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['builtin', 'external', 'unknown'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
             environment: 'bun',
           },
         ],
@@ -4410,7 +4375,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['builtin', 'external', 'unknown'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
             environment: 'bun',
           },
         ],
@@ -5020,74 +4985,64 @@ describe('sort-imports', () => {
       })
     })
 
+    it.each([['removes newlines with 0 option', 0]])(
+      '%s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: '~/y',
+                left: 'a',
+              },
+              messageId: 'extraSpacingBetweenImports',
+            },
+            {
+              data: {
+                right: '~/b',
+                left: '~/z',
+              },
+              messageId: 'unexpectedImportsOrder',
+            },
+            {
+              data: {
+                right: '~/b',
+                left: '~/z',
+              },
+              messageId: 'extraSpacingBetweenImports',
+            },
+          ],
+          code: dedent`
+              import { A } from 'a'
+
+
+             import y from '~/y'
+            import z from '~/z'
+
+                import b from '~/b'
+          `,
+          output: dedent`
+              import { A } from 'a'
+             import b from '~/b'
+            import y from '~/y'
+                import z from '~/z'
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
     it.each([
-      ['removes newlines with never option', 'never'],
-      ['removes newlines with 0 option', 0],
-    ])('%s', async (_description, newlinesBetween) => {
-      await invalid({
-        errors: [
-          {
-            data: {
-              right: '~/y',
-              left: 'a',
-            },
-            messageId: 'extraSpacingBetweenImports',
-          },
-          {
-            data: {
-              right: '~/b',
-              left: '~/z',
-            },
-            messageId: 'unexpectedImportsOrder',
-          },
-          {
-            data: {
-              right: '~/b',
-              left: '~/z',
-            },
-            messageId: 'extraSpacingBetweenImports',
-          },
-        ],
-        code: dedent`
-            import { A } from 'a'
-
-
-           import y from '~/y'
-          import z from '~/z'
-
-              import b from '~/b'
-        `,
-        output: dedent`
-            import { A } from 'a'
-           import b from '~/b'
-          import y from '~/y'
-              import z from '~/z'
-        `,
-        options: [
-          {
-            ...options,
-            newlinesBetween,
-          },
-        ],
-      })
-    })
-
-    it.each([
-      [
-        'enforces spacing when global option is 2 and group option is never',
-        2,
-        'never',
-      ],
       ['enforces spacing when global option is 2 and group option is 0', 2, 0],
       [
         'enforces spacing when global option is 2 and group option is ignore',
         2,
         'ignore',
-      ],
-      [
-        'enforces spacing when global option is never and group option is 2',
-        'never',
-        2,
       ],
       ['enforces spacing when global option is 0 and group option is 2', 0, 2],
       [
@@ -5150,23 +5105,19 @@ describe('sort-imports', () => {
 
     it.each([
       [
-        'removes spacing when never option exists between groups regardless of global setting always',
-        'always',
+        'removes spacing when 0 option exists between groups regardless of global setting 1',
+        1,
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting 2',
+        'removes spacing when 0 option exists between groups regardless of global setting 2',
         2,
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting ignore',
+        'removes spacing when 0 option exists between groups regardless of global setting ignore',
         'ignore',
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting never',
-        'never',
-      ],
-      [
-        'removes spacing when never option exists between groups regardless of global setting 0',
+        'removes spacing when 0 option exists between groups regardless of global setting 0',
         0,
       ],
     ])('%s', async (_description, globalNewlinesBetween) => {
@@ -5194,11 +5145,11 @@ describe('sort-imports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -5227,19 +5178,9 @@ describe('sort-imports', () => {
 
     it.each([
       [
-        'preserves existing spacing when ignore and never options are combined',
-        'ignore',
-        'never',
-      ],
-      [
         'preserves existing spacing when ignore and 0 options are combined',
         'ignore',
         0,
-      ],
-      [
-        'preserves existing spacing when never and ignore options are combined',
-        'never',
-        'ignore',
       ],
       [
         'preserves existing spacing when 0 and ignore options are combined',
@@ -5346,17 +5287,13 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['unknown', 'external'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
     it.each([
-      [
-        'ignores newline fixes between different partitions with never option',
-        'never',
-      ],
       ['ignores newline fixes between different partitions with 0 option', 0],
     ])('%s', async (_description, newlinesBetween) => {
       await invalid({
@@ -6918,7 +6855,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['external', 'internal'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -7212,21 +7149,6 @@ describe('sort-imports', () => {
           // external
           import b from '~/b'; // Comment after b
         `,
-        options: [
-          {
-            ...options,
-            groups: [
-              { commentAbove: 'external' },
-              'external',
-              {
-                commentAbove: 'internal or sibling',
-                newlinesBetween: 'always',
-              },
-              ['internal', 'sibling'],
-            ],
-            newlinesBetween: 'never',
-          },
-        ],
         output: dedent`
           #!/usr/bin/node
           // Some disclaimer
@@ -7241,6 +7163,21 @@ describe('sort-imports', () => {
           // Comment above b
           import b from '~/b'; // Comment after b
         `,
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              {
+                commentAbove: 'internal or sibling',
+                newlinesBetween: 1,
+              },
+              ['internal', 'sibling'],
+            ],
+            newlinesBetween: 0,
+          },
+        ],
       })
     })
   })
@@ -7475,7 +7412,7 @@ describe('sort-imports', () => {
         options: [
           {
             ...options,
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })
@@ -7531,7 +7468,7 @@ describe('sort-imports', () => {
         options: [
           {
             ...options,
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })
@@ -8041,7 +7978,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['builtin', 'external', 'unknown'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
             environment: 'bun',
           },
         ],
@@ -8067,7 +8004,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['builtin', 'external', 'unknown'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
             environment: 'bun',
           },
         ],
@@ -8677,74 +8614,64 @@ describe('sort-imports', () => {
       })
     })
 
+    it.each([['removes newlines with 0 option', 0]])(
+      '%s',
+      async (_description, newlinesBetween) => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                right: '~/y',
+                left: 'aaaa',
+              },
+              messageId: 'extraSpacingBetweenImports',
+            },
+            {
+              data: {
+                right: '~/bb',
+                left: '~/z',
+              },
+              messageId: 'unexpectedImportsOrder',
+            },
+            {
+              data: {
+                right: '~/bb',
+                left: '~/z',
+              },
+              messageId: 'extraSpacingBetweenImports',
+            },
+          ],
+          code: dedent`
+              import { A } from 'aaaa'
+
+
+             import y from '~/y'
+            import z from '~/z'
+
+                import b from '~/bb'
+          `,
+          output: dedent`
+              import { A } from 'aaaa'
+             import b from '~/bb'
+            import y from '~/y'
+                import z from '~/z'
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetween,
+            },
+          ],
+        })
+      },
+    )
+
     it.each([
-      ['removes newlines with never option', 'never'],
-      ['removes newlines with 0 option', 0],
-    ])('%s', async (_description, newlinesBetween) => {
-      await invalid({
-        errors: [
-          {
-            data: {
-              right: '~/y',
-              left: 'aaaa',
-            },
-            messageId: 'extraSpacingBetweenImports',
-          },
-          {
-            data: {
-              right: '~/bb',
-              left: '~/z',
-            },
-            messageId: 'unexpectedImportsOrder',
-          },
-          {
-            data: {
-              right: '~/bb',
-              left: '~/z',
-            },
-            messageId: 'extraSpacingBetweenImports',
-          },
-        ],
-        code: dedent`
-            import { A } from 'aaaa'
-
-
-           import y from '~/y'
-          import z from '~/z'
-
-              import b from '~/bb'
-        `,
-        output: dedent`
-            import { A } from 'aaaa'
-           import b from '~/bb'
-          import y from '~/y'
-              import z from '~/z'
-        `,
-        options: [
-          {
-            ...options,
-            newlinesBetween,
-          },
-        ],
-      })
-    })
-
-    it.each([
-      [
-        'enforces spacing when global option is 2 and group option is never',
-        2,
-        'never',
-      ],
       ['enforces spacing when global option is 2 and group option is 0', 2, 0],
       [
         'enforces spacing when global option is 2 and group option is ignore',
         2,
         'ignore',
-      ],
-      [
-        'enforces spacing when global option is never and group option is 2',
-        'never',
-        2,
       ],
       ['enforces spacing when global option is 0 and group option is 2', 0, 2],
       [
@@ -8807,23 +8734,19 @@ describe('sort-imports', () => {
 
     it.each([
       [
-        'removes spacing when never option exists between groups regardless of global setting always',
-        'always',
+        'removes spacing when 0 option exists between groups regardless of global setting 1',
+        1,
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting 2',
+        'removes spacing when 0 option exists between groups regardless of global setting 2',
         2,
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting ignore',
+        'removes spacing when 0 option exists between groups regardless of global setting ignore',
         'ignore',
       ],
       [
-        'removes spacing when never option exists between groups regardless of global setting never',
-        'never',
-      ],
-      [
-        'removes spacing when never option exists between groups regardless of global setting 0',
+        'removes spacing when 0 option exists between groups regardless of global setting 0',
         0,
       ],
     ])('%s', async (_description, globalNewlinesBetween) => {
@@ -8851,11 +8774,11 @@ describe('sort-imports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -8884,19 +8807,9 @@ describe('sort-imports', () => {
 
     it.each([
       [
-        'preserves existing spacing when ignore and never options are combined',
-        'ignore',
-        'never',
-      ],
-      [
         'preserves existing spacing when ignore and 0 options are combined',
         'ignore',
         0,
-      ],
-      [
-        'preserves existing spacing when never and ignore options are combined',
-        'never',
-        'ignore',
       ],
       [
         'preserves existing spacing when 0 and ignore options are combined',
@@ -9003,17 +8916,13 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['unknown', 'external'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
     it.each([
-      [
-        'ignores newline fixes between different partitions with never option',
-        'never',
-      ],
       ['ignores newline fixes between different partitions with 0 option', 0],
     ])('%s', async (_description, newlinesBetween) => {
       await invalid({
@@ -10603,7 +10512,7 @@ describe('sort-imports', () => {
           {
             ...options,
             groups: ['external', 'internal'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -10897,21 +10806,6 @@ describe('sort-imports', () => {
           // external
           import b from '~/b'; // Comment after b
         `,
-        options: [
-          {
-            ...options,
-            groups: [
-              { commentAbove: 'external' },
-              'external',
-              {
-                commentAbove: 'internal or sibling',
-                newlinesBetween: 'always',
-              },
-              ['internal', 'sibling'],
-            ],
-            newlinesBetween: 'never',
-          },
-        ],
         output: dedent`
           #!/usr/bin/node
           // Some disclaimer
@@ -10926,6 +10820,21 @@ describe('sort-imports', () => {
           // Comment above b
           import b from '~/b'; // Comment after b
         `,
+        options: [
+          {
+            ...options,
+            groups: [
+              { commentAbove: 'external' },
+              'external',
+              {
+                commentAbove: 'internal or sibling',
+                newlinesBetween: 1,
+              },
+              ['internal', 'sibling'],
+            ],
+            newlinesBetween: 0,
+          },
+        ],
       })
     })
 
@@ -11531,7 +11440,7 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['builtin', 'external', 'side-effect'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })
@@ -11548,7 +11457,7 @@ describe('sort-imports', () => {
         options: [
           {
             groups: ['builtin', 'external', 'side-effect'],
-            newlinesBetween: 'never',
+            newlinesBetween: 0,
           },
         ],
       })

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1259,90 +1259,84 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenInterfaceMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
+            messageId: 'missedSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
 
-              b
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
+            b
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
-              b
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
+            b
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
 
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+      })
+    })
 
     it('allows to use new line as partition', async () => {
       await valid({
@@ -1829,62 +1823,59 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            interface Interface {
-              a: () => null,
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            a: () => null,
 
 
-             y: "y",
-            z: "z",
+           y: "y",
+          z: "z",
 
-                b: "b",
-            }
-          `,
-          output: dedent`
-            interface Interface {
-              a: () => null,
-             b: "b",
-            y: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b: "b",
+          }
+        `,
+        output: dedent`
+          interface Interface {
+            a: () => null,
+           b: "b",
+          y: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -2168,56 +2159,53 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              b
-              c
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
+            b
+            c
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              c
-              b
-            }
-          `,
-        })
-      },
-    )
+            c
+            b
+          }
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({
@@ -3875,90 +3863,84 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenInterfaceMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
+            messageId: 'missedSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
 
-              b
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
+            b
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
-              b
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
+            b
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
 
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+      })
+    })
 
     it('allows to use new line as partition', async () => {
       await valid({
@@ -4445,62 +4427,59 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            interface Interface {
-              a: () => null,
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            a: () => null,
 
 
-             y: "y",
-            z: "z",
+           y: "y",
+          z: "z",
 
-                b: "b",
-            }
-          `,
-          output: dedent`
-            interface Interface {
-              a: () => null,
-             b: "b",
-            y: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b: "b",
+          }
+        `,
+        output: dedent`
+          interface Interface {
+            a: () => null,
+           b: "b",
+          y: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -4784,56 +4763,53 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              b
-              c
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
+            b
+            c
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
 
-              // Partition comment
+            // Partition comment
 
-              c
-              b
-            }
-          `,
-        })
-      },
-    )
+            c
+            b
+          }
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({
@@ -6420,90 +6396,84 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenInterfaceMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
+            messageId: 'missedSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
 
-              b
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
+            b
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              a
-              b
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              a
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a
+            b
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            a
 
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+      })
+    })
 
     it('allows to use new line as partition', async () => {
       await valid({
@@ -6983,62 +6953,59 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
-              },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenInterfaceMembers',
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            interface Interface {
-              aaaa: () => null,
+            messageId: 'extraSpacingBetweenInterfaceMembers',
+          },
+        ],
+        code: dedent`
+          interface Interface {
+            aaaa: () => null,
 
 
-             yy: "y",
-            z: "z",
+           yy: "y",
+          z: "z",
 
-                bbb: "b",
-            }
-          `,
-          output: dedent`
-            interface Interface {
-              aaaa: () => null,
-             bbb: "b",
-            yy: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              bbb: "b",
+          }
+        `,
+        output: dedent`
+          interface Interface {
+            aaaa: () => null,
+           bbb: "b",
+          yy: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -7322,56 +7289,53 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaa',
+                groupName: 'a',
               },
-              messageId: 'unexpectedInterfacePropertiesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            interface Interface {
-              aaa
+            messageId: 'unexpectedInterfacePropertiesOrder',
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            aaa
 
-              // Partition comment
+            // Partition comment
 
-              bb
-              c
-            }
-          `,
-          code: dedent`
-            interface Interface {
-              aaa
+            bb
+            c
+          }
+        `,
+        code: dedent`
+          interface Interface {
+            aaa
 
-              // Partition comment
+            // Partition comment
 
-              c
-              bb
-            }
-          `,
-        })
-      },
-    )
+            c
+            bb
+          }
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -1259,10 +1259,7 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([
-      ['always', 'always'],
-      ['1', 1],
-    ] as const)(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1304,10 +1301,7 @@ describe('sort-interfaces', () => {
       },
     )
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1835,10 +1829,7 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1909,16 +1900,16 @@ describe('sort-interfaces', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1975,13 +1966,11 @@ describe('sort-interfaces', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines when global option is %s and group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -2029,8 +2018,8 @@ describe('sort-interfaces', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline when global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2044,11 +2033,11 @@ describe('sort-interfaces', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2081,11 +2070,9 @@ describe('sort-interfaces', () => {
     )
 
     it.each([
-      ['ignore', 'never'],
       ['ignore', 0],
-      ['never', 'ignore'],
       [0, 'ignore'],
-    ] as const)(
+    ])(
       'does not enforce newline when global option is %s and group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await valid({
@@ -2175,16 +2162,13 @@ describe('sort-interfaces', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3891,10 +3875,7 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([
-      ['always', 'always'],
-      ['1', 1],
-    ] as const)(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -3936,10 +3917,7 @@ describe('sort-interfaces', () => {
       },
     )
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -4467,10 +4445,7 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4541,16 +4516,16 @@ describe('sort-interfaces', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4607,13 +4582,11 @@ describe('sort-interfaces', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines when global option is %s and group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -4661,8 +4634,8 @@ describe('sort-interfaces', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline when global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4676,11 +4649,11 @@ describe('sort-interfaces', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4713,11 +4686,9 @@ describe('sort-interfaces', () => {
     )
 
     it.each([
-      ['ignore', 'never'],
       ['ignore', 0],
-      ['never', 'ignore'],
       [0, 'ignore'],
-    ] as const)(
+    ])(
       'does not enforce newline when global option is %s and group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await valid({
@@ -4807,16 +4778,13 @@ describe('sort-interfaces', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -6452,10 +6420,7 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([
-      ['always', 'always'],
-      ['1', 1],
-    ] as const)(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -6497,10 +6462,7 @@ describe('sort-interfaces', () => {
       },
     )
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -7021,10 +6983,7 @@ describe('sort-interfaces', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -7095,16 +7054,16 @@ describe('sort-interfaces', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -7161,13 +7120,11 @@ describe('sort-interfaces', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines when global option is %s and group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -7215,8 +7172,8 @@ describe('sort-interfaces', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+    it.each([1, 2, 'ignore', 0])(
+      'enforces no newline when global option is %s and newlinesBetween: 0 exists between all groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -7230,11 +7187,11 @@ describe('sort-interfaces', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -7267,11 +7224,9 @@ describe('sort-interfaces', () => {
     )
 
     it.each([
-      ['ignore', 'never'],
       ['ignore', 0],
-      ['never', 'ignore'],
       [0, 'ignore'],
-    ] as const)(
+    ])(
       'does not enforce newline when global option is %s and group option is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await valid({
@@ -7361,16 +7316,13 @@ describe('sort-interfaces', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ] as const)(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -7879,7 +7831,7 @@ describe('sort-interfaces', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -863,10 +863,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_, newlinesBetween) => {
         await invalid({
@@ -951,16 +948,16 @@ describe('sort-intersection-types', () => {
             ...options,
             groups: [
               'function',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'object',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'named',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'tuple',
               { newlinesBetween: 'ignore' },
               'nullish',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -992,12 +989,10 @@ describe('sort-intersection-types', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1039,14 +1034,8 @@ describe('sort-intersection-types', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1054,9 +1043,9 @@ describe('sort-intersection-types', () => {
               ...options,
               groups: [
                 'named',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'tuple',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'nullish',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1087,10 +1076,8 @@ describe('sort-intersection-types', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1153,7 +1140,7 @@ describe('sort-intersection-types', () => {
         options: [
           {
             groups: ['literal', 'named'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -1173,10 +1160,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1541,7 +1525,7 @@ describe('sort-intersection-types', () => {
               },
             ],
             groups: ['elementsIncludingFoo', 'unknown'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1595,10 +1579,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines within groups when newlinesInside is %s',
       async (_, newlinesInside) => {
         await invalid({
@@ -1638,10 +1619,7 @@ describe('sort-intersection-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within groups when newlinesInside is %s',
       async (_, newlinesInside) => {
         await invalid({
@@ -2525,10 +2503,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_, newlinesBetween) => {
         await invalid({
@@ -2613,16 +2588,16 @@ describe('sort-intersection-types', () => {
             ...options,
             groups: [
               'function',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'object',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'named',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'tuple',
               { newlinesBetween: 'ignore' },
               'nullish',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -2654,12 +2629,10 @@ describe('sort-intersection-types', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2701,14 +2674,8 @@ describe('sort-intersection-types', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2716,9 +2683,9 @@ describe('sort-intersection-types', () => {
               ...options,
               groups: [
                 'named',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'tuple',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'nullish',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2749,10 +2716,8 @@ describe('sort-intersection-types', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2815,7 +2780,7 @@ describe('sort-intersection-types', () => {
         options: [
           {
             groups: ['literal', 'named'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -2835,10 +2800,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3203,7 +3165,7 @@ describe('sort-intersection-types', () => {
               },
             ],
             groups: ['elementsIncludingFoo', 'unknown'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3257,10 +3219,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines within groups when newlinesInside is %s',
       async (_, newlinesInside) => {
         await invalid({
@@ -3300,10 +3259,7 @@ describe('sort-intersection-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within groups when newlinesInside is %s',
       async (_, newlinesInside) => {
         await invalid({
@@ -4180,10 +4136,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_, newlinesBetween) => {
         await invalid({
@@ -4268,16 +4221,16 @@ describe('sort-intersection-types', () => {
             ...options,
             groups: [
               'function',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'object',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'named',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'tuple',
               { newlinesBetween: 'ignore' },
               'nullish',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -4309,12 +4262,10 @@ describe('sort-intersection-types', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4356,14 +4307,8 @@ describe('sort-intersection-types', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4371,9 +4316,9 @@ describe('sort-intersection-types', () => {
               ...options,
               groups: [
                 'named',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'tuple',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'nullish',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4404,10 +4349,8 @@ describe('sort-intersection-types', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4470,7 +4413,7 @@ describe('sort-intersection-types', () => {
         options: [
           {
             groups: ['literal', 'named'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -4490,10 +4433,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4858,7 +4798,7 @@ describe('sort-intersection-types', () => {
               },
             ],
             groups: ['elementsIncludingFoo', 'unknown'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4912,10 +4852,7 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines within groups when newlinesInside is %s',
       async (_, newlinesInside) => {
         await invalid({
@@ -4955,10 +4892,7 @@ describe('sort-intersection-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within groups when newlinesInside is %s',
       async (_, newlinesInside) => {
         await invalid({
@@ -5109,7 +5043,7 @@ describe('sort-intersection-types', () => {
           {
             ...options,
             groups: ['named', 'literal'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -863,60 +863,57 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: '() => null',
-                right: 'Y',
-              },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '() => null',
+              right: 'Y',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['function', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            type T =
-              (() => null)
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['function', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          type T =
+            (() => null)
 
 
-             & Y
-            & Z
+           & Y
+          & Z
 
-                & B
-          `,
-          output: dedent`
-            type T =
-              (() => null)
-             & B
-            & Y
-                & Z
-          `,
-        })
-      },
-    )
+              & B
+        `,
+        output: dedent`
+          type T =
+            (() => null)
+           & B
+          & Y
+              & Z
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -1160,54 +1157,51 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type =
-              & a
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & a
 
-              // Partition comment
+            // Partition comment
 
-              & b
-              & c
-          `,
-          code: dedent`
-            type Type =
-              & a
+            & b
+            & c
+        `,
+        code: dedent`
+          type Type =
+            & a
 
-              // Partition comment
+            // Partition comment
 
-              & c
-              & b
-          `,
-        })
-      },
-    )
+            & c
+            & b
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({
@@ -1579,86 +1573,80 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines within groups when newlinesInside is %s',
-      async (_, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('enforces newlines within groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenIntersectionTypes',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              & a
+            messageId: 'missedSpacingBetweenIntersectionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
 
-              & b
-          `,
-          code: dedent`
-            type T =
-              & a
-              & b
-          `,
-        })
-      },
-    )
+            & b
+        `,
+        code: dedent`
+          type T =
+            & a
+            & b
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within groups when newlinesInside is %s',
-      async (_, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              & a
-              & b
-          `,
-          code: dedent`
-            type T =
-              & a
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
+            & b
+        `,
+        code: dedent`
+          type T =
+            & a
 
-              & b
-          `,
-        })
-      },
-    )
+            & b
+        `,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -2503,60 +2491,57 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: '() => null',
-                right: 'Y',
-              },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '() => null',
+              right: 'Y',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['function', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            type T =
-              (() => null)
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['function', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          type T =
+            (() => null)
 
 
-             & Y
-            & Z
+           & Y
+          & Z
 
-                & B
-          `,
-          output: dedent`
-            type T =
-              (() => null)
-             & B
-            & Y
-                & Z
-          `,
-        })
-      },
-    )
+              & B
+        `,
+        output: dedent`
+          type T =
+            (() => null)
+           & B
+          & Y
+              & Z
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -2800,54 +2785,51 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type =
-              & a
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & a
 
-              // Partition comment
+            // Partition comment
 
-              & b
-              & c
-          `,
-          code: dedent`
-            type Type =
-              & a
+            & b
+            & c
+        `,
+        code: dedent`
+          type Type =
+            & a
 
-              // Partition comment
+            // Partition comment
 
-              & c
-              & b
-          `,
-        })
-      },
-    )
+            & c
+            & b
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({
@@ -3219,86 +3201,80 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines within groups when newlinesInside is %s',
-      async (_, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('enforces newlines within groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenIntersectionTypes',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              & a
+            messageId: 'missedSpacingBetweenIntersectionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
 
-              & b
-          `,
-          code: dedent`
-            type T =
-              & a
-              & b
-          `,
-        })
-      },
-    )
+            & b
+        `,
+        code: dedent`
+          type T =
+            & a
+            & b
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within groups when newlinesInside is %s',
-      async (_, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              & a
-              & b
-          `,
-          code: dedent`
-            type T =
-              & a
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
+            & b
+        `,
+        code: dedent`
+          type T =
+            & a
 
-              & b
-          `,
-        })
-      },
-    )
+            & b
+        `,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4136,60 +4112,57 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: '() => null',
-                right: 'YY',
-              },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '() => null',
+              right: 'YY',
             },
-            {
-              data: {
-                right: 'BBB',
-                left: 'Z',
-              },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'Z',
             },
-            {
-              data: {
-                right: 'BBB',
-                left: 'Z',
-              },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'Z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['function', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            type T =
-              (() => null)
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['function', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          type T =
+            (() => null)
 
 
-             & YY
-            & Z
+           & YY
+          & Z
 
-                & BBB
-          `,
-          output: dedent`
-            type T =
-              (() => null)
-             & BBB
-            & YY
-                & Z
-          `,
-        })
-      },
-    )
+              & BBB
+        `,
+        output: dedent`
+          type T =
+            (() => null)
+           & BBB
+          & YY
+              & Z
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -4433,54 +4406,51 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedIntersectionTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type =
-              & aaa
+            messageId: 'unexpectedIntersectionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            & aaa
 
-              // Partition comment
+            // Partition comment
 
-              & bb
-              & c
-          `,
-          code: dedent`
-            type Type =
-              & aaa
+            & bb
+            & c
+        `,
+        code: dedent`
+          type Type =
+            & aaa
 
-              // Partition comment
+            // Partition comment
 
-              & c
-              & bb
-          `,
-        })
-      },
-    )
+            & c
+            & bb
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({
@@ -4852,86 +4822,80 @@ describe('sort-intersection-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines within groups when newlinesInside is %s',
-      async (_, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('enforces newlines within groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenIntersectionTypes',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              & a
+            messageId: 'missedSpacingBetweenIntersectionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
 
-              & b
-          `,
-          code: dedent`
-            type T =
-              & a
-              & b
-          `,
-        })
-      },
-    )
+            & b
+        `,
+        code: dedent`
+          type T =
+            & a
+            & b
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within groups when newlinesInside is %s',
-      async (_, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenIntersectionTypes',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              & a
-              & b
-          `,
-          code: dedent`
-            type T =
-              & a
+            messageId: 'extraSpacingBetweenIntersectionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            & a
+            & b
+        `,
+        code: dedent`
+          type T =
+            & a
 
-              & b
-          `,
-        })
-      },
-    )
+            & b
+        `,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -831,10 +831,7 @@ describe('sort-jsx-props', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -897,10 +894,7 @@ describe('sort-jsx-props', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -997,16 +991,16 @@ describe('sort-jsx-props', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1063,12 +1057,10 @@ describe('sort-jsx-props', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1126,14 +1118,8 @@ describe('sort-jsx-props', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1147,11 +1133,11 @@ describe('sort-jsx-props', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1194,7 +1180,7 @@ describe('sort-jsx-props', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2166,10 +2152,7 @@ describe('sort-jsx-props', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2232,10 +2215,7 @@ describe('sort-jsx-props', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2332,16 +2312,16 @@ describe('sort-jsx-props', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2398,12 +2378,10 @@ describe('sort-jsx-props', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2461,14 +2439,8 @@ describe('sort-jsx-props', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2482,11 +2454,11 @@ describe('sort-jsx-props', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2529,7 +2501,7 @@ describe('sort-jsx-props', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3501,10 +3473,7 @@ describe('sort-jsx-props', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3567,10 +3536,7 @@ describe('sort-jsx-props', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3667,16 +3633,16 @@ describe('sort-jsx-props', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3733,12 +3699,10 @@ describe('sort-jsx-props', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -3796,14 +3760,8 @@ describe('sort-jsx-props', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -3817,11 +3775,11 @@ describe('sort-jsx-props', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -3864,7 +3822,7 @@ describe('sort-jsx-props', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4161,7 +4119,7 @@ describe('sort-jsx-props', () => {
       })
     })
 
-    it('adds newlines between groups when newlinesBetween is always', async () => {
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
       await invalid({
         options: [
           {
@@ -4176,7 +4134,7 @@ describe('sort-jsx-props', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -831,136 +831,130 @@ describe('sort-jsx-props', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          <Component
+            a
+
+
+           y
+          z
+
+              b
+          />
+        `,
+        output: dedent`
+          <Component
+            a
+           b
+          y
+              z
+          />
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            <Component
-              a
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+
+           y
+          z
+
+              b
+          />
+        `,
+        code: dedent`
+          <Component
+            a
 
 
-             y
-            z
-
-                b
-            />
-          `,
-          output: dedent`
-            <Component
-              a
-             b
-            y
-                z
-            />
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenJSXPropsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            <Component
-              a
-
-             y
-            z
-
-                b
-            />
-          `,
-          code: dedent`
-            <Component
-              a
-
-
-             z
-            y
-                b
-            />
-          `,
-        })
-      },
-    )
+           z
+          y
+              b
+          />
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -2152,136 +2146,130 @@ describe('sort-jsx-props', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          <Component
+            a
+
+
+           y
+          z
+
+              b
+          />
+        `,
+        output: dedent`
+          <Component
+            a
+           b
+          y
+              z
+          />
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            <Component
-              a
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+
+           y
+          z
+
+              b
+          />
+        `,
+        code: dedent`
+          <Component
+            a
 
 
-             y
-            z
-
-                b
-            />
-          `,
-          output: dedent`
-            <Component
-              a
-             b
-            y
-                z
-            />
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenJSXPropsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            <Component
-              a
-
-             y
-            z
-
-                b
-            />
-          `,
-          code: dedent`
-            <Component
-              a
-
-
-             z
-            y
-                b
-            />
-          `,
-        })
-      },
-    )
+           z
+          y
+              b
+          />
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -3473,136 +3461,130 @@ describe('sort-jsx-props', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          <Component
+            aaaa
+
+
+           yy
+          z
+
+              bbb
+          />
+        `,
+        output: dedent`
+          <Component
+            aaaa
+           bbb
+          yy
+              z
+          />
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'z',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
+            messageId: 'extraSpacingBetweenJSXPropsMembers',
+          },
+          {
+            data: {
+              right: 'yy',
+              left: 'z',
+            },
+            messageId: 'unexpectedJSXPropsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'yy',
+            },
+            messageId: 'missedSpacingBetweenJSXPropsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
               },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
+              {
+                elementNamePattern: 'bbb',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            <Component
-              aaaa
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          <Component
+            aaaa
+
+           yy
+          z
+
+              bbb
+          />
+        `,
+        code: dedent`
+          <Component
+            aaaa
 
 
-             yy
-            z
-
-                bbb
-            />
-          `,
-          output: dedent`
-            <Component
-              aaaa
-             bbb
-            yy
-                z
-            />
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'z',
-              },
-              messageId: 'extraSpacingBetweenJSXPropsMembers',
-            },
-            {
-              data: {
-                right: 'yy',
-                left: 'z',
-              },
-              messageId: 'unexpectedJSXPropsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'yy',
-              },
-              messageId: 'missedSpacingBetweenJSXPropsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'bbb',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            <Component
-              aaaa
-
-             yy
-            z
-
-                bbb
-            />
-          `,
-          code: dedent`
-            <Component
-              aaaa
-
-
-             z
-            yy
-                bbb
-            />
-          `,
-        })
-      },
-    )
+           z
+          yy
+              bbb
+          />
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -951,68 +951,65 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes extra newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes extra newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenMapElementsMembers',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenMapElementsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            new Map([
-              [a, null],
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          new Map([
+            [a, null],
 
 
-             [y, null],
-            [z, null],
+           [y, null],
+          [z, null],
 
-                [b, null]
-            ])
-          `,
-          output: dedent`
-            new Map([
-              [a, null],
-             [b, null],
-            [y, null],
-                [z, null]
-            ])
-          `,
-        })
-      },
-    )
+              [b, null]
+          ])
+        `,
+        output: dedent`
+          new Map([
+            [a, null],
+           [b, null],
+          [y, null],
+              [z, null]
+          ])
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -1307,56 +1304,53 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedMapElementsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            new Map([
-              [a, 'a'],
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, 'a'],
 
-              // Partition comment
+            // Partition comment
 
-              [b, 'b'],
-              [c, 'c'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [a, 'a'],
+            [b, 'b'],
+            [c, 'c'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [a, 'a'],
 
-              // Partition comment
+            // Partition comment
 
-              [c, 'c'],
-              [b, 'b'],
-            ])
-          `,
-        })
-      },
-    )
+            [c, 'c'],
+            [b, 'b'],
+          ])
+        `,
+      })
+    })
 
     it.each([
       ['string pattern', 'foo'],
@@ -2375,68 +2369,65 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes extra newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes extra newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenMapElementsMembers',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenMapElementsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            new Map([
-              [a, null],
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          new Map([
+            [a, null],
 
 
-             [y, null],
-            [z, null],
+           [y, null],
+          [z, null],
 
-                [b, null]
-            ])
-          `,
-          output: dedent`
-            new Map([
-              [a, null],
-             [b, null],
-            [y, null],
-                [z, null]
-            ])
-          `,
-        })
-      },
-    )
+              [b, null]
+          ])
+        `,
+        output: dedent`
+          new Map([
+            [a, null],
+           [b, null],
+          [y, null],
+              [z, null]
+          ])
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -2731,56 +2722,53 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedMapElementsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            new Map([
-              [a, 'a'],
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [a, 'a'],
 
-              // Partition comment
+            // Partition comment
 
-              [b, 'b'],
-              [c, 'c'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [a, 'a'],
+            [b, 'b'],
+            [c, 'c'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [a, 'a'],
 
-              // Partition comment
+            // Partition comment
 
-              [c, 'c'],
-              [b, 'b'],
-            ])
-          `,
-        })
-      },
-    )
+            [c, 'c'],
+            [b, 'b'],
+          ])
+        `,
+      })
+    })
 
     it.each([
       ['string pattern', 'foo'],
@@ -3799,68 +3787,65 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes extra newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
+    it('removes extra newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'unexpectedMapElementsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenMapElementsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenMapElementsMembers',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedMapElementsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenMapElementsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            new Map([
-              [aaaa, null],
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          new Map([
+            [aaaa, null],
 
 
-             [yy, null],
-            [z, null],
+           [yy, null],
+          [z, null],
 
-                [bbb, null]
-            ])
-          `,
-          output: dedent`
-            new Map([
-              [aaaa, null],
-             [bbb, null],
-            [yy, null],
-                [z, null]
-            ])
-          `,
-        })
-      },
-    )
+              [bbb, null]
+          ])
+        `,
+        output: dedent`
+          new Map([
+            [aaaa, null],
+           [bbb, null],
+          [yy, null],
+              [z, null]
+          ])
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -4155,56 +4140,53 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('preserves partition boundaries when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaa',
+                groupName: 'a',
               },
-              messageId: 'unexpectedMapElementsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            new Map([
-              [aaa, 'a'],
+            messageId: 'unexpectedMapElementsOrder',
+          },
+        ],
+        output: dedent`
+          new Map([
+            [aaa, 'a'],
 
-              // Partition comment
+            // Partition comment
 
-              [bb, 'b'],
-              [c, 'c'],
-            ])
-          `,
-          code: dedent`
-            new Map([
-              [aaa, 'a'],
+            [bb, 'b'],
+            [c, 'c'],
+          ])
+        `,
+        code: dedent`
+          new Map([
+            [aaa, 'a'],
 
-              // Partition comment
+            // Partition comment
 
-              [c, 'c'],
-              [bb, 'b'],
-            ])
-          `,
-        })
-      },
-    )
+            [c, 'c'],
+            [bb, 'b'],
+          ])
+        `,
+      })
+    })
 
     it.each([
       ['string pattern', 'foo'],

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -951,10 +951,7 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ])(
+    it.each([['0', 0]])(
       'removes extra newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1031,16 +1028,16 @@ describe('sort-maps', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1097,10 +1094,8 @@ describe('sort-maps', () => {
     })
 
     it.each([
-      ['2 spaces globally with never in group', 2, 'never'],
       ['2 spaces globally with 0 in group', 2, 0],
       ['2 spaces globally with ignore in group', 2, 'ignore'],
-      ['never globally with 2 spaces in group', 'never', 2],
       ['0 globally with 2 spaces in group', 0, 2],
       ['ignore globally with 2 spaces in group', 'ignore', 2],
     ])(
@@ -1152,13 +1147,12 @@ describe('sort-maps', () => {
     )
 
     it.each([
-      ['always', 'always'],
+      ['1 space', 1],
       ['2 spaces', 2],
       ['ignore', 'ignore'],
-      ['never', 'never'],
       ['0', 0],
     ])(
-      'removes newlines when never is between groups despite %s global setting',
+      'removes newlines when 0 is between groups despite %s global setting',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -1172,11 +1166,11 @@ describe('sort-maps', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1209,9 +1203,7 @@ describe('sort-maps', () => {
     )
 
     it.each([
-      ['ignore globally with never in group', 'ignore', 'never'],
       ['ignore globally with 0 in group', 'ignore', 0],
-      ['never globally with ignore in group', 'never', 'ignore'],
       ['0 globally with ignore in group', 0, 'ignore'],
     ])(
       'allows any spacing when %s',
@@ -1282,7 +1274,7 @@ describe('sort-maps', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1315,10 +1307,7 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2386,10 +2375,7 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ])(
+    it.each([['0', 0]])(
       'removes extra newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2466,16 +2452,16 @@ describe('sort-maps', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2532,10 +2518,8 @@ describe('sort-maps', () => {
     })
 
     it.each([
-      ['2 spaces globally with never in group', 2, 'never'],
       ['2 spaces globally with 0 in group', 2, 0],
       ['2 spaces globally with ignore in group', 2, 'ignore'],
-      ['never globally with 2 spaces in group', 'never', 2],
       ['0 globally with 2 spaces in group', 0, 2],
       ['ignore globally with 2 spaces in group', 'ignore', 2],
     ])(
@@ -2587,13 +2571,12 @@ describe('sort-maps', () => {
     )
 
     it.each([
-      ['always', 'always'],
+      ['1 space', 1],
       ['2 spaces', 2],
       ['ignore', 'ignore'],
-      ['never', 'never'],
       ['0', 0],
     ])(
-      'removes newlines when never is between groups despite %s global setting',
+      'removes newlines when 0 is between groups despite %s global setting',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -2607,11 +2590,11 @@ describe('sort-maps', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2644,9 +2627,7 @@ describe('sort-maps', () => {
     )
 
     it.each([
-      ['ignore globally with never in group', 'ignore', 'never'],
       ['ignore globally with 0 in group', 'ignore', 0],
-      ['never globally with ignore in group', 'never', 'ignore'],
       ['0 globally with ignore in group', 0, 'ignore'],
     ])(
       'allows any spacing when %s',
@@ -2717,7 +2698,7 @@ describe('sort-maps', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2750,10 +2731,7 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3821,10 +3799,7 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ])(
+    it.each([['0', 0]])(
       'removes extra newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3901,16 +3876,16 @@ describe('sort-maps', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3967,10 +3942,8 @@ describe('sort-maps', () => {
     })
 
     it.each([
-      ['2 spaces globally with never in group', 2, 'never'],
       ['2 spaces globally with 0 in group', 2, 0],
       ['2 spaces globally with ignore in group', 2, 'ignore'],
-      ['never globally with 2 spaces in group', 'never', 2],
       ['0 globally with 2 spaces in group', 0, 2],
       ['ignore globally with 2 spaces in group', 'ignore', 2],
     ])(
@@ -4022,13 +3995,12 @@ describe('sort-maps', () => {
     )
 
     it.each([
-      ['always', 'always'],
+      ['1 space', 1],
       ['2 spaces', 2],
       ['ignore', 'ignore'],
-      ['never', 'never'],
       ['0', 0],
     ])(
-      'removes newlines when never is between groups despite %s global setting',
+      'removes newlines when 0 is between groups despite %s global setting',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -4042,11 +4014,11 @@ describe('sort-maps', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4079,9 +4051,7 @@ describe('sort-maps', () => {
     )
 
     it.each([
-      ['ignore globally with never in group', 'ignore', 'never'],
       ['ignore globally with 0 in group', 'ignore', 0],
-      ['never globally with ignore in group', 'never', 'ignore'],
       ['0 globally with ignore in group', 0, 'ignore'],
     ])(
       'allows any spacing when %s',
@@ -4152,7 +4122,7 @@ describe('sort-maps', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4185,10 +4155,7 @@ describe('sort-maps', () => {
       })
     })
 
-    it.each([
-      ['never', 'never'],
-      ['0', 0],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4450,7 +4417,7 @@ describe('sort-maps', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -828,82 +828,76 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines between group members when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'type',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'A',
+    it('enforces newlines between group members when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                newlinesInside: 1,
+                selector: 'type',
               },
-              messageId: 'missedSpacingBetweenModulesMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-          output: dedent`
-            type A = {}
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          type A = {}
 
-            type B = {}
-          `,
-          code: dedent`
-            type A = {}
-            type B = {}
-          `,
-        })
-      },
-    )
+          type B = {}
+        `,
+        code: dedent`
+          type A = {}
+          type B = {}
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines between group members when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'type',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'A',
+    it('removes newlines between group members when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                newlinesInside: 0,
+                selector: 'type',
               },
-              messageId: 'extraSpacingBetweenModulesMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-          output: dedent`
-            type A = {}
-            type B = {}
-          `,
-          code: dedent`
-            type A = {}
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          type A = {}
+          type B = {}
+        `,
+        code: dedent`
+          type A = {}
 
-            type B = {}
-          `,
-        })
-      },
-    )
+          type B = {}
+        `,
+      })
+    })
 
     it('prioritizes declare modifier over export modifier', async () => {
       await invalid({
@@ -1769,151 +1763,145 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                leftGroup: 'interface',
-                rightGroup: 'unknown',
-                right: 'y',
-                left: 'A',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'interface',
+              rightGroup: 'unknown',
+              right: 'y',
+              left: 'A',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedModulesOrder',
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenModulesMembers',
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['unknown', 'interface'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-              interface A {}
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown', 'interface'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+            interface A {}
 
 
-             function y() {}
-            function z() {}
+           function y() {}
+          function z() {}
 
-                function b() {}
-          `,
-          output: dedent`
               function b() {}
-             function y() {}
-            function z() {}
-                interface A {}
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'maintains single newline between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'b'],
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'missedSpacingBetweenModulesMembers',
-            },
-          ],
-          output: dedent`
-            function a() {};
-
+        `,
+        output: dedent`
             function b() {}
-          `,
-          code: dedent`
-            function a() {};function b() {}
-          `,
-        })
-
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'A',
-              },
-              messageId: 'extraSpacingBetweenModulesMembers',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-            {
-              data: {
-                right: 'B',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenModulesMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['interface', 'unknown', 'class'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
+           function y() {}
+          function z() {}
               interface A {}
+        `,
+      })
+    })
 
-             function y() {}
-            function z() {}
+    it('maintains single newline between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['a', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          function a() {};
 
-                class B {}
-          `,
-          code: dedent`
-              interface A {}
+          function b() {}
+        `,
+        code: dedent`
+          function a() {};function b() {}
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['interface', 'unknown', 'class'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+            interface A {}
+
+           function y() {}
+          function z() {}
+
+              class B {}
+        `,
+        code: dedent`
+            interface A {}
 
 
-             function z() {}
-            function y() {}
-                class B {}
-          `,
-        })
-      },
-    )
+           function z() {}
+          function y() {}
+              class B {}
+        `,
+      })
+    })
 
     it('handles newlinesBetween settings between consecutive groups', async () => {
       await invalid({
@@ -2177,52 +2165,49 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedModulesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            function a() {}
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {}
 
-            // Partition comment
+          // Partition comment
 
-            function b() {}
-            function c() {}
-          `,
-          code: dedent`
-            function a() {}
+          function b() {}
+          function c() {}
+        `,
+        code: dedent`
+          function a() {}
 
-            // Partition comment
+          // Partition comment
 
-            function c() {}
-            function b() {}
-          `,
-        })
-      },
-    )
+          function c() {}
+          function b() {}
+        `,
+      })
+    })
 
     it('sorts inline non-declare functions correctly', async () => {
       await invalid({
@@ -3395,82 +3380,76 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines between group members when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'type',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'A',
+    it('enforces newlines between group members when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                newlinesInside: 1,
+                selector: 'type',
               },
-              messageId: 'missedSpacingBetweenModulesMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-          output: dedent`
-            type A = {}
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          type A = {}
 
-            type B = {}
-          `,
-          code: dedent`
-            type A = {}
-            type B = {}
-          `,
-        })
-      },
-    )
+          type B = {}
+        `,
+        code: dedent`
+          type A = {}
+          type B = {}
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines between group members when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'type',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'A',
+    it('removes newlines between group members when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                newlinesInside: 0,
+                selector: 'type',
               },
-              messageId: 'extraSpacingBetweenModulesMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-          output: dedent`
-            type A = {}
-            type B = {}
-          `,
-          code: dedent`
-            type A = {}
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          type A = {}
+          type B = {}
+        `,
+        code: dedent`
+          type A = {}
 
-            type B = {}
-          `,
-        })
-      },
-    )
+          type B = {}
+        `,
+      })
+    })
 
     it('prioritizes declare modifier over export modifier', async () => {
       await invalid({
@@ -4336,151 +4315,145 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                leftGroup: 'interface',
-                rightGroup: 'unknown',
-                right: 'y',
-                left: 'A',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'interface',
+              rightGroup: 'unknown',
+              right: 'y',
+              left: 'A',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedModulesOrder',
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenModulesMembers',
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['unknown', 'interface'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-              interface A {}
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown', 'interface'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+            interface A {}
 
 
-             function y() {}
-            function z() {}
+           function y() {}
+          function z() {}
 
-                function b() {}
-          `,
-          output: dedent`
               function b() {}
-             function y() {}
-            function z() {}
-                interface A {}
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'maintains single newline between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'b'],
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'missedSpacingBetweenModulesMembers',
-            },
-          ],
-          output: dedent`
-            function a() {};
-
+        `,
+        output: dedent`
             function b() {}
-          `,
-          code: dedent`
-            function a() {};function b() {}
-          `,
-        })
-
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'A',
-              },
-              messageId: 'extraSpacingBetweenModulesMembers',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-            {
-              data: {
-                right: 'B',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenModulesMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['interface', 'unknown', 'class'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
+           function y() {}
+          function z() {}
               interface A {}
+        `,
+      })
+    })
 
-             function y() {}
-            function z() {}
+    it('maintains single newline between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['a', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          function a() {};
 
-                class B {}
-          `,
-          code: dedent`
-              interface A {}
+          function b() {}
+        `,
+        code: dedent`
+          function a() {};function b() {}
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'A',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['interface', 'unknown', 'class'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+            interface A {}
+
+           function y() {}
+          function z() {}
+
+              class B {}
+        `,
+        code: dedent`
+            interface A {}
 
 
-             function z() {}
-            function y() {}
-                class B {}
-          `,
-        })
-      },
-    )
+           function z() {}
+          function y() {}
+              class B {}
+        `,
+      })
+    })
 
     it('handles newlinesBetween settings between consecutive groups', async () => {
       await invalid({
@@ -4744,52 +4717,49 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedModulesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            function a() {}
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {}
 
-            // Partition comment
+          // Partition comment
 
-            function b() {}
-            function c() {}
-          `,
-          code: dedent`
-            function a() {}
+          function b() {}
+          function c() {}
+        `,
+        code: dedent`
+          function a() {}
 
-            // Partition comment
+          // Partition comment
 
-            function c() {}
-            function b() {}
-          `,
-        })
-      },
-    )
+          function c() {}
+          function b() {}
+        `,
+      })
+    })
 
     it('sorts inline non-declare functions correctly', async () => {
       await invalid({
@@ -5963,82 +5933,76 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines between group members when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'type',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'A',
+    it('enforces newlines between group members when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                newlinesInside: 1,
+                selector: 'type',
               },
-              messageId: 'missedSpacingBetweenModulesMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-          output: dedent`
-            type A = {}
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          type A = {}
 
-            type B = {}
-          `,
-          code: dedent`
-            type A = {}
-            type B = {}
-          `,
-        })
-      },
-    )
+          type B = {}
+        `,
+        code: dedent`
+          type A = {}
+          type B = {}
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines between group members when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'type',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'B',
-                left: 'A',
+    it('removes newlines between group members when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                newlinesInside: 0,
+                selector: 'type',
               },
-              messageId: 'extraSpacingBetweenModulesMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'B',
+              left: 'A',
             },
-          ],
-          output: dedent`
-            type A = {}
-            type B = {}
-          `,
-          code: dedent`
-            type A = {}
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          type A = {}
+          type B = {}
+        `,
+        code: dedent`
+          type A = {}
 
-            type B = {}
-          `,
-        })
-      },
-    )
+          type B = {}
+        `,
+      })
+    })
 
     it('prioritizes declare modifier over export modifier', async () => {
       await invalid({
@@ -6863,151 +6827,145 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                leftGroup: 'interface',
-                rightGroup: 'unknown',
-                left: 'AAAA',
-                right: 'yy',
-              },
-              messageId: 'unexpectedModulesGroupOrder',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'interface',
+              rightGroup: 'unknown',
+              left: 'AAAA',
+              right: 'yy',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedModulesOrder',
+            messageId: 'unexpectedModulesGroupOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenModulesMembers',
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['unknown', 'interface'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-              interface AAAA {}
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['unknown', 'interface'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+            interface AAAA {}
 
 
-             function yy() {}
-            function z() {}
+           function yy() {}
+          function z() {}
 
-                function bbb() {}
-          `,
-          output: dedent`
               function bbb() {}
-             function yy() {}
-            function z() {}
-                interface AAAA {}
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'maintains single newline between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'b'],
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
-              },
-              messageId: 'missedSpacingBetweenModulesMembers',
-            },
-          ],
-          output: dedent`
-            function a() {};
-
-            function b() {}
-          `,
-          code: dedent`
-            function a() {};function b() {}
-          `,
-        })
-
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'AAAA',
-                right: 'z',
-              },
-              messageId: 'extraSpacingBetweenModulesMembers',
-            },
-            {
-              data: {
-                right: 'yy',
-                left: 'z',
-              },
-              messageId: 'unexpectedModulesOrder',
-            },
-            {
-              data: {
-                right: 'BBB',
-                left: 'yy',
-              },
-              messageId: 'missedSpacingBetweenModulesMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['interface', 'unknown', 'class'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
+        `,
+        output: dedent`
+            function bbb() {}
+           function yy() {}
+          function z() {}
               interface AAAA {}
+        `,
+      })
+    })
 
-             function yy() {}
-            function z() {}
+    it('maintains single newline between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
+              },
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
+              },
+            ],
+            groups: ['a', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        output: dedent`
+          function a() {};
 
-                class BBB {}
-          `,
-          code: dedent`
-              interface AAAA {}
+          function b() {}
+        `,
+        code: dedent`
+          function a() {};function b() {}
+        `,
+      })
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'AAAA',
+              right: 'z',
+            },
+            messageId: 'extraSpacingBetweenModulesMembers',
+          },
+          {
+            data: {
+              right: 'yy',
+              left: 'z',
+            },
+            messageId: 'unexpectedModulesOrder',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'yy',
+            },
+            messageId: 'missedSpacingBetweenModulesMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['interface', 'unknown', 'class'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+            interface AAAA {}
+
+           function yy() {}
+          function z() {}
+
+              class BBB {}
+        `,
+        code: dedent`
+            interface AAAA {}
 
 
-             function z() {}
-            function yy() {}
-                class BBB {}
-          `,
-        })
-      },
-    )
+           function z() {}
+          function yy() {}
+              class BBB {}
+        `,
+      })
+    })
 
     it('handles newlinesBetween settings between consecutive groups', async () => {
       await invalid({
@@ -7271,52 +7229,49 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedModulesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            function a() {}
+            messageId: 'unexpectedModulesOrder',
+          },
+        ],
+        output: dedent`
+          function a() {}
 
-            // Partition comment
+          // Partition comment
 
-            function bb() {}
-            function c() {}
-          `,
-          code: dedent`
-            function a() {}
+          function bb() {}
+          function c() {}
+        `,
+        code: dedent`
+          function a() {}
 
-            // Partition comment
+          // Partition comment
 
-            function c() {}
-            function bb() {}
-          `,
-        })
-      },
-    )
+          function c() {}
+          function bb() {}
+        `,
+      })
+    })
 
     it('sorts inline non-declare functions correctly', async () => {
       await invalid({

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -828,10 +828,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines between group members when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -869,10 +866,7 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between group members when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1775,10 +1769,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1833,10 +1824,7 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'maintains single newline between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1941,16 +1929,16 @@ describe('sort-modules', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2003,12 +1991,10 @@ describe('sort-modules', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2053,14 +2039,8 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2074,11 +2054,11 @@ describe('sort-modules', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2107,10 +2087,8 @@ describe('sort-modules', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2178,18 +2156,18 @@ describe('sort-modules', () => {
             messageId: 'unexpectedModulesGroupOrder',
           },
         ],
-        options: [
-          {
-            groups: ['function', 'type'],
-            newlinesBetween: 'always',
-          },
-        ],
         output: dedent`
           function a() {} // Comment after
 
           type B = string
           type C = string
         `,
+        options: [
+          {
+            groups: ['function', 'type'],
+            newlinesBetween: 1,
+          },
+        ],
         code: dedent`
           type B = string
           function a() {} // Comment after
@@ -2199,10 +2177,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3420,10 +3395,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines between group members when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -3461,10 +3433,7 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between group members when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -4367,10 +4336,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4425,10 +4391,7 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'maintains single newline between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4533,16 +4496,16 @@ describe('sort-modules', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4595,12 +4558,10 @@ describe('sort-modules', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4645,14 +4606,8 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4666,11 +4621,11 @@ describe('sort-modules', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4699,10 +4654,8 @@ describe('sort-modules', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4770,18 +4723,18 @@ describe('sort-modules', () => {
             messageId: 'unexpectedModulesGroupOrder',
           },
         ],
-        options: [
-          {
-            groups: ['function', 'type'],
-            newlinesBetween: 'always',
-          },
-        ],
         output: dedent`
           function a() {} // Comment after
 
           type B = string
           type C = string
         `,
+        options: [
+          {
+            groups: ['function', 'type'],
+            newlinesBetween: 1,
+          },
+        ],
         code: dedent`
           type B = string
           function a() {} // Comment after
@@ -4791,10 +4744,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -6013,10 +5963,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines between group members when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -6054,10 +6001,7 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between group members when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -6919,10 +6863,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -6977,10 +6918,7 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'maintains single newline between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -7085,16 +7023,16 @@ describe('sort-modules', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -7147,12 +7085,10 @@ describe('sort-modules', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -7197,14 +7133,8 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -7218,11 +7148,11 @@ describe('sort-modules', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -7251,10 +7181,8 @@ describe('sort-modules', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -7322,18 +7250,18 @@ describe('sort-modules', () => {
             messageId: 'unexpectedModulesGroupOrder',
           },
         ],
-        options: [
-          {
-            groups: ['function', 'type'],
-            newlinesBetween: 'always',
-          },
-        ],
         output: dedent`
           function a() {} // Comment after
 
           type B = string
           type C = string
         `,
+        options: [
+          {
+            groups: ['function', 'type'],
+            newlinesBetween: 1,
+          },
+        ],
         code: dedent`
           type B = string
           function a() {} // Comment after
@@ -7343,10 +7271,7 @@ describe('sort-modules', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -7966,7 +7891,7 @@ describe('sort-modules', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],
@@ -8080,7 +8005,7 @@ describe('sort-modules', () => {
         `,
         options: [
           {
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -965,10 +965,7 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1045,16 +1042,16 @@ describe('sort-named-exports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1111,12 +1108,10 @@ describe('sort-named-exports', () => {
     })
 
     it.each([
-      ['2 and never', 2, 'never' as const],
-      ['2 and 0', 2, 0 as const],
-      ['2 and ignore', 2, 'ignore' as const],
-      ['never and 2', 'never' as const, 2],
-      ['0 and 2', 0 as const, 2],
-      ['ignore and 2', 'ignore' as const, 2],
+      ['2 and 0', 2, 0],
+      ['2 and ignore', 2, 'ignore'],
+      ['0 and 2', 0, 2],
+      ['ignore and 2', 'ignore', 2],
     ])(
       'enforces newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1166,13 +1161,12 @@ describe('sort-named-exports', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['2', 2 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['2', 2],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
-      'enforces no newline when global option is %s and never exists between all groups',
+      'enforces no newline when global option is %s and 0 exists between all groups',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -1186,11 +1180,11 @@ describe('sort-named-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1223,10 +1217,8 @@ describe('sort-named-exports', () => {
     )
 
     it.each([
-      ['ignore and never', 'ignore' as const, 'never' as const],
-      ['ignore and 0', 'ignore' as const, 0 as const],
-      ['never and ignore', 'never' as const, 'ignore' as const],
-      ['0 and ignore', 0 as const, 'ignore' as const],
+      ['ignore and 0', 'ignore', 0],
+      ['0 and ignore', 0, 'ignore'],
     ])(
       'does not enforce newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1296,7 +1288,7 @@ describe('sort-named-exports', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1329,10 +1321,7 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2335,10 +2324,7 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2415,16 +2401,16 @@ describe('sort-named-exports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2481,12 +2467,10 @@ describe('sort-named-exports', () => {
     })
 
     it.each([
-      ['2 and never', 2, 'never' as const],
-      ['2 and 0', 2, 0 as const],
-      ['2 and ignore', 2, 'ignore' as const],
-      ['never and 2', 'never' as const, 2],
-      ['0 and 2', 0 as const, 2],
-      ['ignore and 2', 'ignore' as const, 2],
+      ['2 and 0', 2, 0],
+      ['2 and ignore', 2, 'ignore'],
+      ['0 and 2', 0, 2],
+      ['ignore and 2', 'ignore', 2],
     ])(
       'enforces newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2536,13 +2520,12 @@ describe('sort-named-exports', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['2', 2 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['2', 2],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
-      'enforces no newline when global option is %s and never exists between all groups',
+      'enforces no newline when global option is %s and 0 exists between all groups',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -2556,11 +2539,11 @@ describe('sort-named-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2593,10 +2576,8 @@ describe('sort-named-exports', () => {
     )
 
     it.each([
-      ['ignore and never', 'ignore' as const, 'never' as const],
-      ['ignore and 0', 'ignore' as const, 0 as const],
-      ['never and ignore', 'never' as const, 'ignore' as const],
-      ['0 and ignore', 0 as const, 'ignore' as const],
+      ['ignore and 0', 'ignore', 0],
+      ['0 and ignore', 0, 'ignore'],
     ])(
       'does not enforce newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2666,7 +2647,7 @@ describe('sort-named-exports', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2699,10 +2680,7 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3705,10 +3683,7 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3785,16 +3760,16 @@ describe('sort-named-exports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3851,12 +3826,10 @@ describe('sort-named-exports', () => {
     })
 
     it.each([
-      ['2 and never', 2, 'never' as const],
-      ['2 and 0', 2, 0 as const],
-      ['2 and ignore', 2, 'ignore' as const],
-      ['never and 2', 'never' as const, 2],
-      ['0 and 2', 0 as const, 2],
-      ['ignore and 2', 'ignore' as const, 2],
+      ['2 and 0', 2, 0],
+      ['2 and ignore', 2, 'ignore'],
+      ['0 and 2', 0, 2],
+      ['ignore and 2', 'ignore', 2],
     ])(
       'enforces newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -3906,13 +3879,12 @@ describe('sort-named-exports', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['2', 2 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['2', 2],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
-      'enforces no newline when global option is %s and never exists between all groups',
+      'enforces no newline when global option is %s and 0 exists between all groups',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -3926,11 +3898,11 @@ describe('sort-named-exports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -3963,10 +3935,8 @@ describe('sort-named-exports', () => {
     )
 
     it.each([
-      ['ignore and never', 'ignore' as const, 'never' as const],
-      ['ignore and 0', 'ignore' as const, 0 as const],
-      ['never and ignore', 'never' as const, 'ignore' as const],
-      ['0 and ignore', 0 as const, 'ignore' as const],
+      ['ignore and 0', 'ignore', 0],
+      ['0 and ignore', 0, 'ignore'],
     ])(
       'does not enforce newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4036,7 +4006,7 @@ describe('sort-named-exports', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4069,10 +4039,7 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4209,7 +4176,7 @@ describe('sort-named-exports', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -965,68 +965,65 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenNamedExports',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenNamedExports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            export {
-                a,
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          export {
+              a,
 
 
-               y,
-              z,
+             y,
+            z,
 
-                  b,
-            }
-          `,
-          output: dedent`
-            export {
-                a,
-               b,
-              y,
-                  z,
-            }
-          `,
-        })
-      },
-    )
+                b,
+          }
+        `,
+        output: dedent`
+          export {
+              a,
+             b,
+            y,
+                z,
+          }
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -1321,56 +1318,53 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedNamedExportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            export {
-              a,
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c,
-            } from 'module'
-          `,
-          code: dedent`
-            export {
-              a,
+            b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          export {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b,
-            } from 'module'
-          `,
-        })
-      },
-    )
+            c,
+            b,
+          } from 'module'
+        `,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -2324,68 +2318,65 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenNamedExports',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenNamedExports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            export {
-                a,
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          export {
+              a,
 
 
-               y,
-              z,
+             y,
+            z,
 
-                  b,
-            }
-          `,
-          output: dedent`
-            export {
-                a,
-               b,
-              y,
-                  z,
-            }
-          `,
-        })
-      },
-    )
+                b,
+          }
+        `,
+        output: dedent`
+          export {
+              a,
+             b,
+            y,
+                z,
+          }
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -2680,56 +2671,53 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedNamedExportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            export {
-              a,
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c,
-            } from 'module'
-          `,
-          code: dedent`
-            export {
-              a,
+            b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          export {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b,
-            } from 'module'
-          `,
-        })
-      },
-    )
+            c,
+            b,
+          } from 'module'
+        `,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -3683,68 +3671,65 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenNamedExports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenNamedExports',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedNamedExportsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenNamedExports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            export {
-                aaaa,
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          export {
+              aaaa,
 
 
-               yy,
-              z,
+             yy,
+            z,
 
-                  bbb,
-            }
-          `,
-          output: dedent`
-            export {
-                aaaa,
-               bbb,
-              yy,
-                  z,
-            }
-          `,
-        })
-      },
-    )
+                bbb,
+          }
+        `,
+        output: dedent`
+          export {
+              aaaa,
+             bbb,
+            yy,
+                z,
+          }
+        `,
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -4039,56 +4024,53 @@ describe('sort-named-exports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaa',
+                groupName: 'a',
               },
-              messageId: 'unexpectedNamedExportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            export {
-              aaa,
+            messageId: 'unexpectedNamedExportsOrder',
+          },
+        ],
+        output: dedent`
+          export {
+            aaa,
 
-              // Partition comment
+            // Partition comment
 
-              bb,
-              c,
-            } from 'module'
-          `,
-          code: dedent`
-            export {
-              aaa,
+            bb,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          export {
+            aaa,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              bb,
-            } from 'module'
-          `,
-        })
-      },
-    )
+            c,
+            bb,
+          } from 'module'
+        `,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1113,68 +1113,65 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenNamedImports',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenNamedImports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            import {
-                a,
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          import {
+              a,
 
 
-               y,
-              z,
+             y,
+            z,
 
-                  b,
-            } from 'module'
-          `,
-          output: dedent`
-            import {
-                a,
-               b,
-              y,
-                  z,
-            } from 'module'
-          `,
-        })
-      },
-    )
+                b,
+          } from 'module'
+        `,
+        output: dedent`
+          import {
+              a,
+             b,
+            y,
+                z,
+          } from 'module'
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -1464,56 +1461,53 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedNamedImportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            import {
-              a,
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              a,
+            b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b,
-            } from 'module'
-          `,
-        })
-      },
-    )
+            c,
+            b,
+          } from 'module'
+        `,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -2615,68 +2609,65 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenNamedImports',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenNamedImports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            import {
-                a,
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          import {
+              a,
 
 
-               y,
-              z,
+             y,
+            z,
 
-                  b,
-            } from 'module'
-          `,
-          output: dedent`
-            import {
-                a,
-               b,
-              y,
-                  z,
-            } from 'module'
-          `,
-        })
-      },
-    )
+                b,
+          } from 'module'
+        `,
+        output: dedent`
+          import {
+              a,
+             b,
+            y,
+                z,
+          } from 'module'
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -2966,56 +2957,53 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedNamedImportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            import {
-              a,
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              a,
+            b,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b,
-            } from 'module'
-          `,
-        })
-      },
-    )
+            c,
+            b,
+          } from 'module'
+        `,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4110,68 +4098,65 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenNamedImports',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenNamedImports',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedNamedImportsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenNamedImports',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            import {
-                aaaa,
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          import {
+              aaaa,
 
 
-               yy,
-              z,
+             yy,
+            z,
 
-                  bbb,
-            } from 'module'
-          `,
-          output: dedent`
-            import {
-                aaaa,
-               bbb,
-              yy,
-                  z,
-            } from 'module'
-          `,
-        })
-      },
-    )
+                bbb,
+          } from 'module'
+        `,
+        output: dedent`
+          import {
+              aaaa,
+             bbb,
+            yy,
+                z,
+          } from 'module'
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -4461,56 +4446,53 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaa',
+                groupName: 'a',
               },
-              messageId: 'unexpectedNamedImportsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            import {
-              aaa,
+            messageId: 'unexpectedNamedImportsOrder',
+          },
+        ],
+        output: dedent`
+          import {
+            aaa,
 
-              // Partition comment
+            // Partition comment
 
-              bb,
-              c,
-            } from 'module'
-          `,
-          code: dedent`
-            import {
-              aaa,
+            bb,
+            c,
+          } from 'module'
+        `,
+        code: dedent`
+          import {
+            aaa,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              bb,
-            } from 'module'
-          `,
-        })
-      },
-    )
+            c,
+            bb,
+          } from 'module'
+        `,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1113,10 +1113,7 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_, newlinesBetween) => {
         await invalid({
@@ -1193,16 +1190,16 @@ describe('sort-named-imports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1259,12 +1256,10 @@ describe('sort-named-imports', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1313,14 +1308,8 @@ describe('sort-named-imports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1334,11 +1323,11 @@ describe('sort-named-imports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1371,10 +1360,8 @@ describe('sort-named-imports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1444,7 +1431,7 @@ describe('sort-named-imports', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1477,10 +1464,7 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2631,10 +2615,7 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_, newlinesBetween) => {
         await invalid({
@@ -2711,16 +2692,16 @@ describe('sort-named-imports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2777,12 +2758,10 @@ describe('sort-named-imports', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2831,14 +2810,8 @@ describe('sort-named-imports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2852,11 +2825,11 @@ describe('sort-named-imports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2889,10 +2862,8 @@ describe('sort-named-imports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2962,7 +2933,7 @@ describe('sort-named-imports', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -2995,10 +2966,7 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4142,10 +4110,7 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_, newlinesBetween) => {
         await invalid({
@@ -4222,16 +4187,16 @@ describe('sort-named-imports', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4288,12 +4253,10 @@ describe('sort-named-imports', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4342,14 +4305,8 @@ describe('sort-named-imports', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4363,11 +4320,11 @@ describe('sort-named-imports', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4400,10 +4357,8 @@ describe('sort-named-imports', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4473,7 +4428,7 @@ describe('sort-named-imports', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4506,10 +4461,7 @@ describe('sort-named-imports', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4635,7 +4587,7 @@ describe('sort-named-imports', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2008,7 +2008,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it('ignores newline fixes between different partitions with newlinesBetween: %s', async () => {
+    it('ignores newline fixes between different partitions with newlinesBetween: 0', async () => {
       await invalid({
         options: [
           {
@@ -4547,7 +4547,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it('ignores newline fixes between different partitions with newlinesBetween: %s', async () => {
+    it('ignores newline fixes between different partitions with newlinesBetween: 0', async () => {
       await invalid({
         options: [
           {
@@ -7029,7 +7029,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it('ignores newline fixes between different partitions with newlinesBetween: %s', async () => {
+    it('ignores newline fixes between different partitions with newlinesBetween: 0', async () => {
       await invalid({
         options: [
           {

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -1051,90 +1051,84 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type type = {
-              a
+            messageId: 'missedSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type type = {
+            a
 
-              b
-            }
-          `,
-          code: dedent`
-            type type = {
-              a
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+        code: dedent`
+          type type = {
+            a
+            b
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type type = {
-              a
-              b
-            }
-          `,
-          code: dedent`
-            type type = {
-              a
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type type = {
+            a
+            b
+          }
+        `,
+        code: dedent`
+          type type = {
+            a
 
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+      })
+    })
 
     it('allows to use regex for custom groups', async () => {
       await valid({
@@ -1673,62 +1667,59 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            type Type = {
-              a: () => null,
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            a: () => null,
 
 
-             y: "y",
-            z: "z",
+           y: "y",
+          z: "z",
 
-                b: "b",
-            }
-          `,
-          output: dedent`
-            type Type = {
-              a: () => null,
-             b: "b",
-            y: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b: "b",
+          }
+        `,
+        output: dedent`
+          type Type = {
+            a: () => null,
+           b: "b",
+          y: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -2017,56 +2008,53 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions with newlinesBetween: %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions with newlinesBetween: %s', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedObjectTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type = {
-              a: string
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string
 
-              // Partition comment
+            // Partition comment
 
-              b: string
-              c: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              a: string
+            b: string
+            c: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
 
-              // Partition comment
+            // Partition comment
 
-              c: string
-              b: string
-            }
-          `,
-        })
-      },
-    )
+            c: string
+            b: string
+          }
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({
@@ -3602,90 +3590,84 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type type = {
-              a
+            messageId: 'missedSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type type = {
+            a
 
-              b
-            }
-          `,
-          code: dedent`
-            type type = {
-              a
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+        code: dedent`
+          type type = {
+            a
+            b
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type type = {
-              a
-              b
-            }
-          `,
-          code: dedent`
-            type type = {
-              a
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type type = {
+            a
+            b
+          }
+        `,
+        code: dedent`
+          type type = {
+            a
 
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+      })
+    })
 
     it('allows to use regex for custom groups', async () => {
       await valid({
@@ -4224,62 +4206,59 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            type Type = {
-              a: () => null,
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            a: () => null,
 
 
-             y: "y",
-            z: "z",
+           y: "y",
+          z: "z",
 
-                b: "b",
-            }
-          `,
-          output: dedent`
-            type Type = {
-              a: () => null,
-             b: "b",
-            y: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b: "b",
+          }
+        `,
+        output: dedent`
+          type Type = {
+            a: () => null,
+           b: "b",
+          y: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -4568,56 +4547,53 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions with newlinesBetween: %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('ignores newline fixes between different partitions with newlinesBetween: %s', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedObjectTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type = {
-              a: string
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string
 
-              // Partition comment
+            // Partition comment
 
-              b: string
-              c: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              a: string
+            b: string
+            c: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
 
-              // Partition comment
+            // Partition comment
 
-              c: string
-              b: string
-            }
-          `,
-        })
-      },
-    )
+            c: string
+            b: string
+          }
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({
@@ -6103,90 +6079,84 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenObjectTypeMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type type = {
-              a
+            messageId: 'missedSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type type = {
+            a
 
-              b
-            }
-          `,
-          code: dedent`
-            type type = {
-              a
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+        code: dedent`
+          type type = {
+            a
+            b
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'allows to use newlinesInside: %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('allows to use newlinesInside: 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type type = {
-              a
-              b
-            }
-          `,
-          code: dedent`
-            type type = {
-              a
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        output: dedent`
+          type type = {
+            a
+            b
+          }
+        `,
+        code: dedent`
+          type type = {
+            a
 
-              b
-            }
-          `,
-        })
-      },
-    )
+            b
+          }
+        `,
+      })
+    })
 
     it('allows to use regex for custom groups', async () => {
       await valid({
@@ -6718,62 +6688,59 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
-              },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+    it('removes newlines when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedObjectTypesOrder',
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenObjectTypeMembers',
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            type Type = {
-              aaaa: () => null,
+            messageId: 'extraSpacingBetweenObjectTypeMembers',
+          },
+        ],
+        code: dedent`
+          type Type = {
+            aaaa: () => null,
 
 
-             yy: "y",
-            z: "z",
+           yy: "y",
+          z: "z",
 
-                bbb: "b",
-            }
-          `,
-          output: dedent`
-            type Type = {
-              aaaa: () => null,
-             bbb: "b",
-            yy: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              bbb: "b",
+          }
+        `,
+        output: dedent`
+          type Type = {
+            aaaa: () => null,
+           bbb: "b",
+          yy: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween between consecutive groups', async () => {
       await invalid({
@@ -7062,56 +7029,53 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'ignores newline fixes between different partitions with newlinesBetween: %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('ignores newline fixes between different partitions with newlinesBetween: %s', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedObjectTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type = {
-              a: string
+            messageId: 'unexpectedObjectTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: string
 
-              // Partition comment
+            // Partition comment
 
-              bb: string
-              c: string
-            }
-          `,
-          code: dedent`
-            type Type = {
-              a: string
+            bb: string
+            c: string
+          }
+        `,
+        code: dedent`
+          type Type = {
+            a: string
 
-              // Partition comment
+            // Partition comment
 
-              c: string
-              bb: string
-            }
-          `,
-        })
-      },
-    )
+            c: string
+            bb: string
+          }
+        `,
+      })
+    })
 
     it('sorts inline elements correctly', async () => {
       await invalid({

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -1051,10 +1051,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1096,10 +1093,7 @@ describe('sort-object-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1679,10 +1673,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1753,16 +1744,16 @@ describe('sort-object-types', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1819,12 +1810,10 @@ describe('sort-object-types', () => {
     })
 
     it.each([
-      ['2 and never', 2 as const, 'never' as const],
-      ['2 and 0', 2 as const, 0 as const],
-      ['2 and ignore', 2 as const, 'ignore' as const],
-      ['never and 2', 'never' as const, 2 as const],
-      ['0 and 2', 0 as const, 2 as const],
-      ['ignore and 2', 'ignore' as const, 2 as const],
+      ['2 and 0', 2, 0],
+      ['2 and ignore', 2, 'ignore'],
+      ['0 and 2', 0, 2],
+      ['ignore and 2', 'ignore', 2],
     ])(
       'enforces newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1874,13 +1863,12 @@ describe('sort-object-types', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['2', 2 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['2', 2],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
-      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      'enforces no newline when global option is %s and newlinesBetween: 0 exists between all groups',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -1894,11 +1882,11 @@ describe('sort-object-types', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1931,10 +1919,8 @@ describe('sort-object-types', () => {
     )
 
     it.each([
-      ['ignore and never', 'ignore' as const, 'never' as const],
-      ['ignore and 0', 'ignore' as const, 0 as const],
-      ['never and ignore', 'never' as const, 'ignore' as const],
-      ['0 and ignore', 0 as const, 'ignore' as const],
+      ['ignore and 0', 'ignore', 0],
+      ['0 and ignore', 0, 'ignore'],
     ])(
       'does not enforce a newline when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2025,16 +2011,13 @@ describe('sort-object-types', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions with newlinesBetween: %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3619,10 +3602,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -3664,10 +3644,7 @@ describe('sort-object-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -4247,10 +4224,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4321,16 +4295,16 @@ describe('sort-object-types', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4387,12 +4361,10 @@ describe('sort-object-types', () => {
     })
 
     it.each([
-      ['2 and never', 2 as const, 'never' as const],
-      ['2 and 0', 2 as const, 0 as const],
-      ['2 and ignore', 2 as const, 'ignore' as const],
-      ['never and 2', 'never' as const, 2 as const],
-      ['0 and 2', 0 as const, 2 as const],
-      ['ignore and 2', 'ignore' as const, 2 as const],
+      ['2 and 0', 2, 0],
+      ['2 and ignore', 2, 'ignore'],
+      ['0 and 2', 0, 2],
+      ['ignore and 2', 'ignore', 2],
     ])(
       'enforces newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4442,13 +4414,12 @@ describe('sort-object-types', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['2', 2 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['2', 2],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
-      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      'enforces no newline when global option is %s and newlinesBetween: 0 exists between all groups',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -4462,11 +4433,11 @@ describe('sort-object-types', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4499,10 +4470,8 @@ describe('sort-object-types', () => {
     )
 
     it.each([
-      ['ignore and never', 'ignore' as const, 'never' as const],
-      ['ignore and 0', 'ignore' as const, 0 as const],
-      ['never and ignore', 'never' as const, 'ignore' as const],
-      ['0 and ignore', 0 as const, 'ignore' as const],
+      ['ignore and 0', 'ignore', 0],
+      ['0 and ignore', 0, 'ignore'],
     ])(
       'does not enforce a newline when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4593,16 +4562,13 @@ describe('sort-object-types', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions with newlinesBetween: %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -6137,10 +6103,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -6182,10 +6145,7 @@ describe('sort-object-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'allows to use newlinesInside: %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -6758,10 +6718,7 @@ describe('sort-object-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -6832,16 +6789,16 @@ describe('sort-object-types', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -6898,12 +6855,10 @@ describe('sort-object-types', () => {
     })
 
     it.each([
-      ['2 and never', 2 as const, 'never' as const],
-      ['2 and 0', 2 as const, 0 as const],
-      ['2 and ignore', 2 as const, 'ignore' as const],
-      ['never and 2', 'never' as const, 2 as const],
-      ['0 and 2', 0 as const, 2 as const],
-      ['ignore and 2', 'ignore' as const, 2 as const],
+      ['2 and 0', 2, 0],
+      ['2 and ignore', 2, 'ignore'],
+      ['0 and 2', 0, 2],
+      ['ignore and 2', 'ignore', 2],
     ])(
       'enforces newlines when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -6953,13 +6908,12 @@ describe('sort-object-types', () => {
     )
 
     it.each([
-      ['always', 'always' as const],
-      ['2', 2 as const],
-      ['ignore', 'ignore' as const],
-      ['never', 'never' as const],
-      ['0', 0 as const],
+      ['1', 1],
+      ['2', 2],
+      ['ignore', 'ignore'],
+      ['0', 0],
     ])(
-      'enforces no newline when global option is %s and newlinesBetween: never exists between all groups',
+      'enforces no newline when global option is %s and newlinesBetween: 0 exists between all groups',
       async (_description, globalNewlinesBetween) => {
         await invalid({
           options: [
@@ -6973,11 +6927,11 @@ describe('sort-object-types', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -7010,10 +6964,8 @@ describe('sort-object-types', () => {
     )
 
     it.each([
-      ['ignore and never', 'ignore' as const, 'never' as const],
-      ['ignore and 0', 'ignore' as const, 0 as const],
-      ['never and ignore', 'never' as const, 'ignore' as const],
-      ['0 and ignore', 0 as const, 'ignore' as const],
+      ['ignore and 0', 'ignore', 0],
+      ['0 and ignore', 0, 'ignore'],
     ])(
       'does not enforce a newline when global option is %s',
       async (_description, globalNewlinesBetween, groupNewlinesBetween) => {
@@ -7104,16 +7056,13 @@ describe('sort-object-types', () => {
         options: [
           {
             groups: ['property', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'ignores newline fixes between different partitions with newlinesBetween: %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -7797,7 +7746,7 @@ describe('sort-object-types', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1643,10 +1643,7 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1732,16 +1729,16 @@ describe('sort-objects', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1798,13 +1795,11 @@ describe('sort-objects', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines between non-consecutive groups when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -1852,8 +1847,8 @@ describe('sort-objects', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'removes newlines when never is configured between all groups (global: %s)',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 is configured between all groups (global: %s)',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1867,11 +1862,11 @@ describe('sort-objects', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1904,11 +1899,9 @@ describe('sort-objects', () => {
     )
 
     it.each([
-      ['ignore', 'never'],
       ['ignore', 0],
-      ['never', 'ignore'],
       [0, 'ignore'],
-    ] as const)(
+    ])(
       'allows any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         let testOptions = {
@@ -1982,16 +1975,13 @@ describe('sort-objects', () => {
         options: [
           {
             groups: ['unknown', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves newlines between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2952,10 +2942,7 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines within custom groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -2997,10 +2984,7 @@ describe('sort-objects', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within custom groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -4698,10 +4682,7 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4787,16 +4768,16 @@ describe('sort-objects', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4853,13 +4834,11 @@ describe('sort-objects', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines between non-consecutive groups when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -4907,8 +4886,8 @@ describe('sort-objects', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'removes newlines when never is configured between all groups (global: %s)',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 is configured between all groups (global: %s)',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4922,11 +4901,11 @@ describe('sort-objects', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4959,11 +4938,9 @@ describe('sort-objects', () => {
     )
 
     it.each([
-      ['ignore', 'never'],
       ['ignore', 0],
-      ['never', 'ignore'],
       [0, 'ignore'],
-    ] as const)(
+    ])(
       'allows any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         let testOptions = {
@@ -5037,16 +5014,13 @@ describe('sort-objects', () => {
         options: [
           {
             groups: ['unknown', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves newlines between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -5759,10 +5733,7 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines within custom groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -5804,10 +5775,7 @@ describe('sort-objects', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within custom groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -7512,10 +7480,7 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -7601,16 +7566,16 @@ describe('sort-objects', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -7667,13 +7632,11 @@ describe('sort-objects', () => {
     })
 
     it.each([
-      [2, 'never'],
       [2, 0],
       [2, 'ignore'],
-      ['never', 2],
       [0, 2],
       ['ignore', 2],
-    ] as const)(
+    ])(
       'enforces newlines between non-consecutive groups when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         await invalid({
@@ -7721,8 +7684,8 @@ describe('sort-objects', () => {
       },
     )
 
-    it.each(['always', 2, 'ignore', 'never', 0] as const)(
-      'removes newlines when never is configured between all groups (global: %s)',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 is configured between all groups (global: %s)',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -7736,11 +7699,11 @@ describe('sort-objects', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -7773,11 +7736,9 @@ describe('sort-objects', () => {
     )
 
     it.each([
-      ['ignore', 'never'],
       ['ignore', 0],
-      ['never', 'ignore'],
       [0, 'ignore'],
-    ] as const)(
+    ])(
       'allows any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
         let testOptions = {
@@ -7851,16 +7812,13 @@ describe('sort-objects', () => {
         options: [
           {
             groups: ['unknown', 'method'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves newlines between different partitions when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -8573,10 +8531,7 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'enforces newlines within custom groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -8618,10 +8573,7 @@ describe('sort-objects', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within custom groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -8827,7 +8779,7 @@ describe('sort-objects', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -1643,62 +1643,59 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenObjectMembers',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedObjectsOrder',
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenObjectMembers',
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            let Obj = {
-              a: () => null,
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            a: () => null,
 
 
-             y: "y",
-            z: "z",
+           y: "y",
+          z: "z",
 
-                b: "b",
-            }
-          `,
-          output: dedent`
-            let Obj = {
-              a: () => null,
-             b: "b",
-            y: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b: "b",
+          }
+        `,
+        output: dedent`
+          let Obj = {
+            a: () => null,
+           b: "b",
+          y: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween configuration between consecutive groups', async () => {
       await invalid({
@@ -1981,56 +1978,53 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves newlines between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves newlines between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedObjectsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
+            b,
+            c,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b,
-            }
-          `,
-        })
-      },
-    )
+            c,
+            b,
+          }
+        `,
+      })
+    })
 
     it('sorts inline object properties correctly', async () => {
       await invalid({
@@ -2942,90 +2936,84 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines within custom groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('enforces newlines within custom groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenObjectMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
+            messageId: 'missedSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
 
-              b,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
-              b,
-            }
-          `,
-        })
-      },
-    )
+            b,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            b,
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within custom groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within custom groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenObjectMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
-              b,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
+            b,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
 
-              b,
-            }
-          `,
-        })
-      },
-    )
+            b,
+          }
+        `,
+      })
+    })
 
     it('allows regex patterns in custom groups', async () => {
       await valid({
@@ -4682,62 +4670,59 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenObjectMembers',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedObjectsOrder',
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenObjectMembers',
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            let Obj = {
-              a: () => null,
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            a: () => null,
 
 
-             y: "y",
-            z: "z",
+           y: "y",
+          z: "z",
 
-                b: "b",
-            }
-          `,
-          output: dedent`
-            let Obj = {
-              a: () => null,
-             b: "b",
-            y: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              b: "b",
+          }
+        `,
+        output: dedent`
+          let Obj = {
+            a: () => null,
+           b: "b",
+          y: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween configuration between consecutive groups', async () => {
       await invalid({
@@ -5020,56 +5005,53 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves newlines between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves newlines between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedObjectsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
+            b,
+            c,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b,
-            }
-          `,
-        })
-      },
-    )
+            c,
+            b,
+          }
+        `,
+      })
+    })
 
     it('sorts inline object properties correctly', async () => {
       await invalid({
@@ -5733,90 +5715,84 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines within custom groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('enforces newlines within custom groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenObjectMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
+            messageId: 'missedSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
 
-              b,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
-              b,
-            }
-          `,
-        })
-      },
-    )
+            b,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            b,
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within custom groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within custom groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenObjectMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
-              b,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
+            b,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
 
-              b,
-            }
-          `,
-        })
-      },
-    )
+            b,
+          }
+        `,
+      })
+    })
 
     it('allows regex patterns in custom groups', async () => {
       await valid({
@@ -7480,62 +7456,59 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
-              },
-              messageId: 'extraSpacingBetweenObjectMembers',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedObjectsOrder',
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenObjectMembers',
+            messageId: 'unexpectedObjectsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
             },
-          ],
-          code: dedent`
-            let Obj = {
-              aaaa: () => null,
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        code: dedent`
+          let Obj = {
+            aaaa: () => null,
 
 
-             yy: "y",
-            z: "z",
+           yy: "y",
+          z: "z",
 
-                bbb: "b",
-            }
-          `,
-          output: dedent`
-            let Obj = {
-              aaaa: () => null,
-             bbb: "b",
-            yy: "y",
-                z: "z",
-            }
-          `,
-          options: [
-            {
-              ...options,
-              groups: ['method', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-        })
-      },
-    )
+              bbb: "b",
+          }
+        `,
+        output: dedent`
+          let Obj = {
+            aaaa: () => null,
+           bbb: "b",
+          yy: "y",
+              z: "z",
+          }
+        `,
+        options: [
+          {
+            ...options,
+            groups: ['method', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+      })
+    })
 
     it('handles newlinesBetween configuration between consecutive groups', async () => {
       await invalid({
@@ -7818,56 +7791,53 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves newlines between different partitions when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('preserves newlines between different partitions when newlinesBetween is 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedObjectsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
+            messageId: 'unexpectedObjectsOrder',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              bb,
-              c,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
+            bb,
+            c,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              bb,
-            }
-          `,
-        })
-      },
-    )
+            c,
+            bb,
+          }
+        `,
+      })
+    })
 
     it('sorts inline object properties correctly', async () => {
       await invalid({
@@ -8531,90 +8501,84 @@ describe('sort-objects', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'enforces newlines within custom groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('enforces newlines within custom groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenObjectMembers',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
+            messageId: 'missedSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
 
-              b,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
-              b,
-            }
-          `,
-        })
-      },
-    )
+            b,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
+            b,
+          }
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within custom groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  selector: 'property',
-                  groupName: 'group1',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within custom groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                selector: 'property',
+                groupName: 'group1',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenObjectMembers',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            let obj = {
-              a,
-              b,
-            }
-          `,
-          code: dedent`
-            let obj = {
-              a,
+            messageId: 'extraSpacingBetweenObjectMembers',
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a,
+            b,
+          }
+        `,
+        code: dedent`
+          let obj = {
+            a,
 
-              b,
-            }
-          `,
-        })
-      },
-    )
+            b,
+          }
+        `,
+      })
+    })
 
     it('allows regex patterns in custom groups', async () => {
       await valid({

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1095,70 +1095,67 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        let newlinesOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      let newlinesOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenSetsMembers',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenSetsMembers',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          code: dedent`
-            new Set([
-              'a',
+          groups: ['a', 'unknown'],
+          newlinesBetween: 0,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'a',
 
 
-             'y',
-            'z',
+           'y',
+          'z',
 
-                'b'
-            ])
-          `,
-          output: dedent`
-            new Set([
-              'a',
-             'b',
-            'y',
-                'z'
-            ])
-          `,
-          options: newlinesOptions,
-        })
-      },
-    )
+              'b'
+          ])
+        `,
+        output: dedent`
+          new Set([
+            'a',
+           'b',
+          'y',
+              'z'
+          ])
+        `,
+        options: newlinesOptions,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       let inlineNewlineOptions = [
@@ -1466,58 +1463,55 @@ describe('sort-sets', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        let partitionOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            partitionByComment: true,
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          output: dedent`
-            new Set([
-              'a',
+          groups: ['a', 'unknown'],
+          partitionByComment: true,
+          newlinesBetween: 0,
+        },
+      ]
 
-              // Partition comment
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
 
-              'b',
-              'c',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'a',
+            // Partition comment
 
-              // Partition comment
+            'b',
+            'c',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
 
-              'c',
-              'b',
-            ])
-          `,
-          options: partitionOptions,
-        })
-      },
-    )
+            // Partition comment
+
+            'c',
+            'b',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -2601,70 +2595,67 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        let newlinesOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      let newlinesOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'y',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenSetsMembers',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenSetsMembers',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          code: dedent`
-            new Set([
-              'a',
+          groups: ['a', 'unknown'],
+          newlinesBetween: 0,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'a',
 
 
-             'y',
-            'z',
+           'y',
+          'z',
 
-                'b'
-            ])
-          `,
-          output: dedent`
-            new Set([
-              'a',
-             'b',
-            'y',
-                'z'
-            ])
-          `,
-          options: newlinesOptions,
-        })
-      },
-    )
+              'b'
+          ])
+        `,
+        output: dedent`
+          new Set([
+            'a',
+           'b',
+          'y',
+              'z'
+          ])
+        `,
+        options: newlinesOptions,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       let inlineNewlineOptions = [
@@ -2972,58 +2963,55 @@ describe('sort-sets', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        let partitionOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'a',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            partitionByComment: true,
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'b',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
+              elementNamePattern: 'a',
+              groupName: 'a',
             },
           ],
-          output: dedent`
-            new Set([
-              'a',
+          groups: ['a', 'unknown'],
+          partitionByComment: true,
+          newlinesBetween: 0,
+        },
+      ]
 
-              // Partition comment
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
 
-              'b',
-              'c',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'a',
+            // Partition comment
 
-              // Partition comment
+            'b',
+            'c',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'a',
 
-              'c',
-              'b',
-            ])
-          `,
-          options: partitionOptions,
-        })
-      },
-    )
+            // Partition comment
+
+            'c',
+            'b',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4107,70 +4095,67 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        let newlinesOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'aaaa',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      let newlinesOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
-              },
-              messageId: 'extraSpacingBetweenSetsMembers',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'unexpectedSetsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
-              },
-              messageId: 'extraSpacingBetweenSetsMembers',
+              elementNamePattern: 'aaaa',
+              groupName: 'a',
             },
           ],
-          code: dedent`
-            new Set([
-              'aaaa',
+          groups: ['a', 'unknown'],
+          newlinesBetween: 0,
+        },
+      ]
+
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenSetsMembers',
+          },
+        ],
+        code: dedent`
+          new Set([
+            'aaaa',
 
 
-             'yy',
-            'z',
+           'yy',
+          'z',
 
-                'bbb'
-            ])
-          `,
-          output: dedent`
-            new Set([
-              'aaaa',
-             'bbb',
-            'yy',
-                'z'
-            ])
-          `,
-          options: newlinesOptions,
-        })
-      },
-    )
+              'bbb'
+          ])
+        `,
+        output: dedent`
+          new Set([
+            'aaaa',
+           'bbb',
+          'yy',
+              'z'
+          ])
+        `,
+        options: newlinesOptions,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       let inlineNewlineOptions = [
@@ -4478,58 +4463,55 @@ describe('sort-sets', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        let partitionOptions = [
-          {
-            ...options,
-            customGroups: [
-              {
-                elementNamePattern: 'aaa',
-                groupName: 'a',
-              },
-            ],
-            groups: ['a', 'unknown'],
-            partitionByComment: true,
-            newlinesBetween,
-          },
-        ]
-
-        await invalid({
-          errors: [
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      let partitionOptions = [
+        {
+          ...options,
+          customGroups: [
             {
-              data: {
-                right: 'bb',
-                left: 'c',
-              },
-              messageId: 'unexpectedSetsOrder',
+              elementNamePattern: 'aaa',
+              groupName: 'a',
             },
           ],
-          output: dedent`
-            new Set([
-              'aaa',
+          groups: ['a', 'unknown'],
+          partitionByComment: true,
+          newlinesBetween: 0,
+        },
+      ]
 
-              // Partition comment
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
+            },
+            messageId: 'unexpectedSetsOrder',
+          },
+        ],
+        output: dedent`
+          new Set([
+            'aaa',
 
-              'bb',
-              'c',
-            ])
-          `,
-          code: dedent`
-            new Set([
-              'aaa',
+            // Partition comment
 
-              // Partition comment
+            'bb',
+            'c',
+          ])
+        `,
+        code: dedent`
+          new Set([
+            'aaa',
 
-              'c',
-              'bb',
-            ])
-          `,
-          options: partitionOptions,
-        })
-      },
-    )
+            // Partition comment
+
+            'c',
+            'bb',
+          ])
+        `,
+        options: partitionOptions,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1095,10 +1095,7 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         let newlinesOptions = [
@@ -1192,15 +1189,15 @@ describe('sort-sets', () => {
           groups: [
             'a',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'b',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'c',
             {
-              newlinesBetween: 'never',
+              newlinesBetween: 0,
             },
             'd',
             {
@@ -1208,7 +1205,7 @@ describe('sort-sets', () => {
             },
             'e',
           ],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -1268,12 +1265,10 @@ describe('sort-sets', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1324,16 +1319,10 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
-        let neverBetweenGroupsOptions = [
+        let noNewlineBetweenGroupsOptions = [
           {
             ...options,
             customGroups: [
@@ -1344,11 +1333,11 @@ describe('sort-sets', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -1378,16 +1367,14 @@ describe('sort-sets', () => {
               b,
             ])
           `,
-          options: neverBetweenGroupsOptions,
+          options: noNewlineBetweenGroupsOptions,
         })
       },
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1442,7 +1429,7 @@ describe('sort-sets', () => {
             },
           ],
           groups: ['unknown', 'b|c'],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -1479,10 +1466,7 @@ describe('sort-sets', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         let partitionOptions = [
@@ -2617,10 +2601,7 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         let newlinesOptions = [
@@ -2714,15 +2695,15 @@ describe('sort-sets', () => {
           groups: [
             'a',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'b',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'c',
             {
-              newlinesBetween: 'never',
+              newlinesBetween: 0,
             },
             'd',
             {
@@ -2730,7 +2711,7 @@ describe('sort-sets', () => {
             },
             'e',
           ],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -2790,12 +2771,10 @@ describe('sort-sets', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2846,16 +2825,10 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
-        let neverBetweenGroupsOptions = [
+        let noNewlineBetweenGroupsOptions = [
           {
             ...options,
             customGroups: [
@@ -2866,11 +2839,11 @@ describe('sort-sets', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -2900,16 +2873,14 @@ describe('sort-sets', () => {
               b,
             ])
           `,
-          options: neverBetweenGroupsOptions,
+          options: noNewlineBetweenGroupsOptions,
         })
       },
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2964,7 +2935,7 @@ describe('sort-sets', () => {
             },
           ],
           groups: ['unknown', 'b|c'],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -3001,10 +2972,7 @@ describe('sort-sets', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         let partitionOptions = [
@@ -4139,10 +4107,7 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         let newlinesOptions = [
@@ -4236,15 +4201,15 @@ describe('sort-sets', () => {
           groups: [
             'a',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'b',
             {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
             },
             'c',
             {
-              newlinesBetween: 'never',
+              newlinesBetween: 0,
             },
             'd',
             {
@@ -4252,7 +4217,7 @@ describe('sort-sets', () => {
             },
             'e',
           ],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -4312,12 +4277,10 @@ describe('sort-sets', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4368,16 +4331,10 @@ describe('sort-sets', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
-        let neverBetweenGroupsOptions = [
+        let noNewlineBetweenGroupsOptions = [
           {
             ...options,
             customGroups: [
@@ -4388,11 +4345,11 @@ describe('sort-sets', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'unusedGroup',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
             ],
             newlinesBetween: globalNewlinesBetween,
@@ -4422,16 +4379,14 @@ describe('sort-sets', () => {
               b,
             ])
           `,
-          options: neverBetweenGroupsOptions,
+          options: noNewlineBetweenGroupsOptions,
         })
       },
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4486,7 +4441,7 @@ describe('sort-sets', () => {
             },
           ],
           groups: ['unknown', 'b|c'],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
         },
       ]
 
@@ -4523,10 +4478,7 @@ describe('sort-sets', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         let partitionOptions = [
@@ -4718,7 +4670,7 @@ describe('sort-sets', () => {
               groupName: 'b',
             },
           ],
-          newlinesBetween: 'always',
+          newlinesBetween: 1,
           groups: ['b', 'a'],
         },
       ]

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -870,60 +870,57 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: '() => null',
-                right: 'Y',
-              },
-              messageId: 'extraSpacingBetweenUnionTypes',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '() => null',
+              right: 'Y',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'extraSpacingBetweenUnionTypes',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['function', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            type T =
-              (() => null)
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['function', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          type T =
+            (() => null)
 
 
-             | Y
-            | Z
+           | Y
+          | Z
 
-                | B
-          `,
-          output: dedent`
-            type T =
-              (() => null)
-             | B
-            | Y
-                | Z
-          `,
-        })
-      },
-    )
+              | B
+        `,
+        output: dedent`
+          type T =
+            (() => null)
+           | B
+          | Y
+              | Z
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -1167,54 +1164,51 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedUnionTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type =
-              | a
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | a
 
-              // Partition comment
+            // Partition comment
 
-              | b
-              | c
-          `,
-          code: dedent`
-            type Type =
-              | a
+            | b
+            | c
+        `,
+        code: dedent`
+          type Type =
+            | a
 
-              // Partition comment
+            // Partition comment
 
-              | c
-              | b
-          `,
-        })
-      },
-    )
+            | c
+            | b
+        `,
+      })
+    })
 
     it('sorts single-line union types correctly', async () => {
       await invalid({
@@ -1586,86 +1580,80 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'adds newlines within groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('adds newlines within groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenUnionTypes',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              | a
+            messageId: 'missedSpacingBetweenUnionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
 
-              | b
-          `,
-          code: dedent`
-            type T =
-              | a
-              | b
-          `,
-        })
-      },
-    )
+            | b
+        `,
+        code: dedent`
+          type T =
+            | a
+            | b
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenUnionTypes',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              | a
-              | b
-          `,
-          code: dedent`
-            type T =
-              | a
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
+            | b
+        `,
+        code: dedent`
+          type T =
+            | a
 
-              | b
-          `,
-        })
-      },
-    )
+            | b
+        `,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -2524,60 +2512,57 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: '() => null',
-                right: 'Y',
-              },
-              messageId: 'extraSpacingBetweenUnionTypes',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '() => null',
+              right: 'Y',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-            {
-              data: {
-                right: 'B',
-                left: 'Z',
-              },
-              messageId: 'extraSpacingBetweenUnionTypes',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'B',
+              left: 'Z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['function', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            type T =
-              (() => null)
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['function', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          type T =
+            (() => null)
 
 
-             | Y
-            | Z
+           | Y
+          | Z
 
-                | B
-          `,
-          output: dedent`
-            type T =
-              (() => null)
-             | B
-            | Y
-                | Z
-          `,
-        })
-      },
-    )
+              | B
+        `,
+        output: dedent`
+          type T =
+            (() => null)
+           | B
+          | Y
+              | Z
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -2821,54 +2806,51 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedUnionTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type =
-              | a
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | a
 
-              // Partition comment
+            // Partition comment
 
-              | b
-              | c
-          `,
-          code: dedent`
-            type Type =
-              | a
+            | b
+            | c
+        `,
+        code: dedent`
+          type Type =
+            | a
 
-              // Partition comment
+            // Partition comment
 
-              | c
-              | b
-          `,
-        })
-      },
-    )
+            | c
+            | b
+        `,
+      })
+    })
 
     it('sorts single-line union types correctly', async () => {
       await invalid({
@@ -3240,86 +3222,80 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'adds newlines within groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('adds newlines within groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenUnionTypes',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              | a
+            messageId: 'missedSpacingBetweenUnionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
 
-              | b
-          `,
-          code: dedent`
-            type T =
-              | a
-              | b
-          `,
-        })
-      },
-    )
+            | b
+        `,
+        code: dedent`
+          type T =
+            | a
+            | b
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenUnionTypes',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              | a
-              | b
-          `,
-          code: dedent`
-            type T =
-              | a
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
+            | b
+        `,
+        code: dedent`
+          type T =
+            | a
 
-              | b
-          `,
-        })
-      },
-    )
+            | b
+        `,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4164,60 +4140,57 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: '() => null',
-                right: 'YY',
-              },
-              messageId: 'extraSpacingBetweenUnionTypes',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: '() => null',
+              right: 'YY',
             },
-            {
-              data: {
-                right: 'BBB',
-                left: 'Z',
-              },
-              messageId: 'unexpectedUnionTypesOrder',
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'Z',
             },
-            {
-              data: {
-                right: 'BBB',
-                left: 'Z',
-              },
-              messageId: 'extraSpacingBetweenUnionTypes',
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+          {
+            data: {
+              right: 'BBB',
+              left: 'Z',
             },
-          ],
-          options: [
-            {
-              ...options,
-              groups: ['function', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            type T =
-              (() => null)
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['function', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          type T =
+            (() => null)
 
 
-             | YY
-            | Z
+           | YY
+          | Z
 
-                | BBB
-          `,
-          output: dedent`
-            type T =
-              (() => null)
-             | BBB
-            | YY
-                | Z
-          `,
-        })
-      },
-    )
+              | BBB
+        `,
+        output: dedent`
+          type T =
+            (() => null)
+           | BBB
+          | YY
+              | Z
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -4461,54 +4434,51 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedUnionTypesOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            type Type =
-              | a
+            messageId: 'unexpectedUnionTypesOrder',
+          },
+        ],
+        output: dedent`
+          type Type =
+            | a
 
-              // Partition comment
+            // Partition comment
 
-              | bb
-              | c
-          `,
-          code: dedent`
-            type Type =
-              | a
+            | bb
+            | c
+        `,
+        code: dedent`
+          type Type =
+            | a
 
-              // Partition comment
+            // Partition comment
 
-              | c
-              | bb
-          `,
-        })
-      },
-    )
+            | c
+            | bb
+        `,
+      })
+    })
 
     it('sorts single-line union types correctly', async () => {
       await invalid({
@@ -4880,86 +4850,80 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([['1', 1]])(
-      'adds newlines within groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('adds newlines within groups when newlinesInside is 1', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 1,
               },
-              messageId: 'missedSpacingBetweenUnionTypes',
+            ],
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              | a
+            messageId: 'missedSpacingBetweenUnionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
 
-              | b
-          `,
-          code: dedent`
-            type T =
-              | a
-              | b
-          `,
-        })
-      },
-    )
+            | b
+        `,
+        code: dedent`
+          type T =
+            | a
+            | b
+        `,
+      })
+    })
 
-    it.each([['0', 0]])(
-      'removes newlines within groups when newlinesInside is %s',
-      async (_description, newlinesInside) => {
-        await invalid({
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'group1',
-                  selector: 'named',
-                  newlinesInside,
-                },
-              ],
-              type: 'alphabetical',
-              groups: ['group1'],
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'a',
+    it('removes newlines within groups when newlinesInside is 0', async () => {
+      await invalid({
+        options: [
+          {
+            customGroups: [
+              {
+                groupName: 'group1',
+                selector: 'named',
+                newlinesInside: 0,
               },
-              messageId: 'extraSpacingBetweenUnionTypes',
+            ],
+            type: 'alphabetical',
+            groups: ['group1'],
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'a',
             },
-          ],
-          output: dedent`
-            type T =
-              | a
-              | b
-          `,
-          code: dedent`
-            type T =
-              | a
+            messageId: 'extraSpacingBetweenUnionTypes',
+          },
+        ],
+        output: dedent`
+          type T =
+            | a
+            | b
+        `,
+        code: dedent`
+          type T =
+            | a
 
-              | b
-          `,
-        })
-      },
-    )
+            | b
+        `,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -870,10 +870,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -958,16 +955,16 @@ describe('sort-union-types', () => {
             ...options,
             groups: [
               'function',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'object',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'named',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'tuple',
               { newlinesBetween: 'ignore' },
               'nullish',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -999,12 +996,10 @@ describe('sort-union-types', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1046,14 +1041,8 @@ describe('sort-union-types', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1061,9 +1050,9 @@ describe('sort-union-types', () => {
               ...options,
               groups: [
                 'named',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'tuple',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'nullish',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1094,10 +1083,8 @@ describe('sort-union-types', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1160,7 +1147,7 @@ describe('sort-union-types', () => {
         options: [
           {
             groups: ['literal', 'named'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -1180,10 +1167,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1548,7 +1532,7 @@ describe('sort-union-types', () => {
               },
             ],
             groups: ['elementsIncludingFoo', 'unknown'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1602,10 +1586,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines within groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -1645,10 +1626,7 @@ describe('sort-union-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -2546,10 +2524,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -2634,16 +2609,16 @@ describe('sort-union-types', () => {
             ...options,
             groups: [
               'function',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'object',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'named',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'tuple',
               { newlinesBetween: 'ignore' },
               'nullish',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -2675,12 +2650,10 @@ describe('sort-union-types', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2722,14 +2695,8 @@ describe('sort-union-types', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -2737,9 +2704,9 @@ describe('sort-union-types', () => {
               ...options,
               groups: [
                 'named',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'tuple',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'nullish',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -2770,10 +2737,8 @@ describe('sort-union-types', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -2836,7 +2801,7 @@ describe('sort-union-types', () => {
         options: [
           {
             groups: ['literal', 'named'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -2856,10 +2821,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3224,7 +3186,7 @@ describe('sort-union-types', () => {
               },
             ],
             groups: ['elementsIncludingFoo', 'unknown'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3278,10 +3240,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines within groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -3321,10 +3280,7 @@ describe('sort-union-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -4208,10 +4164,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4296,16 +4249,16 @@ describe('sort-union-types', () => {
             ...options,
             groups: [
               'function',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'object',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'named',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'tuple',
               { newlinesBetween: 'ignore' },
               'nullish',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -4337,12 +4290,10 @@ describe('sort-union-types', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4384,14 +4335,8 @@ describe('sort-union-types', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -4399,9 +4344,9 @@ describe('sort-union-types', () => {
               ...options,
               groups: [
                 'named',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'tuple',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'nullish',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -4432,10 +4377,8 @@ describe('sort-union-types', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -4498,7 +4441,7 @@ describe('sort-union-types', () => {
         options: [
           {
             groups: ['literal', 'named'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`
@@ -4518,10 +4461,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -4886,7 +4826,7 @@ describe('sort-union-types', () => {
               },
             ],
             groups: ['elementsIncludingFoo', 'unknown'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -4940,10 +4880,7 @@ describe('sort-union-types', () => {
       })
     })
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines within groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -4983,10 +4920,7 @@ describe('sort-union-types', () => {
       },
     )
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines within groups when newlinesInside is %s',
       async (_description, newlinesInside) => {
         await invalid({
@@ -5137,7 +5071,7 @@ describe('sort-union-types', () => {
           {
             ...options,
             groups: ['named', 'literal'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         output: dedent`

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -1405,132 +1405,126 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          let
+            a,
+
+
+           y,
+          z,
+
+              b,
+        `,
+        output: dedent`
+          let
+            a,
+           b,
+          y,
+              z,
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            let
-              a,
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          let
+            a,
+
+           y,
+          z,
+
+              b,
+        `,
+        code: dedent`
+          let
+            a,
 
 
-             y,
-            z,
-
-                b,
-          `,
-          output: dedent`
-            let
-              a,
-             b,
-            y,
-                z,
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            let
-              a,
-
-             y,
-            z,
-
-                b,
-          `,
-          code: dedent`
-            let
-              a,
-
-
-             z,
-            y,
-                b,
-          `,
-        })
-      },
-    )
+           z,
+          y,
+              b,
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -1810,54 +1804,51 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedVariableDeclarationsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            let
-              a,
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c
-          `,
-          code: dedent`
-            let
-              a,
+            b,
+            c
+        `,
+        code: dedent`
+          let
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b
-          `,
-        })
-      },
-    )
+            c,
+            b
+        `,
+      })
+    })
   })
 
   describe('natural', () => {
@@ -3244,132 +3235,126 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'y',
-                left: 'a',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'y',
+              left: 'a',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          let
+            a,
+
+
+           y,
+          z,
+
+              b,
+        `,
+        output: dedent`
+          let
+            a,
+           b,
+          y,
+              z,
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              right: 'z',
+              left: 'a',
             },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'y',
+              left: 'z',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'b',
+              left: 'y',
+            },
+            messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'z',
+              {
+                elementNamePattern: 'b',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            let
-              a,
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          let
+            a,
+
+           y,
+          z,
+
+              b,
+        `,
+        code: dedent`
+          let
+            a,
 
 
-             y,
-            z,
-
-                b,
-          `,
-          output: dedent`
-            let
-              a,
-             b,
-            y,
-                z,
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                right: 'z',
-                left: 'a',
-              },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-            },
-            {
-              data: {
-                right: 'y',
-                left: 'z',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-            {
-              data: {
-                right: 'b',
-                left: 'y',
-              },
-              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'b',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            let
-              a,
-
-             y,
-            z,
-
-                b,
-          `,
-          code: dedent`
-            let
-              a,
-
-
-             z,
-            y,
-                b,
-          `,
-        })
-      },
-    )
+           z,
+          y,
+              b,
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -3649,54 +3634,51 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'a',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'b',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'a',
+                groupName: 'a',
               },
-              messageId: 'unexpectedVariableDeclarationsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'b',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            let
-              a,
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              b,
-              c
-          `,
-          code: dedent`
-            let
-              a,
+            b,
+            c
+        `,
+        code: dedent`
+          let
+            a,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              b
-          `,
-        })
-      },
-    )
+            c,
+            b
+        `,
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -5083,132 +5065,126 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'removes newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'yy',
+    it('removes newlines between groups when newlinesBetween is 0', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'yy',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'z',
+            },
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
               },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+            ],
+            groups: ['a', 'unknown'],
+            newlinesBetween: 0,
+          },
+        ],
+        code: dedent`
+          let
+            aaaa,
+
+
+           yy,
+          z,
+
+              bbb,
+        `,
+        output: dedent`
+          let
+            aaaa,
+           bbb,
+          yy,
+              z,
+        `,
+      })
+    })
+
+    it('adds newlines between groups when newlinesBetween is 1', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'aaaa',
+              right: 'z',
             },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
+            messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
+          },
+          {
+            data: {
+              right: 'yy',
+              left: 'z',
+            },
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+          {
+            data: {
+              right: 'bbb',
+              left: 'yy',
+            },
+            messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaaa',
+                groupName: 'a',
               },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'z',
+              {
+                elementNamePattern: 'bbb',
+                groupName: 'b',
               },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              newlinesBetween,
-            },
-          ],
-          code: dedent`
-            let
-              aaaa,
+            ],
+            groups: ['a', 'unknown', 'b'],
+            newlinesBetween: 1,
+          },
+        ],
+        output: dedent`
+          let
+            aaaa,
+
+           yy,
+          z,
+
+              bbb,
+        `,
+        code: dedent`
+          let
+            aaaa,
 
 
-             yy,
-            z,
-
-                bbb,
-          `,
-          output: dedent`
-            let
-              aaaa,
-             bbb,
-            yy,
-                z,
-          `,
-        })
-      },
-    )
-
-    it.each([['1', 1]])(
-      'adds newlines between groups when newlinesBetween is %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          errors: [
-            {
-              data: {
-                left: 'aaaa',
-                right: 'z',
-              },
-              messageId: 'extraSpacingBetweenVariableDeclarationsMembers',
-            },
-            {
-              data: {
-                right: 'yy',
-                left: 'z',
-              },
-              messageId: 'unexpectedVariableDeclarationsOrder',
-            },
-            {
-              data: {
-                right: 'bbb',
-                left: 'yy',
-              },
-              messageId: 'missedSpacingBetweenVariableDeclarationsMembers',
-            },
-          ],
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaaa',
-                  groupName: 'a',
-                },
-                {
-                  elementNamePattern: 'bbb',
-                  groupName: 'b',
-                },
-              ],
-              groups: ['a', 'unknown', 'b'],
-              newlinesBetween,
-            },
-          ],
-          output: dedent`
-            let
-              aaaa,
-
-             yy,
-            z,
-
-                bbb,
-          `,
-          code: dedent`
-            let
-              aaaa,
-
-
-             z,
-            yy,
-                bbb,
-          `,
-        })
-      },
-    )
+           z,
+          yy,
+              bbb,
+        `,
+      })
+    })
 
     it('applies inline newline settings between specific groups', async () => {
       await invalid({
@@ -5488,54 +5464,51 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([['0', 0]])(
-      'preserves partition boundaries regardless of newlinesBetween %s',
-      async (_description, newlinesBetween) => {
-        await invalid({
-          options: [
-            {
-              ...options,
-              customGroups: [
-                {
-                  elementNamePattern: 'aaa',
-                  groupName: 'a',
-                },
-              ],
-              groups: ['a', 'unknown'],
-              partitionByComment: true,
-              newlinesBetween,
-            },
-          ],
-          errors: [
-            {
-              data: {
-                right: 'bb',
-                left: 'c',
+    it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
+      await invalid({
+        options: [
+          {
+            ...options,
+            customGroups: [
+              {
+                elementNamePattern: 'aaa',
+                groupName: 'a',
               },
-              messageId: 'unexpectedVariableDeclarationsOrder',
+            ],
+            groups: ['a', 'unknown'],
+            partitionByComment: true,
+            newlinesBetween: 0,
+          },
+        ],
+        errors: [
+          {
+            data: {
+              right: 'bb',
+              left: 'c',
             },
-          ],
-          output: dedent`
-            let
-              aaa,
+            messageId: 'unexpectedVariableDeclarationsOrder',
+          },
+        ],
+        output: dedent`
+          let
+            aaa,
 
-              // Partition comment
+            // Partition comment
 
-              bb,
-              c
-          `,
-          code: dedent`
-            let
-              aaa,
+            bb,
+            c
+        `,
+        code: dedent`
+          let
+            aaa,
 
-              // Partition comment
+            // Partition comment
 
-              c,
-              bb
-          `,
-        })
-      },
-    )
+            c,
+            bb
+        `,
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -1405,10 +1405,7 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1469,10 +1466,7 @@ describe('sort-variable-declarations', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -1552,16 +1546,16 @@ describe('sort-variable-declarations', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1616,12 +1610,10 @@ describe('sort-variable-declarations', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1668,14 +1660,8 @@ describe('sort-variable-declarations', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -1689,11 +1675,11 @@ describe('sort-variable-declarations', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -1724,10 +1710,8 @@ describe('sort-variable-declarations', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -1795,7 +1779,7 @@ describe('sort-variable-declarations', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -1826,10 +1810,7 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3263,10 +3244,7 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3327,10 +3305,7 @@ describe('sort-variable-declarations', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -3410,16 +3385,16 @@ describe('sort-variable-declarations', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3474,12 +3449,10 @@ describe('sort-variable-declarations', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -3526,14 +3499,8 @@ describe('sort-variable-declarations', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -3547,11 +3514,11 @@ describe('sort-variable-declarations', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -3582,10 +3549,8 @@ describe('sort-variable-declarations', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -3653,7 +3618,7 @@ describe('sort-variable-declarations', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -3684,10 +3649,7 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -5121,10 +5083,7 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'removes newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -5185,10 +5144,7 @@ describe('sort-variable-declarations', () => {
       },
     )
 
-    it.each([
-      ['always', 'always' as const],
-      ['1', 1 as const],
-    ])(
+    it.each([['1', 1]])(
       'adds newlines between groups when newlinesBetween is %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -5268,16 +5224,16 @@ describe('sort-variable-declarations', () => {
             ],
             groups: [
               'a',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'b',
-              { newlinesBetween: 'always' },
+              { newlinesBetween: 1 },
               'c',
-              { newlinesBetween: 'never' },
+              { newlinesBetween: 0 },
               'd',
               { newlinesBetween: 'ignore' },
               'e',
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -5332,12 +5288,10 @@ describe('sort-variable-declarations', () => {
     })
 
     it.each([
-      [2, 'never' as const],
-      [2, 0 as const],
-      [2, 'ignore' as const],
-      ['never' as const, 2],
-      [0 as const, 2],
-      ['ignore' as const, 2],
+      [2, 0],
+      [2, 'ignore'],
+      [0, 2],
+      ['ignore', 2],
     ])(
       'enforces 2 newlines when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -5384,14 +5338,8 @@ describe('sort-variable-declarations', () => {
       },
     )
 
-    it.each([
-      'always' as const,
-      2 as const,
-      'ignore' as const,
-      'never' as const,
-      0 as const,
-    ])(
-      'removes newlines when "never" overrides global %s between specific groups',
+    it.each([1, 2, 'ignore', 0])(
+      'removes newlines when 0 overrides global %s between specific groups',
       async globalNewlinesBetween => {
         await invalid({
           options: [
@@ -5405,11 +5353,11 @@ describe('sort-variable-declarations', () => {
               ],
               groups: [
                 'a',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'unusedGroup',
-                { newlinesBetween: 'never' },
+                { newlinesBetween: 0 },
                 'b',
-                { newlinesBetween: 'always' },
+                { newlinesBetween: 1 },
                 'c',
               ],
               newlinesBetween: globalNewlinesBetween,
@@ -5440,10 +5388,8 @@ describe('sort-variable-declarations', () => {
     )
 
     it.each([
-      ['ignore' as const, 'never' as const],
-      ['ignore' as const, 0 as const],
-      ['never' as const, 'ignore' as const],
-      [0 as const, 'ignore' as const],
+      ['ignore', 0],
+      [0, 'ignore'],
     ])(
       'accepts any spacing when global is %s and group is %s',
       async (globalNewlinesBetween, groupNewlinesBetween) => {
@@ -5511,7 +5457,7 @@ describe('sort-variable-declarations', () => {
               },
             ],
             groups: ['unknown', 'b|c'],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
           },
         ],
         errors: [
@@ -5542,10 +5488,7 @@ describe('sort-variable-declarations', () => {
       })
     })
 
-    it.each([
-      ['never', 'never' as const],
-      ['0', 0 as const],
-    ])(
+    it.each([['0', 0]])(
       'preserves partition boundaries regardless of newlinesBetween %s',
       async (_description, newlinesBetween) => {
         await invalid({
@@ -5665,7 +5608,7 @@ describe('sort-variable-declarations', () => {
                 groupName: 'b',
               },
             ],
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             groups: ['b', 'a'],
           },
         ],

--- a/test/utils/common-json-schemas.test.ts
+++ b/test/utils/common-json-schemas.test.ts
@@ -154,12 +154,9 @@ describe('common-json-schemas', () => {
       newlinesBetweenJsonSchema,
     )
 
-    it.each(['ignore', 'always', 'never'])(
-      "should allow' %s'",
-      newlinesBetween => {
-        expect(newlinesBetweenJsonSchemaValidator(newlinesBetween)).toBeTruthy()
-      },
-    )
+    it.each(['ignore', 1, 0])("should allow '%s'", newlinesBetween => {
+      expect(newlinesBetweenJsonSchemaValidator(newlinesBetween)).toBeTruthy()
+    })
 
     it('should not allow invalid values', () => {
       expect(newlinesBetweenJsonSchemaValidator('invalid')).toBeFalsy()
@@ -180,18 +177,11 @@ describe('common-json-schemas', () => {
     })
 
     describe('newlinesBetween', () => {
-      it.each(['ignore', 'always', 'never'])(
-        "should allow' %s'",
-        newlinesBetween => {
-          expect(
-            groupsJsonSchemaValidator([
-              'group1',
-              { newlinesBetween },
-              'group2',
-            ]),
-          ).toBeTruthy()
-        },
-      )
+      it.each(['ignore', 1, 0])("should allow' %s'", newlinesBetween => {
+        expect(
+          groupsJsonSchemaValidator(['group1', { newlinesBetween }, 'group2']),
+        ).toBeTruthy()
+      })
 
       it('should not allow invalid values', () => {
         expect(
@@ -207,7 +197,7 @@ describe('common-json-schemas', () => {
         expect(
           groupsJsonSchemaValidator([
             'group1',
-            { newlinesBetween: 'always', something: 'something' },
+            { something: 'something', newlinesBetween: 1 },
             'group2',
           ]),
         ).toBeFalsy()
@@ -240,7 +230,7 @@ describe('common-json-schemas', () => {
       expect(
         groupsJsonSchemaValidator([
           'group1',
-          { newlinesBetween: 'always', commentAbove: 'foo' },
+          { commentAbove: 'foo', newlinesBetween: 1 },
           'group2',
         ]),
       ).toBeTruthy()

--- a/test/utils/get-newlines-between-option.test.ts
+++ b/test/utils/get-newlines-between-option.test.ts
@@ -5,12 +5,11 @@ import type { NewlinesBetweenOption } from '../../types/common-options'
 
 import { getNewlinesBetweenOption } from '../../utils/get-newlines-between-option'
 
-const NEVER_OPTIONS = [0] as const
-const ALWAYS_OPTIONS = [1, 2] as const
+const MULTIPLE_LINES_OPTIONS = [1, 2] as const
 
 describe('get-newlines-between-option', () => {
   describe('global "newlinesBetween" option', () => {
-    it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
+    it.each([...MULTIPLE_LINES_OPTIONS, 'ignore', 0] as const)(
       'should return the global option (`%s`) if "customGroups" is not defined',
       newlinesBetween => {
         expect(
@@ -23,7 +22,7 @@ describe('get-newlines-between-option', () => {
       },
     )
 
-    it.each(['ignore', ...NEVER_OPTIONS] as const)(
+    it.each(['ignore', 0] as const)(
       'should return "%s" if "newlinesBetween" is "%s"',
       newlinesBetween => {
         expect(
@@ -36,7 +35,7 @@ describe('get-newlines-between-option', () => {
       },
     )
 
-    it.each(ALWAYS_OPTIONS)(
+    it.each(MULTIPLE_LINES_OPTIONS)(
       'should return the entered newlinesBetween ("%s") if nodeGroupNumber !== nextNodeGroupNumber',
       newlinesBetween => {
         let groups = ['group1', 'group2']
@@ -69,25 +68,22 @@ describe('get-newlines-between-option', () => {
       ).toBe(1)
     })
 
-    it.each(NEVER_OPTIONS)(
-      'should return 0 if "newlinesBetween" is 1 and nodeGroupNumber === nextNodeGroupNumber',
-      () => {
-        let groups = ['group1']
-        expect(
-          getNewlinesBetweenOption({
-            options: {
-              newlinesBetween: 1,
-              customGroups: [],
-              groups,
-            },
-            nextNodeGroupIndex: generateNodeGroupIndex(groups, 'group1'),
-            nodeGroupIndex: generateNodeGroupIndex(groups, 'group1'),
-          }),
-        ).toBe(0)
-      },
-    )
+    it('should return 0 if "newlinesBetween" is 1 and nodeGroupNumber === nextNodeGroupNumber', () => {
+      let groups = ['group1']
+      expect(
+        getNewlinesBetweenOption({
+          options: {
+            newlinesBetween: 1,
+            customGroups: [],
+            groups,
+          },
+          nextNodeGroupIndex: generateNodeGroupIndex(groups, 'group1'),
+          nodeGroupIndex: generateNodeGroupIndex(groups, 'group1'),
+        }),
+      ).toBe(0)
+    })
 
-    it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
+    it.each([...MULTIPLE_LINES_OPTIONS, 'ignore', 0] as const)(
       "should return the global option (`%s`) if the node's group is within an array",
       newlinesBetween => {
         expect(
@@ -106,7 +102,7 @@ describe('get-newlines-between-option', () => {
       },
     )
 
-    it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
+    it.each([...MULTIPLE_LINES_OPTIONS, 'ignore', 0] as const)(
       "should return the global option (`%s`) if the next node's group is within an array",
       newlinesBetween => {
         expect(
@@ -139,7 +135,7 @@ describe('get-newlines-between-option', () => {
         sortingNodeGroup: 'group1',
       } as const
 
-      it.each([...ALWAYS_OPTIONS, ...NEVER_OPTIONS] as const)(
+      it.each([...MULTIPLE_LINES_OPTIONS, 0] as const)(
         'should return the "newlinesInside" option (`%s`) if defined',
         newlinesInside => {
           expect(
@@ -159,7 +155,7 @@ describe('get-newlines-between-option', () => {
         },
       )
 
-      it.each(['ignore', ...NEVER_OPTIONS] as const)(
+      it.each(['ignore', 0] as const)(
         'should return the global option (`%s`) if the "newlinesInside" option is not defined',
         newlinesBetween => {
           expect(
@@ -180,7 +176,7 @@ describe('get-newlines-between-option', () => {
     })
 
     describe('when the node and next node do not belong to the same custom group', () => {
-      it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
+      it.each([...MULTIPLE_LINES_OPTIONS, 'ignore', 0] as const)(
         'should return the global option (`%s`)',
         newlinesBetween => {
           expect(
@@ -203,11 +199,7 @@ describe('get-newlines-between-option', () => {
     })
 
     describe('newlinesBetween option between two groups', () => {
-      let availableOptions = [
-        ...ALWAYS_OPTIONS,
-        ...NEVER_OPTIONS,
-        'ignore',
-      ] as const
+      let availableOptions = [...MULTIPLE_LINES_OPTIONS, 0, 'ignore'] as const
       let availableCombinations: {
         globalNewlinesBetween: NewlinesBetweenOption
         newlinesBetween: NewlinesBetweenOption
@@ -232,7 +224,7 @@ describe('get-newlines-between-option', () => {
       )
 
       describe('non-adjacent groups', () => {
-        it.each([1, 'ignore', ...NEVER_OPTIONS] as const)(
+        it.each([1, 'ignore', 0] as const)(
           'should return 1 if the global option is 1 and `%s` exists between the groups',
           newlinesBetween => {
             expect(
@@ -251,7 +243,7 @@ describe('get-newlines-between-option', () => {
           },
         )
 
-        it.each([1, 'ignore', ...NEVER_OPTIONS] as const)(
+        it.each([1, 'ignore', 0] as const)(
           'should return 1 if 1 exists between the groups and global option is `%s`',
           newlinesBetween => {
             expect(
@@ -270,7 +262,7 @@ describe('get-newlines-between-option', () => {
           },
         )
 
-        it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
+        it.each([...MULTIPLE_LINES_OPTIONS, 'ignore', 0] as const)(
           'should return the maximum of the newlinesBetween options if the global option is `%s`',
           newlinesBetween => {
             expect(
@@ -290,7 +282,7 @@ describe('get-newlines-between-option', () => {
           },
         )
 
-        it.each(['ignore', ...NEVER_OPTIONS] as const)(
+        it.each(['ignore', 0] as const)(
           'should return `ignore` if `ignore` exists between the groups and not 1 with global option `%s`',
           newlinesBetween => {
             expect(
@@ -311,7 +303,7 @@ describe('get-newlines-between-option', () => {
           },
         )
 
-        it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
+        it.each([...MULTIPLE_LINES_OPTIONS, 'ignore', 0] as const)(
           'should return 0 if there are only 0 between all groups and global option is `%s`',
           newlinesBetween => {
             expect(
@@ -332,7 +324,7 @@ describe('get-newlines-between-option', () => {
           },
         )
 
-        it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
+        it.each([...MULTIPLE_LINES_OPTIONS, 'ignore', 0] as const)(
           'should return the global option (`%s`) if no `ignore` or 1 exist',
           newlinesBetween => {
             expect(

--- a/test/utils/get-newlines-between-option.test.ts
+++ b/test/utils/get-newlines-between-option.test.ts
@@ -312,7 +312,7 @@ describe('get-newlines-between-option', () => {
         )
 
         it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
-          'should return 0 if there are only `never` between all groups and global option is `%s`',
+          'should return 0 if there are only 0 between all groups and global option is `%s`',
           newlinesBetween => {
             expect(
               getNewlinesBetweenOption(

--- a/test/utils/get-newlines-between-option.test.ts
+++ b/test/utils/get-newlines-between-option.test.ts
@@ -4,10 +4,9 @@ import type { GetNewlinesBetweenOptionParameters } from '../../utils/get-newline
 import type { NewlinesBetweenOption } from '../../types/common-options'
 
 import { getNewlinesBetweenOption } from '../../utils/get-newlines-between-option'
-import { UnreachableCaseError } from '../../utils/unreachable-case-error'
 
-const NEVER_OPTIONS = [0, 'never'] as const
-const ALWAYS_OPTIONS = [1, 2, 'always'] as const
+const NEVER_OPTIONS = [0] as const
+const ALWAYS_OPTIONS = [1, 2] as const
 
 describe('get-newlines-between-option', () => {
   describe('global "newlinesBetween" option', () => {
@@ -20,7 +19,7 @@ describe('get-newlines-between-option', () => {
               newlinesBetween,
             }),
           ),
-        ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+        ).toBe(newlinesBetween)
       },
     )
 
@@ -33,7 +32,7 @@ describe('get-newlines-between-option', () => {
               newlinesBetween,
             }),
           ),
-        ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+        ).toBe(newlinesBetween)
       },
     )
 
@@ -51,16 +50,16 @@ describe('get-newlines-between-option', () => {
             nextNodeGroupIndex: generateNodeGroupIndex(groups, 'group2'),
             nodeGroupIndex: generateNodeGroupIndex(groups, 'group1'),
           }),
-        ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+        ).toBe(newlinesBetween)
       },
     )
 
-    it('should return 1 if "newlinesBetween" is "always" and nodeGroupIndex !== nextNodeGroupIndex', () => {
+    it('should return 1 if "newlinesBetween" is 1 and nodeGroupIndex !== nextNodeGroupIndex', () => {
       let groups = ['group1', 'group2']
       expect(
         getNewlinesBetweenOption({
           options: {
-            newlinesBetween: 'always',
+            newlinesBetween: 1,
             customGroups: [],
             groups,
           },
@@ -71,13 +70,13 @@ describe('get-newlines-between-option', () => {
     })
 
     it.each(NEVER_OPTIONS)(
-      'should return 0 if "newlinesBetween" is "always" and nodeGroupNumber === nextNodeGroupNumber',
+      'should return 0 if "newlinesBetween" is 1 and nodeGroupNumber === nextNodeGroupNumber',
       () => {
         let groups = ['group1']
         expect(
           getNewlinesBetweenOption({
             options: {
-              newlinesBetween: 'always',
+              newlinesBetween: 1,
               customGroups: [],
               groups,
             },
@@ -103,7 +102,7 @@ describe('get-newlines-between-option', () => {
               newlinesBetween,
             }),
           ),
-        ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+        ).toBe(newlinesBetween)
       },
     )
 
@@ -122,7 +121,7 @@ describe('get-newlines-between-option', () => {
               newlinesBetween,
             }),
           ),
-        ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+        ).toBe(newlinesBetween)
       },
     )
   })
@@ -132,8 +131,8 @@ describe('get-newlines-between-option', () => {
       let parameters = {
         customGroups: [
           {
-            newlinesInside: 'always',
             groupName: 'group1',
+            newlinesInside: 1,
           },
         ],
         nextNodeGroupIndexGroup: 'group1',
@@ -153,10 +152,10 @@ describe('get-newlines-between-option', () => {
                     newlinesInside,
                   },
                 ],
-                newlinesBetween: 'never',
+                newlinesBetween: 0,
               }),
             ),
-          ).toBe(convertNewlinesBetweenOptionToNumber(newlinesInside))
+          ).toBe(newlinesInside)
         },
       )
 
@@ -175,7 +174,7 @@ describe('get-newlines-between-option', () => {
                 newlinesBetween,
               }),
             ),
-          ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+          ).toBe(newlinesBetween)
         },
       )
     })
@@ -198,7 +197,7 @@ describe('get-newlines-between-option', () => {
                 newlinesBetween,
               }),
             ),
-          ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+          ).toBe(newlinesBetween)
         },
       )
     })
@@ -228,13 +227,13 @@ describe('get-newlines-between-option', () => {
                 newlinesBetween: globalNewlinesBetween,
               }),
             ),
-          ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+          ).toBe(newlinesBetween)
         },
       )
 
       describe('non-adjacent groups', () => {
-        it.each(['always', 1, 'ignore', ...NEVER_OPTIONS] as const)(
-          'should return 1 if the global option is `always` and `%s` exists between the groups',
+        it.each([1, 'ignore', ...NEVER_OPTIONS] as const)(
+          'should return 1 if the global option is 1 and `%s` exists between the groups',
           newlinesBetween => {
             expect(
               getNewlinesBetweenOption(
@@ -245,15 +244,15 @@ describe('get-newlines-between-option', () => {
                     { newlinesBetween },
                     'group2',
                   ],
-                  newlinesBetween: 'always',
+                  newlinesBetween: 1,
                 }),
               ),
             ).toBe(1)
           },
         )
 
-        it.each([1, 'always', 'ignore', ...NEVER_OPTIONS] as const)(
-          'should return 1 if `always` exists between the groups and global option is `%s`',
+        it.each([1, 'ignore', ...NEVER_OPTIONS] as const)(
+          'should return 1 if 1 exists between the groups and global option is `%s`',
           newlinesBetween => {
             expect(
               getNewlinesBetweenOption(
@@ -261,7 +260,7 @@ describe('get-newlines-between-option', () => {
                   groups: [
                     'group1',
                     'someOtherGroup',
-                    { newlinesBetween: 'always' },
+                    { newlinesBetween: 1 },
                     'group2',
                   ],
                   newlinesBetween,
@@ -292,7 +291,7 @@ describe('get-newlines-between-option', () => {
         )
 
         it.each(['ignore', ...NEVER_OPTIONS] as const)(
-          'should return `ignore` if `ignore` exists between the groups and not `always` with global option `%s`',
+          'should return `ignore` if `ignore` exists between the groups and not 1 with global option `%s`',
           newlinesBetween => {
             expect(
               getNewlinesBetweenOption(
@@ -302,7 +301,7 @@ describe('get-newlines-between-option', () => {
                     'someOtherGroup',
                     { newlinesBetween: 'ignore' },
                     'group2',
-                    { newlinesBetween: 'always' },
+                    { newlinesBetween: 1 },
                     'someOtherGroup2',
                   ],
                   newlinesBetween,
@@ -320,9 +319,9 @@ describe('get-newlines-between-option', () => {
                 buildParameters({
                   groups: [
                     'group1',
-                    { newlinesBetween: 'never' },
+                    { newlinesBetween: 0 },
                     'someOtherGroup',
-                    { newlinesBetween: 'never' },
+                    { newlinesBetween: 0 },
                     'group2',
                     'someOtherGroup2',
                   ],
@@ -334,7 +333,7 @@ describe('get-newlines-between-option', () => {
         )
 
         it.each([...ALWAYS_OPTIONS, 'ignore', ...NEVER_OPTIONS] as const)(
-          'should return the global option (`%s`) if no `ignore` or `always` exist',
+          'should return the global option (`%s`) if no `ignore` or 1 exist',
           newlinesBetween => {
             expect(
               getNewlinesBetweenOption(
@@ -342,15 +341,15 @@ describe('get-newlines-between-option', () => {
                   groups: [
                     'group1',
                     'someOtherGroup',
-                    { newlinesBetween: 'never' },
+                    { newlinesBetween: 0 },
                     'group2',
-                    { newlinesBetween: 'always' },
+                    { newlinesBetween: 1 },
                     'someOtherGroup2',
                   ],
                   newlinesBetween,
                 }),
               ),
-            ).toBe(convertNewlinesBetweenOptionToNumber(newlinesBetween))
+            ).toBe(newlinesBetween)
           },
         )
       })
@@ -395,21 +394,3 @@ describe('get-newlines-between-option', () => {
     return groups.indexOf(group)
   }
 })
-
-function convertNewlinesBetweenOptionToNumber(
-  newlinesBetween: NewlinesBetweenOption,
-): 'ignore' | number {
-  if (typeof newlinesBetween === 'number') {
-    return newlinesBetween
-  }
-  switch (newlinesBetween) {
-    case 'ignore':
-      return 'ignore'
-    case 'always':
-      return 1
-    case 'never':
-      return 0
-    default:
-      throw new UnreachableCaseError(newlinesBetween)
-  }
-}

--- a/test/utils/validate-generated-groups-configuration.test.ts
+++ b/test/utils/validate-generated-groups-configuration.test.ts
@@ -106,8 +106,8 @@ describe('validate-generated-groups-configuration', () => {
   })
 
   it.each([
-    { groups: [{ newlinesBetween: 'always' }, { newlinesBetween: 'always' }] },
-    { groups: [{ newlinesBetween: 'always' }, { commentAbove: 'foo' }] },
+    { groups: [{ newlinesBetween: 1 }, { newlinesBetween: 1 }] },
+    { groups: [{ newlinesBetween: 1 }, { commentAbove: 'foo' }] },
     { groups: [{ commentAbove: 'foo' }, { commentAbove: 'bar' }] },
   ] as const)(
     'throws an error with consecutive newlines/commentAbove objects (%s)',

--- a/test/utils/validate-newlines-and-partition-configuration.test.ts
+++ b/test/utils/validate-newlines-and-partition-configuration.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { validateNewlinesAndPartitionConfiguration } from '../../utils/validate-newlines-and-partition-configuration'
 
 describe('validate-newlines-and-partition-configuration', () => {
-  it.each(['always', 'never'] as const)(
+  it.each([1, 0] as const)(
     "throws an error when 'partitionByNewline' is enabled and 'newlinesBetween' is '%s'",
     newlinesBetween => {
       expect(() => {
@@ -18,7 +18,7 @@ describe('validate-newlines-and-partition-configuration', () => {
     },
   )
 
-  it.each(['always', 'never', 'ignore'] as const)(
+  it.each([1, 0, 'ignore'] as const)(
     "throws an error when 'partitionByNewline' is enabled and `newlinesBetween: '%s'` objects exist in 'groups'",
     newlinesBetween => {
       expect(() => {
@@ -43,7 +43,7 @@ describe('validate-newlines-and-partition-configuration', () => {
     }).not.toThrow()
   })
 
-  it.each(['always', 'never', 'ignore'] as const)(
+  it.each([1, 0, 'ignore'] as const)(
     "allows `newlinesBetween: '%s'` when 'partitionByNewline' is 'false'",
     newlinesBetween => {
       expect(() => {

--- a/test/utils/validate-no-duplicated-groups.test.ts
+++ b/test/utils/validate-no-duplicated-groups.test.ts
@@ -9,7 +9,7 @@ describe('validate-no-duplicated-groups', () => {
         groups: [
           ['group1'],
           'group2',
-          { newlinesBetween: 'always' },
+          { newlinesBetween: 1 },
           'group1',
           'group2',
         ],

--- a/test/utils/validate-objects-inside-groups.test.ts
+++ b/test/utils/validate-objects-inside-groups.test.ts
@@ -22,9 +22,9 @@ function buildAllPossibleCases(): {
   first: (typeof cases)[number]
 }[] {
   let cases = [
-    { newlinesBetween: 'always' },
+    { newlinesBetween: 1 },
     { commentAbove: 'comment' },
-    { newlinesBetween: 'always', commentAbove: 'comment' },
+    { commentAbove: 'comment', newlinesBetween: 1 },
   ] as const
 
   let returnValue: {

--- a/types/common-options.ts
+++ b/types/common-options.ts
@@ -86,7 +86,7 @@ export interface CommonOptions {
  *       anyOf: ['react', 'react-*'],
  *       type: 'alphabetical',
  *       order: 'asc',
- *       newlinesInside: 'always',
+ *       newlinesInside: 1,
  *     },
  *     {
  *       groupName: 'lodash',
@@ -105,19 +105,13 @@ export type CustomGroupsOption<
   AdditionalOptions = Record<never, never>,
 > = ({
   /**
-   * Controls newline behavior within the custom group.
-   *
-   * - 'always': Enforce newlines between elements in this group
-   * - 'never': Disallow newlines between elements in this group
-   * - Number: Specify exact number of newlines required.
-   */
-  newlinesInside?: 'always' | 'never' | number
-
-  /**
    * Fallback sorting configuration used when primary sort returns equal. Useful
    * for stable sorting when elements have identical primary sort values.
    */
   fallbackSort?: FallbackSortOption
+
+  /** Specify the exact number of newlines required. */
+  newlinesInside?: number
 
   /**
    * Sort direction for this custom group. Overrides the global order setting
@@ -185,45 +179,6 @@ export type TypeOption =
    * 'alphabet' option to specify character precedence.
    */
   | 'custom'
-
-/**
- * Configuration for managing newlines between sorted elements.
- *
- * Controls how blank lines are handled between elements, either preserving,
- * enforcing, or removing them based on the configuration.
- *
- * @example
- *   // Always require one blank line between elements
- *   const newlines: NewlinesBetweenOption = 'always'
- *
- * @example
- *   // Require exactly 2 blank lines
- *   const newlines: NewlinesBetweenOption = 2
- */
-export type NewlinesBetweenOption =
-  /**
-   * Preserve existing newlines without modification. The plugin will not add or
-   * remove blank lines.
-   */
-  | 'ignore'
-
-  /**
-   * Always require exactly one blank line between elements. Adds missing
-   * newlines and removes extra ones.
-   */
-  | 'always'
-
-  /**
-   * Never allow blank lines between elements. Removes all blank lines to keep
-   * elements together.
-   */
-  | 'never'
-
-  /**
-   * Require exactly this number of blank lines between elements. Enforces
-   * consistent spacing with the specified line count.
-   */
-  | number
 
 /**
  * Configuration for handling special characters during string comparison.
@@ -331,6 +286,33 @@ export interface FallbackSortOption {
 }
 
 /**
+ * Configuration for managing newlines between sorted elements.
+ *
+ * Controls how blank lines are handled between elements, either preserving,
+ * enforcing, or removing them based on the configuration.
+ *
+ * @example
+ *   // Always require one blank line between elements
+ *   const newlines: NewlinesBetweenOption = 'always'
+ *
+ * @example
+ *   // Require exactly 2 blank lines
+ *   const newlines: NewlinesBetweenOption = 2
+ */
+export type NewlinesBetweenOption =
+  /**
+   * Preserve existing newlines without modification. The plugin will not add or
+   * remove blank lines.
+   */
+  | 'ignore'
+
+  /**
+   * Require exactly this number of blank lines between elements. Enforces
+   * consistent spacing with the specified line count.
+   */
+  | number
+
+/**
  * Sort direction that determines the ordering of elements.
  *
  * Controls whether elements are arranged from smallest to largest (ascending)
@@ -367,7 +349,7 @@ export type OrderOption =
  * @example
  *   const groups = [
  *     'imports',
- *     { newlinesBetween: 'always' }, // One newline after imports
+ *     { newlinesBetween: 1 }, // One newline after imports
  *     'types',
  *   ]
  */
@@ -432,7 +414,7 @@ export interface GroupCommentAboveOption {
  * @example
  *   const groups: GroupsOptions<'imports' | 'types' | 'components'> = [
  *     'imports',
- *     { newlinesBetween: 'always' },
+ *     { newlinesBetween: 1 },
  *     'types',
  *     { commentAbove: '// Components' },
  *     ['components', 'hooks'], // Composite group

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -147,7 +147,7 @@ export let newlinesBetweenJsonSchema: JSONSchema4 = {
   oneOf: [
     {
       description: 'Specifies how to handle newlines between groups.',
-      enum: ['ignore', 'always', 'never'],
+      enum: ['ignore'],
       type: 'string',
     },
     {
@@ -444,26 +444,16 @@ function buildCommonCustomGroupJsonSchemas({
   additionalFallbackSortProperties?: Record<string, JSONSchema4>
 } = {}): Record<string, JSONSchema4> {
   return {
-    newlinesInside: {
-      oneOf: [
-        {
-          description:
-            'Specifies how to handle newlines between members of the custom group.',
-          enum: ['always', 'never'],
-          type: 'string',
-        },
-        {
-          type: 'number',
-          minimum: 0,
-        },
-      ],
-    },
     fallbackSort: buildFallbackSortJsonSchema({
       additionalProperties: additionalFallbackSortProperties,
     }),
     groupName: {
       description: 'Custom group name.',
       type: 'string',
+    },
+    newlinesInside: {
+      type: 'number',
+      minimum: 0,
     },
     order: orderJsonSchema,
     type: typeJsonSchema,

--- a/utils/get-newlines-between-errors.ts
+++ b/utils/get-newlines-between-errors.ts
@@ -42,7 +42,7 @@ interface GetNewlinesBetweenErrorsParameters<
 > {
   /** Configuration options for newlines and groups. */
   options: {
-    /** Newlines configuration: 'always', 'never', 'ignore', or numeric value. */
+    /** Newlines configuration: 'ignore', or numeric value. */
     newlinesBetween: NewlinesBetweenOption
 
     /** Optional custom groups configuration. */
@@ -95,7 +95,7 @@ interface GetNewlinesBetweenErrorsParameters<
  * @example
  *   // Configuration requires 1 newline between different groups
  *   const errors = getNewlinesBetweenErrors({
- *     options: { newlinesBetween: 'always', groups: ['imports', 'types'] },
+ *     options: { newlinesBetween: 1, groups: ['imports', 'types'] },
  *     leftGroupIndex: 0, // imports group
  *     rightGroupIndex: 1, // types group
  *     left: importNode,

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -15,10 +15,7 @@ import { isNewlinesBetweenOption } from './is-newlines-between-option'
 export interface GetNewlinesBetweenOptionParameters {
   /** Configuration options for newlines and groups. */
   options: {
-    /**
-     * Global newlines configuration: 'always', 'never', 'ignore', or numeric
-     * value.
-     */
+    /** Global newlines configuration: 'ignore', or numeric value. */
     newlinesBetween: NewlinesBetweenOption
 
     /**

--- a/utils/get-newlines-between-option.ts
+++ b/utils/get-newlines-between-option.ts
@@ -5,7 +5,6 @@ import type {
 } from '../types/common-options'
 
 import { isNewlinesBetweenOption } from './is-newlines-between-option'
-import { UnreachableCaseError } from './unreachable-case-error'
 
 /**
  * Parameters for determining newlines requirement between nodes.
@@ -86,9 +85,7 @@ export function getNewlinesBetweenOption({
       nodeCustomGroup.groupName === nextNodeCustomGroup.groupName
     ) {
       if (nodeCustomGroup.newlinesInside !== undefined) {
-        return convertNewlinesBetweenOptionToNumber(
-          nodeCustomGroup.newlinesInside,
-        )
+        return nodeCustomGroup.newlinesInside
       }
       return globalNewlinesBetweenOption
     }
@@ -99,9 +96,7 @@ export function getNewlinesBetweenOption({
     if (nextNodeGroupIndex === nodeGroupIndex + 2) {
       let groupBetween = options.groups[nodeGroupIndex + 1]!
       if (isNewlinesBetweenOption(groupBetween)) {
-        return convertNewlinesBetweenOptionToNumber(
-          groupBetween.newlinesBetween,
-        )
+        return groupBetween.newlinesBetween
       }
     } else {
       let relevantGroups = options.groups.slice(
@@ -115,8 +110,7 @@ export function getNewlinesBetweenOption({
       let newlinesBetweenOptions = new Set(
         groupsWithAllNewlinesBetween
           .filter(isNewlinesBetweenOption)
-          .map(group => group.newlinesBetween)
-          .map(convertNewlinesBetweenOptionToNumber),
+          .map(group => group.newlinesBetween),
       )
 
       let numberNewlinesBetween = [...newlinesBetweenOptions].filter(
@@ -211,47 +205,11 @@ function getGlobalNewlinesBetweenOption({
   nextNodeGroupIndex: number
   nodeGroupIndex: number
 }): 'ignore' | number {
-  let numberNewlinesBetween =
-    convertNewlinesBetweenOptionToNumber(newlinesBetween)
-
-  if (numberNewlinesBetween === 'ignore') {
+  if (newlinesBetween === 'ignore') {
     return 'ignore'
   }
   if (nodeGroupIndex === nextNodeGroupIndex) {
     return 0
   }
-  return numberNewlinesBetween
-}
-
-/**
- * Converts newlines configuration value to a numeric value or 'ignore'.
- *
- * Transforms string configuration values to their numeric equivalents:
- *
- * - 'always' → 1 (one newline required)
- * - 'never' → 0 (no newlines allowed)
- * - 'ignore' → 'ignore' (skip checking)
- * - Number → number (exact count required).
- *
- * @param newlinesBetween - Configuration value to convert.
- * @returns Numeric newlines requirement or 'ignore'.
- * @throws {UnreachableCaseError} If an unknown configuration value is provided.
- */
-function convertNewlinesBetweenOptionToNumber(
-  newlinesBetween: NewlinesBetweenOption,
-): 'ignore' | number {
-  if (typeof newlinesBetween === 'number') {
-    return newlinesBetween
-  }
-  switch (newlinesBetween) {
-    case 'ignore':
-      return 'ignore'
-    case 'always':
-      return 1
-    case 'never':
-      return 0
-    /* v8 ignore next 2 */
-    default:
-      throw new UnreachableCaseError(newlinesBetween)
-  }
+  return newlinesBetween
 }

--- a/utils/is-comment-above-option.ts
+++ b/utils/is-comment-above-option.ts
@@ -18,7 +18,7 @@ import type {
  *     'imports',
  *     { commentAbove: '// Components' },
  *     'components',
- *     { newlinesBetween: 'always' },
+ *     { newlinesBetween: 1 },
  *     'utils',
  *   ]
  *

--- a/utils/is-newlines-between-option.ts
+++ b/utils/is-newlines-between-option.ts
@@ -17,7 +17,7 @@ import type {
  * @example
  *   const groups = [
  *     'imports',
- *     { newlinesBetween: 'always' }, // Add 1 newline between imports and types
+ *     { newlinesBetween: 1 }, // Add 1 newline between imports and types
  *     'types',
  *     { newlinesBetween: 2 }, // Add 2 newlines between types and components
  *     'components',

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -92,7 +92,7 @@ export interface MakeFixesParameters<T extends SortingNode> {
  *     sortedNodes: sortedNodes,
  *     options: {
  *       groups: ['imports', 'types', 'functions'],
- *       newlinesBetween: 'always',
+ *       newlinesBetween: 1,
  *     },
  *     sourceCode,
  *     fixer,

--- a/utils/make-newlines-between-fixes.ts
+++ b/utils/make-newlines-between-fixes.ts
@@ -68,7 +68,7 @@ interface MakeNewlinesBetweenFixesParameters<T extends SortingNode> {
  *   // Configuration with newlines between groups
  *   const options = {
  *     groups: ['imports', 'types', 'functions'],
- *     newlinesBetween: 'always', // 1 newline between groups
+ *     newlinesBetween: 1, // 1 newline between groups
  *   }
  *
  *   // Original: imports and types with no separation

--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -75,7 +75,7 @@ interface ReportAllErrorsParameters<
    *   type: 'alphabetical',
    *   order: 'asc',
    *   groups: ['static-property', 'property', 'constructor', 'method'],
-   *   newlinesBetween: 'always',
+   *   newlinesBetween: 1,
    *   partitionByComment: true
    *   }
    */

--- a/utils/validate-newlines-and-partition-configuration.ts
+++ b/utils/validate-newlines-and-partition-configuration.ts
@@ -42,7 +42,7 @@ interface Options {
  *   // Invalid: Conflicting options
  *   validateNewlinesAndPartitionConfiguration({
  *     partitionByNewLine: true,
- *     newlinesBetween: 'always', // Conflicts with partitionByNewLine
+ *     newlinesBetween: 1, // Conflicts with partitionByNewLine
  *     groups: ['react', 'external', 'internal'],
  *   })
  *   // Throws: The 'partitionByNewLine' and 'newlinesBetween' options cannot be used together
@@ -54,7 +54,7 @@ interface Options {
  *     newlinesBetween: 'ignore',
  *     groups: [
  *       'external',
- *       { newlinesBetween: 'always' }, // Can't use with partitions
+ *       { newlinesBetween: 1 }, // Can't use with partitions
  *       'internal',
  *     ],
  *   })
@@ -64,12 +64,12 @@ interface Options {
  *   // Valid: Using newlinesBetween without partitions
  *   validateNewlinesAndPartitionConfiguration({
  *     partitionByNewLine: false,
- *     newlinesBetween: 'always',
+ *     newlinesBetween: 1,
  *     groups: [
  *       'react',
- *       { newlinesBetween: 'always' },
+ *       { newlinesBetween: 1 },
  *       'external',
- *       { newlinesBetween: 'always' },
+ *       { newlinesBetween: 1 },
  *       'internal',
  *     ],
  *   })
@@ -87,7 +87,7 @@ interface Options {
  *   // Option 2: Enforce consistent spacing
  *   validateNewlinesAndPartitionConfiguration({
  *     partitionByNewLine: false,
- *     newlinesBetween: 'always',
+ *     newlinesBetween: 1,
  *     groups: ['react', 'external', '@company', 'internal', 'relative'],
  *   })
  *   // Choose one approach, not both

--- a/utils/validate-objects-inside-groups.ts
+++ b/utils/validate-objects-inside-groups.ts
@@ -13,7 +13,7 @@ import type { GroupsOptions } from '../types/common-options'
  *   validateObjectsInsideGroups({
  *     groups: [
  *       'react',
- *       { newlinesBetween: 'always' },
+ *       { newlinesBetween: 1 },
  *       { commentAbove: '// External libraries' }, // Error: consecutive objects
  *       'external',
  *     ],
@@ -26,7 +26,7 @@ import type { GroupsOptions } from '../types/common-options'
  *     groups: [
  *       'react',
  *       {
- *         newlinesBetween: 'always',
+ *         newlinesBetween: 1,
  *         commentAbove: '// External libraries',
  *       },
  *       'external',
@@ -39,9 +39,9 @@ import type { GroupsOptions } from '../types/common-options'
  *   validateObjectsInsideGroups({
  *     groups: [
  *       'react',
- *       { newlinesBetween: 'always' },
+ *       { newlinesBetween: 1 },
  *       'external',
- *       { newlinesBetween: 'always' },
+ *       { newlinesBetween: 1 },
  *       'internal',
  *     ],
  *   })


### PR DESCRIPTION
## Description

> [!NOTE]
> Most of the changes are whitespace changes in tests (`it.each` becoming `it`).

In favor of `newlinesBetween: number`:
- `newlinesBetween: 'always'` ➡️ `newlinesBetween: 1`.
- `newlinesBetween: 'never'` ➡️ `newlinesBetween: 0`.

`newlinesBetween: 'ignore'` is still supported.

## What is the purpose of this pull request?

- [x] Other