### PR TITLE
fix(sort-switch-case): skip condition-shaped switch statements

### DIFF
--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -29,6 +29,19 @@ const ORDER_ERROR_ID = 'unexpectedSwitchCaseOrder'
 
 type MessageId = typeof ORDER_ERROR_ID
 
+let conditionOperators = new Set<string>([
+  'instanceof',
+  '===',
+  '!==',
+  '==',
+  '!=',
+  '<=',
+  '>=',
+  'in',
+  '<',
+  '>',
+])
+
 let defaultOptions: Required<Options[number]> = {
   fallbackSort: { type: 'unsorted' },
   specialCharacters: 'keep',
@@ -54,10 +67,13 @@ export default createEslintRule<Options, MessageId>({
       validateCustomSortConfiguration(options)
 
       let { sourceCode } = context
-      let isDiscriminantTrue =
-        switchNode.discriminant.type === AST_NODE_TYPES.Literal &&
-        switchNode.discriminant.value === true
-      if (isDiscriminantTrue) {
+      let isConditionCaseSwitch =
+        isConditionExpression(switchNode.discriminant) ||
+        switchNode.cases.some(
+          caseNode =>
+            caseNode.test !== null && isConditionExpression(caseNode.test),
+        )
+      if (isConditionCaseSwitch) {
         return
       }
 
@@ -322,6 +338,32 @@ function reduceCaseSortingNodes(
     },
     [[]],
   )
+}
+
+/**
+ * Checks if an expression is condition-shaped.
+ *
+ * Condition-shaped expressions produce boolean values: boolean literals,
+ * logical negations, comparison binary expressions and logical expressions.
+ * Switch statements built on such expressions (e.g. `switch (true)`) encode
+ * their program logic in the case order, so sorting them is unsafe.
+ *
+ * @param node - The expression AST node to check.
+ * @returns True if the expression is condition-shaped.
+ */
+function isConditionExpression(node: TSESTree.Expression): boolean {
+  switch (node.type) {
+    case AST_NODE_TYPES.LogicalExpression:
+      return true
+    case AST_NODE_TYPES.BinaryExpression:
+      return conditionOperators.has(node.operator)
+    case AST_NODE_TYPES.UnaryExpression:
+      return node.operator === '!'
+    case AST_NODE_TYPES.Literal:
+      return typeof node.value === 'boolean'
+    default:
+      return false
+  }
 }
 
 /**

--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -10,6 +10,7 @@ import { defaultComparatorByOptionsComputer } from '../utils/compare/default-com
 import { makeSingleNodeCommentAfterFixes } from '../utils/make-single-node-comment-after-fixes'
 import { validateCustomSortConfiguration } from '../utils/validate-custom-sort-configuration'
 import { buildCommonJsonSchemas } from '../utils/json-schemas/common-json-schemas'
+import { isConditionExpression } from './sort-switch-case/is-condition-expression'
 import { reportErrors, ORDER_ERROR, RIGHT, LEFT } from '../utils/report-errors'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
 import { createEslintRule } from '../utils/create-eslint-rule'
@@ -28,19 +29,6 @@ interface SortSwitchCaseSortingNode extends SortingNode<TSESTree.SwitchCase> {
 const ORDER_ERROR_ID = 'unexpectedSwitchCaseOrder'
 
 type MessageId = typeof ORDER_ERROR_ID
-
-let conditionOperators = new Set<string>([
-  'instanceof',
-  '===',
-  '!==',
-  '==',
-  '!=',
-  '<=',
-  '>=',
-  'in',
-  '<',
-  '>',
-])
 
 let defaultOptions: Required<Options[number]> = {
   fallbackSort: { type: 'unsorted' },
@@ -338,32 +326,6 @@ function reduceCaseSortingNodes(
     },
     [[]],
   )
-}
-
-/**
- * Checks if an expression is condition-shaped.
- *
- * Condition-shaped expressions produce boolean values: boolean literals,
- * logical negations, comparison binary expressions and logical expressions.
- * Switch statements built on such expressions (e.g. `switch (true)`) encode
- * their program logic in the case order, so sorting them is unsafe.
- *
- * @param node - The expression AST node to check.
- * @returns True if the expression is condition-shaped.
- */
-function isConditionExpression(node: TSESTree.Expression): boolean {
-  switch (node.type) {
-    case AST_NODE_TYPES.LogicalExpression:
-      return true
-    case AST_NODE_TYPES.BinaryExpression:
-      return conditionOperators.has(node.operator)
-    case AST_NODE_TYPES.UnaryExpression:
-      return node.operator === '!'
-    case AST_NODE_TYPES.Literal:
-      return typeof node.value === 'boolean'
-    default:
-      return false
-  }
 }
 
 /**

--- a/rules/sort-switch-case/is-condition-expression.ts
+++ b/rules/sort-switch-case/is-condition-expression.ts
@@ -1,0 +1,28 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
+/**
+ * Checks if an expression is condition-shaped.
+ *
+ * Condition-shaped expressions are boolean literals, logical negations, binary
+ * expressions and logical expressions. Switch statements built on such
+ * expressions (e.g. `switch (true)`) encode their program logic in the case
+ * order, so sorting them is unsafe.
+ *
+ * @param node - The expression AST node to check.
+ * @returns True if the expression is condition-shaped.
+ */
+export function isConditionExpression(node: TSESTree.Expression): boolean {
+  switch (node.type) {
+    case AST_NODE_TYPES.LogicalExpression:
+    case AST_NODE_TYPES.BinaryExpression:
+      return true
+    case AST_NODE_TYPES.UnaryExpression:
+      return node.operator === '!'
+    case AST_NODE_TYPES.Literal:
+      return typeof node.value === 'boolean'
+    default:
+      return false
+  }
+}

--- a/test/rules/sort-switch-case.test.ts
+++ b/test/rules/sort-switch-case.test.ts
@@ -1012,6 +1012,40 @@ describe('sort-switch-case', () => {
         options: [{}],
       })
     })
+
+    it('keeps autofix even when reordered cases may match the same value', async () => {
+      await invalid({
+        output: dedent`
+          const bb = 1
+          const aaa = 1
+          function f(x) {
+            switch (x) {
+              case aaa: return 'a'
+              case bb: return 'b'
+              default: return 'd'
+            }
+          }
+        `,
+        code: dedent`
+          const bb = 1
+          const aaa = 1
+          function f(x) {
+            switch (x) {
+              case bb: return 'b'
+              case aaa: return 'a'
+              default: return 'd'
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        options: [options],
+      })
+    })
   })
 
   describe('natural', () => {
@@ -1998,6 +2032,40 @@ describe('sort-switch-case', () => {
           }
         `,
         options: [{}],
+      })
+    })
+
+    it('keeps autofix even when reordered cases may match the same value', async () => {
+      await invalid({
+        output: dedent`
+          const bb = 1
+          const aaa = 1
+          function f(x) {
+            switch (x) {
+              case aaa: return 'a'
+              case bb: return 'b'
+              default: return 'd'
+            }
+          }
+        `,
+        code: dedent`
+          const bb = 1
+          const aaa = 1
+          function f(x) {
+            switch (x) {
+              case bb: return 'b'
+              case aaa: return 'a'
+              default: return 'd'
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        options: [options],
       })
     })
   })
@@ -2988,6 +3056,100 @@ describe('sort-switch-case', () => {
         options: [{}],
       })
     })
+
+    it('keeps autofix even when reordered cases may match the same value', async () => {
+      await invalid({
+        output: dedent`
+          const bb = 1
+          const aaa = 1
+          function f(x) {
+            switch (x) {
+              case aaa: return 'a'
+              case bb: return 'b'
+              default: return 'd'
+            }
+          }
+        `,
+        code: dedent`
+          const bb = 1
+          const aaa = 1
+          function f(x) {
+            switch (x) {
+              case bb: return 'b'
+              case aaa: return 'a'
+              default: return 'd'
+            }
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: { right: 'aaa', left: 'bb' },
+          },
+        ],
+        options: [options],
+      })
+    })
+
+    it('keeps autofix even when literals share the same runtime value', async () => {
+      await invalid({
+        output: dedent`
+          switch (x) {
+            case 0x61:
+              break
+            case 97:
+              break
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: { right: '97', left: '97' },
+          },
+        ],
+        code: dedent`
+          switch (x) {
+            case 97:
+              break
+            case 0x61:
+              break
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('keeps autofix for unary numeric literal cases', async () => {
+      await invalid({
+        output: dedent`
+          switch (x) {
+            case -2:
+              break
+            case +3:
+              break
+            case 1:
+              break
+          }
+        `,
+        code: dedent`
+          switch (x) {
+            case 1:
+              break
+            case -2:
+              break
+            case +3:
+              break
+          }
+        `,
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: { right: '-2', left: '1' },
+          },
+        ],
+        options: [options],
+      })
+    })
   })
 
   describe('custom', () => {
@@ -3270,6 +3432,106 @@ describe('sort-switch-case', () => {
         `,
         options: [{ type: 'alphabetical', order: 'asc' }],
         settings,
+      })
+    })
+
+    describe('condition-shaped switches', () => {
+      it('not works if discriminant and case tests are comparisons', async () => {
+        await valid({
+          code: dedent`
+            const b = 10
+            const a = 2
+            function f(x) {
+              switch (x > 0) {
+                case b > 5: return 'b'
+                case a > 1: return 'a'
+                default: return 'd'
+              }
+            }
+          `,
+        })
+      })
+
+      it('not works if discriminant is a boolean literal, negation or equality check', async () => {
+        await valid({
+          code: dedent`
+            switch (false) {
+              case name === 'bb':
+                return 'b'
+              case name === 'aaa':
+                return 'a'
+            }
+          `,
+        })
+
+        await valid({
+          code: dedent`
+            switch (!!x) {
+              case b > 5:
+                return 'b'
+              case a > 1:
+                return 'a'
+            }
+          `,
+        })
+
+        await valid({
+          code: dedent`
+            switch (x === y) {
+              case 'b':
+                return 'b'
+              case 'a':
+                return 'a'
+            }
+          `,
+        })
+      })
+
+      it('not works if case tests are conditions', async () => {
+        await valid({
+          code: dedent`
+            switch (someBool) {
+              case b > 5: return 'b'
+              case a > 1: return 'a'
+              default: return 'd'
+            }
+          `,
+        })
+      })
+
+      it('not works if discriminant is a logical or relational expression', async () => {
+        await valid({
+          code: dedent`
+            switch (a && b) {
+              case 'b':
+                return 'b'
+              case 'a':
+                return 'a'
+            }
+          `,
+        })
+
+        await valid({
+          code: dedent`
+            switch (key in object) {
+              case 'b':
+                return 'b'
+              case 'a':
+                return 'a'
+            }
+          `,
+        })
+
+        await valid({
+          code: dedent`
+            switch (value instanceof Error) {
+              case 'b':
+                return 'b'
+              case 'a':
+                return 'a'
+            }
+          `,
+        })
       })
     })
 

--- a/test/rules/sort-switch-case.test.ts
+++ b/test/rules/sort-switch-case.test.ts
@@ -1013,7 +1013,7 @@ describe('sort-switch-case', () => {
       })
     })
 
-    it('keeps autofix even when reordered cases may match the same value', async () => {
+    it('sorts even when reordered cases may match the same value', async () => {
       await invalid({
         output: dedent`
           const bb = 1
@@ -2035,7 +2035,7 @@ describe('sort-switch-case', () => {
       })
     })
 
-    it('keeps autofix even when reordered cases may match the same value', async () => {
+    it('sorts even when reordered cases may match the same value', async () => {
       await invalid({
         output: dedent`
           const bb = 1
@@ -3057,7 +3057,7 @@ describe('sort-switch-case', () => {
       })
     })
 
-    it('keeps autofix even when reordered cases may match the same value', async () => {
+    it('sorts even when reordered cases may match the same value', async () => {
       await invalid({
         output: dedent`
           const bb = 1
@@ -3091,7 +3091,7 @@ describe('sort-switch-case', () => {
       })
     })
 
-    it('keeps autofix even when literals share the same runtime value', async () => {
+    it('sorts even when literals share the same runtime value', async () => {
       await invalid({
         output: dedent`
           switch (x) {
@@ -3119,7 +3119,7 @@ describe('sort-switch-case', () => {
       })
     })
 
-    it('keeps autofix for unary numeric literal cases', async () => {
+    it('sorts unary numeric literal cases', async () => {
       await invalid({
         output: dedent`
           switch (x) {
@@ -3436,7 +3436,7 @@ describe('sort-switch-case', () => {
     })
 
     describe('condition-shaped switches', () => {
-      it('not works if discriminant and case tests are comparisons', async () => {
+      it('does not sort switches where discriminant and case tests are comparisons', async () => {
         await valid({
           code: dedent`
             const b = 10
@@ -3452,7 +3452,7 @@ describe('sort-switch-case', () => {
         })
       })
 
-      it('not works if discriminant is a boolean literal, negation or equality check', async () => {
+      it('does not sort switches where discriminant is a boolean literal, negation or equality check', async () => {
         await valid({
           code: dedent`
             switch (false) {
@@ -3487,7 +3487,7 @@ describe('sort-switch-case', () => {
         })
       })
 
-      it('not works if case tests are conditions', async () => {
+      it('does not sort switches where case tests are conditions', async () => {
         await valid({
           code: dedent`
             switch (someBool) {
@@ -3499,7 +3499,7 @@ describe('sort-switch-case', () => {
         })
       })
 
-      it('not works if discriminant is a logical or relational expression', async () => {
+      it('does not sort switches where discriminant is a logical or binary expression', async () => {
         await valid({
           code: dedent`
             switch (a && b) {
@@ -3525,6 +3525,17 @@ describe('sort-switch-case', () => {
         await valid({
           code: dedent`
             switch (value instanceof Error) {
+              case 'b':
+                return 'b'
+              case 'a':
+                return 'a'
+            }
+          `,
+        })
+
+        await valid({
+          code: dedent`
+            switch (a + b) {
               case 'b':
                 return 'b'
               case 'a':


### PR DESCRIPTION
### Description

Switches whose discriminant or any case test is condition-shaped (boolean literal, negation, comparison, or logical expression) are no longer sorted or reported: there the case order is the program logic, because the first matching case wins.

Example:

```js
function grade(score) {
  switch (true) {
    case score >= 90: return 'A';
    case score >= 80: return 'B';
  }
  return 'C';
}

function gradeSorted(score) { // 'score >= 80' < 'score >= 90'
  switch (true) {
    case score >= 80: return 'B';
    case score >= 90: return 'A';
  }
  return 'C';
}

console.log(grade(95));       // 'A'
console.log(gradeSorted(95)); // 'B' 
```

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
