### PR TITLE
docs(sort-intersection-types): add banner about callable and named types

### DIFF
--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -29,6 +29,14 @@ This rule promotes a standardized ordering of intersection types, making it easi
 If you use the [`sort-type-constituents`](https://typescript-eslint.io/rules/sort-type-constituents) rule from the [`@typescript-eslint/eslint-plugin`](https://typescript-eslint.io) plugin, it is highly recommended to [disable it](https://eslint.org/docs/latest/use/configure/rules#using-configuration-files-1) to avoid conflicts.
 </Important>
 
+<Important title="Function intersections are order-sensitive">
+Intersections of function types act as overloads, which TypeScript resolves left to right. Reordering them can silently change type inference.
+
+By default, the [`ignoreCallableTypes`](#ignorecallabletypes) option leaves intersections containing inline callable types unsorted.
+However, named function types (e.g. `MyFunction`) cannot be detected as callable and will still be sorted.
+Use an [ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) to exclude those intersections from sorting.
+</Important>
+
 ## Try it out
 
 <CodeExample

--- a/docs/content/rules/sort-intersection-types.mdx
+++ b/docs/content/rules/sort-intersection-types.mdx
@@ -176,12 +176,14 @@ Specifies the sorting locales. Refer To [String.prototype.localeCompare() - loca
 
 <sub>default: `true`</sub>
 
-When `true`, the rule will not sort inline intersection type members if any member is a callable type.
+Specifies whether to ignore sorting types containing an **inline** callable type.
 
 This preserves TypeScript's overload resolution order, which depends on the left-to-right order of callable members in an intersection.
 
 <Important title="Named type references">
 Named type references (e.g. `MyFunction`) are not detected as callable. Only inline callable types are recognized.
+
+</Important>
 
 - `true` — Leave callable intersections unsorted to preserve overload semantics.
 - `false` — Sort all intersection type members regardless of whether they are callable.
@@ -192,7 +194,6 @@ type Overloaded =
   & ((x: string) => string)
   & ((x: any) => any)
 ```
-</Important>
 
 ### partitionByComment
 


### PR DESCRIPTION
- Related comment: https://github.com/azat-io/eslint-plugin-perfectionist/issues/743#issuecomment-4881894161

### Description

This PR simply adds a header warning in `sort-intersection-types` to inform users about the impact of the rule regarding named types referring to callable types.