### PR TITLE
feat(sort-variable-declarations): add 2 `useConfigurationIf` options: `allNamesMatchPattern` and `matchesAstSelector`

### DIFF
--- a/docs/content/rules/sort-variable-declarations.mdx
+++ b/docs/content/rules/sort-variable-declarations.mdx
@@ -180,6 +180,7 @@ Specifies the sorting locales. Refer To [String.prototype.localeCompare() - loca
       | string[]
       | { pattern: string; flags: string }
       | { pattern: string; flags: string }[]
+    matchesAstSelector?: string
   }
   ```
 </sub>
@@ -215,6 +216,27 @@ Example configuration:
       useConfigurationIf: {
         allNamesMatchPattern: '^[rgb]$',
       },
+    },
+    {
+      type: 'alphabetical' // Fallback configuration
+    }
+  ],
+}
+```
+
+- `matchesAstSelector` — An [AST selector](https://eslint.org/docs/latest/extend/selectors) matching a `VariableDeclaration` node.
+To avoid unexpected behavior, do not use `:exit` or `:enter` pseudo-selectors.
+
+Example configuration: don't sort `let` variable declarations.
+```ts
+{
+  'perfectionist/sort-variable-declarations': [
+    'error',
+    {
+      useConfigurationIf: {
+        matchesAstSelector: 'VariableDeclaration[kind="let"]',
+      },
+      type: 'unsorted'
     },
     {
       type: 'alphabetical' // Fallback configuration

--- a/rules/sort-variable-declarations.ts
+++ b/rules/sort-variable-declarations.ts
@@ -1,3 +1,5 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
 import type { MessageId, Options } from './sort-variable-declarations/types'
 
 import {
@@ -11,6 +13,7 @@ import {
 import {
   useExperimentalDependencyDetectionJsonSchema,
   buildUseConfigurationIfJsonSchema,
+  matchesAstSelectorJsonSchema,
   buildCommonJsonSchemas,
 } from '../utils/json-schemas/common-json-schemas'
 import {
@@ -29,8 +32,8 @@ import {
   defaultOptions,
 } from './sort-variable-declarations/sort-variable-declaration'
 import { buildCommonGroupsJsonSchemas } from '../utils/json-schemas/common-groups-json-schemas'
+import { buildAstListeners } from '../utils/build-ast-listeners'
 import { createEslintRule } from '../utils/create-eslint-rule'
-import { getSettings } from '../utils/get-settings'
 
 export default createEslintRule<Options, MessageId>({
   meta: {
@@ -42,9 +45,13 @@ export default createEslintRule<Options, MessageId>({
             additionalCustomGroupMatchProperties:
               additionalCustomGroupMatchOptionsJsonSchema,
           }),
+          useConfigurationIf: buildUseConfigurationIfJsonSchema({
+            additionalProperties: {
+              matchesAstSelector: matchesAstSelectorJsonSchema,
+            },
+          }),
           useExperimentalDependencyDetection:
             useExperimentalDependencyDetectionJsonSchema,
-          useConfigurationIf: buildUseConfigurationIfJsonSchema(),
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
         },
@@ -69,18 +76,12 @@ export default createEslintRule<Options, MessageId>({
     type: 'suggestion',
     fixable: 'code',
   },
-  create: context => {
-    let settings = getSettings(context.settings)
-
-    return {
-      VariableDeclaration: node =>
-        sortVariableDeclaration({
-          settings,
-          context,
-          node,
-        }),
-    }
-  },
+  create: context =>
+    buildAstListeners({
+      nodeTypes: [AST_NODE_TYPES.VariableDeclaration],
+      sorter: sortVariableDeclaration,
+      context,
+    }),
   name: 'sort-variable-declarations',
   defaultOptions: [defaultOptions],
 })

--- a/rules/sort-variable-declarations/compute-matched-context-options.ts
+++ b/rules/sort-variable-declarations/compute-matched-context-options.ts
@@ -5,6 +5,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { Options } from './types'
 
 import { filterOptionsByAllNamesMatch } from '../../utils/context-matching/filter-options-by-all-names-match'
+import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast-selector-filter'
 import { computeNodeName } from './compute-node-name'
 
 /**
@@ -13,16 +14,20 @@ import { computeNodeName } from './compute-node-name'
  * @param params - Parameters.
  * @param params.node - The variable declaration node to compute the context
  *   options for.
+ * @param params.matchedAstSelectors - The matched AST selectors for an object
+ *   node.
  * @param params.sourceCode - The ESLint source code object.
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
 export function computeMatchedContextOptions<MessageIds extends string>({
+  matchedAstSelectors,
   sourceCode,
   context,
   node,
 }: {
   context: Readonly<RuleContext<MessageIds, Options>>
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.VariableDeclaration
   sourceCode: TSESLint.SourceCode
 }): Options[number] | undefined {
@@ -35,5 +40,22 @@ export function computeMatchedContextOptions<MessageIds extends string>({
     nodeNames,
   })
 
-  return matchedContextOptions[0]
+  return matchedContextOptions.find(isContextOptionMatching)
+
+  function isContextOptionMatching(options: Options[number]): boolean {
+    if (!options.useConfigurationIf) {
+      return true
+    }
+
+    if (
+      !passesAstSelectorFilter({
+        matchesAstSelector: options.useConfigurationIf.matchesAstSelector,
+        matchedAstSelectors,
+      })
+    ) {
+      return false
+    }
+
+    return true
+  }
 }

--- a/rules/sort-variable-declarations/sort-variable-declaration.ts
+++ b/rules/sort-variable-declarations/sort-variable-declaration.ts
@@ -64,11 +64,13 @@ export let defaultOptions: Required<Options[number]> = {
 }
 
 export function sortVariableDeclaration({
+  matchedAstSelectors,
   settings,
   context,
   node,
 }: {
   context: TSESLint.RuleContext<MessageId, Options>
+  matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.VariableDeclaration
   settings: Settings
 }): void {
@@ -79,6 +81,7 @@ export function sortVariableDeclaration({
   let { sourceCode, id } = context
 
   let matchedContextOptions = computeMatchedContextOptions({
+    matchedAstSelectors,
     sourceCode,
     context,
     node,

--- a/rules/sort-variable-declarations/types.ts
+++ b/rules/sort-variable-declarations/types.ts
@@ -40,6 +40,11 @@ export type Options = Partial<
        * names. The rule is only applied when all names match this pattern.
        */
       allNamesMatchPattern?: RegexOption
+
+      /**
+       * AST selector to match against VariableDeclaration nodes.
+       */
+      matchesAstSelector?: string
     }
 
     /**

--- a/test/rules/sort-variable-declarations.test.ts
+++ b/test/rules/sort-variable-declarations.test.ts
@@ -2122,6 +2122,220 @@ describe('sort-variable-declarations', () => {
         },
       )
     })
+
+    describe('useConfigurationIf.matchesAstSelector', () => {
+      it('matches configuration based off matchesAstSelector', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'ExportNamedDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let a, b
+          `,
+          code: dedent`
+            let b, a
+          `,
+        })
+
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'VariableDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          code: dedent`
+            let b, a
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'VariableDeclaration',
+                allNamesMatchPattern: '^[ac]$',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'VariableDeclaration',
+              },
+              type: 'alphabetical',
+            },
+            {
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let a, b
+          `,
+          code: dedent`
+            let b, a
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'VariableDeclaration',
+                allNamesMatchPattern: '^[ac]$',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                allNamesMatchPattern: '^[ab]$',
+              },
+              type: 'alphabetical',
+              order: 'desc',
+            },
+            {
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'b',
+                left: 'a',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let b, a
+          `,
+          code: dedent`
+            let a, b
+          `,
+        })
+      })
+
+      it('applies first matching option when selectors overlap', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'VariableDeclaration',
+              },
+              type: 'unsorted',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > VariableDeclaration',
+              },
+              type: 'alphabetical',
+            },
+          ],
+          code: dedent`
+            let b, a
+          `,
+        })
+
+        await invalid({
+          options: [
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'VariableDeclaration',
+              },
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: '* > VariableDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let a, b
+          `,
+          code: dedent`
+            let b, a
+          `,
+        })
+      })
+
+      it('picks the first matching option when multiple options match', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              type: 'alphabetical',
+            },
+            {
+              ...options,
+              useConfigurationIf: {
+                matchesAstSelector: 'VariableDeclaration',
+              },
+              type: 'unsorted',
+            },
+          ],
+          errors: [
+            {
+              data: {
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedVariableDeclarationsOrder',
+            },
+          ],
+          output: dedent`
+            let a, b
+          `,
+          code: dedent`
+            let b, a
+          `,
+        })
+      })
+    })
   })
 
   describe('natural', () => {


### PR DESCRIPTION
## Description

This PR adds support for the following `sort-variable-declarations` options:
- `useConfigurationIf.allNamesMatchPattern`.
- `useConfigurationIf.matchesAstSelector`.

## How to use `useConfigurationIf.matchesAstSelector`

Users need to pass an AST selector that matches a `VariableDeclaration` node.