### PR TITLE
fix(sort-arrays): add missing `minItems: 1`

### DIFF
--- a/rules/sort-arrays.ts
+++ b/rules/sort-arrays.ts
@@ -82,6 +82,7 @@ let jsonSchema: JSONSchema4 = {
   },
   uniqueItems: true,
   type: 'array',
+  minItems: 1,
 }
 
 export default createEslintRule<Options, MessageId>({

--- a/test/rules/sort-arrays.test.ts
+++ b/test/rules/sort-arrays.test.ts
@@ -5980,10 +5980,12 @@ describe('sort-arrays', () => {
 
     it('handles empty arrays and single-element arrays', async () => {
       await valid({
+        options: [options],
         code: '[]',
       })
 
       await valid({
+        options: [options],
         code: "['a']",
       })
     })


### PR DESCRIPTION
# Description

`sort-arrays` requires the user to pass an explicit `useConfigurationIf` object to avoid accidently sorting arrays.

- ✅ If an options object is passed, `useConfigurationIf` is required and enforced.
- 💥 If no options object is passed, the configuration is accepted and all arrays are sorted.

## Bug severity

Very low:
- The rule is disabled by default, so this case can only happen when a user explicitly activates the rule without any option.
- All arrays would be immediately sorted, which would make this bug very visible. Users that experienced it likely reverted their changes and/or updated their configuration.

## The fix

Enforce at least one options object to be passed.