### PR TITLE
docs(sort-imports): add subpaths/hyphenated packages sorting example

### DIFF
--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -181,7 +181,25 @@ Used only when the [`type`](#type) option is set to `'custom'`. Specifies the cu
 
 Use the `Alphabet` utility class from `eslint-plugin-perfectionist/alphabet` to quickly generate a custom alphabet.
 
-Example: `0123456789abcdef...`
+#### Example: Sort subpaths before hyphenated packages
+
+Use the following alphabet to sort subpaths before hyphenated packages.
+
+```ts
+const alphabet = Alphabet.generateRecommendedAlphabet()
+  .sortByNaturalSort()
+  .placeCharacterBefore({ characterBefore: "/", characterAfter: "-" })
+  .placeCharacterBefore({ characterBefore: ".", characterAfter: "/" })
+  .getCharacters();
+```
+
+Result:
+
+```ts
+import { Linter } from "eslint";
+import { globalIgnores } from "eslint/config";
+import { FlatConfigComposer } from "eslint-flat-config-utils";
+```
 
 ### ignoreCase
 


### PR DESCRIPTION
- Request from https://github.com/azat-io/eslint-plugin-perfectionist/issues/566#issuecomment-3570901239

### Description

This PR adds an `alphabet` example for users to see how to customize subpaths/hyphenated packages sorting. 

### What is the purpose of this pull request?

- [x] Documentation update
