### PR TITLE
fix: fix complex comments cases not being auto-fixed correctly

### DIFF
--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -2196,6 +2196,27 @@ describe('sort-array-includes', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedArrayIncludesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          [
+            a,
+            b // b
+          ].includes(value)
+        `,
+        code: dedent`
+          [
+            b, // b
+            a].includes(value)
+        `,
+        options: [options],
+      })
     })
 
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {

--- a/test/rules/sort-array-includes.test.ts
+++ b/test/rules/sort-array-includes.test.ts
@@ -2176,6 +2176,28 @@ describe('sort-array-includes', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedArrayIncludesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          [
+            a, /* a */
+            b /* b */ ].includes(x)
+        `,
+        code: dedent`
+          [
+            b, /* b */
+            a /* a */ ].includes(x)
+        `,
+        options: [options],
+      })
+    })
+
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
       let partitionOptions = [
         {

--- a/test/rules/sort-arrays.test.ts
+++ b/test/rules/sort-arrays.test.ts
@@ -2173,6 +2173,27 @@ describe('sort-arrays', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedArraysOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          [
+            a,
+            b // b
+           ]
+        `,
+        code: dedent`
+          [
+            b, // b
+            a ]
+        `,
+        options: [options],
+      })
     })
 
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {

--- a/test/rules/sort-arrays.test.ts
+++ b/test/rules/sort-arrays.test.ts
@@ -2153,6 +2153,28 @@ describe('sort-arrays', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedArraysOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          [
+            a, /* a */
+            b /* b */ ]
+        `,
+        code: dedent`
+          [
+            b, /* b */
+            a /* a */ ]
+        `,
+        options: [options],
+      })
+    })
+
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
       let partitionOptions = [
         {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4635,6 +4635,27 @@ describe('sort-classes', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedClassesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          class Class {
+            a = 2
+            b = 1; // b
+           }
+        `,
+        code: dedent`
+          class Class {
+            b = 1; // b
+            a = 2 }
+        `,
+        options: [options],
+      })
     })
 
     it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -4615,6 +4615,28 @@ describe('sort-classes', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedClassesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          class Class {
+            a = 2 /* a */
+            b = 1; /* b */ }
+        `,
+        code: dedent`
+          class Class {
+            b = 1; /* b */
+            a = 2 /* a */ }
+        `,
+        options: [options],
+      })
+    })
+
     it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
       await invalid({
         options: [

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -205,6 +205,27 @@ describe('sort-enums', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedEnumsOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = 'a',
+            B = 'b' // b
+           }
+        `,
+        code: dedent`
+          enum Enum {
+            B = 'b', // b
+            A = 'a' }
+        `,
+        options: [options],
+      })
     })
 
     it('preserves implicit values in enums', async () => {

--- a/test/rules/sort-enums.test.ts
+++ b/test/rules/sort-enums.test.ts
@@ -185,6 +185,28 @@ describe('sort-enums', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedEnumsOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          enum Enum {
+            A = 'a', /* a */
+            B = 'b' /* b */ }
+        `,
+        code: dedent`
+          enum Enum {
+            B = 'b', /* b */
+            A = 'a' /* a */ }
+        `,
+        options: [options],
+      })
+    })
+
     it('preserves implicit values in enums', async () => {
       await valid({
         code: dedent`

--- a/test/rules/sort-export-attributes.test.ts
+++ b/test/rules/sort-export-attributes.test.ts
@@ -653,6 +653,28 @@ describe('sort-export-attributes', () => {
         })
       })
     })
+
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedExportAttributesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          export { x } from 'module' with {
+            a: 'y', /* a */
+            b: 'x' /* b */ }
+        `,
+        code: dedent`
+          export { x } from 'module' with {
+            b: 'x', /* b */
+            a: 'y' /* a */ }
+        `,
+        options: [options],
+      })
+    })
   })
 
   describe('natural', () => {

--- a/test/rules/sort-export-attributes.test.ts
+++ b/test/rules/sort-export-attributes.test.ts
@@ -674,6 +674,27 @@ describe('sort-export-attributes', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedExportAttributesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          export { x } from 'module' with {
+            a: 'y',
+            b: 'x' // b
+           }
+        `,
+        code: dedent`
+          export { x } from 'module' with {
+            b: 'x', // b
+            a: 'y' }
+        `,
+        options: [options],
+      })
     })
   })
 

--- a/test/rules/sort-heritage-clauses.test.ts
+++ b/test/rules/sort-heritage-clauses.test.ts
@@ -164,6 +164,27 @@ describe('sort-heritage-clauses', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedHeritageClausesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          interface Interface extends
+            A,
+            B // b
+           {}
+        `,
+        code: dedent`
+          interface Interface extends
+            B, // b
+            A {}
+        `,
+        options: [options],
+      })
     })
 
     it('sorts heritage clauses with inline comments', async () => {

--- a/test/rules/sort-heritage-clauses.test.ts
+++ b/test/rules/sort-heritage-clauses.test.ts
@@ -144,6 +144,28 @@ describe('sort-heritage-clauses', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedHeritageClausesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          interface Interface extends
+            A, /* a */
+            B /* b */ {}
+        `,
+        code: dedent`
+          interface Interface extends
+            B, /* b */
+            A /* a */ {}
+        `,
+        options: [options],
+      })
+    })
+
     it('sorts heritage clauses with inline comments', async () => {
       await invalid({
         errors: [

--- a/test/rules/sort-import-attributes.test.ts
+++ b/test/rules/sort-import-attributes.test.ts
@@ -660,14 +660,35 @@ describe('sort-import-attributes', () => {
           },
         ],
         output: dedent`
-          import x from 'module' with {
+          import x from 'm' with {
             a: 'y', /* a */
             b: 'x' /* b */ }
         `,
         code: dedent`
-          import x from 'module' with {
+          import x from 'm' with {
             b: 'x', /* b */
             a: 'y' /* a */ }
+        `,
+        options: [options],
+      })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedImportAttributesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import x from 'module' with {
+            a: 'y',
+            b: 'x' // b
+           }
+        `,
+        code: dedent`
+          import x from 'module' with {
+            b: 'x', // b
+            a: 'y' }
         `,
         options: [options],
       })

--- a/test/rules/sort-import-attributes.test.ts
+++ b/test/rules/sort-import-attributes.test.ts
@@ -650,6 +650,28 @@ describe('sort-import-attributes', () => {
         })
       })
     })
+
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedImportAttributesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import x from 'module' with {
+            a: 'y', /* a */
+            b: 'x' /* b */ }
+        `,
+        code: dedent`
+          import x from 'module' with {
+            b: 'x', /* b */
+            a: 'y' /* a */ }
+        `,
+        options: [options],
+      })
+    })
   })
 
   describe('natural', () => {

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -355,6 +355,28 @@ describe('sort-interfaces', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedInterfacePropertiesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string /* a */
+            b: string; /* b */ }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string; /* b */
+            a: string /* a */ }
+        `,
+        options: [options],
+      })
+    })
+
     it('sorts interfaces with semi and comments on the same line', async () => {
       await invalid({
         errors: [

--- a/test/rules/sort-interfaces.test.ts
+++ b/test/rules/sort-interfaces.test.ts
@@ -375,6 +375,27 @@ describe('sort-interfaces', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedInterfacePropertiesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          interface Interface {
+            a: string
+            b: string; // b
+           }
+        `,
+        code: dedent`
+          interface Interface {
+            b: string; // b
+            a: string }
+        `,
+        options: [options],
+      })
     })
 
     it('sorts interfaces with semi and comments on the same line', async () => {

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -221,6 +221,28 @@ describe('sort-intersection-types', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedIntersectionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          type Type = (
+            & A /* a */
+            & B /* b */ )
+        `,
+        code: dedent`
+          type Type = (
+            & B /* b */
+            & A /* a */ )
+        `,
+        options: [options],
+      })
+    })
+
     it('sorts intersections using groups', async () => {
       await valid({
         code: dedent`

--- a/test/rules/sort-intersection-types.test.ts
+++ b/test/rules/sort-intersection-types.test.ts
@@ -241,6 +241,27 @@ describe('sort-intersection-types', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedIntersectionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          type Type = (
+            & A
+            & B // b
+           )
+        `,
+        code: dedent`
+          type Type = (
+            & B // b
+            & A )
+        `,
+        options: [options],
+      })
     })
 
     it('sorts intersections using groups', async () => {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1309,6 +1309,27 @@ describe('sort-jsx-props', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedJSXPropsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          <Component
+            a
+            b // b
+           />
+        `,
+        code: dedent`
+          <Component
+            b // b
+            a />
+        `,
+        options: [options],
+      })
     })
 
     describe('useConfigurationIf.allNamesMatchPattern', () => {

--- a/test/rules/sort-jsx-props.test.ts
+++ b/test/rules/sort-jsx-props.test.ts
@@ -1289,6 +1289,28 @@ describe('sort-jsx-props', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedJSXPropsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          <Component
+            a /* a */
+            b /* b */ />
+        `,
+        code: dedent`
+          <Component
+            b /* b */
+            a /* a */ />
+        `,
+        options: [options],
+      })
+    })
+
     describe('useConfigurationIf.allNamesMatchPattern', () => {
       it.each([
         ['string pattern', '^[rgb]$'],

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1440,6 +1440,27 @@ describe('sort-maps', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedMapElementsOrder',
+            data: { right: "'a'", left: "'b'" },
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['a', 2],
+            ['b', 1] // b
+           ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 1], // b
+            ['a', 2] ])
+        `,
+        options: [options],
+      })
     })
 
     it('preserves partition boundaries when newlinesBetween is 0', async () => {

--- a/test/rules/sort-maps.test.ts
+++ b/test/rules/sort-maps.test.ts
@@ -1420,6 +1420,28 @@ describe('sort-maps', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedMapElementsOrder',
+            data: { right: "'a'", left: "'b'" },
+          },
+        ],
+        output: dedent`
+          new Map([
+            ['a', 2], /* a */
+            ['b', 1] /* b */ ])
+        `,
+        code: dedent`
+          new Map([
+            ['b', 1], /* b */
+            ['a', 2] /* a */ ])
+        `,
+        options: [options],
+      })
+    })
+
     it('preserves partition boundaries when newlinesBetween is 0', async () => {
       await invalid({
         options: [

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1388,6 +1388,28 @@ describe('sort-named-exports', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedNamedExportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          export {
+            a, /* a */
+            b /* b */ }
+        `,
+        code: dedent`
+          export {
+            b, /* b */
+            a /* a */ }
+        `,
+        options: [options],
+      })
+    })
+
     it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {
       await invalid({
         options: [

--- a/test/rules/sort-named-exports.test.ts
+++ b/test/rules/sort-named-exports.test.ts
@@ -1408,6 +1408,27 @@ describe('sort-named-exports', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedNamedExportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          export {
+            a,
+            b // b
+           }
+        `,
+        code: dedent`
+          export {
+            b, // b
+            a }
+        `,
+        options: [options],
+      })
     })
 
     it('ignores newline fixes between different partitions when newlinesBetween is 0', async () => {

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1539,6 +1539,27 @@ describe('sort-named-imports', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedNamedImportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import {
+            a,
+            b // b
+           } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, // b
+            a } from 'module'
+        `,
+        options: [options],
+      })
     })
 
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {

--- a/test/rules/sort-named-imports.test.ts
+++ b/test/rules/sort-named-imports.test.ts
@@ -1519,6 +1519,28 @@ describe('sort-named-imports', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedNamedImportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          import {
+            a, /* a */
+            b /* b */ } from 'module'
+        `,
+        code: dedent`
+          import {
+            b, /* b */
+            a /* a */ } from 'module'
+        `,
+        options: [options],
+      })
+    })
+
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
       await invalid({
         options: [

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2240,6 +2240,27 @@ describe('sort-object-types', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedObjectTypesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: 2
+            b: 1, // b
+           }
+        `,
+        code: dedent`
+          type Type = {
+            b: 1, // b
+            a: 2 }
+        `,
+        options: [options],
+      })
     })
 
     it('ignores newline fixes between different partitions with newlinesBetween: 0', async () => {

--- a/test/rules/sort-object-types.test.ts
+++ b/test/rules/sort-object-types.test.ts
@@ -2220,6 +2220,28 @@ describe('sort-object-types', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedObjectTypesOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          type Type = {
+            a: 2 /* a */
+            b: 1, /* b */ }
+        `,
+        code: dedent`
+          type Type = {
+            b: 1, /* b */
+            a: 2 /* a */ }
+        `,
+        options: [options],
+      })
+    })
+
     it('ignores newline fixes between different partitions with newlinesBetween: 0', async () => {
       await invalid({
         options: [

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -332,6 +332,27 @@ describe('sort-objects', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedObjectsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: 2,
+            b: 1 // b
+           }
+        `,
+        code: dedent`
+          let obj = {
+            b: 1, // b
+            a: 2 }
+        `,
+        options: [options],
+      })
     })
 
     it('sorts objects without trailing comma when last element has a comment', async () => {

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -312,6 +312,28 @@ describe('sort-objects', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedObjectsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          let obj = {
+            a: 2, /* a */
+            b: 1 /* b */ }
+        `,
+        code: dedent`
+          let obj = {
+            b: 1, /* b */
+            a: 2 /* a */ }
+        `,
+        options: [options],
+      })
+    })
+
     it('sorts objects without trailing comma when last element has a comment', async () => {
       await invalid({
         errors: [

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1976,6 +1976,27 @@ describe('sort-sets', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedSetsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a',
+            'b' // b
+           ])
+        `,
+        code: dedent`
+          new Set([
+            'b', // b
+            'a' ])
+        `,
+        options: [options],
+      })
     })
 
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {

--- a/test/rules/sort-sets.test.ts
+++ b/test/rules/sort-sets.test.ts
@@ -1956,6 +1956,28 @@ describe('sort-sets', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedSetsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          new Set([
+            'a', /* a */
+            'b' /* b */ ])
+        `,
+        code: dedent`
+          new Set([
+            'b', /* b */
+            'a' /* a */ ])
+        `,
+        options: [options],
+      })
+    })
+
     it('preserves partition boundaries regardless of newlinesBetween 0', async () => {
       let partitionOptions = [
         {

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -217,6 +217,28 @@ describe('sort-union-types', () => {
       })
     })
 
+    it('keeps trailing comments attached when elements are reordered', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          type Type = (
+            | A /* a */
+            | B /* b */ )
+        `,
+        code: dedent`
+          type Type = (
+            | B /* b */
+            | A /* a */ )
+        `,
+        options: [options],
+      })
+    })
+
     it('keeps multiline trailing block comments anchored when sorting', async () => {
       await invalid({
         errors: [

--- a/test/rules/sort-union-types.test.ts
+++ b/test/rules/sort-union-types.test.ts
@@ -237,6 +237,27 @@ describe('sort-union-types', () => {
         `,
         options: [options],
       })
+
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedUnionTypesOrder',
+            data: { right: 'A', left: 'B' },
+          },
+        ],
+        output: dedent`
+          type Type = (
+            | A
+            | B // b
+           )
+        `,
+        code: dedent`
+          type Type = (
+            | B // b
+            | A )
+        `,
+        options: [options],
+      })
     })
 
     it('keeps multiline trailing block comments anchored when sorting', async () => {

--- a/utils/make-single-node-comment-after-fixes.ts
+++ b/utils/make-single-node-comment-after-fixes.ts
@@ -77,17 +77,41 @@ export function makeSingleNodeCommentAfterFixes({
 
   fixes.push(fixer.replaceTextRange(range, ''))
 
-  let tokenAfterNode = sourceCode.getTokenAfter(node)
-  fixes.push(
-    fixer.insertTextAfter(
-      tokenAfterNode?.loc.end.line === node.loc.end.line ?
-        tokenAfterNode
-      : node,
-      sourceCode.text.slice(...range),
-    ),
-  )
+  let nodeToInsertAfter = computeNodeToInsertAfter({
+    sourceCode,
+    node,
+  })
+  let commentText = computeCommentTextToInsertAfter({
+    sourceCode,
+    range,
+  })
+  fixes.push(fixer.insertTextAfter(nodeToInsertAfter, commentText))
 
   return fixes
+}
+
+function computeNodeToInsertAfter({
+  sourceCode,
+  node,
+}: {
+  node: TSESTree.Token | TSESTree.Node
+  sourceCode: TSESLint.SourceCode
+}): TSESTree.Token | TSESTree.Node {
+  let tokenAfterNode = sourceCode.getTokenAfter(node)
+
+  return tokenAfterNode?.loc.end.line === node.loc.end.line ?
+      tokenAfterNode
+    : node
+}
+
+function computeCommentTextToInsertAfter({
+  sourceCode,
+  range,
+}: {
+  sourceCode: TSESLint.SourceCode
+  range: TSESTree.Range
+}): string {
+  return sourceCode.text.slice(...range)
 }
 
 /**

--- a/utils/make-single-node-comment-after-fixes.ts
+++ b/utils/make-single-node-comment-after-fixes.ts
@@ -82,6 +82,8 @@ export function makeSingleNodeCommentAfterFixes({
     node,
   })
   let commentText = computeCommentTextToInsertAfter({
+    nodeToInsertAfter,
+    commentAfter,
     sourceCode,
     range,
   })
@@ -125,13 +127,29 @@ function computeNodeToInsertAfter({
 }
 
 function computeCommentTextToInsertAfter({
+  nodeToInsertAfter,
+  commentAfter,
   sourceCode,
   range,
 }: {
+  nodeToInsertAfter: TSESTree.Token | TSESTree.Node
   sourceCode: TSESLint.SourceCode
+  commentAfter: TSESTree.Comment
   range: TSESTree.Range
 }): string {
-  return sourceCode.text.slice(...range)
+  let commentText = sourceCode.text.slice(...range)
+
+  if (commentAfter.type !== 'Line') {
+    return commentText
+  }
+
+  let tokenAfterInsertion = sourceCode.getTokenAfter(nodeToInsertAfter)
+  if (tokenAfterInsertion?.loc.start.line !== nodeToInsertAfter.loc.end.line) {
+    return commentText
+  }
+  commentText += '\n'
+
+  return commentText
 }
 
 /**

--- a/utils/make-single-node-comment-after-fixes.ts
+++ b/utils/make-single-node-comment-after-fixes.ts
@@ -99,9 +99,29 @@ function computeNodeToInsertAfter({
 }): TSESTree.Token | TSESTree.Node {
   let tokenAfterNode = sourceCode.getTokenAfter(node)
 
-  return tokenAfterNode?.loc.end.line === node.loc.end.line ?
-      tokenAfterNode
-    : node
+  if (tokenAfterNode?.type !== 'Punctuator') {
+    return node
+  }
+  if (!isRelevantPunctuator(tokenAfterNode)) {
+    return node
+  }
+  if (tokenAfterNode.loc.end.line !== node.loc.end.line) {
+    return node
+  }
+
+  return tokenAfterNode
+
+  function isRelevantPunctuator(
+    punctuatorToken: TSESTree.PunctuatorToken,
+  ): boolean {
+    switch (punctuatorToken.value) {
+      case ',':
+      case ':':
+        return true
+      default:
+        return false
+    }
+  }
 }
 
 function computeCommentTextToInsertAfter({


### PR DESCRIPTION
# Description

The 2 following cases are not auto-fixed correctly, for multple rules

## Block comment case

```ts
[
  b, /* b */
  a /* a */ ].includes(x)
```

gets autofixed to

```ts
[
a, /* a */
b ] /* b */.includes(x)
```

## Line comments case

```ts
[
  b, // b
  a].includes(value)
```

gets autofixed to

```ts
[
  a,
  b] // b.includes(value)
```

which completely breaks compilation and runtime.

# Bug severity

Extremely low: those syntaxes are very unconventional.