### PR TITLE
fix(sort-modules): prevent usage-sort autofix loop with order desc

### DIFF
--- a/rules/sort-modules/build-comparator-by-options-computer.ts
+++ b/rules/sort-modules/build-comparator-by-options-computer.ts
@@ -39,7 +39,6 @@ export function buildComparatorByOptionsComputer({
           ignoreEslintDisabledNodes,
           sortingNodes,
           sourceCode,
-          options,
         })
       /* v8 ignore next 2 -- @preserve Exhaustive guard. */
       default:

--- a/rules/sort-modules/build-usage-comparator.ts
+++ b/rules/sort-modules/build-usage-comparator.ts
@@ -1,14 +1,13 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
 import type { Comparator } from '../../utils/compare/default-comparator-by-options-computer'
-import type { SortModulesSortingNode, SortModulesNode, Options } from './types'
+import type { SortModulesSortingNode, SortModulesNode } from './types'
 
 import { populateSortingNodeGroupsWithDependencies } from '../../utils/populate-sorting-node-groups-with-dependencies'
 import { computeDependenciesBySortingNode } from './compute-dependencies-by-sorting-node'
 import { isNodeDependentOnOtherNode } from '../../utils/is-node-dependent-on-other-node'
 import { buildSortingNodeByNodeMap } from '../../utils/build-sorting-node-by-node-map'
 import { sortNodesByDependencies } from '../../utils/sort-nodes-by-dependencies'
-import { computeOrderedValue } from '../../utils/compare/compute-ordered-value'
 import { computeDependencies } from './compute-dependencies'
 
 type PartialSortModulesSortingNode = Pick<
@@ -26,7 +25,6 @@ type PartialSortModulesSortingNode = Pick<
  * @param params.useExperimentalDependencyDetection - Whether to use
  *   experimental dependency detection.
  * @param params.sourceCode - The source code object.
- * @param params.options - The sorting options.
  * @returns A comparator function for sorting module nodes by usage.
  */
 export function buildUsageComparator({
@@ -34,11 +32,9 @@ export function buildUsageComparator({
   ignoreEslintDisabledNodes,
   sortingNodes,
   sourceCode,
-  options,
 }: {
   useExperimentalDependencyDetection: boolean
   sortingNodes: SortModulesSortingNode[]
-  options: Required<Options[number]>
   ignoreEslintDisabledNodes: boolean
   sourceCode: TSESLint.SourceCode
 }): Comparator<SortModulesSortingNode> {
@@ -59,16 +55,18 @@ export function buildUsageComparator({
     let sortedOrderB = orderBySortedNode.get(nodeB)!
     let unsortedOrderB = orderByUnsortedNode.get(nodeB)!
 
-    let sortedOrderedValue = computeOrderedValue(
-      sortedOrderA - sortedOrderB,
-      options.order,
-    )
-    let unsortedOrderedValue = computeOrderedValue(
-      unsortedOrderA - unsortedOrderB,
-      options.order,
-    )
+    /**
+     * The dependency direction must not be flipped by `options.order`: the
+     * unconditional forward-topological post-pass (`sortNodesByDependencies` in
+     * `sort-modules.ts`) owns the dependency direction. Negating the
+     * dependency-resolved index here would fight that post-pass and make the
+     * autofix oscillate forever (see issue #739). Only the sign (direction) of
+     * the index difference matters to a comparator.
+     */
+    let sortedOrderedValue = sortedOrderA - sortedOrderB
+    let unsortedOrderedValue = unsortedOrderA - unsortedOrderB
 
-    if (sortedOrderedValue !== unsortedOrderedValue) {
+    if (Math.sign(sortedOrderedValue) !== Math.sign(unsortedOrderedValue)) {
       return sortedOrderedValue
     }
 

--- a/rules/sort-modules/build-usage-comparator.ts
+++ b/rules/sort-modules/build-usage-comparator.ts
@@ -55,14 +55,6 @@ export function buildUsageComparator({
     let sortedOrderB = orderBySortedNode.get(nodeB)!
     let unsortedOrderB = orderByUnsortedNode.get(nodeB)!
 
-    /**
-     * The dependency direction must not be flipped by `options.order`: the
-     * unconditional forward-topological post-pass (`sortNodesByDependencies` in
-     * `sort-modules.ts`) owns the dependency direction. Negating the
-     * dependency-resolved index here would fight that post-pass and make the
-     * autofix oscillate forever (see issue #739). Only the sign (direction) of
-     * the index difference matters to a comparator.
-     */
     let sortedOrderedValue = sortedOrderA - sortedOrderB
     let unsortedOrderedValue = unsortedOrderA - unsortedOrderB
 

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -8885,6 +8885,94 @@ describe('sort-modules', () => {
           })
         })
 
+        it('sorts diamond dependencies without an autofix loop (#739)', async () => {
+          await invalid({
+            errors: [
+              {
+                data: { left: 'Independent', right: 'Leaf' },
+                messageId: 'unexpectedModulesOrder',
+              },
+              {
+                data: { left: 'Caller2', right: 'Other' },
+                messageId: 'unexpectedModulesOrder',
+              },
+            ],
+            output: dedent`
+              type Leaf = 'leaf';
+              type Caller1 = Leaf;
+              type Other = 'other';
+              type Independent = Other;
+              type Caller2 = Leaf;
+            `,
+            code: dedent`
+              type Caller1 = Leaf;
+              type Independent = Other;
+              type Leaf = 'leaf';
+              type Caller2 = Leaf;
+              type Other = 'other';
+            `,
+            options: [
+              {
+                ...options,
+                useExperimentalDependencyDetection,
+                order: 'desc',
+              },
+            ],
+          })
+        })
+
+        it('keeps a sorted diamond stable with order desc (#739)', async () => {
+          await valid({
+            code: dedent`
+              type Leaf = 'leaf';
+              type Caller1 = Leaf;
+              type Other = 'other';
+              type Independent = Other;
+              type Caller2 = Leaf;
+            `,
+            options: [
+              {
+                ...options,
+                useExperimentalDependencyDetection,
+                order: 'desc',
+              },
+            ],
+          })
+        })
+
+        it('orders independent members via fallbackSort with order desc (#739)', async () => {
+          await invalid({
+            errors: [
+              {
+                messageId: 'unexpectedModulesOrder',
+                data: { right: 'B', left: 'A' },
+              },
+              {
+                messageId: 'unexpectedModulesOrder',
+                data: { right: 'C', left: 'B' },
+              },
+            ],
+            options: [
+              {
+                ...options,
+                fallbackSort: { type: 'alphabetical' },
+                useExperimentalDependencyDetection,
+                order: 'desc',
+              },
+            ],
+            output: dedent`
+              type C = 'c';
+              type B = 'b';
+              type A = 'a';
+            `,
+            code: dedent`
+              type A = 'a';
+              type B = 'b';
+              type C = 'c';
+            `,
+          })
+        })
+
         it('detects usages in interface values', async () => {
           await invalid({
             output: dedent`


### PR DESCRIPTION
### Description

`sort-modules` with type: `'usage'` + `order: 'desc'` caused an infinite autofix loop on diamond-shaped dependencies. 

The usage comparator negated the dependency-resolved index for `desc`, which conflicted with the unconditional forward-topological post-pass - the order flipped on every pass. 

#739

### Reviewer notes

N/A. 

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
