### PR TITLE
docs: fix memory leaks on website

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -67,10 +67,6 @@ export default defineConfig({
     }),
     mdx(),
   ],
-  prefetch: {
-    defaultStrategy: 'viewport',
-    prefetchAll: true,
-  },
   build: {
     inlineStylesheets: 'always',
     format: 'file',
@@ -79,6 +75,9 @@ export default defineConfig({
     clientPrerender: true,
   },
   publicDir: path.join(dirname, './docs/public'),
+  prefetch: {
+    defaultStrategy: 'hover',
+  },
   server: {
     port: 3000,
     host: true,

--- a/docs/components/CodeTabs.svelte
+++ b/docs/components/CodeTabs.svelte
@@ -42,7 +42,10 @@
 
   onMount(() => {
     mounted = true
-    startKeyUX(globalThis, [focusGroupKeyUX()])
+    let stop = startKeyUX(globalThis, [focusGroupKeyUX()])
+    return () => {
+      stop()
+    }
   })
 </script>
 

--- a/docs/components/Head.astro
+++ b/docs/components/Head.astro
@@ -140,7 +140,14 @@ let isProduction = import.meta.env.PROD
       localStorage.setItem('theme', theme)
     }
     initialize()
-    document.addEventListener('astro:after-swap', initialize)
+    let handlerKey = '__perfectionistThemeAfterSwap__'
+    if (!globalThis[handlerKey]) {
+      let handleAfterSwap = () => {
+        initialize()
+      }
+      document.addEventListener('astro:after-swap', handleAfterSwap)
+      globalThis[handlerKey] = handleAfterSwap
+    }
   </script>
 
   <ClientRouter />

--- a/docs/components/Header.astro
+++ b/docs/components/Header.astro
@@ -33,35 +33,75 @@ let { border = false } = Astro.props
 <script>
   import { toggleMenu } from '../stores/menu-open'
 
-  let initMenu = () => {
-    document
-      .getElementById('menu-button')!
-      .addEventListener('click', toggleMenu)
+  let menuController: AbortController | undefined
+  let scrollController: AbortController | undefined
+
+  let cleanup = () => {
+    menuController?.abort()
+    scrollController?.abort()
+    menuController = undefined
+    scrollController = undefined
   }
 
-  document.addEventListener('astro:after-swap', initMenu)
-  initMenu()
-</script>
+  let setupMenu = () => {
+    let menuButton = document.getElementById('menu-button')
+    if (!menuButton) {
+      return
+    }
 
-<script>
-  let initHeader = () => {
-    let header = document.querySelector('.header')!
-
-    document.addEventListener('scroll', () => {
-      let { scrollY } = globalThis
-
-      if (!header.classList.contains('border')) {
-        if (scrollY > 24) {
-          header.classList.add('scroll')
-        } else {
-          header.classList.remove('scroll')
-        }
-      }
+    menuController = new AbortController()
+    menuButton.addEventListener('click', toggleMenu, {
+      signal: menuController.signal,
     })
   }
 
-  document.addEventListener('astro:after-swap', initHeader)
-  initHeader()
+  let setupScroll = () => {
+    let header = document.querySelector('.header')
+    if (!header) {
+      return
+    }
+
+    let handleScroll = () => {
+      if (header.classList.contains('border')) {
+        return
+      }
+
+      header.classList.toggle('scroll', globalThis.scrollY > 24)
+    }
+
+    scrollController = new AbortController()
+    document.addEventListener('scroll', handleScroll, {
+      signal: scrollController.signal,
+      passive: true,
+    })
+    handleScroll()
+  }
+
+  let scheduleNext = () => {
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        cleanup()
+      },
+      { once: true },
+    )
+    document.addEventListener(
+      'astro:after-swap',
+      () => {
+        setup()
+      },
+      { once: true },
+    )
+  }
+
+  let setup = () => {
+    cleanup()
+    setupMenu()
+    setupScroll()
+    scheduleNext()
+  }
+
+  setup()
 </script>
 
 <style>

--- a/docs/components/Navigation.astro
+++ b/docs/components/Navigation.astro
@@ -49,14 +49,48 @@ import IconSun from '../icons/sun.svg'
 <script>
   import { toggleTheme } from '../stores/theme'
 
-  let initToggleTheme = () => {
-    document
-      .getElementById('toggle-theme')!
-      .addEventListener('click', toggleTheme)
+  let controller: AbortController | undefined
+
+  let cleanup = () => {
+    controller?.abort()
+    controller = undefined
   }
 
-  document.addEventListener('astro:after-swap', initToggleTheme)
-  initToggleTheme()
+  let scheduleNext = () => {
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        cleanup()
+      },
+      { once: true },
+    )
+    document.addEventListener(
+      'astro:after-swap',
+      () => {
+        setup()
+      },
+      { once: true },
+    )
+  }
+
+  let setup = () => {
+    cleanup()
+
+    let toggleButton = document.getElementById('toggle-theme')
+    if (!toggleButton) {
+      scheduleNext()
+      return
+    }
+
+    controller = new AbortController()
+    toggleButton.addEventListener('click', toggleTheme, {
+      signal: controller.signal,
+    })
+
+    scheduleNext()
+  }
+
+  setup()
 </script>
 
 <style>

--- a/docs/components/Sidebar/Sidebar.astro
+++ b/docs/components/Sidebar/Sidebar.astro
@@ -31,11 +31,44 @@ let { isMobileOnly = false } = Astro.props
 <script>
   import { toggleMenu, menuOpen } from '../../stores/menu-open'
 
-  let initMenu = async () => {
-    let menu = document.getElementById('menu')!
+  let controller: AbortController | undefined
+  let unsubscribe: undefined | (() => void)
+
+  let cleanup = () => {
+    controller?.abort()
+    controller = undefined
+    unsubscribe?.()
+    unsubscribe = undefined
+  }
+
+  let scheduleNext = () => {
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        cleanup()
+      },
+      { once: true },
+    )
+    document.addEventListener(
+      'astro:after-swap',
+      () => {
+        setup()
+      },
+      { once: true },
+    )
+  }
+
+  let setup = () => {
+    cleanup()
+
+    let menu = document.getElementById('menu')
+    if (!menu) {
+      scheduleNext()
+      return
+    }
 
     menuOpen.set(false)
-    menuOpen.subscribe(menuOpenValue => {
+    unsubscribe = menuOpen.subscribe(menuOpenValue => {
       if (menuOpenValue) {
         menu.classList.add('menu-open')
       } else {
@@ -45,33 +78,80 @@ let { isMobileOnly = false } = Astro.props
       }
     })
 
-    document
-      .getElementById('menu-close-button')!
-      .addEventListener('click', toggleMenu)
+    controller = new AbortController()
+    let closeButton = document.getElementById('menu-close-button')
+    if (closeButton) {
+      closeButton.addEventListener('click', toggleMenu, {
+        signal: controller.signal,
+      })
+    }
+
+    scheduleNext()
   }
 
-  document.addEventListener('astro:after-swap', initMenu)
-  initMenu()
+  setup()
 </script>
 
 <script is:inline>
   const SIDEBAR_SCROLL_POSITION = 'SIDEBAR_SCROLL_POSITION'
 
-  let initSidebarScroll = () => {
-    let savedScrollPosition = sessionStorage.getItem(SIDEBAR_SCROLL_POSITION)
-    if (savedScrollPosition) {
-      let menu = document.getElementById('menu')
-      menu.scrollTop = Number(savedScrollPosition)
-    }
-    let menu = document.getElementById('menu')
-    menu.addEventListener('scrollend', event => {
-      let scrollPosition = event.target.scrollTop
-      sessionStorage.setItem(SIDEBAR_SCROLL_POSITION, scrollPosition)
-    })
+  let controller
+
+  let cleanup = () => {
+    controller?.abort()
+    controller = undefined
   }
 
-  document.addEventListener('astro:after-swap', initSidebarScroll)
-  initSidebarScroll()
+  let scheduleNext = () => {
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        cleanup()
+      },
+      { once: true },
+    )
+    document.addEventListener(
+      'astro:after-swap',
+      () => {
+        setup()
+      },
+      { once: true },
+    )
+  }
+
+  let setup = () => {
+    cleanup()
+
+    let menu = document.getElementById('menu')
+    if (!menu) {
+      scheduleNext()
+      return
+    }
+
+    let savedScrollPosition = sessionStorage.getItem(SIDEBAR_SCROLL_POSITION)
+    if (savedScrollPosition) {
+      menu.scrollTop = Number(savedScrollPosition)
+    }
+
+    controller = new AbortController()
+    menu.addEventListener(
+      'scrollend',
+      event => {
+        let target = event.target
+        if (target && 'scrollTop' in target) {
+          sessionStorage.setItem(
+            SIDEBAR_SCROLL_POSITION,
+            String(target.scrollTop ?? 0),
+          )
+        }
+      },
+      { signal: controller.signal },
+    )
+
+    scheduleNext()
+  }
+
+  setup()
 </script>
 
 <style>

--- a/docs/components/SkipToContent.astro
+++ b/docs/components/SkipToContent.astro
@@ -3,18 +3,70 @@ import IconArrowTurnRightDown from '../icons/arrow-turn-right-down.svg'
 ---
 
 <script is:inline>
-  let initSkipLink = () => {
-    let skipLink = document.getElementById('skip-link')
-    skipLink.addEventListener('click', event => {
-      event.preventDefault()
-      let main = document.querySelector('main')
-      main.setAttribute('tabindex', '-1')
-      main.focus()
-    })
+  let controller
+
+  let cleanup = () => {
+    controller?.abort()
+    controller = undefined
   }
 
-  document.addEventListener('astro:after-swap', initSkipLink)
-  document.addEventListener('DOMContentLoaded', initSkipLink)
+  let scheduleNext = () => {
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        cleanup()
+      },
+      { once: true },
+    )
+    document.addEventListener(
+      'astro:after-swap',
+      () => {
+        setup()
+      },
+      { once: true },
+    )
+  }
+
+  let setup = () => {
+    cleanup()
+
+    let skipLink = document.getElementById('skip-link')
+    if (!skipLink) {
+      scheduleNext()
+      return
+    }
+
+    controller = new AbortController()
+    skipLink.addEventListener(
+      'click',
+      event => {
+        event.preventDefault()
+        let main = document.querySelector('main')
+        if (!main) {
+          return
+        }
+        if (main instanceof HTMLElement) {
+          main.setAttribute('tabindex', '-1')
+          main.focus()
+        }
+      },
+      { signal: controller.signal },
+    )
+
+    scheduleNext()
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener(
+      'DOMContentLoaded',
+      () => {
+        setup()
+      },
+      { once: true },
+    )
+  } else {
+    setup()
+  }
 </script>
 
 <a class="skip-link" id="skip-link" href="#main">

--- a/docs/components/TableOfContents/TableOfContents.astro
+++ b/docs/components/TableOfContents/TableOfContents.astro
@@ -56,47 +56,10 @@ let toc = buildToc(headings)
   )
 }
 
-<script>
-  let initToc = () => {
-    let observer = new IntersectionObserver(
-      entries => {
-        if (globalThis.scrollY === 0) {
-          let firstTocItem = document.querySelector('.table-of-content a')
-          let previouslyActivatedItem = document.querySelector('.active')
-          previouslyActivatedItem?.classList.remove('active')
-          firstTocItem?.classList.add('active')
-          return
-        }
+<script type="module" lang="ts" is:inline>
+  import { setupTableOfContents } from './table-of-contents.client'
 
-        for (let entry of entries) {
-          let headingFragment = `#${entry.target.id}`
-          let tocItem = document.querySelector(
-            `.table-of-content a[href="${headingFragment}"]`,
-          )
-          if (entry.isIntersecting) {
-            let previouslyActivatedItem = document.querySelector('.active')
-            previouslyActivatedItem?.classList.remove('active')
-            tocItem?.classList.add('active')
-          } else {
-            let isAnyOtherEntryIntersecting = entries.some(
-              e => e.target.id !== entry.target.id && e.isIntersecting,
-            )
-
-            if (isAnyOtherEntryIntersecting) {
-              tocItem?.classList.remove('active')
-            }
-          }
-        }
-      },
-      { root: null, rootMargin: '0px', threshold: [1] },
-    )
-    let sectionHeadings = document.querySelectorAll('article h2, article h3')
-    for (let heading of Array.from(sectionHeadings)) {
-      observer.observe(heading)
-    }
-  }
-  document.addEventListener('astro:after-swap', initToc)
-  initToc()
+  setupTableOfContents()
 </script>
 
 <style>

--- a/docs/components/TableOfContents/table-of-contents.client.ts
+++ b/docs/components/TableOfContents/table-of-contents.client.ts
@@ -1,0 +1,108 @@
+let cleanup: () => void = () => {}
+
+function handleEntries(entries: IntersectionObserverEntry[]): void {
+  if (globalThis.scrollY === 0) {
+    let firstTocItem = document.querySelector<HTMLAnchorElement>(
+      '.table-of-content a',
+    )
+    let previouslyActivatedItem =
+      document.querySelector<HTMLAnchorElement>('.active')
+    previouslyActivatedItem?.classList.remove('active')
+    firstTocItem?.classList.add('active')
+    return
+  }
+
+  for (let entry of entries) {
+    let headingFragment = `#${entry.target.id}`
+    let tocItem = document.querySelector<HTMLAnchorElement>(
+      `.table-of-content a[href="${headingFragment}"]`,
+    )
+    if (!tocItem) {
+      continue
+    }
+
+    if (entry.isIntersecting) {
+      let previouslyActivatedItem =
+        document.querySelector<HTMLAnchorElement>('.active')
+      previouslyActivatedItem?.classList.remove('active')
+      tocItem.classList.add('active')
+    } else {
+      let isAnyOtherEntryIntersecting = entries.some(
+        otherEntry =>
+          otherEntry.target.id !== entry.target.id && otherEntry.isIntersecting,
+      )
+
+      if (isAnyOtherEntryIntersecting) {
+        tocItem.classList.remove('active')
+      }
+    }
+  }
+}
+
+function initToc(): void {
+  cleanup()
+
+  // eslint-disable-next-line unicorn/prefer-spread
+  let sectionHeadings = Array.from(
+    document.querySelectorAll<HTMLElement>('article h2, article h3'),
+  )
+  if (sectionHeadings.length === 0) {
+    scheduleNext()
+    return
+  }
+
+  let observer = new IntersectionObserver(handleEntries, {
+    rootMargin: '0px',
+    threshold: [1],
+    root: null,
+  })
+
+  for (let heading of sectionHeadings) {
+    observer.observe(heading)
+  }
+
+  cleanup = () => {
+    observer.disconnect()
+  }
+
+  handleEntries(observer.takeRecords())
+  scheduleNext()
+}
+
+function scheduleNext(): void {
+  document.addEventListener(
+    'astro:before-swap',
+    () => {
+      cleanup()
+    },
+    { once: true },
+  )
+  document.addEventListener(
+    'astro:after-swap',
+    () => {
+      initToc()
+    },
+    { once: true },
+  )
+}
+
+let marker = '__perfectionistTocInitialized__'
+
+export function setupTableOfContents(): void {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  if (!(marker in globalThis)) {
+    Object.defineProperty(globalThis, marker, {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: true,
+    })
+    initToc()
+    return
+  }
+
+  initToc()
+}


### PR DESCRIPTION
### Description

Sometimes, after a while, I receive information about memory leak issues on the documentation website. This PR switches prefetch to hover-only and adds proper setup/teardown for all client scripts (menu, sidebar, TOC, etc.) so event listeners and observers don’t accumulate over time.

### Additional context

N/A.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
