### PR TITLE
fix: prevent reordering members with equal runtime keys

### DIFF
--- a/cspell.config.ts
+++ b/cspell.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     'pcss',
     'playform',
     'poppanator',
+    'quasis',
     'rehype',
     'renminbi',
     'shiki',

--- a/rules/sort-jsx-props/sort-jsx-object.ts
+++ b/rules/sort-jsx-props/sort-jsx-object.ts
@@ -19,6 +19,8 @@ import { defaultComparatorByOptionsComputer } from '../../utils/compare/default-
 import { buildOptionsByGroupIndexComputer } from '../../utils/build-options-by-group-index-computer'
 import { validateCustomSortConfiguration } from '../../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../../utils/validate-groups-configuration'
+import { computeCollidingNodeGroups } from '../../utils/compute-colliding-node-groups'
+import { restoreCollidingNodesOrder } from '../../utils/restore-colliding-nodes-order'
 import { generatePredefinedGroups } from '../../utils/generate-predefined-groups'
 import { computeMatchedContextOptions } from './compute-matched-context-options'
 import { getEslintDisabledLines } from '../../utils/get-eslint-disabled-lines'
@@ -172,12 +174,19 @@ export function sortJsxObject({
   for (let currentNodes of formattedMembers) {
     function createSortNodesExcludingEslintDisabled(nodes: SortingNode[]) {
       return function (ignoreEslintDisabledNodes: boolean): SortingNode[] {
-        return sortNodesByGroups({
-          comparatorByOptionsComputer: defaultComparatorByOptionsComputer,
-          optionsByGroupIndexComputer,
-          ignoreEslintDisabledNodes,
-          groups: options.groups,
-          nodes,
+        return restoreCollidingNodesOrder({
+          sortedNodes: sortNodesByGroups({
+            comparatorByOptionsComputer: defaultComparatorByOptionsComputer,
+            optionsByGroupIndexComputer,
+            ignoreEslintDisabledNodes,
+            groups: options.groups,
+            nodes,
+          }),
+          collidingNodeGroups: computeCollidingNodeGroups({
+            computeCollisionKey: ({ name }) => name,
+            ignoreEslintDisabledNodes,
+            nodes,
+          }),
         })
       }
     }

--- a/rules/sort-maps/compute-collision-key.ts
+++ b/rules/sort-maps/compute-collision-key.ts
@@ -1,0 +1,61 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
+import { computeStaticKeyValue } from '../../utils/compute-static-key-value'
+
+/**
+ * Computes the collision key of a Map element for duplicate-key detection.
+ *
+ * For array expressions (key-value pairs), the runtime Map key is the first
+ * element. Statically-known keys are tagged with their type so that entries
+ * such as `16` and `0x10` collide while `16` and `'16'` do not, matching
+ * SameValueZero key equality. Dynamic keys collide only on identical source
+ * text. Elements that are not key-value pairs return null.
+ *
+ * @param params - Parameters object.
+ * @param params.sourceCode - The ESLint source code object.
+ * @param params.node - The Map element expression.
+ * @returns The collision key, or null when the element has no detectable key.
+ */
+export function computeCollisionKey({
+  sourceCode,
+  node,
+}: {
+  sourceCode: TSESLint.SourceCode
+  node: TSESTree.Expression
+}): string | null {
+  if (node.type !== AST_NODE_TYPES.ArrayExpression) {
+    return null
+  }
+
+  let [left] = node.elements
+
+  if (!left) {
+    return computeStaticValueCollisionKey(undefined)
+  }
+
+  if (left.type !== AST_NODE_TYPES.SpreadElement) {
+    let staticKeyValue = computeStaticKeyValue(left)
+    if (staticKeyValue) {
+      return computeStaticValueCollisionKey(staticKeyValue.value)
+    }
+  }
+
+  return `text:${sourceCode.getText(left)}`
+}
+
+/**
+ * Builds the collision key of a statically-known Map key value.
+ *
+ * The value is tagged with its type so that keys equal under SameValueZero
+ * collide (an omitted key and `void 0` both produce the `undefined` key) while
+ * keys of different types such as `16` and `'16'` do not.
+ *
+ * @param value - Statically-known runtime key value.
+ * @returns The type-tagged collision key shared by all spellings of the value.
+ */
+function computeStaticValueCollisionKey(value: unknown): string {
+  return `value:${typeof value}:${String(value)}`
+}

--- a/rules/sort-maps/sort-potential-map.ts
+++ b/rules/sort-maps/sort-potential-map.ts
@@ -16,6 +16,8 @@ import { defaultComparatorByOptionsComputer } from '../../utils/compare/default-
 import { buildOptionsByGroupIndexComputer } from '../../utils/build-options-by-group-index-computer'
 import { validateCustomSortConfiguration } from '../../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../../utils/validate-groups-configuration'
+import { computeCollidingNodeGroups } from '../../utils/compute-colliding-node-groups'
+import { restoreCollidingNodesOrder } from '../../utils/restore-colliding-nodes-order'
 import { computeMatchedContextOptions } from './compute-matched-context-options'
 import { getEslintDisabledLines } from '../../utils/get-eslint-disabled-lines'
 import { doesCustomGroupMatch } from '../../utils/does-custom-group-match'
@@ -23,6 +25,7 @@ import { isNodeEslintDisabled } from '../../utils/is-node-eslint-disabled'
 import { sortNodesByGroups } from '../../utils/sort-nodes-by-groups'
 import { reportAllErrors } from '../../utils/report-all-errors'
 import { shouldPartition } from '../../utils/should-partition'
+import { computeCollisionKey } from './compute-collision-key'
 import { computeGroup } from '../../utils/compute-group'
 import { rangeToDiff } from '../../utils/range-to-diff'
 import { getSettings } from '../../utils/get-settings'
@@ -158,12 +161,23 @@ export function sortPotentialMap({
         sortingNodes: SortingNode[],
       ) {
         return function (ignoreEslintDisabledNodes: boolean): SortingNode[] {
-          return sortNodesByGroups({
-            comparatorByOptionsComputer: defaultComparatorByOptionsComputer,
-            optionsByGroupIndexComputer,
-            ignoreEslintDisabledNodes,
-            groups: options.groups,
-            nodes: sortingNodes,
+          return restoreCollidingNodesOrder({
+            collidingNodeGroups: computeCollidingNodeGroups({
+              computeCollisionKey: sortingNode =>
+                computeCollisionKey({
+                  node: sortingNode.node as TSESTree.Expression,
+                  sourceCode,
+                }),
+              ignoreEslintDisabledNodes,
+              nodes: sortingNodes,
+            }),
+            sortedNodes: sortNodesByGroups({
+              comparatorByOptionsComputer: defaultComparatorByOptionsComputer,
+              optionsByGroupIndexComputer,
+              ignoreEslintDisabledNodes,
+              groups: options.groups,
+              nodes: sortingNodes,
+            }),
           })
         }
       }

--- a/rules/sort-objects/compute-colliding-node-groups.ts
+++ b/rules/sort-objects/compute-colliding-node-groups.ts
@@ -1,0 +1,100 @@
+import type { TSESTree } from '@typescript-eslint/types'
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
+import type { SortObjectsSortingNode } from './types'
+
+import { computeCollidingNodeGroups } from '../../utils/compute-colliding-node-groups'
+import { computeStaticKeyValue } from '../../utils/compute-static-key-value'
+
+/**
+ * Computes groups of object members whose keys collide at runtime.
+ *
+ * Object property keys are normalized to property-key strings: non-computed
+ * keys use the identifier name or the stringified literal value, computed keys
+ * with statically-known values normalize the same way, and dynamic computed
+ * keys collide only on identical source text.
+ *
+ * Accessor exception: a lone get/set pair with the same key is not a collision
+ * (defining them in either order yields the same combined accessor). However,
+ * an accessor together with a data property or method, two getters, or two
+ * setters do collide.
+ *
+ * @param params - Parameters.
+ * @param params.nodes - Object members in source order.
+ * @param params.ignoreEslintDisabledNodes - Whether to exclude ESLint-disabled
+ *   members from collision groups.
+ * @param params.sourceCode - The source code object.
+ * @returns Groups of colliding members in source order.
+ */
+export function computeObjectsCollidingNodeGroups({
+  ignoreEslintDisabledNodes,
+  sourceCode,
+  nodes,
+}: {
+  ignoreEslintDisabledNodes: boolean
+  nodes: SortObjectsSortingNode[]
+  sourceCode: TSESLint.SourceCode
+}): SortObjectsSortingNode[][] {
+  return computeCollidingNodeGroups({
+    computeCollisionKey: ({ node }) =>
+      computeCollisionKey({ property: node, sourceCode }),
+    ignoreEslintDisabledNodes,
+    nodes,
+  }).flatMap(splitCollidingNodeGroupByAccessors)
+}
+
+/**
+ * Computes the collision key of an object member as a normalized property-key
+ * string.
+ *
+ * @param params - Parameters.
+ * @param params.property - The property to compute the collision key for.
+ * @param params.sourceCode - The source code object.
+ * @returns The collision key of the property.
+ */
+function computeCollisionKey({
+  sourceCode,
+  property,
+}: {
+  sourceCode: TSESLint.SourceCode
+  property: TSESTree.Property
+}): string {
+  if (property.computed) {
+    let staticKeyValue = computeStaticKeyValue(property.key)
+    return staticKeyValue ?
+        `key:${String(staticKeyValue.value)}`
+      : `text:${sourceCode.getText(property.key)}`
+  }
+  switch (property.key.type) {
+    case AST_NODE_TYPES.Identifier:
+      return `key:${property.key.name}`
+    case AST_NODE_TYPES.Literal:
+      return `key:${String(property.key.value)}`
+    /* v8 ignore next 2 -- @preserve Non-computed keys are identifiers or literals. */
+    default:
+      return `text:${sourceCode.getText(property.key)}`
+  }
+}
+
+/**
+ * Splits a colliding node group according to the accessor exception.
+ *
+ * A group containing a data property or method collides as a whole. A group
+ * consisting only of accessors collides per accessor kind: two or more getters
+ * collide, two or more setters collide, and a lone get/set pair does not.
+ *
+ * @param collidingNodeGroup - Group of members with the same collision key.
+ * @returns Groups of members that must keep their source order.
+ */
+function splitCollidingNodeGroupByAccessors(
+  collidingNodeGroup: SortObjectsSortingNode[],
+): SortObjectsSortingNode[][] {
+  let getters = collidingNodeGroup.filter(({ node }) => node.kind === 'get')
+  let setters = collidingNodeGroup.filter(({ node }) => node.kind === 'set')
+  if (getters.length + setters.length < collidingNodeGroup.length) {
+    return [collidingNodeGroup]
+  }
+  return [getters, setters].filter(accessors => accessors.length >= 2)
+}

--- a/rules/sort-objects/sort-object.ts
+++ b/rules/sort-objects/sort-object.ts
@@ -27,6 +27,8 @@ import { computePropertyOrVariableDeclaratorName } from './compute-property-or-v
 import { buildOptionsByGroupIndexComputer } from '../../utils/build-options-by-group-index-computer'
 import { validateCustomSortConfiguration } from '../../utils/validate-custom-sort-configuration'
 import { validateGroupsConfiguration } from '../../utils/validate-groups-configuration'
+import { restoreCollidingNodesOrder } from '../../utils/restore-colliding-nodes-order'
+import { computeObjectsCollidingNodeGroups } from './compute-colliding-node-groups'
 import { generatePredefinedGroups } from '../../utils/generate-predefined-groups'
 import { computeMatchedContextOptions } from './compute-matched-context-options'
 import { sortNodesByDependencies } from '../../utils/sort-nodes-by-dependencies'
@@ -261,8 +263,21 @@ export function sortObject({
       }),
     )
 
-    return sortNodesByDependencies(nodesSortedByGroups, {
+    let sortedNodes = sortNodesByDependencies(nodesSortedByGroups, {
       ignoreEslintDisabledNodes,
+    })
+
+    if (isDestructuredObject) {
+      return sortedNodes
+    }
+
+    return restoreCollidingNodesOrder({
+      collidingNodeGroups: computeObjectsCollidingNodeGroups({
+        ignoreEslintDisabledNodes,
+        nodes: sortingNodes,
+        sourceCode,
+      }),
+      sortedNodes,
     })
   }
 }

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1747,6 +1747,62 @@ describe('sort-jsx-props', () => {
         })
       })
     })
+
+    describe('duplicate props', () => {
+      it('preserves source order of duplicate props', async () => {
+        await valid({
+          code: dedent`
+            let v = 2; let x = <A a={v} a />
+          `,
+          options: [{ ...options, groups: ['shorthand-prop', 'unknown'] }],
+        })
+      })
+
+      it('keeps duplicate props in source order while sorting other props', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedJSXPropsOrder',
+              data: { right: 'bb', left: 'b' },
+            },
+          ],
+          output: dedent`
+            let v = 2; let x = <A b={v} bb b />
+          `,
+          code: dedent`
+            let v = 2; let x = <A b={v} b bb />
+          `,
+          options: [{ ...options, groups: ['shorthand-prop', 'unknown'] }],
+        })
+      })
+
+      it('sorts duplicate props split by a spread element independently', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedJSXPropsOrder',
+              data: { right: 'a', left: 'c' },
+            },
+          ],
+          output: dedent`
+            let x = <A a c {...s} c />
+          `,
+          code: dedent`
+            let x = <A c a {...s} c />
+          `,
+          options: [options],
+        })
+      })
+
+      it('preserves source order of duplicate namespaced props', async () => {
+        await valid({
+          code: dedent`
+            let v = 2; let x = <A ns:a={v} ns:a />
+          `,
+          options: [{ ...options, groups: ['shorthand-prop', 'unknown'] }],
+        })
+      })
+    })
   })
 
   describe('natural', () => {
@@ -2998,6 +3054,62 @@ describe('sort-jsx-props', () => {
         })
       },
     )
+
+    describe('duplicate props', () => {
+      it('preserves source order of duplicate props', async () => {
+        await valid({
+          code: dedent`
+            let v = 2; let x = <A a={v} a />
+          `,
+          options: [{ ...options, groups: ['shorthand-prop', 'unknown'] }],
+        })
+      })
+
+      it('keeps duplicate props in source order while sorting other props', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedJSXPropsOrder',
+              data: { right: 'bb', left: 'b' },
+            },
+          ],
+          output: dedent`
+            let v = 2; let x = <A b={v} bb b />
+          `,
+          code: dedent`
+            let v = 2; let x = <A b={v} b bb />
+          `,
+          options: [{ ...options, groups: ['shorthand-prop', 'unknown'] }],
+        })
+      })
+
+      it('sorts duplicate props split by a spread element independently', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedJSXPropsOrder',
+              data: { right: 'a', left: 'c' },
+            },
+          ],
+          output: dedent`
+            let x = <A a c {...s} c />
+          `,
+          code: dedent`
+            let x = <A c a {...s} c />
+          `,
+          options: [options],
+        })
+      })
+
+      it('preserves source order of duplicate namespaced props', async () => {
+        await valid({
+          code: dedent`
+            let v = 2; let x = <A ns:a={v} ns:a />
+          `,
+          options: [{ ...options, groups: ['shorthand-prop', 'unknown'] }],
+        })
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4252,6 +4364,62 @@ describe('sort-jsx-props', () => {
         })
       },
     )
+
+    describe('duplicate props', () => {
+      it('preserves source order of duplicate props', async () => {
+        await valid({
+          code: dedent`
+            let long = 2; let x = <A a a={long} />
+          `,
+          options: [options],
+        })
+      })
+
+      it('keeps duplicate props in source order while sorting other props', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedJSXPropsOrder',
+              data: { right: 'bb', left: 'b' },
+            },
+          ],
+          output: dedent`
+            let v = 2; let x = <A bb b={v} b />
+          `,
+          code: dedent`
+            let v = 2; let x = <A b={v} b bb />
+          `,
+          options: [{ ...options, groups: ['shorthand-prop', 'unknown'] }],
+        })
+      })
+
+      it('sorts duplicate props split by a spread element independently', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedJSXPropsOrder',
+              data: { right: 'aa', left: 'c' },
+            },
+          ],
+          output: dedent`
+            let x = <A aa c {...s} c />
+          `,
+          code: dedent`
+            let x = <A c aa {...s} c />
+          `,
+          options: [options],
+        })
+      })
+
+      it('preserves source order of duplicate namespaced props', async () => {
+        await valid({
+          code: dedent`
+            let v = 2; let x = <A ns:a ns:a={v} />
+          `,
+          options: [options],
+        })
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1843,6 +1843,103 @@ describe('sort-maps', () => {
         })
       })
     })
+
+    describe('duplicate runtime keys', () => {
+      it('keeps source order for numeric keys with equal runtime values', async () => {
+        await valid({
+          code: "let m = new Map([[16, 'sixteen'], [0x10, 'hex']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[-1, 'aa'], [-0x1, 'b']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[16n, 'bb'], [0x10n, 'a']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[-16n, 'bb'], [-0x10n, 'a']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[1, 'xxxxxxxxxx'], [+1, 'y']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for entries with omitted keys', async () => {
+        await valid({
+          code: "new Map([[void 0, 'x'], [, 'y']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for undefined keys spelled differently', async () => {
+        await valid({
+          code: "new Map([[void 0, 'xxxxxxxxxx'], [undefined, 'y']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[void x, 'xxxxxxxxxx'], [undefined, 'y']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for string and template keys with equal cooked values', async () => {
+        await valid({
+          code: "new Map([[`a`, 'tpl'], ['a', 'str']])",
+          options: [options],
+        })
+      })
+
+      it('sorts remaining entries around keys with equal runtime values', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { left: '0x10', right: '1' },
+            },
+          ],
+          output: "new Map([[16, 'a'], [1, 'b'], [0x10, 'c']])",
+          code: "new Map([[16, 'a'], [0x10, 'c'], [1, 'b']])",
+          options: [options],
+        })
+      })
+
+      it('distinguishes numeric keys from string keys with the same text', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { right: "'16'", left: '16' },
+            },
+          ],
+          output: "new Map([['16', 'a'], [16, 'b']])",
+          code: "new Map([[16, 'b'], ['16', 'a']])",
+          options: [options],
+        })
+      })
+
+      it('sorts elements that are not key-value pairs', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { right: 'a', left: 'b' },
+            },
+          ],
+          output: 'new Map([a, b])',
+          code: 'new Map([b, a])',
+          options: [options],
+        })
+      })
+    })
   })
 
   describe('natural', () => {
@@ -3185,6 +3282,103 @@ describe('sort-maps', () => {
         })
       },
     )
+
+    describe('duplicate runtime keys', () => {
+      it('keeps source order for numeric keys with equal runtime values', async () => {
+        await valid({
+          options: [{ ...options, fallbackSort: { type: 'alphabetical' } }],
+          code: "let m = new Map([[16, 'sixteen'], [0x10, 'hex']])",
+        })
+
+        await valid({
+          code: "new Map([[-0x1, 'b'], [-1, 'aa']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[16n, 'bb'], [0x10n, 'a']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[-0x10n, 'a'], [-16n, 'bb']])",
+          options: [options],
+        })
+
+        await valid({
+          options: [{ ...options, fallbackSort: { type: 'alphabetical' } }],
+          code: "new Map([[1, 'xxxxxxxxxx'], [+1, 'y']])",
+        })
+      })
+
+      it('keeps source order for entries with omitted keys', async () => {
+        await valid({
+          code: "new Map([[void 0, 'x'], [, 'y']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for undefined keys spelled differently', async () => {
+        await valid({
+          code: "new Map([[void 0, 'xxxxxxxxxx'], [undefined, 'y']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[void x, 'xxxxxxxxxx'], [undefined, 'y']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for string and template keys with equal cooked values', async () => {
+        await valid({
+          code: "new Map([[`a`, 'tpl'], ['a', 'str']])",
+          options: [options],
+        })
+      })
+
+      it('sorts remaining entries around keys with equal runtime values', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { left: '0x10n', right: '1n' },
+            },
+          ],
+          output: "new Map([[16n, 'a'], [1n, 'b'], [0x10n, 'c']])",
+          code: "new Map([[16n, 'a'], [0x10n, 'c'], [1n, 'b']])",
+          options: [options],
+        })
+      })
+
+      it('distinguishes numeric keys from string keys with the same text', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { left: "'16'", right: '16' },
+            },
+          ],
+          output: "new Map([[16, 'b'], ['16', 'a']])",
+          code: "new Map([['16', 'a'], [16, 'b']])",
+          options: [options],
+        })
+      })
+
+      it('sorts elements that are not key-value pairs', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { right: 'a', left: 'b' },
+            },
+          ],
+          output: 'new Map([a, b])',
+          code: 'new Map([b, a])',
+          options: [options],
+        })
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4530,6 +4724,176 @@ describe('sort-maps', () => {
         })
       },
     )
+
+    describe('duplicate runtime keys', () => {
+      it('keeps source order for numeric keys with equal runtime values', async () => {
+        await valid({
+          code: "let m = new Map([[16, 'a'], [0x10, 'sixteen']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[-1, 'b'], [-0x1, 'aa']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[16n, 'a'], [0x10n, 'bb']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[-16n, 'a'], [-0x10n, 'bb']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[1, 'y'], [+1, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for entries with omitted keys', async () => {
+        await valid({
+          code: "new Map([[, 'y'], [, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[void 0, 'y'], [, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for undefined keys spelled differently', async () => {
+        await valid({
+          code: "new Map([[void 0, 'y'], [void 0, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[void 0, 'y'], [undefined, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[void x, 'y'], [undefined, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for string and template keys with equal cooked values', async () => {
+        await valid({
+          code: "new Map([[`a`, 'y'], ['a', 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([['a', 'y'], ['a', 'xxxxxxxxxx']])",
+          options: [options],
+        })
+      })
+
+      it('keeps source order for dynamic keys with identical source text', async () => {
+        await valid({
+          code: "new Map([[key, 'y'], [key, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[/a/, 'y'], [/a/, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[null, 'y'], [null, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          // eslint-disable-next-line no-template-curly-in-string
+          code: "new Map([[`a${x}`, 'y'], [`a${x}`, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[-'a', 'y'], [-'a', 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[+'a', 'y'], [+'a', 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[-x, 'y'], [-x, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[+x, 'y'], [+x, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[~1, 'y'], [~1, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[a.b, 'y'], [a.b, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+
+        await valid({
+          code: "new Map([[...x, 'y'], [...x, 'xxxxxxxxxx']])",
+          options: [options],
+        })
+      })
+
+      it('sorts remaining entries around keys with equal runtime values', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { left: '0x10', right: '1' },
+            },
+          ],
+          output: "new Map([[1, 'bbbbbbbb'], [16, 'a'], [0x10, 'ccc']])",
+          code: "new Map([[16, 'a'], [0x10, 'ccc'], [1, 'bbbbbbbb']])",
+          options: [options],
+        })
+      })
+
+      it('distinguishes numeric keys from string keys with the same text', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { left: "'16'", right: '16' },
+            },
+          ],
+          output: "new Map([[16, 'bbbbbb'], ['16', 'a']])",
+          code: "new Map([['16', 'a'], [16, 'bbbbbb']])",
+          options: [options],
+        })
+      })
+
+      it('sorts elements that are not key-value pairs', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedMapElementsOrder',
+              data: { right: 'aa', left: 'b' },
+            },
+          ],
+          output: 'new Map([aa, b])',
+          code: 'new Map([b, aa])',
+          options: [options],
+        })
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -5163,16 +5163,10 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
-            let obj = {
-              a: 'b',
-              a: 'a',
-            }
+            let { a: x = 'b', a: y = 'a' } = obj
           `,
         })
       })
@@ -5198,16 +5192,10 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
-            let obj = {
-              a: 'b',
-              a: 'a',
-            }
+            let { a: x = 'b', a: y = 'a' } = obj
           `,
         })
       })
@@ -5234,17 +5222,137 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
+            let { a: x = 'b', a: y = 'a' } = obj
+          `,
+        })
+      })
+    })
+
+    describe('duplicate runtime keys', () => {
+      it('keeps colliding property and method in source order', async () => {
+        await valid({
+          code: dedent`
+            let obj = { b: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('sorts non-colliding members around pinned colliding members', async () => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'property',
+                leftGroup: 'method',
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = { b: 1, a: 0, b() {} }
+          `,
+          code: dedent`
+            let obj = { b: 1, b() {}, a: 0 }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('treats computed literal keys as colliding with matching plain keys', async () => {
+        await valid({
+          code: dedent`
+            let obj = { ['b']: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { [\`b\`]: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('treats numeric and string keys with the same name as colliding', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              fallbackSort: { type: 'alphabetical', sortBy: 'value' },
+            },
+          ],
+          code: dedent`
+            let obj = { 1: 'b', '1': 'a' }
+          `,
+        })
+      })
+
+      it('treats identical computed keys as colliding', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              fallbackSort: { type: 'alphabetical', sortBy: 'value' },
+            },
+          ],
+          code: dedent`
+            let obj = { [x]: 'b', [x]: 'a' }
+          `,
+        })
+      })
+
+      it('treats unary plus keys as colliding with plain numeric keys', async () => {
+        await valid({
+          code: dedent`
+            let obj = { 1: 'x', [+1]: 'y' }
+          `,
+          options: [options],
+        })
+      })
+
+      it('treats undefined keys spelled differently as colliding', async () => {
+        await valid({
+          code: dedent`
+            let obj = { [void 0]: 'x', undefined: 'y' }
+          `,
+          options: [options],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { [void 0]: 'x', [undefined]: 'y' }
+          `,
+          options: [options],
+        })
+      })
+
+      it('keeps colliding accessor and data property in source order', async () => {
+        await valid({
+          code: dedent`
+            let obj = { b: 1, get b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('excludes eslint-disabled members from collision groups', async () => {
+        await valid({
+          code: dedent`
             let obj = {
-              a: 'b',
-              a: 'a',
+              b: 1,
+              b() {},
+              // eslint-disable-next-line
+              a: 0,
             }
           `,
+          options: [{ ...options, groups: ['method', 'property'] }],
         })
       })
     })
@@ -8014,16 +8122,10 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
-            let obj = {
-              a: 'b',
-              a: 'a',
-            }
+            let { a: x = 'b', a: y = 'a' } = obj
           `,
         })
       })
@@ -8049,16 +8151,10 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
-            let obj = {
-              a: 'b',
-              a: 'a',
-            }
+            let { a: x = 'b', a: y = 'a' } = obj
           `,
         })
       })
@@ -8085,17 +8181,142 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
+            let { a: x = 'b', a: y = 'a' } = obj
+          `,
+        })
+      })
+    })
+
+    describe('duplicate runtime keys', () => {
+      it('keeps colliding property and method in source order', async () => {
+        await valid({
+          code: dedent`
+            let obj = { b: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('sorts non-colliding members around pinned colliding members', async () => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'property',
+                leftGroup: 'method',
+                right: 'a',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = { b: 1, a: 0, b() {} }
+          `,
+          code: dedent`
+            let obj = { b: 1, b() {}, a: 0 }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('treats computed literal keys as colliding with matching plain keys', async () => {
+        await valid({
+          code: dedent`
+            let obj = { ['b']: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { [\`b\`]: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('treats numeric and string keys with the same name as colliding', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              fallbackSort: { type: 'alphabetical', sortBy: 'value' },
+            },
+          ],
+          code: dedent`
+            let obj = { 1: 'b', '1': 'a' }
+          `,
+        })
+      })
+
+      it('treats identical computed keys as colliding', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              fallbackSort: { type: 'alphabetical', sortBy: 'value' },
+            },
+          ],
+          code: dedent`
+            let obj = { [x]: 'b', [x]: 'a' }
+          `,
+        })
+      })
+
+      it('treats unary plus keys as colliding with plain numeric keys', async () => {
+        await valid({
+          options: [
+            {
+              ...options,
+              fallbackSort: { type: 'alphabetical', sortBy: 'value' },
+            },
+          ],
+          code: dedent`
+            let obj = { 1: 'b', [+1]: 'a' }
+          `,
+        })
+      })
+
+      it('treats undefined keys spelled differently as colliding', async () => {
+        await valid({
+          code: dedent`
+            let obj = { [void 0]: 'x', undefined: 'y' }
+          `,
+          options: [options],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { [void 0]: 'x', [undefined]: 'y' }
+          `,
+          options: [options],
+        })
+      })
+
+      it('keeps colliding accessor and data property in source order', async () => {
+        await valid({
+          code: dedent`
+            let obj = { b: 1, get b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('excludes eslint-disabled members from collision groups', async () => {
+        await valid({
+          code: dedent`
             let obj = {
-              a: 'b',
-              a: 'a',
+              b: 1,
+              b() {},
+              // eslint-disable-next-line
+              a: 0,
             }
           `,
+          options: [{ ...options, groups: ['method', 'property'] }],
         })
       })
     })
@@ -10777,6 +10998,163 @@ describe('sort-objects', () => {
         ],
       })
     })
+
+    describe('duplicate runtime keys', () => {
+      it('keeps colliding property and method in source order', async () => {
+        await valid({
+          code: dedent`
+            let obj = { b: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('sorts non-colliding members around pinned colliding members', async () => {
+        await invalid({
+          errors: [
+            {
+              data: {
+                rightGroup: 'property',
+                leftGroup: 'method',
+                right: 'aaa',
+                left: 'b',
+              },
+              messageId: 'unexpectedObjectsGroupOrder',
+            },
+          ],
+          output: dedent`
+            let obj = { b: 1, aaa: 0, b() {} }
+          `,
+          code: dedent`
+            let obj = { b: 1, b() {}, aaa: 0 }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('treats computed literal keys as colliding with matching plain keys', async () => {
+        await valid({
+          code: dedent`
+            let obj = { ['b']: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { [\`b\`]: 1, b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('treats numeric and string keys with the same name as colliding', async () => {
+        await valid({
+          code: dedent`
+            let obj = { 1: 'a', '1': 'bbb' }
+          `,
+          options: [options],
+        })
+      })
+
+      it('treats identical computed keys as colliding', async () => {
+        await valid({
+          code: dedent`
+            let obj = { [x]: 'a', [x]: 'bbb' }
+          `,
+          options: [options],
+        })
+      })
+
+      it('treats unary plus keys as colliding with plain numeric keys', async () => {
+        await valid({
+          code: dedent`
+            let obj = { 1: 'y', [+1]: 'xxxxxxxxxx' }
+          `,
+          options: [options],
+        })
+      })
+
+      it('treats undefined keys spelled differently as colliding', async () => {
+        await valid({
+          code: dedent`
+            let obj = { undefined: 'y', [void 0]: 'xxxxxxxxxx' }
+          `,
+          options: [options],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { [undefined]: 'y', [void 0]: 'xxxxxxxxxx' }
+          `,
+          options: [options],
+        })
+      })
+
+      it('sorts a lone get and set pair', async () => {
+        await invalid({
+          errors: [
+            {
+              messageId: 'unexpectedObjectsOrder',
+              data: { right: 'b', left: 'b' },
+            },
+          ],
+          output: dedent`
+            let obj = { get b() { return 1 }, set b(v) {} }
+          `,
+          code: dedent`
+            let obj = { set b(v) {}, get b() { return 1 } }
+          `,
+          options: [options],
+        })
+      })
+
+      it('keeps colliding accessor and data property in source order', async () => {
+        await valid({
+          code: dedent`
+            let obj = { b: 1, get b() { return 2 } }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+
+      it('keeps colliding accessors in source order', async () => {
+        await valid({
+          code: dedent`
+            let obj = { b() {}, get b() { return 1 } }
+          `,
+          options: [options],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { get b() {}, get b() { return 1 } }
+          `,
+          options: [options],
+        })
+
+        await valid({
+          code: dedent`
+            let obj = { set b(v) {}, set b(v) { let c = v } }
+          `,
+          options: [options],
+        })
+      })
+
+      it('excludes eslint-disabled members from collision groups', async () => {
+        await valid({
+          code: dedent`
+            let obj = {
+              b: 1,
+              b() {},
+              // eslint-disable-next-line
+              aaa: 0,
+            }
+          `,
+          options: [{ ...options, groups: ['method', 'property'] }],
+        })
+      })
+    })
   })
 
   describe('custom', () => {
@@ -10949,16 +11327,10 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
-            let obj = {
-              a: 'b',
-              a: 'a',
-            }
+            let { a: x = 'b', a: y = 'a' } = obj
           `,
         })
       })
@@ -10984,16 +11356,10 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
-            let obj = {
-              a: 'b',
-              a: 'a',
-            }
+            let { a: x = 'b', a: y = 'a' } = obj
           `,
         })
       })
@@ -11020,16 +11386,10 @@ describe('sort-objects', () => {
             },
           ],
           output: dedent`
-            let obj = {
-              a: 'a',
-              a: 'b',
-            }
+            let { a: y = 'a', a: x = 'b' } = obj
           `,
           code: dedent`
-            let obj = {
-              a: 'b',
-              a: 'a',
-            }
+            let { a: x = 'b', a: y = 'a' } = obj
           `,
         })
       })

--- a/utils/compute-colliding-node-groups.ts
+++ b/utils/compute-colliding-node-groups.ts
@@ -1,0 +1,76 @@
+import type { SortingNode } from '../types/sorting-node'
+
+/**
+ * Parameters for computing colliding node groups.
+ *
+ * @template T - Type of sorting node.
+ */
+interface ComputeCollidingNodeGroupsParameters<T extends SortingNode> {
+  /**
+   * Computes the collision key for a node. Nodes sharing the same key are
+   * considered to collide at runtime. Returning null excludes the node from
+   * collision detection.
+   */
+  computeCollisionKey(node: T): string | null
+
+  /**
+   * Whether to exclude ESLint-disabled nodes from collision groups. Disabled
+   * nodes keep their original positions during sorting, so they never
+   * participate in collision-order restoration.
+   */
+  ignoreEslintDisabledNodes: boolean
+
+  /**
+   * Nodes to check, in source order.
+   */
+  nodes: T[]
+}
+
+/**
+ * Groups nodes whose keys provably collide at runtime.
+ *
+ * Buckets nodes by their rule-supplied collision key, skipping nodes without a
+ * statically-known key and, when requested, ESLint-disabled nodes. Only buckets
+ * containing at least two nodes are returned, each preserving source order.
+ *
+ * Used together with `restoreCollidingNodesOrder` to prevent autofixes from
+ * reordering members whose keys overwrite each other at runtime.
+ *
+ * @example
+ *
+ * ```ts
+ * // Map entries: [[16, 'sixteen'], [0x10, 'hex'], [1, 'one']]
+ * computeCollidingNodeGroups({
+ *   computeCollisionKey,
+ *   ignoreEslintDisabledNodes: false,
+ *   nodes,
+ * })
+ * // Returns: [[node16, node0x10]] (both keys evaluate to the number 16)
+ * ```
+ *
+ * @template T - Type of sorting node.
+ * @param params - Parameters for collision detection.
+ * @returns Groups of colliding nodes in source order.
+ */
+export function computeCollidingNodeGroups<T extends SortingNode>({
+  ignoreEslintDisabledNodes,
+  computeCollisionKey,
+  nodes,
+}: ComputeCollidingNodeGroupsParameters<T>): T[][] {
+  let nodesByCollisionKey = new Map<string, T[]>()
+  for (let node of nodes) {
+    if (ignoreEslintDisabledNodes && node.isEslintDisabled) {
+      continue
+    }
+    let collisionKey = computeCollisionKey(node)
+    if (collisionKey === null) {
+      continue
+    }
+    let collidingNodes = nodesByCollisionKey.get(collisionKey) ?? []
+    collidingNodes.push(node)
+    nodesByCollisionKey.set(collisionKey, collidingNodes)
+  }
+  return [...nodesByCollisionKey.values()].filter(
+    collidingNodes => collidingNodes.length >= 2,
+  )
+}

--- a/utils/compute-static-key-value.ts
+++ b/utils/compute-static-key-value.ts
@@ -1,0 +1,104 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
+/**
+ * Computes the statically-known runtime value of a key expression.
+ *
+ * Resolves expressions whose runtime value can be determined without
+ * evaluation: literals (including bigint), template literals without
+ * expressions, unary minus over numeric or bigint literals, unary plus over
+ * numeric literals, `void` expressions and the `undefined` identifier. Regex
+ * literals are excluded because each evaluation produces a distinct object.
+ *
+ * The value is wrapped in an object so that a statically-known `null` or
+ * `undefined` value can be distinguished from "not statically known".
+ *
+ * @example
+ *
+ * ```ts
+ * // Key expression: 0x10
+ * computeStaticKeyValue(node) // Returns: { value: 16 }
+ * ```
+ *
+ * @example
+ *
+ * ```ts
+ * // Key expression: `a${x}`
+ * computeStaticKeyValue(node) // Returns: null
+ * ```
+ *
+ * @param node - Key expression to resolve.
+ * @returns Wrapped static value, or null if the value is not statically known.
+ */
+export function computeStaticKeyValue(
+  node: TSESTree.Node,
+): { value: unknown } | null {
+  switch (node.type) {
+    case AST_NODE_TYPES.TemplateLiteral:
+      return node.expressions.length === 0 ?
+          { value: node.quasis[0]!.value.cooked }
+        : null
+    case AST_NODE_TYPES.UnaryExpression:
+      return computeUnaryStaticKeyValue(node)
+    case AST_NODE_TYPES.Identifier:
+      return node.name === 'undefined' ? { value: undefined } : null
+    case AST_NODE_TYPES.Literal:
+      return 'regex' in node ? null : { value: node.value }
+    default:
+      return null
+  }
+}
+
+/**
+ * Computes the static value of a unary expression.
+ *
+ * `void` expressions always evaluate to `undefined` regardless of their
+ * operand. Unary minus resolves over numeric or bigint literals, and unary plus
+ * over numeric literals (unary plus over a bigint throws at runtime).
+ *
+ * @param node - Unary expression to resolve.
+ * @returns Wrapped static value, or null if the value is not statically known.
+ */
+function computeUnaryStaticKeyValue(
+  node: TSESTree.UnaryExpression,
+): { value: unknown } | null {
+  switch (node.operator) {
+    case 'void':
+      return { value: undefined }
+    case '-':
+      return computeNegatedStaticKeyValue(node)
+    case '+':
+      return (
+          node.argument.type === AST_NODE_TYPES.Literal &&
+            typeof node.argument.value === 'number'
+        ) ?
+          { value: node.argument.value }
+        : null
+    default:
+      return null
+  }
+}
+
+/**
+ * Computes the static value of a unary minus expression over a numeric or
+ * bigint literal.
+ *
+ * @param node - Unary expression to resolve.
+ * @returns Wrapped negated value, or null if the value is not statically known.
+ */
+function computeNegatedStaticKeyValue(
+  node: TSESTree.UnaryExpression,
+): { value: unknown } | null {
+  if (node.operator !== '-' || node.argument.type !== AST_NODE_TYPES.Literal) {
+    return null
+  }
+  let { value } = node.argument
+  if (typeof value === 'number') {
+    return { value: -value }
+  }
+  if (typeof value === 'bigint') {
+    return { value: -value }
+  }
+  return null
+}

--- a/utils/restore-colliding-nodes-order.ts
+++ b/utils/restore-colliding-nodes-order.ts
@@ -1,0 +1,56 @@
+import type { SortingNode } from '../types/sorting-node'
+
+/**
+ * Restores the source order of colliding nodes within a sorted list.
+ *
+ * For each collision group, its members re-occupy exactly the positions they
+ * hold in the sorted list, but in source order. All other nodes keep their
+ * sorted positions. This guarantees that members whose keys collide at runtime
+ * never cross each other, preserving last-write-wins semantics, while
+ * non-colliding members still sort fully.
+ *
+ * The returned array is a pure permutation of `sortedNodes`: node identities
+ * are unchanged, so index maps and fixes derived from the result stay
+ * consistent.
+ *
+ * @example
+ *
+ * ```ts
+ * // Source order: [b: 1, b() {}, a: 0]
+ * // Sorted order: [b() {}, a: 0, b: 1]
+ * restoreCollidingNodesOrder({
+ *   collidingNodeGroups: [[bProperty, bMethod]],
+ *   sortedNodes: [bMethod, aProperty, bProperty],
+ * })
+ * // Returns: [bProperty, aProperty, bMethod]
+ * ```
+ *
+ * @template T - Type of sorting node.
+ * @param params - Parameters for order restoration.
+ * @param params.collidingNodeGroups - Groups of colliding nodes in source
+ *   order.
+ * @param params.sortedNodes - Nodes produced by the sorting pipeline.
+ * @returns Sorted nodes with each collision group restored to source order.
+ */
+export function restoreCollidingNodesOrder<T extends SortingNode>({
+  collidingNodeGroups,
+  sortedNodes,
+}: {
+  collidingNodeGroups: T[][]
+  sortedNodes: T[]
+}): T[] {
+  let result = [...sortedNodes]
+  for (let collidingNodeGroup of collidingNodeGroups) {
+    let collidingNodes = new Set(collidingNodeGroup)
+    let sortedIndices: number[] = []
+    for (let [index, node] of result.entries()) {
+      if (collidingNodes.has(node)) {
+        sortedIndices.push(index)
+      }
+    }
+    for (let [nodeIndex, sortedIndex] of sortedIndices.entries()) {
+      result[sortedIndex] = collidingNodeGroup[nodeIndex]!
+    }
+  }
+  return result
+}


### PR DESCRIPTION
### Description

`sort-objects`, `sort-maps` and `sort-jsx-props` autofixes could reorder members whose keys are provably equal at runtime (`16` vs `0x10`, `'a'` vs `` `a` ``, `1` vs `+1`, `undefined` vs `void 0`, `['b']` vs `b`, duplicate props), silently changing last-write-wins behavior:

```js
const original = { b: 1, b() { return 2 } };
console.log('original.b:', typeof original.b);  // "function"
console.log('original.b():', original.b());     // 2
```

```js
const autofixed = { b() { return 2 }, b: 1 };
console.log('autofixed.b:', typeof autofixed.b); // "number"
console.log('autofixed.b():', autofixed.b());    // 💥 TypeError: autofixed.b is not a function
```

```js
const originalMap = new Map([[16, 'decimal'], [0x10, 'hex']]);
console.log(originalMap.get(16)); // "hex" (0x10 === 16)

const autofixedMap = new Map([[0x10, 'hex'], [16, 'decimal']]);
console.log(autofixedMap.get(16)); // "decimal"
```

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
