### PR TITLE
fix: make selector match priority deterministic across overlapping options

### DIFF
--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -111,15 +111,13 @@ export default createEslintRule<Options, MessageId>({
 })
 
 function sortPotentiallyValidArray({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   context,
   node,
 }: {
-  alreadyParsedNodes: Set<TSESTree.ArrayExpression | TSESTree.NewExpression>
   node: TSESTree.ArrayExpression | TSESTree.NewExpression
   context: Readonly<RuleContext<MessageId, Options>>
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
 }): void {
   if (!isValidArray()) {
     return
@@ -133,9 +131,8 @@ function sortPotentiallyValidArray({
       unexpectedOrder: ORDER_ERROR_ID,
     },
     cachedGroupsByModifiersAndSelectors,
-    alreadyParsedNodes,
+    matchedAstSelectors,
     defaultOptions,
-    astSelector,
     context,
     node,
   })

--- a/rules/sort-array-includes/compute-matched-context-options.ts
+++ b/rules/sort-array-includes/compute-matched-context-options.ts
@@ -11,20 +11,21 @@ import { computeNodeName } from './compute-node-name'
  * Computes the matched context options for a given array node.
  *
  * @param params - Parameters.
- * @param params.astSelector - The AST selector string currently evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for an array
+ *   node.
  * @param params.elements - The array elements to compute the context options
  *   for.
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
 export function computeMatchedContextOptions<MessageIds extends string>({
-  astSelector,
+  matchedAstSelectors,
   elements,
   context,
 }: {
   elements: (TSESTree.SpreadElement | TSESTree.Expression | null)[]
   context: Readonly<RuleContext<MessageIds, Options>>
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
 }): Options[number] | undefined {
   let nodeNames = elements
     .filter(element => element !== null)
@@ -37,12 +38,21 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return matchedContextOptions.find(isContextOptionMatching)
+  return (
+    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
+    matchedContextOptions.find(isFallbackContextOptionMatching)
+  )
 
-  function isContextOptionMatching(options: Options[number]): boolean {
+  function isSelectorBasedContextOptionMatching(
+    options: Options[number],
+  ): boolean {
     return passesAstSelectorFilter({
       matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      astSelector,
+      matchedAstSelectors,
     })
+  }
+
+  function isFallbackContextOptionMatching(options: Options[number]): boolean {
+    return options.useConfigurationIf?.matchesAstSelector === undefined
   }
 }

--- a/rules/sort-array-includes/sort-array.ts
+++ b/rules/sort-array-includes/sort-array.ts
@@ -35,9 +35,8 @@ type SortArraySortingNode = SortingNode<
 export function sortArray<MessageIds extends string>({
   cachedGroupsByModifiersAndSelectors,
   availableMessageIds,
-  alreadyParsedNodes,
+  matchedAstSelectors,
   defaultOptions,
-  astSelector,
   context,
   node,
 }: {
@@ -47,12 +46,11 @@ export function sortArray<MessageIds extends string>({
     unexpectedGroupOrder: MessageIds
     unexpectedOrder: MessageIds
   }
-  alreadyParsedNodes: Set<TSESTree.ArrayExpression | TSESTree.NewExpression>
   cachedGroupsByModifiersAndSelectors: Map<string, string[]>
   node: TSESTree.ArrayExpression | TSESTree.NewExpression
   context: Readonly<RuleContext<MessageIds, Options>>
   defaultOptions: Required<Options[number]>
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
 }): void {
   let elements = computeArrayElements(node)
   if (!elements) {
@@ -67,18 +65,10 @@ export function sortArray<MessageIds extends string>({
   let settings = getSettings(context.settings)
 
   let matchedContextOptions = computeMatchedContextOptions({
-    astSelector,
+    matchedAstSelectors,
     elements,
     context,
   })
-  if (!matchedContextOptions && astSelector) {
-    return
-  }
-
-  if (alreadyParsedNodes.has(node)) {
-    return
-  }
-  alreadyParsedNodes.add(node)
 
   let options = complete(matchedContextOptions, settings, defaultOptions)
   validateCustomSortConfiguration(options)

--- a/rules/sort-classes/compute-matched-context-options.ts
+++ b/rules/sort-classes/compute-matched-context-options.ts
@@ -13,18 +13,19 @@ import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast
  * Computes the matched context options for a given class node.
  *
  * @param params - Parameters.
- * @param params.astSelector - The AST selector string currently evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for a class
+ *   node.
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
 export function computeMatchedContextOptions<MessageIds extends string>({
+  matchedAstSelectors,
   classElements,
-  astSelector,
   context,
 }: {
   context: Readonly<RuleContext<MessageIds, Options>>
+  matchedAstSelectors: ReadonlySet<string>
   classElements: TSESTree.ClassElement[]
-  astSelector: string | null
 }): Options[number] | undefined {
   let nodeNames = classElements
     .filter(
@@ -42,12 +43,21 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return matchedContextOptions.find(isContextOptionMatching)
+  return (
+    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
+    matchedContextOptions.find(isFallbackContextOptionMatching)
+  )
 
-  function isContextOptionMatching(options: Options[number]): boolean {
+  function isSelectorBasedContextOptionMatching(
+    options: Options[number],
+  ): boolean {
     return passesAstSelectorFilter({
       matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      astSelector,
+      matchedAstSelectors,
     })
+  }
+
+  function isFallbackContextOptionMatching(options: Options[number]): boolean {
+    return options.useConfigurationIf?.matchesAstSelector === undefined
   }
 }

--- a/rules/sort-classes/sort-class.ts
+++ b/rules/sort-classes/sort-class.ts
@@ -104,15 +104,13 @@ export let defaultOptions: Required<Options[number]> = {
 }
 
 export function sortClass({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   settings,
   context,
   node,
 }: {
   context: Readonly<TSESLint.RuleContext<MessageId, Options>>
-  alreadyParsedNodes: Set<TSESTree.ClassBody>
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.ClassBody
   settings: Settings
 }): void {
@@ -122,18 +120,10 @@ export function sortClass({
   }
 
   let matchedContextOptions = computeMatchedContextOptions({
+    matchedAstSelectors,
     classElements,
-    astSelector,
     context,
   })
-  if (!matchedContextOptions && astSelector) {
-    return
-  }
-
-  if (alreadyParsedNodes.has(node)) {
-    return
-  }
-  alreadyParsedNodes.add(node)
 
   let options = complete(matchedContextOptions, settings, defaultOptions)
   validateCustomSortConfiguration(options)

--- a/rules/sort-enums/compute-matched-context-options.ts
+++ b/rules/sort-enums/compute-matched-context-options.ts
@@ -12,18 +12,19 @@ import { computeNodeName } from './compute-node-name'
  *
  * @param params - Parameters.
  * @param params.enumMembers - The enum members of the enum declaration node.
- * @param params.astSelector - The AST selector string currently evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for an enum
+ *   node.
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
 export function computeMatchedContextOptions<MessageIds extends string>({
+  matchedAstSelectors,
   enumMembers,
-  astSelector,
   context,
 }: {
   context: Readonly<RuleContext<MessageIds, Options>>
+  matchedAstSelectors: ReadonlySet<string>
   enumMembers: TSESTree.TSEnumMember[]
-  astSelector: string | null
 }): Options[number] | undefined {
   let nodeNames = enumMembers.map(enumMember =>
     computeNodeName({ sourceCode: context.sourceCode, node: enumMember }),
@@ -34,12 +35,21 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return matchedContextOptions.find(isContextOptionMatching)
+  return (
+    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
+    matchedContextOptions.find(isFallbackContextOptionMatching)
+  )
 
-  function isContextOptionMatching(options: Options[number]): boolean {
+  function isSelectorBasedContextOptionMatching(
+    options: Options[number],
+  ): boolean {
     return passesAstSelectorFilter({
       matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      astSelector,
+      matchedAstSelectors,
     })
+  }
+
+  function isFallbackContextOptionMatching(options: Options[number]): boolean {
+    return options.useConfigurationIf?.matchesAstSelector === undefined
   }
 }

--- a/rules/sort-enums/sort-enum.ts
+++ b/rules/sort-enums/sort-enum.ts
@@ -57,16 +57,14 @@ export let defaultOptions: Required<Options[number]> = {
 }
 
 export function sortEnum({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   settings,
   context,
   node,
 }: {
-  alreadyParsedNodes: Set<TSESTree.TSEnumDeclaration>
   context: Readonly<RuleContext<MessageId, Options>>
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.TSEnumDeclaration
-  astSelector: string | null
   settings: Settings
 }): void {
   let members = getEnumMembers(node)
@@ -79,17 +77,9 @@ export function sortEnum({
 
   let matchedContextOptions = computeMatchedContextOptions({
     enumMembers: members,
-    astSelector,
+    matchedAstSelectors,
     context,
   })
-  if (!matchedContextOptions && astSelector) {
-    return
-  }
-
-  if (alreadyParsedNodes.has(node)) {
-    return
-  }
-  alreadyParsedNodes.add(node)
 
   let options = complete(matchedContextOptions, settings, defaultOptions)
   validateCustomSortConfiguration(options)

--- a/rules/sort-jsx-props/compute-matched-context-options.ts
+++ b/rules/sort-jsx-props/compute-matched-context-options.ts
@@ -15,21 +15,21 @@ import { matches } from '../../utils/matches'
  * Computes the matched context options for a given JSX element node.
  *
  * @param params - Parameters.
- * @param params.astSelector - The AST selector string currently evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for a JSX node.
  * @param params.sourceCode - The source code object.
  * @param params.node - The JSX element node to evaluate.
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
 export function computeMatchedContextOptions({
-  astSelector,
+  matchedAstSelectors,
   sourceCode,
   context,
   node,
 }: {
   context: TSESLint.RuleContext<string, Options>
+  matchedAstSelectors: ReadonlySet<string>
   sourceCode: TSESLint.SourceCode
-  astSelector: string | null
   node: TSESTree.JSXElement
 }): Options[number] | undefined {
   let nodeNames = node.openingElement.attributes
@@ -41,18 +41,35 @@ export function computeMatchedContextOptions({
     nodeNames,
   })
 
-  return matchedContextOptions.find(isContextOptionMatching)
+  return (
+    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
+    matchedContextOptions.find(isFallbackContextOptionMatching)
+  )
 
-  function isContextOptionMatching(options: Options[number]): boolean {
+  function isSelectorBasedContextOptionMatching(
+    options: Options[number],
+  ): boolean {
     if (
       !passesAstSelectorFilter({
         matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-        astSelector,
+        matchedAstSelectors,
       })
     ) {
       return false
     }
 
+    return passesUseConfigurationIfFilters(options)
+  }
+
+  function isFallbackContextOptionMatching(options: Options[number]): boolean {
+    if (options.useConfigurationIf?.matchesAstSelector !== undefined) {
+      return false
+    }
+
+    return passesUseConfigurationIfFilters(options)
+  }
+
+  function passesUseConfigurationIfFilters(options: Options[number]): boolean {
     if (!options.useConfigurationIf) {
       return true
     }

--- a/rules/sort-jsx-props/sort-jsx-object.ts
+++ b/rules/sort-jsx-props/sort-jsx-object.ts
@@ -57,15 +57,13 @@ export let defaultOptions: Required<Options[number]> = {
 }
 
 export function sortJsxObject({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   settings,
   context,
   node,
 }: {
   context: Readonly<TSESLint.RuleContext<MessageId, Options>>
-  alreadyParsedNodes: Set<TSESTree.JSXElement>
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.JSXElement
   settings: Settings
 }): void {
@@ -76,19 +74,11 @@ export function sortJsxObject({
   let { sourceCode, id } = context
 
   let matchedContextOptions = computeMatchedContextOptions({
-    astSelector,
+    matchedAstSelectors,
     sourceCode,
     context,
     node,
   })
-  if (!matchedContextOptions && astSelector) {
-    return
-  }
-
-  if (alreadyParsedNodes.has(node)) {
-    return
-  }
-  alreadyParsedNodes.add(node)
 
   let options = complete(matchedContextOptions, settings, defaultOptions)
   validateCustomSortConfiguration(options)

--- a/rules/sort-maps/compute-matched-context-options.ts
+++ b/rules/sort-maps/compute-matched-context-options.ts
@@ -13,19 +13,19 @@ import { computeNodeName } from './compute-node-name'
  * Computes the matched context options for a given map node.
  *
  * @param params - Parameters.
- * @param params.astSelector - The AST selector string currently evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for a map node.
  * @param params.elements - The map elements to compute the context options for.
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
 export function computeMatchedContextOptions<MessageIds extends string>({
-  astSelector,
+  matchedAstSelectors,
   elements,
   context,
 }: {
   elements: (TSESTree.SpreadElement | TSESTree.Expression | null)[]
   context: Readonly<RuleContext<MessageIds, Options>>
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
 }): Options[number] | undefined {
   let nodeNames = elements
     .filter(
@@ -41,12 +41,21 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return matchedContextOptions.find(isContextOptionMatching)
+  return (
+    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
+    matchedContextOptions.find(isFallbackContextOptionMatching)
+  )
 
-  function isContextOptionMatching(options: Options[number]): boolean {
+  function isSelectorBasedContextOptionMatching(
+    options: Options[number],
+  ): boolean {
     return passesAstSelectorFilter({
       matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      astSelector,
+      matchedAstSelectors,
     })
+  }
+
+  function isFallbackContextOptionMatching(options: Options[number]): boolean {
+    return options.useConfigurationIf?.matchesAstSelector === undefined
   }
 }

--- a/rules/sort-maps/sort-potential-map.ts
+++ b/rules/sort-maps/sort-potential-map.ts
@@ -48,16 +48,14 @@ export let defaultOptions: Required<Options[number]> = {
 }
 
 export function sortPotentialMap({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   settings,
   context,
   node,
 }: {
   context: TSESLint.RuleContext<MessageId, Options>
-  alreadyParsedNodes: Set<TSESTree.NewExpression>
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.NewExpression
-  astSelector: string | null
   settings: Settings
 }): void {
   if (
@@ -76,18 +74,10 @@ export function sortPotentialMap({
   let { sourceCode, id } = context
 
   let matchedContextOptions = computeMatchedContextOptions({
-    astSelector,
+    matchedAstSelectors,
     elements,
     context,
   })
-  if (!matchedContextOptions && astSelector) {
-    return
-  }
-
-  if (alreadyParsedNodes.has(node)) {
-    return
-  }
-  alreadyParsedNodes.add(node)
 
   let options = complete(matchedContextOptions, settings, defaultOptions)
   validateCustomSortConfiguration(options)

--- a/rules/sort-named-exports/compute-matched-context-options.ts
+++ b/rules/sort-named-exports/compute-matched-context-options.ts
@@ -13,18 +13,19 @@ import { computeNodeName } from './compute-node-name'
  * @param params - Parameters.
  * @param params.node - The named export node to compute the context options
  *   for.
- * @param params.astSelector - The AST selector string currently evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for a named
+ *   export node.
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
 export function computeMatchedContextOptions<MessageIds extends string>({
-  astSelector,
+  matchedAstSelectors,
   context,
   node,
 }: {
   context: Readonly<RuleContext<MessageIds, Options>>
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.ExportNamedDeclaration
-  astSelector: string | null
 }): Options[number] | undefined {
   let nodeNames = node.specifiers.map(specifier =>
     computeNodeName(specifier, true),
@@ -35,12 +36,21 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return matchedContextOptions.find(isContextOptionMatching)
+  return (
+    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
+    matchedContextOptions.find(isFallbackContextOptionMatching)
+  )
 
-  function isContextOptionMatching(options: Options[number]): boolean {
+  function isSelectorBasedContextOptionMatching(
+    options: Options[number],
+  ): boolean {
     return passesAstSelectorFilter({
       matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      astSelector,
+      matchedAstSelectors,
     })
+  }
+
+  function isFallbackContextOptionMatching(options: Options[number]): boolean {
+    return options.useConfigurationIf?.matchesAstSelector === undefined
   }
 }

--- a/rules/sort-named-exports/sort-named-export.ts
+++ b/rules/sort-named-exports/sort-named-export.ts
@@ -62,16 +62,14 @@ export let defaultOptions: Required<Options[number]> = {
 }
 
 export function sortNamedExport({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   settings,
   context,
   node,
 }: {
-  alreadyParsedNodes: Set<TSESTree.ExportNamedDeclaration>
   context: TSESLint.RuleContext<MessageId, Options>
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.ExportNamedDeclaration
-  astSelector: string | null
   settings: Settings
 }): void {
   if (!isSortable(node.specifiers)) {
@@ -79,18 +77,10 @@ export function sortNamedExport({
   }
 
   let matchedContextOptions = computeMatchedContextOptions({
-    astSelector,
+    matchedAstSelectors,
     context,
     node,
   })
-  if (!matchedContextOptions && astSelector) {
-    return
-  }
-
-  if (alreadyParsedNodes.has(node)) {
-    return
-  }
-  alreadyParsedNodes.add(node)
 
   let options = complete(matchedContextOptions, settings, defaultOptions)
   validateCustomSortConfiguration(options)

--- a/rules/sort-objects/compute-matched-context-options.ts
+++ b/rules/sort-objects/compute-matched-context-options.ts
@@ -20,7 +20,8 @@ import { objectParentTypes } from './types'
  *
  * @param params - Parameters.
  * @param params.isDestructuredObject - Whether the object is destructured.
- * @param params.astSelector - The AST selector string currently evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for an object
+ *   node.
  * @param params.sourceCode - The source code object.
  * @param params.nodeObject - The object node to evaluate.
  * @param params.context - The rule context.
@@ -28,16 +29,16 @@ import { objectParentTypes } from './types'
  */
 export function computeMatchedContextOptions({
   isDestructuredObject,
-  astSelector,
+  matchedAstSelectors,
   sourceCode,
   nodeObject,
   context,
 }: {
   nodeObject: TSESTree.ObjectExpression | TSESTree.ObjectPattern
   context: TSESLint.RuleContext<MessageId, Options>
+  matchedAstSelectors: ReadonlySet<string>
   sourceCode: TSESLint.SourceCode
   isDestructuredObject: boolean
-  astSelector: string | null
 }): Options[number] | undefined {
   let filteredContextOptions = filterOptionsByAllNamesMatch({
     nodeNames: nodeObject.properties
@@ -59,22 +60,32 @@ export function computeMatchedContextOptions({
     maxParent: null,
   })
 
-  return filteredContextOptions.find(options =>
-    isContextOptionMatching({
-      isDestructuredObject,
-      astSelector,
-      parentNodes,
-      sourceCode,
-      nodeObject,
-      options,
-    }),
+  return (
+    filteredContextOptions.find(options =>
+      isSelectorBasedContextOptionMatching({
+        isDestructuredObject,
+        matchedAstSelectors,
+        parentNodes,
+        sourceCode,
+        nodeObject,
+        options,
+      }),
+    ) ??
+    filteredContextOptions.find(options =>
+      isFallbackContextOptionMatching({
+        isDestructuredObject,
+        parentNodes,
+        sourceCode,
+        nodeObject,
+        options,
+      }),
+    )
   )
 }
 
-function isContextOptionMatching({
+function passesUseConfigurationIfFilters({
   isDestructuredObject,
   parentNodes,
-  astSelector,
   sourceCode,
   nodeObject,
   options,
@@ -83,18 +94,8 @@ function isContextOptionMatching({
   sourceCode: TSESLint.SourceCode
   isDestructuredObject: boolean
   parentNodes: ObjectParent[]
-  astSelector: string | null
   options: Options[number]
 }): boolean {
-  if (
-    !passesAstSelectorFilter({
-      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      astSelector,
-    })
-  ) {
-    return false
-  }
-
   if (!options.useConfigurationIf) {
     return true
   }
@@ -165,6 +166,65 @@ function passesHasNumericKeysOnlyFilter({
         throw new UnreachableCaseError(object)
     }
   }
+}
+
+function isSelectorBasedContextOptionMatching({
+  isDestructuredObject,
+  matchedAstSelectors,
+  parentNodes,
+  sourceCode,
+  nodeObject,
+  options,
+}: {
+  nodeObject: TSESTree.ObjectExpression | TSESTree.ObjectPattern
+  matchedAstSelectors: ReadonlySet<string>
+  sourceCode: TSESLint.SourceCode
+  isDestructuredObject: boolean
+  parentNodes: ObjectParent[]
+  options: Options[number]
+}): boolean {
+  if (
+    !passesAstSelectorFilter({
+      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
+      matchedAstSelectors,
+    })
+  ) {
+    return false
+  }
+
+  return passesUseConfigurationIfFilters({
+    isDestructuredObject,
+    parentNodes,
+    sourceCode,
+    nodeObject,
+    options,
+  })
+}
+
+function isFallbackContextOptionMatching({
+  isDestructuredObject,
+  parentNodes,
+  sourceCode,
+  nodeObject,
+  options,
+}: {
+  nodeObject: TSESTree.ObjectExpression | TSESTree.ObjectPattern
+  sourceCode: TSESLint.SourceCode
+  isDestructuredObject: boolean
+  parentNodes: ObjectParent[]
+  options: Options[number]
+}): boolean {
+  if (options.useConfigurationIf?.matchesAstSelector !== undefined) {
+    return false
+  }
+
+  return passesUseConfigurationIfFilters({
+    isDestructuredObject,
+    parentNodes,
+    sourceCode,
+    nodeObject,
+    options,
+  })
 }
 
 function passesObjectTypeFilter({

--- a/rules/sort-objects/sort-object.ts
+++ b/rules/sort-objects/sort-object.ts
@@ -75,16 +75,14 @@ export let defaultOptions: Required<Options[number]> = {
 }
 
 export function sortObject({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   settings,
   context,
   node,
 }: {
-  alreadyParsedNodes: Set<TSESTree.ObjectExpression | TSESTree.ObjectPattern>
   context: Readonly<TSESLint.RuleContext<MessageId, Options>>
   node: TSESTree.ObjectExpression | TSESTree.ObjectPattern
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
   settings: Settings
 }): void {
   if (!isSortable(node.properties)) {
@@ -96,19 +94,11 @@ export function sortObject({
   let isDestructuredObject = node.type === AST_NODE_TYPES.ObjectPattern
   let matchedContextOptions = computeMatchedContextOptions({
     isDestructuredObject,
+    matchedAstSelectors,
     nodeObject: node,
-    astSelector,
     sourceCode,
     context,
   })
-  if (!matchedContextOptions && astSelector) {
-    return
-  }
-
-  if (alreadyParsedNodes.has(node)) {
-    return
-  }
-  alreadyParsedNodes.add(node)
 
   let options = complete(matchedContextOptions, settings, defaultOptions)
   validateCustomSortConfiguration(options)

--- a/rules/sort-sets.ts
+++ b/rules/sort-sets.ts
@@ -60,15 +60,13 @@ export default createEslintRule<Options, MessageId>({
 })
 
 function sortPotentiallyValidArray({
-  alreadyParsedNodes,
-  astSelector,
+  matchedAstSelectors,
   context,
   node,
 }: {
-  alreadyParsedNodes: Set<TSESTree.ArrayExpression | TSESTree.NewExpression>
   node: TSESTree.ArrayExpression | TSESTree.NewExpression
   context: Readonly<RuleContext<MessageId, Options>>
-  astSelector: string | null
+  matchedAstSelectors: ReadonlySet<string>
 }): void {
   if (!isValidArray()) {
     return
@@ -82,9 +80,8 @@ function sortPotentiallyValidArray({
       unexpectedOrder: ORDER_ERROR_ID,
     },
     cachedGroupsByModifiersAndSelectors,
-    alreadyParsedNodes,
+    matchedAstSelectors,
     defaultOptions,
-    astSelector,
     context,
     node,
   })

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1562,6 +1562,73 @@ describe('sort-array-includes', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ArrayExpression',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ArrayExpression',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            [
+              b,
+              a,
+            ].includes(value)
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ArrayExpression',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ArrayExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+          ],
+          output: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              b,
+              a,
+            ].includes(value)
+          `,
+        })
+      })
     })
 
     it('removes newlines between and inside groups by default when "newlinesBetween" is 0', async () => {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -5015,6 +5015,73 @@ describe('sort-classes', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ClassBody',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ClassBody',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            class Class {
+              b
+              a
+            }
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ClassBody',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ClassBody',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            class Class {
+              b
+              a
+            }
+          `,
+        })
+      })
     })
   })
 

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1357,6 +1357,73 @@ describe('sort-enums', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'TSEnumDeclaration',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > TSEnumDeclaration',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            enum Enum {
+              b = 'b',
+              a = 'a',
+            }
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'TSEnumDeclaration',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > TSEnumDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              a = 'a',
+              b = 'b',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              b = 'b',
+              a = 'a',
+            }
+          `,
+        })
+      })
     })
 
     it('removes newlines between and inside groups by default when "newlinesBetween" is 0', async () => {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1624,6 +1624,79 @@ describe('sort-jsx-props', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'JSXElement',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > JSXElement',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            let Component = () => (
+              <Element
+                b="b"
+                a="a"
+              />
+            )
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'JSXElement',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > JSXElement',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+          ],
+          output: dedent`
+            let Component = () => (
+              <Element
+                a="a"
+                b="b"
+              />
+            )
+          `,
+          code: dedent`
+            let Component = () => (
+              <Element
+                b="b"
+                a="a"
+              />
+            )
+          `,
+        })
+      })
     })
   })
 

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1730,6 +1730,73 @@ describe('sort-maps', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'NewExpression',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > NewExpression',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            new Map([
+              [b, 'b'],
+              [a, 'a'],
+            ])
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'NewExpression',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > NewExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [b, 'b'],
+              [a, 'a'],
+            ])
+          `,
+        })
+      })
     })
   })
 

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -2902,6 +2902,116 @@ describe('sort-named-exports', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ExportNamedDeclaration',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ExportNamedDeclaration',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            export { b, a }
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ExportNamedDeclaration',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ExportNamedDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedNamedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export { a, b }
+          `,
+          code: dedent`
+            export { b, a }
+          `,
+        })
+      })
+
+      it('prioritizes selector-based options over fallback options', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ExportNamedDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          code: dedent`
+            export { b, a }
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ExportNamedDeclaration',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedNamedExportsOrder',
+            },
+          ],
+          output: dedent`
+            export { a, b }
+          `,
+          code: dedent`
+            export { b, a }
+          `,
+        })
+      })
     })
   })
 

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -3969,6 +3969,73 @@ describe('sort-objects', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ObjectExpression',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ObjectExpression',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            let obj = {
+              b: "b",
+              a: "a",
+            }
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ObjectExpression',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ObjectExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: "a",
+              b: "b",
+            }
+          `,
+          code: dedent`
+            let obj = {
+              b: "b",
+              a: "a",
+            }
+          `,
+        })
+      })
     })
 
     it('applies configuration when object only has numeric keys', async () => {

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1396,6 +1396,73 @@ describe('sort-sets', () => {
           `,
         })
       })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ArrayExpression',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ArrayExpression',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            new Set([
+              b,
+              a,
+            ])
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ArrayExpression',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > ArrayExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              b,
+              a,
+            ])
+          `,
+        })
+      })
     })
 
     it('removes newlines between and inside groups by default when "newlinesBetween" is 0', async () => {

--- a/utils/build-ast-listeners.ts
+++ b/utils/build-ast-listeners.ts
@@ -13,9 +13,8 @@ type Sorter<
   NodeTypes extends AST_NODE_TYPES,
 > = (parameters: {
   context: Readonly<RuleContext<MessageId, Options>>
-  alreadyParsedNodes: Set<NodeOfType<NodeTypes>>
+  matchedAstSelectors: ReadonlySet<string>
   node: NodeOfType<NodeTypes>
-  astSelector: string | null
   settings: Settings
 }) => void
 
@@ -55,23 +54,27 @@ export function buildAstListeners<
   nodeTypes: NodeTypes[]
 }): AstListeners<NodeTypes> {
   let settings = getSettings(context.settings)
+  let emptyMatchedAstSelectors = new Set<string>()
+  let matchedAstSelectorsByNode = new WeakMap<
+    NodeOfType<NodeTypes>,
+    Set<string>
+  >()
 
-  let alreadyParsedNodes = new Set<NodeOfType<NodeTypes>>()
-
-  let allAstSelectors = context.options
-    .map(option => option.useConfigurationIf?.matchesAstSelector)
-    .filter(matchesAstSelector => matchesAstSelector !== undefined)
+  let allAstSelectors = [
+    ...new Set(
+      context.options
+        .map(option => option.useConfigurationIf?.matchesAstSelector)
+        .filter(matchesAstSelector => matchesAstSelector !== undefined),
+    ),
+  ]
   let allAstSelectorMatchers = allAstSelectors.map(
     astSelector =>
       [
         astSelector,
-        buildPotentialNodeSorter({
-          alreadyParsedNodes,
+        buildMatchedAstSelectorsCollector({
+          matchedAstSelectorsByNode,
           astSelector,
           nodeTypes,
-          settings,
-          context,
-          sorter,
         }),
       ] as const,
   )
@@ -88,8 +91,8 @@ export function buildAstListeners<
       `${nodeType}:exit`,
       (node: NodeOfType<NodeTypes>) =>
         sorter({
-          alreadyParsedNodes,
-          astSelector: null,
+          matchedAstSelectors:
+            matchedAstSelectorsByNode.get(node) ?? emptyMatchedAstSelectors,
           settings,
           context,
           node,
@@ -98,40 +101,31 @@ export function buildAstListeners<
   }
 }
 
-function buildPotentialNodeSorter<
-  MessageId extends string,
-  Options extends BaseOptions[],
-  NodeTypes extends AST_NODE_TYPES,
->({
-  alreadyParsedNodes,
+function buildMatchedAstSelectorsCollector<NodeTypes extends AST_NODE_TYPES>({
+  matchedAstSelectorsByNode,
   astSelector,
   nodeTypes,
-  settings,
-  context,
-  sorter,
 }: {
-  context: Readonly<RuleContext<MessageId, Options>>
-  alreadyParsedNodes: Set<NodeOfType<NodeTypes>>
-  sorter: Sorter<MessageId, Options, NodeTypes>
+  matchedAstSelectorsByNode: WeakMap<NodeOfType<NodeTypes>, Set<string>>
   nodeTypes: NodeTypes[]
   astSelector: string
-  settings: Settings
 }): (node: TSESTree.Node) => void {
-  return potentialNodeSorter
+  return collectMatchedAstSelectors
 
-  function potentialNodeSorter(node: TSESTree.Node): void {
+  function collectMatchedAstSelectors(node: TSESTree.Node): void {
     if (!isNodeOfType(node)) {
       return
     }
 
-    sorter({
-      alreadyParsedNodes,
-      astSelector,
-      settings,
-      context,
-      node,
-    })
+    let matchedAstSelectors = matchedAstSelectorsByNode.get(node)
+    if (!matchedAstSelectors) {
+      matchedAstSelectors = new Set()
+      matchedAstSelectorsByNode.set(node, matchedAstSelectors)
+    }
+
+    matchedAstSelectors.add(astSelector)
   }
+
   function isNodeOfType(node: TSESTree.Node): node is NodeOfType<NodeTypes> {
     return (nodeTypes as string[]).includes(node.type)
   }

--- a/utils/context-matching/passes-ast-selector-filter.ts
+++ b/utils/context-matching/passes-ast-selector-filter.ts
@@ -4,21 +4,20 @@
  * @param params - The parameters object.
  * @param params.matchesAstSelector - The AST selector to match against, or
  *   undefined if no selector is specified.
- * @param params.astSelector - The AST selector currently being evaluated, or
- *   null if no selector is being evaluated.
+ * @param params.matchedAstSelectors - The matched AST selectors for a node.
  * @returns True if the given AST selector matches the expected AST selector,
  *   false otherwise.
  */
 export function passesAstSelectorFilter({
+  matchedAstSelectors,
   matchesAstSelector,
-  astSelector,
 }: {
+  matchedAstSelectors: ReadonlySet<string>
   matchesAstSelector: undefined | string
-  astSelector: string | null
 }): boolean {
   if (!matchesAstSelector) {
-    return astSelector === null
+    return false
   }
 
-  return matchesAstSelector === astSelector
+  return matchedAstSelectors.has(matchesAstSelector)
 }


### PR DESCRIPTION
### Description

This PR fixes non-deterministic option selection when multiple `useConfigurationIf.matchesAstSelector` entries match the same AST node. 

Previously, the applied config depended on ESLint listener execution order rather than the position in `context.options`. 

Now, AST selector matches are collected during enter listeners and resolved once on `:exit`, ensuring stable "first matching option wins" precedence. Fallback behavior for options without `matchesAstSelector` is preserved.               

### Reviewer notes

N/A.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
