### PR TITLE
feat: add `newlinesBetweenOverloadSignatures` option to `sort-classes` and `sort-modules`

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -337,6 +337,19 @@ or [`customGroups`](#customgroups) options.
 
 This option is only applicable when [`partitionByNewLine`](#partitionbynewline) is `false`.
 
+### newlinesBetweenOverloadSignatures
+
+<sub>
+  type: `number | 'ignore'`
+</sub>
+<sub>default: `0`</sub>
+
+Specifies how to handle newlines between overload signatures and the implementation of the same method.
+
+- `'ignore'` — Do not report errors related to newlines.
+- `0` — No newlines are allowed.
+- Any other number — Enforce this number of newlines between each overload signature.
+
 ### ignoreCallbackDependenciesPatterns
 
 <sub>

--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -355,6 +355,19 @@ or [`customGroups`](#customgroups) options.
 
 This option is only applicable when [`partitionByNewLine`](#partitionbynewline) is `false`.
 
+### newlinesBetweenOverloadSignatures
+
+<sub>
+  type: `number | 'ignore'`
+</sub>
+<sub>default: `0`</sub>
+
+Specifies how to handle newlines between overload signatures and the implementation of the same function.
+
+- `'ignore'` — Do not report errors related to newlines.
+- `0` — No newlines are allowed.
+- Any other number — Enforce this number of newlines between each overload signature.
+
 ### groups
 
 <sub>

--- a/rules/sort-classes.ts
+++ b/rules/sort-classes.ts
@@ -28,7 +28,10 @@ import {
   partitionByCommentJsonSchema,
   partitionByNewLineJsonSchema,
 } from '../utils/json-schemas/common-partition-json-schemas'
-import { buildCommonGroupsJsonSchemas } from '../utils/json-schemas/common-groups-json-schemas'
+import {
+  buildCommonGroupsJsonSchemas,
+  newlinesBetweenJsonSchema,
+} from '../utils/json-schemas/common-groups-json-schemas'
 import { defaultOptions, sortClass } from './sort-classes/sort-class'
 import { buildAstListeners } from '../utils/build-ast-listeners'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -50,6 +53,7 @@ export default createEslintRule<Options, MessageId>({
           }),
           useExperimentalDependencyDetection:
             useExperimentalDependencyDetectionJsonSchema,
+          newlinesBetweenOverloadSignatures: newlinesBetweenJsonSchema,
           ignoreCallbackDependenciesPatterns: buildRegexJsonSchema(),
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,

--- a/rules/sort-classes/sort-class.ts
+++ b/rules/sort-classes/sort-class.ts
@@ -88,6 +88,7 @@ export let defaultOptions: Required<Options[number]> = {
   ],
   useExperimentalDependencyDetection: true,
   ignoreCallbackDependenciesPatterns: [],
+  newlinesBetweenOverloadSignatures: 0,
   fallbackSort: { type: 'unsorted' },
   newlinesInside: 'newlinesBetween',
   partitionByComment: false,
@@ -140,7 +141,9 @@ export function sortClass({
   })
   let optionsByGroupIndexComputer = buildOptionsByGroupIndexComputer(options)
   let overloadSignatureNewlinesBetweenValueGetter =
-    buildOverloadSignatureNewlinesBetweenValueGetter()
+    buildOverloadSignatureNewlinesBetweenValueGetter(
+      options.newlinesBetweenOverloadSignatures,
+    )
 
   let className = node.parent.id?.name
 

--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNodeWithDependencies } from '../../utils/sort-nodes-by-dependencies'
+import type { NewlinesBetweenOption } from '../../types/common-groups-options'
 import type { RegexOption, TypeOption } from '../../types/common-options'
 import type { AllCommonOptions } from '../../types/all-common-options'
 
@@ -46,6 +47,12 @@ export type Options = Partial<
        */
       matchesAstSelector?: string
     }
+
+    /**
+     * Determines how many newlines should be placed between overload signatures
+     * of the same method.
+     */
+    newlinesBetweenOverloadSignatures: NewlinesBetweenOption
 
     /**
      * Regex patterns for function names whose callback argument dependencies

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -28,13 +28,16 @@ import {
   useExperimentalDependencyDetectionJsonSchema,
   buildCommonJsonSchemas,
 } from '../utils/json-schemas/common-json-schemas'
+import {
+  buildCommonGroupsJsonSchemas,
+  newlinesBetweenJsonSchema,
+} from '../utils/json-schemas/common-groups-json-schemas'
 import { populateSortingNodeGroupsWithDependencies } from '../utils/populate-sorting-node-groups-with-dependencies'
 import { validateNewlinesAndPartitionConfiguration } from '../utils/validate-newlines-and-partition-configuration'
 import { buildComparatorByOptionsComputer } from './sort-modules/build-comparator-by-options-computer'
 import { computeDependenciesBySortingNode } from './sort-modules/compute-dependencies-by-sorting-node'
 import { buildOptionsByGroupIndexComputer } from '../utils/build-options-by-group-index-computer'
 import { computeOverloadSignatureGroups } from './sort-modules/compute-overload-signature-groups'
-import { buildCommonGroupsJsonSchemas } from '../utils/json-schemas/common-groups-json-schemas'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
 import { generatePredefinedGroups } from '../utils/generate-predefined-groups'
@@ -88,6 +91,7 @@ let defaultOptions: Required<Options[number]> = {
     'function',
   ],
   useExperimentalDependencyDetection: true,
+  newlinesBetweenOverloadSignatures: 0,
   fallbackSort: { type: 'unsorted' },
   newlinesInside: 'newlinesBetween',
   partitionByComment: false,
@@ -117,6 +121,7 @@ export default createEslintRule<Options, MessageId>({
           }),
           useExperimentalDependencyDetection:
             useExperimentalDependencyDetectionJsonSchema,
+          newlinesBetweenOverloadSignatures: newlinesBetweenJsonSchema,
           partitionByComment: partitionByCommentJsonSchema,
           partitionByNewLine: partitionByNewLineJsonSchema,
         },
@@ -186,7 +191,9 @@ function analyzeModule({
 }): void {
   let optionsByGroupIndexComputer = buildOptionsByGroupIndexComputer(options)
   let overloadSignatureNewlinesBetweenValueGetter =
-    buildOverloadSignatureNewlinesBetweenValueGetter()
+    buildOverloadSignatureNewlinesBetweenValueGetter(
+      options.newlinesBetweenOverloadSignatures,
+    )
 
   let sortingNodeGroupsWithoutOverloadSignature: Omit<
     SortModulesSortingNode,

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -2,6 +2,7 @@ import type { JSONSchema4 } from '@typescript-eslint/utils/json-schema'
 import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNodeWithDependencies } from '../../utils/sort-nodes-by-dependencies'
+import type { NewlinesBetweenOption } from '../../types/common-groups-options'
 import type { RegexOption, TypeOption } from '../../types/common-options'
 import type { AllCommonOptions } from '../../types/all-common-options'
 
@@ -31,6 +32,12 @@ export type SortModulesNode =
 export type Options = [
   Partial<
     {
+      /**
+       * Determines how many newlines should be placed between overload
+       * signatures of the same function.
+       */
+      newlinesBetweenOverloadSignatures: NewlinesBetweenOption
+
       /**
        * Enables experimental dependency detection.
        */

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -12,17 +12,6 @@ import {
 } from '../../utils/json-schemas/common-groups-json-schemas'
 import { buildRegexJsonSchema } from '../../utils/json-schemas/common-json-schemas'
 
-export type SortModulesNode =
-  | TSESTree.ExportDefaultDeclaration
-  | TSESTree.ExportNamedDeclaration
-  | TSESTree.TSInterfaceDeclaration
-  | TSESTree.TSTypeAliasDeclaration
-  | TSESTree.FunctionDeclaration
-  | TSESTree.TSModuleDeclaration
-  | TSESTree.TSDeclareFunction
-  | TSESTree.TSEnumDeclaration
-  | TSESTree.ClassDeclaration
-
 /**
  * Configuration options for the sort-modules rule.
  *
@@ -49,6 +38,17 @@ export type Options = [
     >
   >,
 ]
+
+export type SortModulesNode =
+  | TSESTree.ExportDefaultDeclaration
+  | TSESTree.ExportNamedDeclaration
+  | TSESTree.TSInterfaceDeclaration
+  | TSESTree.TSTypeAliasDeclaration
+  | TSESTree.FunctionDeclaration
+  | TSESTree.TSModuleDeclaration
+  | TSESTree.TSDeclareFunction
+  | TSESTree.TSEnumDeclaration
+  | TSESTree.ClassDeclaration
 
 /**
  * Represents a sorting node for a module statement.

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4061,8 +4061,111 @@ describe('sort-classes', () => {
       })
     })
 
+    describe('newlinesBetweenOverloadSignatures', () => {
+      it('removes newlines between when newlinesBetweenOverloadSignatures is 0', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'extraSpacingBetweenClassMembers',
+              data: { right: 'method', left: 'method' },
+            },
+            {
+              messageId: 'extraSpacingBetweenClassMembers',
+              data: { right: 'method', left: 'method' },
+            },
+          ],
+          output: dedent`
+            class Class {
+              method(a: string): void
+              method(a: number): void
+              method(a: string | number): void {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              method(a: string): void
+
+              method(a: number): void
+
+              method(a: string | number): void {}
+            }
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetweenOverloadSignatures: 0,
+              newlinesBetween: 1,
+            },
+          ],
+        })
+      })
+
+      it('ignores newlines between when newlinesBetweenOverloadSignatures is "ignore"', async () => {
+        await valid({
+          code: dedent`
+            class Class {
+              method(a: string): void
+
+
+              method(a: number): void
+
+              method(a: string | number): void {}
+            }
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetweenOverloadSignatures: 'ignore',
+              newlinesBetween: 1,
+            },
+          ],
+        })
+      })
+
+      it('enforces newlines between when newlinesBetweenOverloadSignatures is > 0', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'missedSpacingBetweenClassMembers',
+              data: { right: 'method', left: 'method' },
+            },
+            {
+              messageId: 'missedSpacingBetweenClassMembers',
+              data: { right: 'method', left: 'method' },
+            },
+          ],
+          output: dedent`
+            class Class {
+              method(a: string): void
+
+
+              method(a: number): void
+
+
+              method(a: string | number): void {}
+            }
+          `,
+          code: dedent`
+            class Class {
+              method(a: string): void
+              method(a: number): void
+
+              method(a: string | number): void {}
+            }
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetweenOverloadSignatures: 2,
+              newlinesBetween: 1,
+            },
+          ],
+        })
+      })
+    })
+
     it.each([1, 'ignore', 0])(
-      'enforces 0 newline between overload signatures when newlinesBetween is %s',
+      'enforces 0 newline between overload signatures by default when newlinesBetween is %s',
       async newlinesBetween => {
         await invalid({
           errors: [

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -1176,8 +1176,101 @@ describe('sort-modules', () => {
       })
     })
 
+    describe('newlinesBetweenOverloadSignatures', () => {
+      it('removes newlines between when newlinesBetweenOverloadSignatures is 0', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'extraSpacingBetweenModulesMembers',
+              data: { right: 'a', left: 'a' },
+            },
+            {
+              messageId: 'extraSpacingBetweenModulesMembers',
+              data: { right: 'a', left: 'a' },
+            },
+          ],
+          output: dedent`
+            function a(arg: string): void
+            function a(arg: number): void
+            export function a(arg: string | number): void {}
+          `,
+          code: dedent`
+            function a(arg: string): void
+
+            function a(arg: number): void
+
+            export function a(arg: string | number): void {}
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetweenOverloadSignatures: 0,
+              newlinesBetween: 1,
+            },
+          ],
+        })
+      })
+
+      it('ignores newlines between when newlinesBetweenOverloadSignatures is "ignore"', async () => {
+        await valid({
+          code: dedent`
+            function a(arg: string): void
+
+
+            function a(arg: number): void
+
+            export function a(arg: string | number): void {}
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetweenOverloadSignatures: 'ignore',
+              newlinesBetween: 1,
+            },
+          ],
+        })
+      })
+
+      it('enforces newlines between when newlinesBetweenOverloadSignatures is > 0', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'missedSpacingBetweenModulesMembers',
+              data: { right: 'a', left: 'a' },
+            },
+            {
+              messageId: 'missedSpacingBetweenModulesMembers',
+              data: { right: 'a', left: 'a' },
+            },
+          ],
+          output: dedent`
+            function a(arg: string): void
+
+
+            function a(arg: number): void
+
+
+            export function a(arg: string | number): void {}
+          `,
+          code: dedent`
+            function a(arg: string): void
+            function a(arg: number): void
+
+            export function a(arg: string | number): void {}
+          `,
+          options: [
+            {
+              ...options,
+              newlinesBetweenOverloadSignatures: 2,
+              newlinesBetween: 1,
+            },
+          ],
+        })
+      })
+    })
+
     it.each([1, 'ignore', 0])(
-      'enforces 0 newline between overload signatures when newlinesBetween is %s',
+      'enforces 0 newline between overload signatures by default when newlinesBetween is %s',
       async newlinesBetween => {
         await invalid({
           errors: [

--- a/test/utils/overload-signature/build-overload-signature-newlines-between-value-getter.test.ts
+++ b/test/utils/overload-signature/build-overload-signature-newlines-between-value-getter.test.ts
@@ -1,0 +1,74 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { describe, expect, it } from 'vitest'
+
+import type { SortingNodeWithOverloadSignatureImplementation } from '../../../utils/overload-signature/overload-signature-group'
+
+import { buildOverloadSignatureNewlinesBetweenValueGetter } from '../../../utils/overload-signature/build-overload-signature-newlines-between-value-getter'
+
+describe('build-overload-signature-newlines-between-value-getter', () => {
+  it('should return newlinesBetweenOverloadSignatures when left and right share the same overloadSignatureImplementation', () => {
+    let newlinesBetweenOverloadSignatures = 42
+    let commonImplementation = buildImplementation()
+    let left =
+      buildSortingNodeWithOverloadSignatureImplementation(commonImplementation)
+    let right =
+      buildSortingNodeWithOverloadSignatureImplementation(commonImplementation)
+    let overloadSignatureNewlinesBetweenValueGetter =
+      buildOverloadSignatureNewlinesBetweenValueGetter(
+        newlinesBetweenOverloadSignatures,
+      )
+
+    let result = overloadSignatureNewlinesBetweenValueGetter({
+      computedNewlinesBetween: 2,
+      right,
+      left,
+    })
+
+    expect(result).toBe(newlinesBetweenOverloadSignatures)
+  })
+
+  it.each([
+    {
+      right: buildSortingNodeWithOverloadSignatureImplementation(
+        buildImplementation(),
+      ),
+      left: buildSortingNodeWithOverloadSignatureImplementation(null),
+    },
+    {
+      right: buildSortingNodeWithOverloadSignatureImplementation(
+        buildImplementation(),
+      ),
+      left: buildSortingNodeWithOverloadSignatureImplementation(
+        buildImplementation(),
+      ),
+    },
+  ])(
+    'should return computedNewlinesBetween when left and right do not share the same overloadSignatureImplementation',
+    ({ right, left }) => {
+      let computedNewlinesBetween = 42
+      let overloadSignatureNewlinesBetweenValueGetter =
+        buildOverloadSignatureNewlinesBetweenValueGetter(2)
+
+      let result = overloadSignatureNewlinesBetweenValueGetter({
+        computedNewlinesBetween,
+        right,
+        left,
+      })
+
+      expect(result).toBe(computedNewlinesBetween)
+    },
+  )
+
+  function buildSortingNodeWithOverloadSignatureImplementation(
+    overloadSignatureImplementation: object | null,
+  ): SortingNodeWithOverloadSignatureImplementation<TSESTree.Node> {
+    return {
+      overloadSignatureImplementation,
+    } as unknown as SortingNodeWithOverloadSignatureImplementation<TSESTree.Node>
+  }
+
+  function buildImplementation(): Record<string, never> {
+    return {}
+  }
+})

--- a/utils/overload-signature/build-overload-signature-newlines-between-value-getter.ts
+++ b/utils/overload-signature/build-overload-signature-newlines-between-value-getter.ts
@@ -2,15 +2,20 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import type { SortingNodeWithOverloadSignatureImplementation } from './overload-signature-group'
 import type { NewlinesBetweenValueGetter } from '../get-newlines-between-errors'
+import type { NewlinesBetweenOption } from '../../types/common-groups-options'
 
 /**
  * Newlines between value getter for overload signatures.
  *
+ * @param newlinesBetweenOverloadSignatures - Newlines between overload
+ *   signatures option value.
  * @returns NewlinesBetween option value.
  */
 export function buildOverloadSignatureNewlinesBetweenValueGetter<
   T extends TSESTree.Node,
->(): NewlinesBetweenValueGetter<
+>(
+  newlinesBetweenOverloadSignatures: NewlinesBetweenOption,
+): NewlinesBetweenValueGetter<
   SortingNodeWithOverloadSignatureImplementation<T>
 > {
   return ({ computedNewlinesBetween, right, left }) => {
@@ -19,7 +24,7 @@ export function buildOverloadSignatureNewlinesBetweenValueGetter<
       left.overloadSignatureImplementation ===
         right.overloadSignatureImplementation
     ) {
-      return 0
+      return newlinesBetweenOverloadSignatures
     }
     return computedNewlinesBetween
   }


### PR DESCRIPTION
- Resolves #734

### Description

Today, `sort-modules` and `sort-classes` enforce that **no newline** exists between function/method overload signatures.

https://github.com/azat-io/eslint-plugin-perfectionist/blob/05b28192a0beb4f21e6a5680f556c14f39d7d857/utils/overload-signature/build-overload-signature-newlines-between-value-getter.ts#L11-L26

This is generally the expected behavior, but it may feel too restrictive as well in some rare cases.

---

This PR adds a new option for both rules: `newlinesBetweenOverloadSignatures: 'ignore' | number` (by default, `0`).