### PR TITLE
fix(sort-modules): allow sorting of decorated exported classes

### DIFF
--- a/docs/content/rules/sort-modules.mdx
+++ b/docs/content/rules/sort-modules.mdx
@@ -171,8 +171,6 @@ This rule sorts the following module members:
 The following elements are not sorted by this rule:
 - `imports` (see the `sort-imports` rule).
 - `'from' exports` (see the `sort-exports` rule).
-- Decorated **then** exported classes due to a known ESLint [limitation](https://github.com/estree/estree/issues/315).
-Place the `export`/`export default` keyword **before** the decorators in order to sort those classes.
 - Any other `expression`, in order to ensure compilation and runtime behavior.
 
 ## Options

--- a/rules/sort-classes/compute-matched-context-options.ts
+++ b/rules/sort-classes/compute-matched-context-options.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options } from './types'
+import type { MessageId, Options } from './types'
 
 import { passesAllNamesMatchPatternFilter } from '../../utils/context-matching/passes-all-names-match-pattern-filter'
 import { computeMethodOrPropertyNameDetails } from './node-info/compute-method-or-property-name-details'
@@ -18,12 +18,12 @@ import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
-export function computeMatchedContextOptions<MessageIds extends string>({
+export function computeMatchedContextOptions({
   matchedAstSelectors,
   classElements,
   context,
 }: {
-  context: Readonly<RuleContext<MessageIds, Options>>
+  context: Readonly<RuleContext<MessageId, Options>>
   matchedAstSelectors: ReadonlySet<string>
   classElements: TSESTree.ClassElement[]
 }): Options[number] | undefined {

--- a/rules/sort-classes/sort-class.ts
+++ b/rules/sort-classes/sort-class.ts
@@ -161,13 +161,13 @@ export function sortClass({
       let dependencies: string[] = []
 
       let isDecorated = false
-      let decorators: string[] = []
+      let decoratorNames: string[] = []
 
       if ('decorators' in member) {
-        decorators = getNodeDecorators(member).map(decorator =>
+        decoratorNames = getNodeDecorators(member).map(decorator =>
           getDecoratorName({ sourceCode, decorator }),
         )
-        isDecorated = decorators.length > 0
+        isDecorated = decoratorNames.length > 0
       }
 
       let addSafetySemicolonWhenInline: boolean
@@ -271,8 +271,8 @@ export function sortClass({
           doesCustomGroupMatch({
             elementValue: memberValue,
             elementName: name,
+            decoratorNames,
             customGroup,
-            decorators,
             modifiers,
             selectors,
           }),

--- a/rules/sort-enums/compute-matched-context-options.ts
+++ b/rules/sort-enums/compute-matched-context-options.ts
@@ -1,7 +1,7 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { Options } from './types'
+import type { MessageId, Options } from './types'
 
 import { passesAllNamesMatchPatternFilter } from '../../utils/context-matching/passes-all-names-match-pattern-filter'
 import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast-selector-filter'
@@ -17,12 +17,12 @@ import { computeNodeName } from './compute-node-name'
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
-export function computeMatchedContextOptions<MessageIds extends string>({
+export function computeMatchedContextOptions({
   matchedAstSelectors,
   enumMembers,
   context,
 }: {
-  context: Readonly<RuleContext<MessageIds, Options>>
+  context: Readonly<RuleContext<MessageId, Options>>
   matchedAstSelectors: ReadonlySet<string>
   enumMembers: TSESTree.TSEnumMember[]
 }): Options[number] | undefined {

--- a/rules/sort-heritage-clauses/compute-matched-context-options.ts
+++ b/rules/sort-heritage-clauses/compute-matched-context-options.ts
@@ -1,7 +1,7 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { Options } from './types'
+import type { MessageId, Options } from './types'
 
 import { passesAllNamesMatchPatternFilter } from '../../utils/context-matching/passes-all-names-match-pattern-filter'
 import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast-selector-filter'
@@ -17,13 +17,13 @@ import { computeNodeName } from './compute-node-name'
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
-export function computeMatchedContextOptions<MessageIds extends string>({
+export function computeMatchedContextOptions({
   matchedAstSelectors,
   heritageClauses,
   context,
 }: {
   heritageClauses: TSESTree.TSInterfaceHeritage[] | TSESTree.TSClassImplements[]
-  context: Readonly<RuleContext<MessageIds, Options>>
+  context: Readonly<RuleContext<MessageId, Options>>
   matchedAstSelectors: ReadonlySet<string>
 }): Options[number] | undefined {
   let nodeNames = heritageClauses.map(clause =>

--- a/rules/sort-maps/compute-matched-context-options.ts
+++ b/rules/sort-maps/compute-matched-context-options.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options } from './types'
+import type { MessageId, Options } from './types'
 
 import { passesAllNamesMatchPatternFilter } from '../../utils/context-matching/passes-all-names-match-pattern-filter'
 import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast-selector-filter'
@@ -18,13 +18,13 @@ import { computeNodeName } from './compute-node-name'
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
-export function computeMatchedContextOptions<MessageIds extends string>({
+export function computeMatchedContextOptions({
   matchedAstSelectors,
   elements,
   context,
 }: {
   elements: (TSESTree.SpreadElement | TSESTree.Expression | null)[]
-  context: Readonly<RuleContext<MessageIds, Options>>
+  context: Readonly<RuleContext<MessageId, Options>>
   matchedAstSelectors: ReadonlySet<string>
 }): Options[number] | undefined {
   let nodeNames = elements

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -48,6 +48,7 @@ import { isNodeEslintDisabled } from '../utils/is-node-eslint-disabled'
 import { doesCustomGroupMatch } from '../utils/does-custom-group-match'
 import { sortNodesByGroups } from '../utils/sort-nodes-by-groups'
 import { createEslintRule } from '../utils/create-eslint-rule'
+import { getDecoratorName } from '../utils/get-decorator-name'
 import { reportAllErrors } from '../utils/report-all-errors'
 import { shouldPartition } from '../utils/should-partition'
 import { getGroupIndex } from '../utils/get-group-index'
@@ -248,7 +249,6 @@ function analyzeModule({
     let details = computeNodeDetails({
       useExperimentalDependencyDetection:
         options.useExperimentalDependencyDetection,
-      sourceCode,
       node,
     })
 
@@ -283,12 +283,18 @@ function analyzeModule({
       selectors: [selector],
       modifiers,
     })
+    let decoratorNames = decorators.map(decorator =>
+      getDecoratorName({
+        sourceCode,
+        decorator,
+      }),
+    )
     let group = computeGroup({
       customGroupMatcher: customGroup =>
         doesCustomGroupMatch({
-          decoratorNames: decorators,
           selectors: [selector],
           elementName: name,
+          decoratorNames,
           customGroup,
           modifiers,
         }),
@@ -302,6 +308,7 @@ function analyzeModule({
     > = {
       isEslintDisabled: isNodeEslintDisabled(node, eslintDisabledLines),
       size: rangeToDiff(node, sourceCode),
+      implicitDecorators: decorators,
       addSafetySemicolonWhenInline,
       dependencyNames: [name],
       dependencyDetection,

--- a/rules/sort-modules.ts
+++ b/rules/sort-modules.ts
@@ -286,10 +286,10 @@ function analyzeModule({
     let group = computeGroup({
       customGroupMatcher: customGroup =>
         doesCustomGroupMatch({
+          decoratorNames: decorators,
           selectors: [selector],
           elementName: name,
           customGroup,
-          decorators,
           modifiers,
         }),
       predefinedGroups,

--- a/rules/sort-modules/compute-node-details.ts
+++ b/rules/sort-modules/compute-node-details.ts
@@ -1,5 +1,4 @@
 import type { TSESTree } from '@typescript-eslint/types'
-import type { TSESLint } from '@typescript-eslint/utils'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
@@ -12,7 +11,6 @@ import type {
 
 import { isPropertyOrAccessorNode } from './is-property-or-accessor-node'
 import { getNodeDecorators } from '../../utils/get-node-decorators'
-import { getDecoratorName } from '../../utils/get-decorator-name'
 import { isArrowFunctionNode } from './is-arrow-function-node'
 import { computeDependencies } from './compute-dependencies'
 
@@ -20,9 +18,9 @@ interface ParsableNodeDetails {
   nodeDetails: {
     dependencyDetection: DependencyDetection
     addSafetySemicolonWhenInline: boolean
+    decorators: TSESTree.Decorator[]
     dependencies: string[]
     modifiers: Modifier[]
-    decorators: string[]
     selector: Selector
     name: string
   }
@@ -40,7 +38,6 @@ type Details = NonParsableNodeDetails | ParsableNodeDetails
  * Compute details about a module-related node.
  *
  * @param params - The parameters object.
- * @param params.sourceCode - The source code object.
  * @param params.node - The AST node to compute details for.
  * @param params.useExperimentalDependencyDetection - Whether to use
  *   experimental dependency detection.
@@ -49,31 +46,24 @@ type Details = NonParsableNodeDetails | ParsableNodeDetails
  */
 export function computeNodeDetails({
   useExperimentalDependencyDetection,
-  sourceCode,
   node,
 }: {
   useExperimentalDependencyDetection: boolean
-  sourceCode: TSESLint.SourceCode
   node: SortModulesNode
 }): Details {
   let selector: undefined | Selector
   let name: undefined | string
   let modifiers: Modifier[] = []
   let dependencies: string[] = []
-  let decorators: string[] = []
+  let decorators: TSESTree.Decorator[] = []
   let addSafetySemicolonWhenInline: boolean = false
   let moduleBlock: TSESTree.TSModuleBlock | null = null
   let shouldPartitionAfterNode: boolean = false
-  let ignoredDueToDecoratorBeforeExportClass: boolean = false
   let dependencyDetection: DependencyDetection = 'soft'
-  let exportNode:
-    | TSESTree.ExportDefaultDeclaration
-    | TSESTree.ExportNamedDeclaration
 
   parseNode(node)
 
-  // eslint-disable-next-line typescript/no-unnecessary-condition
-  if (!selector || !name || ignoredDueToDecoratorBeforeExportClass) {
+  if (!selector || !name) {
     return {
       shouldPartitionAfterNode,
       moduleBlock,
@@ -103,13 +93,17 @@ export function computeNodeDetails({
     }
     switch (nodeToParse.type) {
       case AST_NODE_TYPES.ExportDefaultDeclaration:
-        exportNode = nodeToParse
         modifiers.push('default', 'export')
+        if ('decorators' in nodeToParse.declaration) {
+          decorators = getNodeDecorators(nodeToParse.declaration)
+        }
         parseNode(nodeToParse.declaration)
         break
       case AST_NODE_TYPES.ExportNamedDeclaration:
-        exportNode = nodeToParse
         if (nodeToParse.declaration) {
+          if ('decorators' in nodeToParse.declaration) {
+            decorators = getNodeDecorators(nodeToParse.declaration)
+          }
           parseNode(nodeToParse.declaration)
         }
         modifiers.push('export')
@@ -159,17 +153,8 @@ export function computeNodeDetails({
         let nodeDecorators = getNodeDecorators(nodeToParse)
         if (nodeDecorators[0]) {
           modifiers.push('decorated')
-          ignoredDueToDecoratorBeforeExportClass = isExportAfterDecorators({
-            firstDecorator: nodeDecorators[0],
-            exportNode,
-          })
         }
-        decorators = nodeDecorators.map(decorator =>
-          getDecoratorName({
-            sourceCode,
-            decorator,
-          }),
-        )
+        decorators = nodeDecorators
         dependencyDetection = 'hard'
         dependencies.push(
           ...extractDependencies(
@@ -221,21 +206,4 @@ function extractDependencies(
     searchStaticMethodsAndFunctionProperties,
     type: 'hard',
   })
-}
-
-function isExportAfterDecorators({
-  firstDecorator,
-  exportNode,
-}: {
-  exportNode:
-    | TSESTree.ExportDefaultDeclaration
-    | TSESTree.ExportNamedDeclaration
-    | undefined
-  firstDecorator: TSESTree.Decorator
-}): boolean {
-  if (!exportNode) {
-    return false
-  }
-
-  return exportNode.range[0] > firstDecorator.range[0]
 }

--- a/rules/sort-named-exports/compute-matched-context-options.ts
+++ b/rules/sort-named-exports/compute-matched-context-options.ts
@@ -1,7 +1,7 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { Options } from './types'
+import type { MessageId, Options } from './types'
 
 import { passesAllNamesMatchPatternFilter } from '../../utils/context-matching/passes-all-names-match-pattern-filter'
 import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast-selector-filter'
@@ -18,12 +18,12 @@ import { computeNodeName } from './compute-node-name'
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
-export function computeMatchedContextOptions<MessageIds extends string>({
+export function computeMatchedContextOptions({
   matchedAstSelectors,
   context,
   node,
 }: {
-  context: Readonly<RuleContext<MessageIds, Options>>
+  context: Readonly<RuleContext<MessageId, Options>>
   matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.ExportNamedDeclaration
 }): Options[number] | undefined {

--- a/rules/sort-named-imports/compute-matched-context-options.ts
+++ b/rules/sort-named-imports/compute-matched-context-options.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types'
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
-import type { Options } from './types'
+import type { MessageId, Options } from './types'
 
 import { passesAllNamesMatchPatternFilter } from '../../utils/context-matching/passes-all-names-match-pattern-filter'
 import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast-selector-filter'
@@ -20,12 +20,12 @@ import { computeNodeName } from './compute-node-name'
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
-export function computeMatchedContextOptions<MessageIds extends string>({
+export function computeMatchedContextOptions({
   matchedAstSelectors,
   context,
   node,
 }: {
-  context: Readonly<RuleContext<MessageIds, Options>>
+  context: Readonly<RuleContext<MessageId, Options>>
   matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.ImportDeclaration
 }): Options[number] | undefined {

--- a/rules/sort-variable-declarations/compute-matched-context-options.ts
+++ b/rules/sort-variable-declarations/compute-matched-context-options.ts
@@ -2,7 +2,7 @@ import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { TSESLint } from '@typescript-eslint/utils'
 import type { TSESTree } from '@typescript-eslint/types'
 
-import type { Options } from './types'
+import type { MessageId, Options } from './types'
 
 import { passesAllNamesMatchPatternFilter } from '../../utils/context-matching/passes-all-names-match-pattern-filter'
 import { passesAstSelectorFilter } from '../../utils/context-matching/passes-ast-selector-filter'
@@ -20,13 +20,13 @@ import { computeNodeName } from './compute-node-name'
  * @param params.context - The rule context.
  * @returns The matched context options or undefined if none match.
  */
-export function computeMatchedContextOptions<MessageIds extends string>({
+export function computeMatchedContextOptions({
   matchedAstSelectors,
   sourceCode,
   context,
   node,
 }: {
-  context: Readonly<RuleContext<MessageIds, Options>>
+  context: Readonly<RuleContext<MessageId, Options>>
   matchedAstSelectors: ReadonlySet<string>
   node: TSESTree.VariableDeclaration
   sourceCode: TSESLint.SourceCode

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -3478,34 +3478,46 @@ describe('sort-modules', () => {
         })
       })
 
-      it('ignores decorated then exported classes when sorting', async () => {
+      it('correctly sorts exported classes with decorators', async () => {
         await invalid({
           output: dedent`
-            @B
-            class B {}
-
-            @A
+            @A1
+            @A2
+            // A
             export class A {}
 
-            @C
+            @B1
+            @B2
+            /* B */
+            class B {}
+
+            @C1
+            @C2
+            // C
             class C {}
+          `,
+          code: dedent`
+            @C1
+            @C2
+            // C
+            class C {}
+
+            @A1
+            @A2
+            // A
+            export class A {}
+
+            @B1
+            @B2
+            /* B */
+            class B {}
           `,
           errors: [
             {
               messageId: 'unexpectedModulesOrder',
-              data: { right: 'B', left: 'C' },
+              data: { right: 'A', left: 'C' },
             },
           ],
-          code: dedent`
-            @C
-            class C {}
-
-            @A
-            export class A {}
-
-            @B
-            class B {}
-          `,
           options: [
             {
               ...options,
@@ -3516,29 +3528,41 @@ describe('sort-modules', () => {
 
         await invalid({
           output: dedent`
-            @B
-            class B {}
-
-            @A
+            @A1
+            @A2
+            // A
             export default class A {}
 
-            @C
+            @B1
+            @B2
+            /* B */
+            class B {}
+
+            @C1
+            @C2
+            // C
             class C {}
           `,
           code: dedent`
-            @C
+            @C1
+            @C2
+            // C
             class C {}
 
-            @A
+            @A1
+            @A2
+            // A
             export default class A {}
 
-            @B
+            @B1
+            @B2
+            /* B */
             class B {}
           `,
           errors: [
             {
               messageId: 'unexpectedModulesOrder',
-              data: { right: 'B', left: 'C' },
+              data: { right: 'A', left: 'C' },
             },
           ],
           options: [
@@ -5931,34 +5955,40 @@ describe('sort-modules', () => {
       })
     })
 
-    it('ignores exported decorated classes when sorting', async () => {
+    it('correctly sorts exported classes with decorators', async () => {
       await invalid({
-        errors: [
-          {
-            messageId: 'unexpectedModulesOrder',
-            data: { right: 'B', left: 'C' },
-          },
-        ],
         output: dedent`
-          @B
-          class B {}
-
-          @A
+          @A1
+          @A2
           export class A {}
 
-          @C
+          @B1
+          @B2
+          class B {}
+
+          @C1
+          @C2
           class C {}
         `,
         code: dedent`
-          @C
+          @C1
+          @C2
           class C {}
 
-          @A
+          @A1
+          @A2
           export class A {}
 
-          @B
+          @B1
+          @B2
           class B {}
         `,
+        errors: [
+          {
+            messageId: 'unexpectedModulesOrder',
+            data: { right: 'A', left: 'C' },
+          },
+        ],
         options: [
           {
             ...options,
@@ -8311,34 +8341,40 @@ describe('sort-modules', () => {
       })
     })
 
-    it('ignores exported decorated classes when sorting', async () => {
+    it('correctly sorts exported classes with decorators', async () => {
       await invalid({
-        errors: [
-          {
-            messageId: 'unexpectedModulesOrder',
-            data: { right: 'BB', left: 'C' },
-          },
-        ],
         output: dedent`
-          @B
-          class BB {}
-
-          @A
+          @A1
+          @A2
           export class AAA {}
 
-          @C
+          @B1
+          @B2
+          class BB {}
+
+          @C1
+          @C2
           class C {}
         `,
         code: dedent`
-          @C
+          @C1
+          @C2
           class C {}
 
-          @A
+          @A1
+          @A2
           export class AAA {}
 
-          @B
+          @B1
+          @B2
           class BB {}
         `,
+        errors: [
+          {
+            messageId: 'unexpectedModulesOrder',
+            data: { right: 'AAA', left: 'C' },
+          },
+        ],
         options: [
           {
             ...options,

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -689,121 +689,164 @@ describe('sort-modules', () => {
       },
     )
 
-    it.each([
-      ['string pattern', 'Hello'],
-      ['array with string pattern', ['noMatch', 'Hello']],
-      ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
-      [
-        'array with regex object',
-        ['noMatch', { pattern: 'HELLO', flags: 'i' }],
-      ],
-    ])(
-      'filters classes by decorator name pattern - %s',
-      async (_description, decoratorNamePattern) => {
+    describe('decoratorNamePattern', () => {
+      it.each([
+        ['string pattern', 'Hello'],
+        ['array with string pattern', ['noMatch', 'Hello']],
+        ['case-insensitive regex object', { pattern: 'HELLO', flags: 'i' }],
+        [
+          'array with regex object',
+          ['noMatch', { pattern: 'HELLO', flags: 'i' }],
+        ],
+      ])(
+        'filters classes by decorator name pattern - %s',
+        async (_description, decoratorNamePattern) => {
+          await invalid({
+            errors: [
+              {
+                data: {
+                  rightGroup: 'classesWithDecoratorStartingWithHello',
+                  leftGroup: 'unknown',
+                  left: 'func',
+                  right: 'C',
+                },
+                messageId: 'unexpectedModulesGroupOrder',
+              },
+              {
+                data: { right: 'AnotherClass', left: 'C' },
+                messageId: 'unexpectedModulesOrder',
+              },
+            ],
+            options: [
+              {
+                customGroups: [
+                  {
+                    groupName: 'classesWithDecoratorStartingWithHello',
+                    decoratorNamePattern,
+                    selector: 'class',
+                  },
+                ],
+                groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
+              },
+            ],
+            output: dedent`
+              @HelloDecorator()
+              class AnotherClass {}
+
+              @HelloDecorator
+              class C {}
+
+              @Decorator
+              class A {}
+
+              class B {}
+
+              function func() {}
+            `,
+            code: dedent`
+              @Decorator
+              class A {}
+
+              class B {}
+
+              function func() {}
+
+              @HelloDecorator
+              class C {}
+
+              @HelloDecorator()
+              class AnotherClass {}
+            `,
+          })
+        },
+      )
+
+      it('filters elements using complex decorator name patterns', async () => {
         await invalid({
+          options: [
+            {
+              customGroups: [
+                {
+                  decoratorNamePattern: 'B',
+                  groupName: 'B',
+                },
+                {
+                  decoratorNamePattern: 'A',
+                  groupName: 'A',
+                },
+              ],
+              type: 'alphabetical',
+              groups: ['B', 'A'],
+              order: 'asc',
+            },
+          ],
           errors: [
             {
               data: {
-                rightGroup: 'classesWithDecoratorStartingWithHello',
+                rightGroup: 'B',
+                leftGroup: 'A',
+                right: 'B',
+                left: 'A',
+              },
+              messageId: 'unexpectedModulesGroupOrder',
+            },
+          ],
+          output: dedent`
+            @B.B()
+            class B {}
+
+            @A.A.A(() => A)
+            class A {}
+          `,
+          code: dedent`
+            @A.A.A(() => A)
+            class A {}
+
+            @B.B()
+            class B {}
+          `,
+        })
+      })
+
+      it('matches an exported decorated class by decoratorNamePattern', async () => {
+        await invalid({
+          options: [
+            {
+              ...options,
+              customGroups: [
+                {
+                  groupName: 'classesWithHelloDecorator',
+                  decoratorNamePattern: 'Hello',
+                  selector: 'class',
+                },
+              ],
+              groups: ['classesWithHelloDecorator', 'unknown'],
+            },
+          ],
+          errors: [
+            {
+              data: {
+                rightGroup: 'classesWithHelloDecorator',
                 leftGroup: 'unknown',
                 left: 'func',
                 right: 'C',
               },
               messageId: 'unexpectedModulesGroupOrder',
             },
-            {
-              data: { right: 'AnotherClass', left: 'C' },
-              messageId: 'unexpectedModulesOrder',
-            },
-          ],
-          options: [
-            {
-              customGroups: [
-                {
-                  groupName: 'classesWithDecoratorStartingWithHello',
-                  decoratorNamePattern,
-                  selector: 'class',
-                },
-              ],
-              groups: ['classesWithDecoratorStartingWithHello', 'unknown'],
-            },
           ],
           output: dedent`
-            @HelloDecorator()
-            class AnotherClass {}
-
             @HelloDecorator
-            class C {}
-
-            @Decorator
-            class A {}
-
-            class B {}
+            export class C {}
 
             function func() {}
           `,
           code: dedent`
-            @Decorator
-            class A {}
-
-            class B {}
-
             function func() {}
 
             @HelloDecorator
-            class C {}
-
-            @HelloDecorator()
-            class AnotherClass {}
+            export class C {}
           `,
         })
-      },
-    )
-
-    it('filters elements using complex decorator name patterns', async () => {
-      await invalid({
-        options: [
-          {
-            customGroups: [
-              {
-                decoratorNamePattern: 'B',
-                groupName: 'B',
-              },
-              {
-                decoratorNamePattern: 'A',
-                groupName: 'A',
-              },
-            ],
-            type: 'alphabetical',
-            groups: ['B', 'A'],
-            order: 'asc',
-          },
-        ],
-        errors: [
-          {
-            data: {
-              rightGroup: 'B',
-              leftGroup: 'A',
-              right: 'B',
-              left: 'A',
-            },
-            messageId: 'unexpectedModulesGroupOrder',
-          },
-        ],
-        output: dedent`
-          @B.B()
-          class B {}
-
-          @A.A.A(() => A)
-          class A {}
-        `,
-        code: dedent`
-          @A.A.A(() => A)
-          class A {}
-
-          @B.B()
-          class B {}
-        `,
       })
     })
 
@@ -3406,6 +3449,19 @@ describe('sort-modules', () => {
     })
 
     describe('exported decorated classes', () => {
+      it('accepts already sorted decorated exports', async () => {
+        await valid({
+          code: dedent`
+            @A
+            export class A {}
+
+            @B
+            class B {}
+          `,
+          options: [{ ...options, groups: ['unknown'] }],
+        })
+      })
+
       it('allows exported then decorated classes to be sorted', async () => {
         await invalid({
           output: dedent`

--- a/test/rules/sort-modules.test.ts
+++ b/test/rules/sort-modules.test.ts
@@ -3573,6 +3573,70 @@ describe('sort-modules', () => {
           ],
         })
       })
+
+      it('keeps a line comment attached to its exported decorated class', async () => {
+        await invalid({
+          output: dedent`
+            // doc for A1
+            @A
+            // doc for A2
+            export class A {}
+
+            // doc for B1
+            @B
+            // doc for B2
+            class B {}
+          `,
+          code: dedent`
+            // doc for B1
+            @B
+            // doc for B2
+            class B {}
+
+            // doc for A1
+            @A
+            // doc for A2
+            export class A {}
+          `,
+          errors: [
+            {
+              messageId: 'unexpectedModulesOrder',
+              data: { right: 'A', left: 'B' },
+            },
+          ],
+          options: [{ ...options, groups: ['unknown'] }],
+        })
+      })
+
+      it('keeps a JSDoc block comment attached to its exported decorated class', async () => {
+        await invalid({
+          output: dedent`
+            /** doc for A */
+            @A
+            export class A {}
+
+            /** doc for B */
+            @B
+            class B {}
+          `,
+          code: dedent`
+            /** doc for B */
+            @B
+            class B {}
+
+            /** doc for A */
+            @A
+            export class A {}
+          `,
+          errors: [
+            {
+              messageId: 'unexpectedModulesOrder',
+              data: { right: 'A', left: 'B' },
+            },
+          ],
+          options: [{ ...options, groups: ['unknown'] }],
+        })
+      })
     })
   })
 

--- a/test/utils/does-custom-group-match.test.ts
+++ b/test/utils/does-custom-group-match.test.ts
@@ -115,7 +115,7 @@ describe('does-custom-group-match', () => {
           customGroup: {
             decoratorNamePattern,
           },
-          decorators: ['foo', 'hello'],
+          decoratorNames: ['foo', 'hello'],
           elementName: '',
           modifiers: [],
           selectors: [],

--- a/types/sorting-node.ts
+++ b/types/sorting-node.ts
@@ -17,6 +17,17 @@ import type { TSESTree } from '@typescript-eslint/types'
  */
 export interface SortingNode<Node extends TSESTree.Node = TSESTree.Node> {
   /**
+   * Decorators associated with this node that are not directly accessible via
+   * the AST node's own `decorators` property.
+   *
+   * Used in contexts where decorators are tracked separately from their
+   * decorated node. When provided, these decorators override the node's own
+   * `decorators` in range calculations, ensuring they are included when the
+   * node is moved during sorting fixes.
+   */
+  implicitDecorators?: TSESTree.Decorator[]
+
+  /**
    * Indicates whether a safety semicolon should be added when the node is moved
    * inline.
    *

--- a/utils/does-custom-group-match.ts
+++ b/utils/does-custom-group-match.ts
@@ -20,7 +20,7 @@ interface DoesCustomGroupMatchParameters {
    * Optional list of decorator names applied to the element. Used for matching
    * against decoratorNamePattern in custom groups.
    */
-  decorators?: string[]
+  decoratorNames?: string[]
 
   /**
    * List of modifiers applied to the element (e.g., 'static', 'private',
@@ -100,7 +100,7 @@ interface BaseCustomGroupMatchOptions {
  *   selectors: ['property'],
  *   modifiers: ['static', 'readonly'],
  *   elementValue: null,
- *   decorators: [],
+ *   decoratorNames: [],
  * })
  * // Returns: true
  * ```
@@ -174,20 +174,20 @@ export function doesCustomGroupMatch<
  * @param params.elementValue - Optional value of the element.
  * @param params.selectors - Element's selectors.
  * @param params.modifiers - Element's modifiers.
- * @param params.decorators - Element's decorators.
+ * @param params.decoratorNames - Element's decorator names.
  * @returns True if all specified criteria match, false otherwise.
  */
 function doesSingleCustomGroupMatch({
+  decoratorNames,
   elementValue,
   customGroup,
   elementName,
-  decorators,
   selectors,
   modifiers,
 }: {
   customGroup: BaseCustomGroupMatchOptions
   elementValue?: string | null
-  decorators?: string[]
+  decoratorNames?: string[]
   selectors?: string[]
   modifiers?: string[]
   elementName: string
@@ -229,7 +229,7 @@ function doesSingleCustomGroupMatch({
     customGroup.decoratorNamePattern
   ) {
     let decoratorPattern = customGroup.decoratorNamePattern
-    let matchesDecoratorNamePattern = decorators?.some(decorator =>
+    let matchesDecoratorNamePattern = decoratorNames?.some(decorator =>
       matches(decorator, decoratorPattern),
     )
     if (!matchesDecoratorNamePattern) {

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -22,6 +22,17 @@ interface GetNodeRangeParameters {
   options?: Pick<CommonPartitionOptions, 'partitionByComment'>
 
   /**
+   * Decorators associated with this node that are not directly accessible via
+   * the AST node's own `decorators` property.
+   *
+   * Used in contexts where decorators are tracked separately from their
+   * decorated node. When provided, these decorators override the node's own
+   * `decorators` in range calculations, ensuring they are included when the
+   * node is moved during sorting fixes.
+   */
+  implicitDecorators?: TSESTree.Decorator[]
+
+  /**
    * Whether to exclude the highest-level block comment from the range. Useful
    * for preserving file-level documentation comments in their original
    * position.
@@ -89,12 +100,19 @@ interface GetNodeRangeParameters {
  */
 export function getNodeRange({
   ignoreHighestBlockComment,
+  implicitDecorators,
   sourceCode,
   options,
   node,
 }: GetNodeRangeParameters): TSESTree.Range {
   let start = node.range.at(0)!
   let end = node.range.at(1)!
+
+  let decorators =
+    implicitDecorators ?? ('decorators' in node ? node.decorators : [])
+  if (decorators[0]) {
+    start = Math.min(start, decorators[0].range[0])
+  }
 
   if (ASTUtils.isParenthesized(node, sourceCode)) {
     let bodyOpeningParen = sourceCode.getTokenBefore(
@@ -107,7 +125,7 @@ export function getNodeRange({
       ASTUtils.isClosingParenToken,
     )!
 
-    start = bodyOpeningParen.range.at(0)!
+    start = Math.min(start, bodyOpeningParen.range.at(0)!)
     end = bodyClosingParen.range.at(1)!
   }
 
@@ -158,7 +176,7 @@ export function getNodeRange({
   }
 
   if (relevantTopComment) {
-    start = relevantTopComment.range.at(0)!
+    start = Math.min(start, relevantTopComment.range.at(0)!)
   }
 
   return [start, end]

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -112,6 +112,16 @@ export function getNodeRange({
     implicitDecorators ?? ('decorators' in node ? node.decorators : [])
   if (decorators[0]) {
     start = Math.min(start, decorators[0].range[0])
+
+    let decoratorTopCommentStart = computeHighestCommentStart({
+      comments: getCommentsBefore({ node: decorators[0], sourceCode }),
+      anchorLine: decorators[0].loc.start.line,
+      ignoreHighestBlockComment,
+      options,
+    })
+    if (decoratorTopCommentStart !== undefined) {
+      start = Math.min(start, decoratorTopCommentStart)
+    }
   }
 
   if (ASTUtils.isParenthesized(node, sourceCode)) {

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -129,20 +129,35 @@ export function getNodeRange({
     end = bodyClosingParen.range.at(1)!
   }
 
-  let comments = getCommentsBefore({
-    sourceCode,
-    node,
+  let topCommentStart = computeHighestCommentStart({
+    comments: getCommentsBefore({ sourceCode, node }),
+    anchorLine: node.loc.start.line,
+    ignoreHighestBlockComment,
+    options,
   })
-  let highestBlockComment = comments.find(comment => comment.type === 'Block')
+  if (topCommentStart !== undefined) {
+    start = Math.min(start, topCommentStart)
+  }
 
-  /**
-   * Iterate on all comments starting from the bottom until we reach the last of
-   * the comments, a newline between comments, a partition comment, or a
-   * eslint-disable comment.
-   */
-  let relevantTopComment: TSESTree.Comment | undefined
+  return [start, end]
+}
+
+function computeHighestCommentStart({
+  ignoreHighestBlockComment,
+  anchorLine,
+  comments,
+  options,
+}: Pick<GetNodeRangeParameters, 'ignoreHighestBlockComment' | 'options'> & {
+  comments: TSESTree.Comment[]
+  anchorLine: number
+}): undefined | number {
+  let highestBlockComment = comments.find(comment => comment.type === 'Block')
+  let highestCommentStart: undefined | number
   for (let i = comments.length - 1; i >= 0; i--) {
     let comment = comments[i]!
+    if (ignoreHighestBlockComment && comment === highestBlockComment) {
+      break
+    }
 
     let eslintDisabledRules = getEslintDisabledRules(comment.value)
     if (
@@ -160,24 +175,13 @@ export function getNodeRange({
      * Check for newlines between comments or between the first comment and the
      * node.
      */
-    let previousCommentOrNodeStartLine =
-      i === comments.length - 1 ?
-        node.loc.start.line
-      : comments[i + 1]!.loc.start.line
-    if (comment.loc.end.line !== previousCommentOrNodeStartLine - 1) {
+    let previousCommentOrAnchorLine =
+      i === comments.length - 1 ? anchorLine : comments[i + 1]!.loc.start.line
+    if (comment.loc.end.line !== previousCommentOrAnchorLine - 1) {
       break
     }
 
-    if (ignoreHighestBlockComment && comment === highestBlockComment) {
-      break
-    }
-
-    relevantTopComment = comment
+    highestCommentStart = comment.range.at(0)
   }
-
-  if (relevantTopComment) {
-    start = Math.min(start, relevantTopComment.range.at(0)!)
-  }
-
-  return [start, end]
+  return highestCommentStart
 }

--- a/utils/make-order-fixes.ts
+++ b/utils/make-order-fixes.ts
@@ -97,7 +97,7 @@ export function makeOrderFixes({
   for (let max = nodes.length, i = 0; i < max; i++) {
     let sortingNode = nodes.at(i)!
     let sortedSortingNode = sortedNodes.at(i)!
-    let { node } = sortingNode
+    let { implicitDecorators, node } = sortingNode
     let { addSafetySemicolonWhenInline, node: sortedNode } = sortedSortingNode
     let isNodeFirstNode = node === nodes.at(0)!.node
     let isSortedNodeFirstNode = sortedNode === nodes.at(0)!.node
@@ -110,6 +110,7 @@ export function makeOrderFixes({
       ...getNodeRange({
         ignoreHighestBlockComment:
           ignoreFirstNodeHighestBlockComment && isSortedNodeFirstNode,
+        implicitDecorators: sortedSortingNode.implicitDecorators,
         node: sortedNode,
         sourceCode,
         options,
@@ -141,6 +142,7 @@ export function makeOrderFixes({
         getNodeRange({
           ignoreHighestBlockComment:
             ignoreFirstNodeHighestBlockComment && isNodeFirstNode,
+          implicitDecorators,
           sourceCode,
           options,
           node,


### PR DESCRIPTION
- Related issues:
  - https://github.com/azat-io/eslint-plugin-perfectionist/issues/376
  - https://github.com/azat-io/eslint-plugin-perfectionist/pull/675 

## Description

ESLint's parser doesn't seem to detect (https://github.com/estree/estree/issues/315) the decorator ranges correctly with the following syntax:

### Code example

```ts
class B {}

@A
export class A {}
```

This will result in

```ts
export class A {}

@A
class B {}
```

Because of that, decorated and exported classes are not sorted in `sort-modules`.

Support of this is necessary for the upcoming [`sort-constructor-parameters`](https://github.com/azat-io/eslint-plugin-perfectionist/pull/738), as a similar issue exists here with parameter decorators.

The idea is to allow rules to pass an `implicitDecorators` field to `SortingNode`, referencing decorators that are not directly associated with the evaluated node.

When `implicitDecorators` are passed, we examine the first of these decorators and adjust the permutation range when sorting nodes.