### PR TITLE
fix: preserve uncased character positions

### DIFF
--- a/test/utils/alphabet.test.ts
+++ b/test/utils/alphabet.test.ts
@@ -278,6 +278,24 @@ describe('alphabet', () => {
               .getCharacters(),
           ).toBe('abcdABCD')
         })
+
+        it('preserves position of uncased characters between cased ones', () => {
+          expect(
+            Alphabet.generateFrom('a-A.b/B+')
+              .placeAllWithCaseBeforeAllWithOtherCase('uppercase')
+              .getCharacters(),
+          ).toBe('-A./B+ab')
+        })
+
+        it('does not relocate uppercase letters ahead of digits when combining marks have case mappings', () => {
+          let alphabet = Alphabet.generateRecommendedAlphabet()
+            .sortByLocaleCompare('en-US')
+            .placeAllWithCaseBeforeAllWithOtherCase('uppercase')
+            .getCharacters()
+          let chars = [...alphabet]
+          expect(chars.indexOf('9')).toBeLessThan(chars.indexOf('A'))
+          expect(chars.indexOf('A')).toBeLessThan(chars.indexOf('a'))
+        })
       })
     })
   })

--- a/test/utils/compare/compare-by-custom-sort.test.ts
+++ b/test/utils/compare/compare-by-custom-sort.test.ts
@@ -82,4 +82,28 @@ describe('compare-by-custom-sort', () => {
 
     expect(result).toBe(expected)
   })
+
+  it('sorts base16 palette keys in hex order with uppercase-first custom alphabet', () => {
+    let base16Options = {
+      alphabet: Alphabet.generateRecommendedAlphabet()
+        .sortByLocaleCompare('en-US')
+        .placeAllWithCaseBeforeAllWithOtherCase('uppercase')
+        .getCharacters(),
+      specialCharacters: 'keep' as const,
+      order: 'asc' as const,
+      ignoreCase: false,
+    }
+    let keys = ['base0F', 'base09', 'base0A', 'base00', 'base0B', 'base05']
+    let sorted = keys.toSorted((a, b) =>
+      compareByCustomSort(a, b, base16Options),
+    )
+    expect(sorted).toEqual([
+      'base00',
+      'base05',
+      'base09',
+      'base0A',
+      'base0B',
+      'base0F',
+    ])
+  })
 })

--- a/utils/alphabet.ts
+++ b/utils/alphabet.ts
@@ -247,22 +247,18 @@ export class Alphabet {
   public placeAllWithCaseBeforeAllWithOtherCase(
     caseToComeFirst: 'uppercase' | 'lowercase',
   ): this {
-    let charactersWithCase = this.getCharactersWithCase()
-    let orderedCharacters = [
-      ...charactersWithCase.filter(character =>
-        caseToComeFirst === 'uppercase' ?
-          !character.character.uppercaseCharacterCodePoint
-        : character.character.uppercaseCharacterCodePoint,
-      ),
-      ...charactersWithCase.filter(character =>
-        caseToComeFirst === 'uppercase' ?
-          character.character.uppercaseCharacterCodePoint
-        : !character.character.uppercaseCharacterCodePoint,
-      ),
-    ]
-    for (let [i, element] of charactersWithCase.entries()) {
-      this.characters[element.index] = orderedCharacters[i]!.character
+    let otherCaseKey:
+      | 'lowercaseCharacterCodePoint'
+      | 'uppercaseCharacterCodePoint' =
+      caseToComeFirst === 'uppercase' ?
+        'uppercaseCharacterCodePoint'
+      : 'lowercaseCharacterCodePoint'
+    let keep: Character[] = []
+    let move: Character[] = []
+    for (let character of this.characters) {
+      ;(character[otherCaseKey] === undefined ? keep : move).push(character)
     }
+    this.characters = [...keep, ...move]
     return this
   }
 


### PR DESCRIPTION
### Description

The previous implementation of placeAllWithCaseBeforeAllWithOtherCase collected every cased-character slot across the whole alphabet and refilled them uppercase-first. This meant a single outlier cased character — e.g. the Greek combining mark ͅ(U+0345), which has a case mapping to Ι and lands at an early position under en-US locale collation — created a "cased slot" thousands of positions ahead of the Latin block. The refill then placed 'A' into that distant slot, putting uppercase letters ahead of digits and breaking the expected ordering (e.g. base0A sorting before base09).

Rewrite the method as a stable partition: characters in the "other" case move to the end; all other characters (including uncased ones like digits and punctuation) keep their relative positions. This preserves the documented uppercase-first / lowercase-first semantics on purely cased alphabets while leaving uncased characters untouched.

Add regression tests covering the partition semantics, the recommended alphabet under en-US locale, and a realistic base16 palette sort that reproduces the original user-facing failure.

### Reviewer notes

Here is a concrete demonstration of what I ran into:

```
aaron@bow:~/src/honeymux$ bun eslint

/home/aaron/src/honeymux/src/util/config.ts
  132:7  error  Expected "base0A" to come before "base09"  perfectionist/sort-objects

error: "eslint" exited with code 1
aaron@bow:~/src/honeymux$ grep -A 5 -B 10 base0A src/util/config.ts
      base00: "#000000",
      base01: "#111111",
      base02: "#222222",
      base03: "#444444",
      base04: "#888888",
      base05: "#bbbbbb",
      base06: "#dddddd",
      base07: "#ffffff",
      base08: "#555555",
      base09: "#999999",
      base0A: "#cccccc",
      base0B: "#666666",
      base0C: "#777777",
      base0D: "#aaaaaa",
      base0E: "#eeeeee",
      base0F: "#333333",
aaron@bow:~/src/honeymux$ bun eslint --fix src/util/config.ts
aaron@bow:~/src/honeymux$ git diff src/util/config.ts
diff --git a/src/util/config.ts b/src/util/config.ts
index adc9f1a..19ff6b4 100644
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -119,6 +119,7 @@ export function defaultConfig(): HoneymuxConfig {
     screenshotMaxHeightPixels: 65535,
     themeBuiltin: DEFAULT_SCHEME,
     themeCustom: {
+      base0A: "#cccccc",
       base00: "#000000",
       base01: "#111111",
       base02: "#222222",
@@ -129,8 +130,6 @@ export function defaultConfig(): HoneymuxConfig {
       base07: "#ffffff",
       base08: "#555555",
       base09: "#999999",
-      base0A: "#cccccc",
       base0B: "#666666",
       base0C: "#777777",
       base0D: "#aaaaaa",
aaron@bow:~/src/honeymux$
```

i.e. it was incorrectly re-ordering:

`base00, ... base09, base0A, base0B, ...`

to

`base0A, base00, ..., base09, base0B, ...`

which is clearly not what someone would want.

---

### Pre-merge checklist

- [✓] No similar open PR exists
- [✓] Description explains problem/solution or links an issue
- [✓] Tests added/updated when needed
