### PR TITLE
feat: export class option types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -147,3 +147,27 @@ export default {
   ...plugin,
   configs,
 } as { configs: PluginConfigs } & ESLint.Plugin
+
+export type { Options as SortVariableDeclarationsOptions } from './rules/sort-variable-declarations/types'
+export type { Options as SortIntersectionTypesOptions } from './rules/sort-intersection-types/types'
+export type { Options as SortImportAttributesOptions } from './rules/sort-import-attributes/types'
+export type { Options as SortExportAttributesOptions } from './rules/sort-export-attributes/types'
+export type { Options as SortHeritageClausesOptions } from './rules/sort-heritage-clauses/types'
+export type { Options as SortArrayIncludesOptions } from './rules/sort-array-includes/types'
+export type { Options as SortNamedImportsOptions } from './rules/sort-named-imports/types'
+export type { Options as SortNamedExportsOptions } from './rules/sort-named-exports/types'
+export type { Options as SortObjectTypesOptions } from './rules/sort-object-types/types'
+export type { Options as SortSwitchCaseOptions } from './rules/sort-switch-case/types'
+export type { Options as SortUnionTypesOptions } from './rules/sort-union-types/types'
+export type { Options as SortInterfacesOptions } from './rules/sort-interfaces/types'
+export type { Options as SortDecoratorsOptions } from './rules/sort-decorators/types'
+export type { Options as SortJsxPropsOptions } from './rules/sort-jsx-props/types'
+export type { Options as SortClassesOptions } from './rules/sort-classes/types'
+export type { Options as SortImportsOptions } from './rules/sort-imports/types'
+export type { Options as SortExportsOptions } from './rules/sort-exports/types'
+export type { Options as SortObjectsOptions } from './rules/sort-objects/types'
+export type { Options as SortModulesOptions } from './rules/sort-modules/types'
+export type { Options as SortArraysOptions } from './rules/sort-arrays/types'
+export type { Options as SortEnumsOptions } from './rules/sort-enums/types'
+export type { Options as SortMapsOptions } from './rules/sort-maps/types'
+export type { Options as SortSetsOptions } from './rules/sort-sets/types'

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -4,7 +4,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options } from './sort-arrays/types'
+import type { Options } from './sort-array-includes/types'
 
 import {
   buildUseConfigurationIfJsonSchema,

--- a/rules/sort-array-includes/types.ts
+++ b/rules/sort-array-includes/types.ts
@@ -1,0 +1,3 @@
+import type { Options as SortArraysOptions } from '../sort-arrays/types'
+
+export type Options = SortArraysOptions

--- a/rules/sort-export-attributes.ts
+++ b/rules/sort-export-attributes.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options as SortImportAttributesOptions } from './sort-import-attributes/types'
+import type { Options } from './sort-export-attributes/types'
 
 import {
   MISSED_SPACING_ERROR,
@@ -26,8 +26,6 @@ type MessageId =
   | typeof EXTRA_SPACING_ERROR_ID
   | typeof GROUP_ORDER_ERROR_ID
   | typeof ORDER_ERROR_ID
-
-type Options = SortImportAttributesOptions
 
 let defaultOptions: Required<Options[0]> = {
   fallbackSort: { type: 'unsorted' },

--- a/rules/sort-export-attributes/types.ts
+++ b/rules/sort-export-attributes/types.ts
@@ -1,0 +1,3 @@
+import type { Options as SortImportAttributesOptions } from '../sort-import-attributes/types'
+
+export type Options = SortImportAttributesOptions

--- a/rules/sort-interfaces.ts
+++ b/rules/sort-interfaces.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options as SortObjectTypesOptions } from './sort-object-types/types'
+import type { Options } from './sort-interfaces/types'
 
 import {
   MISSED_SPACING_ERROR,
@@ -15,8 +15,6 @@ import { sortObjectTypeElements } from './sort-object-types/sort-object-type-ele
 import { defaultOptions, jsonSchema } from './sort-object-types'
 import { buildAstListeners } from '../utils/build-ast-listeners'
 import { createEslintRule } from '../utils/create-eslint-rule'
-
-type Options = SortObjectTypesOptions
 
 const ORDER_ERROR_ID = 'unexpectedInterfacePropertiesOrder'
 const GROUP_ORDER_ERROR_ID = 'unexpectedInterfacePropertiesGroupOrder'

--- a/rules/sort-interfaces/types.ts
+++ b/rules/sort-interfaces/types.ts
@@ -1,0 +1,3 @@
+import type { Options as SortObjectTypesOptions } from '../sort-object-types/types'
+
+export type Options = SortObjectTypesOptions

--- a/rules/sort-intersection-types.ts
+++ b/rules/sort-intersection-types.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options as SortUnionTypesOptions } from './sort-union-types/types'
+import type { Options } from './sort-intersection-types/types'
 
 import {
   MISSED_SPACING_ERROR,
@@ -31,8 +31,6 @@ type MessageId =
   | typeof EXTRA_SPACING_ERROR_ID
   | typeof GROUP_ORDER_ERROR_ID
   | typeof ORDER_ERROR_ID
-
-type Options = SortUnionTypesOptions
 
 let defaultOptions: Required<Options[number]> = {
   fallbackSort: { type: 'unsorted' },

--- a/rules/sort-intersection-types/types.ts
+++ b/rules/sort-intersection-types/types.ts
@@ -1,0 +1,3 @@
+import type { Options as SortUnionTypesOptions } from '../sort-union-types/types'
+
+export type Options = SortUnionTypesOptions

--- a/rules/sort-sets.ts
+++ b/rules/sort-sets.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options } from './sort-arrays/types'
+import type { Options } from './sort-sets/types'
 
 import {
   MISSED_SPACING_ERROR,

--- a/rules/sort-sets/types.ts
+++ b/rules/sort-sets/types.ts
@@ -1,0 +1,3 @@
+import type { Options as SortArraysOptions } from '../sort-arrays/types'
+
+export type Options = SortArraysOptions

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -3,8 +3,8 @@ import type { TSESLint } from '@typescript-eslint/utils'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { CommonOptions, TypeOption } from '../types/common-options'
 import type { SortingNode } from '../types/sorting-node'
+import type { Options } from './sort-switch-case/types'
 
 import { defaultComparatorByOptionsComputer } from '../utils/compare/default-comparator-by-options-computer'
 import { makeSingleNodeCommentAfterFixes } from '../utils/make-single-node-comment-after-fixes'
@@ -26,8 +26,6 @@ interface SortSwitchCaseSortingNode extends SortingNode<TSESTree.SwitchCase> {
 }
 
 const ORDER_ERROR_ID = 'unexpectedSwitchCaseOrder'
-
-type Options = [Partial<CommonOptions<TypeOption>>]
 
 type MessageId = typeof ORDER_ERROR_ID
 

--- a/rules/sort-switch-case/types.ts
+++ b/rules/sort-switch-case/types.ts
@@ -1,0 +1,3 @@
+import type { CommonOptions, TypeOption } from '../../types/common-options'
+
+export type Options = [Partial<CommonOptions<TypeOption>>]


### PR DESCRIPTION
- Resolves #730.

## Description

This PR exposes each rule's `Options`.

Other internal types are not exposed as in theory, exposed types should avoid being modified to prevent breaking changes.

## Example

```ts
import type { SortNamedExportsOptions } from 'eslint-plugin-perfectionist';
```