### PR TITLE
fix: guard getAllComments return value against undefined

### DIFF
--- a/test/utils/get-eslint-disabled-lines.test.ts
+++ b/test/utils/get-eslint-disabled-lines.test.ts
@@ -1,0 +1,24 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import { describe, expect, it } from 'vitest'
+
+import { getEslintDisabledLines } from '../../utils/get-eslint-disabled-lines'
+
+describe('getEslintDisabledLines', () => {
+  it('returns empty array when getAllComments returns undefined', () => {
+    expect(
+      getEslintDisabledLines({
+        sourceCode: getSourceCodeMock(undefined),
+        ruleName: 'perfectionist/sort-imports',
+      }),
+    ).toStrictEqual([])
+  })
+})
+
+function getSourceCodeMock(
+  comments: undefined,
+): TSESLint.SourceCode {
+  return {
+    getAllComments: () => comments,
+  } as unknown as TSESLint.SourceCode
+}

--- a/utils/get-eslint-disabled-lines.ts
+++ b/utils/get-eslint-disabled-lines.ts
@@ -52,7 +52,8 @@ export function getEslintDisabledLines(props: {
   let { sourceCode, ruleName } = props
   let returnValue: number[] = []
   let lineRulePermanentlyDisabled: number | null = null
-  for (let comment of sourceCode.getAllComments()) {
+  // eslint-disable-next-line typescript/no-unnecessary-condition
+  for (let comment of sourceCode.getAllComments() ?? []) {
     let eslintDisabledRules = getEslintDisabledRules(comment.value)
     if (!eslintDisabledRules) {
       continue


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Hey! I ran into this while using `@antfu/eslint-config` (related issue: antfu/eslint-config#837). When ESLint processes non-JS files (e.g. markdown code blocks via `@eslint/markdown`), `sourceCode.getAllComments()` can return `undefined`, causing a crash:

```
TypeError: sourceCode.getAllComments is not a function or its return value is not iterable
```

The fix is a `?? []` guard. I ripped this pattern from `utils/get-node-decorators.ts`, for what I assume is the same reason, so it felt like the right approach here too.

I didn't open an issue beforehand since the fix is so small, but happy to do so if that's a hard requirement. First OSS contribution so feel free to roast me.

### Reviewer notes

The fix is a single line in `utils/get-eslint-disabled-lines.ts`. The test covers the specific case where `getAllComments` returns `undefined`.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
