### PR TITLE
docs: add missing `fallbackSort` documentation for groups with overridden settings

### DIFF
--- a/docs/content/rules/sort-array-includes.mdx
+++ b/docs/content/rules/sort-array-includes.mdx
@@ -347,6 +347,7 @@ Example configuration:
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -353,6 +353,7 @@ Without `ignoreCallbackDependenciesPatterns: ['^computed$']`, `role` and `userna
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-decorators.mdx
+++ b/docs/content/rules/sort-decorators.mdx
@@ -299,6 +299,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -262,6 +262,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-export-attributes.mdx
+++ b/docs/content/rules/sort-export-attributes.mdx
@@ -193,6 +193,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-exports.mdx
+++ b/docs/content/rules/sort-exports.mdx
@@ -242,6 +242,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
           commentAbove?: string;
         }

--- a/docs/content/rules/sort-heritage-clauses.mdx
+++ b/docs/content/rules/sort-heritage-clauses.mdx
@@ -212,6 +212,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-import-attributes.mdx
+++ b/docs/content/rules/sort-import-attributes.mdx
@@ -193,6 +193,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -351,6 +351,7 @@ If `rootDir` is empty, the rule will not search for a `tsconfig.json` file.
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
           commentAbove?: string;
         }

--- a/docs/content/rules/sort-interfaces.mdx
+++ b/docs/content/rules/sort-interfaces.mdx
@@ -460,6 +460,7 @@ Example configuration:
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -241,6 +241,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-jsx-props.mdx
+++ b/docs/content/rules/sort-jsx-props.mdx
@@ -352,6 +352,7 @@ Example configuration:
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-maps.mdx
+++ b/docs/content/rules/sort-maps.mdx
@@ -306,6 +306,7 @@ Example configuration:
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -358,6 +358,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'usage' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-named-exports.mdx
+++ b/docs/content/rules/sort-named-exports.mdx
@@ -279,6 +279,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-named-imports.mdx
+++ b/docs/content/rules/sort-named-imports.mdx
@@ -278,6 +278,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -428,6 +428,7 @@ Example configuration:
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-objects.mdx
+++ b/docs/content/rules/sort-objects.mdx
@@ -508,6 +508,7 @@ Example configuration:
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-sets.mdx
+++ b/docs/content/rules/sort-sets.mdx
@@ -351,6 +351,7 @@ Example configuration:
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-union-types.mdx
+++ b/docs/content/rules/sort-union-types.mdx
@@ -261,6 +261,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >

--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -245,6 +245,7 @@ This option is only applicable when [`partitionByNewLine`](#partitionbynewline) 
           group: string | string[];
           type?: 'alphabetical' | 'natural' | 'line-length' | 'custom' | 'unsorted';
           order?: 'asc' | 'desc';
+          fallbackSort?: { type: string; order?: 'asc' | 'desc' };
           newlinesInside?: number | 'ignore';
         }
     >


### PR DESCRIPTION
### Description

This PR adds missing documentation from https://github.com/azat-io/eslint-plugin-perfectionist/pull/657 regarding `fallbackSort`.

### What is the purpose of this pull request?

- [x] Documentation update