### PR TITLE
docs: fix default group names in sort-imports

### DIFF
--- a/docs/content/rules/sort-imports.mdx
+++ b/docs/content/rules/sort-imports.mdx
@@ -38,11 +38,12 @@ Rule `perfectionist/sort-imports` works in a similar way to rule `import/order`,
 1. Supporting for new import types:
   - `'side-effect'`
   - `'style'`
-  - `'builtin-type'`
-  - `'internal-type'`
-  - `'parent-type'`
-  - `'sibling-type'`
-  - `'index-type'`
+  - `'type-builtin'`
+  - `'type-import'`
+  - `'type-internal'`
+  - `'type-parent'`
+  - `'type-sibling'`
+  - `'type-index'`
 2. Supporting for adding custom import groups
 3. Sorting not only alphabetically, but also naturally and by line length
 


### PR DESCRIPTION
### Description

The [sort-imports section of the documentation](https://perfectionist.dev/rules/sort-imports#groups) refers to  `*-type` groups, which have been removed from 5.0.0 (as per f0894880df92bf5). They are now available under `type-*`. This PR fixes the documentation.

I also added `type-import` which was missing.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/contributing.md).
