### PR TITLE
docs(integrations): add VS Code formatter info

### DIFF
--- a/docs/content/guide/integrations.mdx
+++ b/docs/content/guide/integrations.mdx
@@ -48,11 +48,14 @@ Then add the following code to your `settings.json`:
 
 ### Formatter
 
-The ESLint VS Code extension can also be used as a formatter:
+The ESLint VS Code extension can also be used as a formatter. This example also sets it as the default formatter for TypeScript:
 
 ```json
 {
-  "eslint.format.enable": true
+  "eslint.format.enable": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
 }
 ```
 
@@ -61,6 +64,9 @@ To run multiple formatters like ESLint & Prettier, the [Format ATT](https://gith
 ```json
 {
   "eslint.format.enable": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "unimorphic.format-att"
+  },
   "format-att.formatters": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

After recently discovering this awesome ESLint plugin, I found myself wanting to use it as a formatter in VS Code but still also wanting to use Prettier, so I made a VS Code extension to do this: https://github.com/unimorphic/vscode-format-att

Added info to the docs for using the ESLint VS Code extension as a formatter with and without my extension

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [ ] Tests added/updated when needed
