### PR TITLE
fix(754): fix call expressions not always being matched for `ignoreCallbackDependenciesPatterns`

### DIFF
--- a/rules/sort-classes/compute-dependencies-by-sorting-node.ts
+++ b/rules/sort-classes/compute-dependencies-by-sorting-node.ts
@@ -107,24 +107,26 @@ function computeIdentifierOrThisExpressionDependency({
     }
   }
   function shouldIgnoreCallbackDependency(): boolean {
-    let [firstCallExpressionParent] = computeParentNodesWithTypes({
+    let callExpressionParents = computeParentNodesWithTypes({
       allowedTypes: [AST_NODE_TYPES.CallExpression],
       maxParent: classElement,
       consecutiveOnly: false,
       node,
     })
-    if (!firstCallExpressionParent) {
-      return false
-    }
 
-    if (!('name' in firstCallExpressionParent.callee)) {
-      return false
-    }
+    return callExpressionParents.some(shouldIgnoreCallExpression)
 
-    return matches(
-      firstCallExpressionParent.callee.name,
-      ignoreCallbackDependenciesPatterns,
-    )
+    function shouldIgnoreCallExpression(
+      callExpressionParent: TSESTree.CallExpression,
+    ): boolean {
+      return (
+        'name' in callExpressionParent.callee &&
+        matches(
+          callExpressionParent.callee.name,
+          ignoreCallbackDependenciesPatterns,
+        )
+      )
+    }
   }
 }
 

--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -3749,6 +3749,24 @@ describe('sort-classes', () => {
                 },
               ],
             })
+
+            await valid({
+              code: dedent`
+                class Class {
+                  a = computed(() => {
+                    console.log(this.b)
+                  });
+
+                  b;
+                }
+              `,
+              options: [
+                {
+                  ignoreCallbackDependenciesPatterns,
+                  useExperimentalDependencyDetection,
+                },
+              ],
+            })
           },
         )
 


### PR DESCRIPTION
- Fixes https://github.com/azat-io/eslint-plugin-perfectionist/issues/754

### Description

When `ignoreCallbackDependenciesPatterns` is passed with `useExperimentalDependencyDetection: true`, only the first call expression is being evaluated, sometimes leading to a forced dependency error being raised.