### PR TITLE
fix: stop treating multiline trailing block comments as leading comments

### DIFF
--- a/test/rules/sort-exports.test.ts
+++ b/test/rules/sort-exports.test.ts
@@ -383,6 +383,28 @@ describe('sort-exports', () => {
       })
     })
 
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedExportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          export { a } from 'a' /* comment
+          */
+          export { b } from 'b'
+        `,
+        code: dedent`
+          export { b } from 'b' /* comment
+          */
+          export { a } from 'a'
+        `,
+        options: [options],
+      })
+    })
+
     it('allows to trim special characters', async () => {
       await valid({
         code: dedent`
@@ -1975,6 +1997,28 @@ describe('sort-exports', () => {
       })
     })
 
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedExportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          export { a } from 'a' /* comment
+          */
+          export { b } from 'b'
+        `,
+        code: dedent`
+          export { b } from 'b' /* comment
+          */
+          export { a } from 'a'
+        `,
+        options: [options],
+      })
+    })
+
     it('allows to trim special characters', async () => {
       await valid({
         code: dedent`
@@ -3347,6 +3391,28 @@ describe('sort-exports', () => {
           /* I am a partition comment because I don't have f o o */
           export * from './a'
         `,
+      })
+    })
+
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedExportsOrder',
+            data: { right: 'bb', left: 'a' },
+          },
+        ],
+        output: dedent`
+          export { b } from 'bb' /* comment
+          */
+          export { a } from 'a'
+        `,
+        code: dedent`
+          export { a } from 'a' /* comment
+          */
+          export { b } from 'bb'
+        `,
+        options: [options],
       })
     })
 

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -468,6 +468,28 @@ describe('sort-imports', () => {
       })
     })
 
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedImportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import a from 'a' /* comment
+          */
+          import b from 'b'
+        `,
+        code: dedent`
+          import b from 'b' /* comment
+          */
+          import a from 'a'
+        `,
+        options: [options],
+      })
+    })
+
     it('ignores comments when calculating spacing between imports', async () => {
       await valid({
         code: dedent`
@@ -4078,6 +4100,28 @@ describe('sort-imports', () => {
       })
     })
 
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedImportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import a from 'a' /* comment
+          */
+          import b from 'b'
+        `,
+        code: dedent`
+          import b from 'b' /* comment
+          */
+          import a from 'a'
+        `,
+        options: [options],
+      })
+    })
+
     it('ignores comments when calculating spacing between imports', async () => {
       await valid({
         code: dedent`
@@ -7423,6 +7467,28 @@ describe('sort-imports', () => {
           import { b1, b2 } from 'b' // Comment
           import { a } from 'a'
           import { c } from 'c'
+        `,
+        options: [options],
+      })
+    })
+
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedImportsOrder',
+            data: { right: 'aaa', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import aaa from 'aaa' /* comment
+          */
+          import b from 'b'
+        `,
+        code: dedent`
+          import b from 'b' /* comment
+          */
+          import aaa from 'aaa'
         `,
         options: [options],
       })

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1564,6 +1564,32 @@ describe('sort-named-imports', () => {
       })
     })
 
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedNamedImportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import {
+            a, /* comment
+           */
+            b
+          } from 'm'
+        `,
+        code: dedent`
+          import {
+            b, /* comment
+           */
+            a
+          } from 'm'
+        `,
+        options: [options],
+      })
+    })
+
     describe('useConfigurationIf.allNamesMatchPattern', () => {
       it.each([
         ['string pattern', 'foo'],
@@ -3334,6 +3360,32 @@ describe('sort-named-imports', () => {
         ],
       })
     })
+
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedNamedImportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import {
+            a, /* comment
+           */
+            b
+          } from 'm'
+        `,
+        code: dedent`
+          import {
+            b, /* comment
+           */
+            a
+          } from 'm'
+        `,
+        options: [options],
+      })
+    })
   })
 
   describe('line-length', () => {
@@ -4736,6 +4788,32 @@ describe('sort-named-imports', () => {
             data: { right: 'bb', left: 'c' },
           },
         ],
+      })
+    })
+
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedNamedImportsOrder',
+            data: { right: 'bb', left: 'a' },
+          },
+        ],
+        output: dedent`
+          import {
+            bb, /* comment
+           */
+            a
+          } from 'm'
+        `,
+        code: dedent`
+          import {
+            a, /* comment
+           */
+            bb
+          } from 'm'
+        `,
+        options: [options],
       })
     })
   })

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -217,6 +217,57 @@ describe('sort-union-types', () => {
       })
     })
 
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          type T =
+            | A /* comment
+          */
+            | B
+        `,
+        code: dedent`
+          type T =
+            | B /* comment
+          */
+            | A
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+        output: dedent`
+          type T =
+            | A /* comment
+          */
+            | B
+        `,
+        code: dedent`
+          type T =
+            | B /* comment
+          */
+            | A
+        `,
+      })
+    })
+
     it('sorts unions by groups', async () => {
       await valid({
         code: dedent`
@@ -2161,6 +2212,57 @@ describe('sort-union-types', () => {
       })
     })
 
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          type T =
+            | A /* comment
+          */
+            | B
+        `,
+        code: dedent`
+          type T =
+            | B /* comment
+          */
+            | A
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+        output: dedent`
+          type T =
+            | A /* comment
+          */
+            | B
+        `,
+        code: dedent`
+          type T =
+            | B /* comment
+          */
+            | A
+        `,
+      })
+    })
+
     it('sorts unions by groups', async () => {
       await valid({
         code: dedent`
@@ -3721,6 +3823,57 @@ describe('sort-union-types', () => {
           type Step = 1 | 100 | 2 | 4 | 3 | 5; // Comment
         `,
         options: [options],
+      })
+    })
+
+    it('keeps multiline trailing block comments anchored when sorting', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'BB', left: 'A' },
+          },
+        ],
+        output: dedent`
+          type T =
+            | BB /* comment
+          */
+            | A
+        `,
+        code: dedent`
+          type T =
+            | A /* comment
+          */
+            | BB
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'BB', left: 'A' },
+          },
+        ],
+        options: [
+          {
+            ...options,
+            partitionByComment: true,
+          },
+        ],
+        output: dedent`
+          type T =
+            | BB /* comment
+          */
+            | A
+        `,
+        code: dedent`
+          type T =
+            | A /* comment
+          */
+            | BB
+        `,
       })
     })
 

--- a/utils/get-comments-before.ts
+++ b/utils/get-comments-before.ts
@@ -48,7 +48,7 @@ function getRelevantCommentsBeforeNodeOrToken(
        * filter those out.
        */
       let tokenBeforeComment = source.getTokenBefore(comment)
-      return tokenBeforeComment?.loc.end.line !== comment.loc.end.line
+      return tokenBeforeComment?.loc.end.line !== comment.loc.start.line
     })
 }
 


### PR DESCRIPTION
### Description

Multiline block comments opening on the previous element's line were misclassified as leading comments of the next element and traveled with it during sorting - gluing statements into syntax errors (`sort-exports`, `sort-imports`) and misplacing comments in other rules; they are now treated as trailing comments and stay anchored in place.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
