### PR TITLE
fix: fix `useConfigurationIf.matchesAstSelector` configurations not respecting configurations order

### DIFF
--- a/rules/sort-array-includes/compute-matched-context-options.ts
+++ b/rules/sort-array-includes/compute-matched-context-options.ts
@@ -38,21 +38,22 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return (
-    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
-    matchedContextOptions.find(isFallbackContextOptionMatching)
-  )
+  return matchedContextOptions.find(isContextOptionMatching)
 
-  function isSelectorBasedContextOptionMatching(
-    options: Options[number],
-  ): boolean {
-    return passesAstSelectorFilter({
-      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      matchedAstSelectors,
-    })
-  }
+  function isContextOptionMatching(options: Options[number]): boolean {
+    if (!options.useConfigurationIf) {
+      return true
+    }
 
-  function isFallbackContextOptionMatching(options: Options[number]): boolean {
-    return options.useConfigurationIf?.matchesAstSelector === undefined
+    if (
+      !passesAstSelectorFilter({
+        matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+        matchedAstSelectors,
+      })
+    ) {
+      return false
+    }
+
+    return true
   }
 }

--- a/rules/sort-classes/compute-matched-context-options.ts
+++ b/rules/sort-classes/compute-matched-context-options.ts
@@ -43,21 +43,22 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return (
-    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
-    matchedContextOptions.find(isFallbackContextOptionMatching)
-  )
+  return matchedContextOptions.find(isContextOptionMatching)
 
-  function isSelectorBasedContextOptionMatching(
-    options: Options[number],
-  ): boolean {
-    return passesAstSelectorFilter({
-      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      matchedAstSelectors,
-    })
-  }
+  function isContextOptionMatching(options: Options[number]): boolean {
+    if (!options.useConfigurationIf) {
+      return true
+    }
 
-  function isFallbackContextOptionMatching(options: Options[number]): boolean {
-    return options.useConfigurationIf?.matchesAstSelector === undefined
+    if (
+      !passesAstSelectorFilter({
+        matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+        matchedAstSelectors,
+      })
+    ) {
+      return false
+    }
+
+    return true
   }
 }

--- a/rules/sort-enums/compute-matched-context-options.ts
+++ b/rules/sort-enums/compute-matched-context-options.ts
@@ -35,21 +35,22 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return (
-    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
-    matchedContextOptions.find(isFallbackContextOptionMatching)
-  )
+  return matchedContextOptions.find(isContextOptionMatching)
 
-  function isSelectorBasedContextOptionMatching(
-    options: Options[number],
-  ): boolean {
-    return passesAstSelectorFilter({
-      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      matchedAstSelectors,
-    })
-  }
+  function isContextOptionMatching(options: Options[number]): boolean {
+    if (!options.useConfigurationIf) {
+      return true
+    }
 
-  function isFallbackContextOptionMatching(options: Options[number]): boolean {
-    return options.useConfigurationIf?.matchesAstSelector === undefined
+    if (
+      !passesAstSelectorFilter({
+        matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+        matchedAstSelectors,
+      })
+    ) {
+      return false
+    }
+
+    return true
   }
 }

--- a/rules/sort-jsx-props/compute-matched-context-options.ts
+++ b/rules/sort-jsx-props/compute-matched-context-options.ts
@@ -41,44 +41,24 @@ export function computeMatchedContextOptions({
     nodeNames,
   })
 
-  return (
-    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
-    matchedContextOptions.find(isFallbackContextOptionMatching)
-  )
+  return matchedContextOptions.find(isContextOptionMatching)
 
-  function isSelectorBasedContextOptionMatching(
-    options: Options[number],
-  ): boolean {
-    if (
-      !passesAstSelectorFilter({
-        matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-        matchedAstSelectors,
-      })
-    ) {
-      return false
-    }
-
-    return passesUseConfigurationIfFilters(options)
-  }
-
-  function isFallbackContextOptionMatching(options: Options[number]): boolean {
-    if (options.useConfigurationIf?.matchesAstSelector !== undefined) {
-      return false
-    }
-
-    return passesUseConfigurationIfFilters(options)
-  }
-
-  function passesUseConfigurationIfFilters(options: Options[number]): boolean {
+  function isContextOptionMatching(options: Options[number]): boolean {
     if (!options.useConfigurationIf) {
       return true
     }
 
-    return passesTagMatchesPatternFilter({
-      tagMatchesPattern: options.useConfigurationIf.tagMatchesPattern,
-      sourceCode,
-      node,
-    })
+    return (
+      passesAstSelectorFilter({
+        matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+        matchedAstSelectors,
+      }) &&
+      passesTagMatchesPatternFilter({
+        tagMatchesPattern: options.useConfigurationIf.tagMatchesPattern,
+        sourceCode,
+        node,
+      })
+    )
   }
 }
 

--- a/rules/sort-maps/compute-matched-context-options.ts
+++ b/rules/sort-maps/compute-matched-context-options.ts
@@ -41,21 +41,22 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return (
-    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
-    matchedContextOptions.find(isFallbackContextOptionMatching)
-  )
+  return matchedContextOptions.find(isContextOptionMatching)
 
-  function isSelectorBasedContextOptionMatching(
-    options: Options[number],
-  ): boolean {
-    return passesAstSelectorFilter({
-      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      matchedAstSelectors,
-    })
-  }
+  function isContextOptionMatching(options: Options[number]): boolean {
+    if (!options.useConfigurationIf) {
+      return true
+    }
 
-  function isFallbackContextOptionMatching(options: Options[number]): boolean {
-    return options.useConfigurationIf?.matchesAstSelector === undefined
+    if (
+      !passesAstSelectorFilter({
+        matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+        matchedAstSelectors,
+      })
+    ) {
+      return false
+    }
+
+    return true
   }
 }

--- a/rules/sort-named-exports/compute-matched-context-options.ts
+++ b/rules/sort-named-exports/compute-matched-context-options.ts
@@ -36,21 +36,22 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return (
-    matchedContextOptions.find(isSelectorBasedContextOptionMatching) ??
-    matchedContextOptions.find(isFallbackContextOptionMatching)
-  )
+  return matchedContextOptions.find(isContextOptionMatching)
 
-  function isSelectorBasedContextOptionMatching(
-    options: Options[number],
-  ): boolean {
-    return passesAstSelectorFilter({
-      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      matchedAstSelectors,
-    })
-  }
+  function isContextOptionMatching(options: Options[number]): boolean {
+    if (!options.useConfigurationIf) {
+      return true
+    }
 
-  function isFallbackContextOptionMatching(options: Options[number]): boolean {
-    return options.useConfigurationIf?.matchesAstSelector === undefined
+    if (
+      !passesAstSelectorFilter({
+        matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+        matchedAstSelectors,
+      })
+    ) {
+      return false
+    }
+
+    return true
   }
 }

--- a/rules/sort-objects/compute-matched-context-options.ts
+++ b/rules/sort-objects/compute-matched-context-options.ts
@@ -60,37 +60,28 @@ export function computeMatchedContextOptions({
     maxParent: null,
   })
 
-  return (
-    filteredContextOptions.find(options =>
-      isSelectorBasedContextOptionMatching({
-        isDestructuredObject,
-        matchedAstSelectors,
-        parentNodes,
-        sourceCode,
-        nodeObject,
-        options,
-      }),
-    ) ??
-    filteredContextOptions.find(options =>
-      isFallbackContextOptionMatching({
-        isDestructuredObject,
-        parentNodes,
-        sourceCode,
-        nodeObject,
-        options,
-      }),
-    )
+  return filteredContextOptions.find(options =>
+    isContextOptionMatching({
+      isDestructuredObject,
+      matchedAstSelectors,
+      parentNodes,
+      sourceCode,
+      nodeObject,
+      options,
+    }),
   )
 }
 
-function passesUseConfigurationIfFilters({
+function isContextOptionMatching({
   isDestructuredObject,
+  matchedAstSelectors,
   parentNodes,
   sourceCode,
   nodeObject,
   options,
 }: {
   nodeObject: TSESTree.ObjectExpression | TSESTree.ObjectPattern
+  matchedAstSelectors: ReadonlySet<string>
   sourceCode: TSESLint.SourceCode
   isDestructuredObject: boolean
   parentNodes: ObjectParent[]
@@ -126,6 +117,10 @@ function passesUseConfigurationIfFilters({
         options.useConfigurationIf.declarationCommentMatchesPattern,
       parentNodes,
       sourceCode,
+    }) &&
+    passesAstSelectorFilter({
+      matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+      matchedAstSelectors,
     })
   )
 }
@@ -166,65 +161,6 @@ function passesHasNumericKeysOnlyFilter({
         throw new UnreachableCaseError(object)
     }
   }
-}
-
-function isSelectorBasedContextOptionMatching({
-  isDestructuredObject,
-  matchedAstSelectors,
-  parentNodes,
-  sourceCode,
-  nodeObject,
-  options,
-}: {
-  nodeObject: TSESTree.ObjectExpression | TSESTree.ObjectPattern
-  matchedAstSelectors: ReadonlySet<string>
-  sourceCode: TSESLint.SourceCode
-  isDestructuredObject: boolean
-  parentNodes: ObjectParent[]
-  options: Options[number]
-}): boolean {
-  if (
-    !passesAstSelectorFilter({
-      matchesAstSelector: options.useConfigurationIf?.matchesAstSelector,
-      matchedAstSelectors,
-    })
-  ) {
-    return false
-  }
-
-  return passesUseConfigurationIfFilters({
-    isDestructuredObject,
-    parentNodes,
-    sourceCode,
-    nodeObject,
-    options,
-  })
-}
-
-function isFallbackContextOptionMatching({
-  isDestructuredObject,
-  parentNodes,
-  sourceCode,
-  nodeObject,
-  options,
-}: {
-  nodeObject: TSESTree.ObjectExpression | TSESTree.ObjectPattern
-  sourceCode: TSESLint.SourceCode
-  isDestructuredObject: boolean
-  parentNodes: ObjectParent[]
-  options: Options[number]
-}): boolean {
-  if (options.useConfigurationIf?.matchesAstSelector !== undefined) {
-    return false
-  }
-
-  return passesUseConfigurationIfFilters({
-    isDestructuredObject,
-    parentNodes,
-    sourceCode,
-    nodeObject,
-    options,
-  })
 }
 
 function passesObjectTypeFilter({

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -1629,6 +1629,45 @@ describe('sort-array-includes', () => {
           `,
         })
       })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ArrayExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedArrayIncludesOrder',
+            },
+          ],
+          output: dedent`
+            [
+              a,
+              b,
+            ].includes(value)
+          `,
+          code: dedent`
+            [
+              b,
+              a,
+            ].includes(value)
+          `,
+        })
+      })
     })
 
     it('removes newlines between and inside groups by default when "newlinesBetween" is 0', async () => {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -5082,6 +5082,45 @@ describe('sort-classes', () => {
           `,
         })
       })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ClassBody',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedClassesOrder',
+            },
+          ],
+          output: dedent`
+            class Class {
+              a
+              b
+            }
+          `,
+          code: dedent`
+            class Class {
+              b
+              a
+            }
+          `,
+        })
+      })
     })
   })
 

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -1424,6 +1424,45 @@ describe('sort-enums', () => {
           `,
         })
       })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'TSEnumDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedEnumsOrder',
+            },
+          ],
+          output: dedent`
+            enum Enum {
+              a = 'a',
+              b = 'b',
+            }
+          `,
+          code: dedent`
+            enum Enum {
+              b = 'b',
+              a = 'a',
+            }
+          `,
+        })
+      })
     })
 
     it('removes newlines between and inside groups by default when "newlinesBetween" is 0', async () => {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1697,6 +1697,49 @@ describe('sort-jsx-props', () => {
           `,
         })
       })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'JSXElement',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedJSXPropsOrder',
+            },
+          ],
+          output: dedent`
+            let Component = () => (
+              <Element
+                a="a"
+                b="b"
+              />
+            )
+          `,
+          code: dedent`
+            let Component = () => (
+              <Element
+                b="b"
+                a="a"
+              />
+            )
+          `,
+        })
+      })
     })
   })
 

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1797,6 +1797,45 @@ describe('sort-maps', () => {
           `,
         })
       })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'NewExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedMapElementsOrder',
+            },
+          ],
+          output: dedent`
+            new Map([
+              [a, 'a'],
+              [b, 'b'],
+            ])
+          `,
+          code: dedent`
+            new Map([
+              [b, 'b'],
+              [a, 'a'],
+            ])
+          `,
+        })
+      })
     })
   })
 

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1684,38 +1684,19 @@ describe('sort-named-exports', () => {
         })
       })
 
-      it('prioritizes selector-based options over fallback options', async () => {
-        await valid({
-          options: [
-            {
-              ...options,
-              type: 'alphabetical',
-            },
-            {
-              ...options,
-              useConfigurationIf: {
-                matchesAstSelector: 'ExportNamedDeclaration',
-              },
-              type: 'unsorted',
-            },
-          ],
-          code: dedent`
-            export { b, a }
-          `,
-        })
-
+      it('picks the first matching option when multiple options match', async () => {
         await invalid({
           options: [
             {
               ...options,
-              type: 'unsorted',
+              type: 'alphabetical',
             },
             {
               ...options,
               useConfigurationIf: {
                 matchesAstSelector: 'ExportNamedDeclaration',
               },
-              type: 'alphabetical',
+              type: 'unsorted',
             },
           ],
           errors: [

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -4036,6 +4036,45 @@ describe('sort-objects', () => {
           `,
         })
       })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ObjectExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsOrder',
+            },
+          ],
+          output: dedent`
+            let obj = {
+              a: "a",
+              b: "b",
+            }
+          `,
+          code: dedent`
+            let obj = {
+              b: "b",
+              a: "a",
+            }
+          `,
+        })
+      })
     })
 
     it('applies configuration when object only has numeric keys', async () => {

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1463,6 +1463,45 @@ describe('sort-sets', () => {
           `,
         })
       })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ArrayExpression',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedSetsOrder',
+            },
+          ],
+          output: dedent`
+            new Set([
+              a,
+              b,
+            ])
+          `,
+          code: dedent`
+            new Set([
+              b,
+              a,
+            ])
+          `,
+        })
+      })
     })
 
     it('removes newlines between and inside groups by default when "newlinesBetween" is 0', async () => {

--- a/utils/context-matching/passes-ast-selector-filter.ts
+++ b/utils/context-matching/passes-ast-selector-filter.ts
@@ -5,8 +5,8 @@
  * @param params.matchesAstSelector - The AST selector to match against, or
  *   undefined if no selector is specified.
  * @param params.matchedAstSelectors - The matched AST selectors for a node.
- * @returns True if the given AST selector matches the expected AST selector,
- *   false otherwise.
+ * @returns True if the given AST selector matches the expected AST selector, or
+ *   if no selector is specified; otherwise, false.
  */
 export function passesAstSelectorFilter({
   matchedAstSelectors,
@@ -16,7 +16,7 @@ export function passesAstSelectorFilter({
   matchesAstSelector: undefined | string
 }): boolean {
   if (!matchesAstSelector) {
-    return false
+    return true
   }
 
   return matchedAstSelectors.has(matchesAstSelector)


### PR DESCRIPTION
- Cf comment: https://github.com/azat-io/eslint-plugin-perfectionist/pull/714/files#r2900503639

### Description

Since https://github.com/azat-io/eslint-plugin-perfectionist/pull/714, configurations using `useConfigurationsIf.matchesAstSelector` would take priority over configurations not using it, even if those configurations were placed before them.
