### PR TITLE
fix(#611): force `fallbackSort.type` to be defined

### DIFF
--- a/test/utils/common-json-schemas.test.ts
+++ b/test/utils/common-json-schemas.test.ts
@@ -96,20 +96,22 @@ describe('common-json-schemas', () => {
           ).toBeTruthy()
         })
 
+        it('should not allow undefined type', () => {
+          expect(
+            commonJsonSchemaValidator({
+              fallbackSort: {
+                order: 'asc',
+              },
+            }),
+          ).toBeFalsy()
+        })
+
         it('should not allow invalid values', () => {
           expect(
             commonJsonSchemaValidator({
               fallbackSort: {
                 type: 'invalid',
               },
-            }),
-          ).toBeFalsy()
-        })
-
-        it('should not allow the empty object', () => {
-          expect(
-            commonJsonSchemaValidator({
-              fallbackSort: {},
             }),
           ).toBeFalsy()
         })
@@ -120,6 +122,7 @@ describe('common-json-schemas', () => {
           expect(
             commonJsonSchemaValidator({
               fallbackSort: {
+                type: 'alphabetical',
                 order,
               },
             }),
@@ -130,6 +133,7 @@ describe('common-json-schemas', () => {
           expect(
             commonJsonSchemaValidator({
               fallbackSort: {
+                type: 'alphabetical',
                 order: 'invalid',
               },
             }),
@@ -142,6 +146,7 @@ describe('common-json-schemas', () => {
           commonJsonSchemaValidator({
             fallbackSort: {
               somethingElse: 'something',
+              type: 'alphabetical',
             },
           }),
         ).toBeFalsy()

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -124,7 +124,7 @@ function buildFallbackSortJsonSchema({
     },
     description: 'Fallback sort order.',
     additionalProperties: false,
-    minProperties: 1,
+    required: ['type'],
     type: 'object',
   }
 }


### PR DESCRIPTION
- Related issue: https://github.com/azat-io/eslint-plugin-perfectionist/issues/611.

### Description

`fallbackSort.type` is marked as required in the typings, but not in the JSON Schema.

https://github.com/azat-io/eslint-plugin-perfectionist/blob/100833f50a710832772c8806ca34df1678d9dc56/types/common-options.ts#L330

https://github.com/azat-io/eslint-plugin-perfectionist/blob/100833f50a710832772c8806ca34df1678d9dc56/utils/common-json-schemas.ts#L119-L128

Fallback sort by definition requires the user to write the new sort type.

### What is the purpose of this pull request?

- [x] Bug fix
