### PR TITLE
fix: add js extensions to relative imports in decl files

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,36 @@ import dts from 'vite-plugin-dts'
 import path from 'node:path'
 
 export default defineConfig({
+  plugins: [
+    dts({
+      beforeWriteFile: (filePath, content) => ({
+        content: content.replaceAll(
+          /(?<importPath>(?:from|import\s*\()\s*["']\..*?)(?<quote>["'])/gu,
+          (...replaceArguments) => {
+            let { importPath, quote } = replaceArguments.at(-1) as {
+              importPath: string
+              quote: string
+            }
+            if (importPath.endsWith('.js') || importPath.endsWith('.json')) {
+              return `${importPath}${quote}`
+            }
+            return `${importPath}.js${quote}`
+          },
+        ),
+        filePath,
+      }),
+      include: [
+        path.join(import.meta.dirname, 'index.ts'),
+        path.join(import.meta.dirname, 'types'),
+        path.join(import.meta.dirname, 'rules'),
+        path.join(import.meta.dirname, 'utils'),
+      ],
+      insertTypesEntry: true,
+      copyDtsFiles: true,
+      strictOutput: true,
+    }),
+    prettierFormat(),
+  ],
   build: {
     lib: {
       entry: [
@@ -23,18 +53,4 @@ export default defineConfig({
     },
     minify: false,
   },
-  plugins: [
-    dts({
-      include: [
-        path.join(import.meta.dirname, 'index.ts'),
-        path.join(import.meta.dirname, 'types'),
-        path.join(import.meta.dirname, 'rules'),
-        path.join(import.meta.dirname, 'utils'),
-      ],
-      insertTypesEntry: true,
-      copyDtsFiles: true,
-      strictOutput: true,
-    }),
-    prettierFormat(),
-  ],
 })


### PR DESCRIPTION
### Description

Added .js extensions to relative imports in generated .d.ts files.

### Additional context

#642

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
