### PR TITLE
fix(757): ignore TypeScript 7 (in its current state)

### DIFF
--- a/rules/sort-imports/get-typescript-import.ts
+++ b/rules/sort-imports/get-typescript-import.ts
@@ -13,12 +13,26 @@ let cachedImport: typeof ts | undefined
  */
 let hasTriedLoadingTypescript: boolean = false
 
+let requiredTypescriptAttributes = [
+  'convertCompilerOptionsFromJson',
+  'createModuleResolutionCache',
+  'isExternalModuleNameRelative',
+  'parseJsonConfigFileContent',
+  'readConfigFile',
+  'resolveModuleName',
+  'sys',
+] as const satisfies (keyof typeof ts)[]
+export type TypescriptImport = Pick<
+  typeof ts,
+  (typeof requiredTypescriptAttributes)[number]
+>
+
 /**
  * Dynamically loads the typescript module if it's available and caches it.
  *
  * @returns The TypeScript module or null if it's not available.
  */
-export function getTypescriptImport(): typeof ts | null {
+export function getTypescriptImport(): TypescriptImport | null {
   if (cachedImport) {
     return cachedImport
   }
@@ -27,10 +41,21 @@ export function getTypescriptImport(): typeof ts | null {
   }
   hasTriedLoadingTypescript = true
   try {
-    cachedImport = createRequire(import.meta.url)('typescript') as typeof ts
+    let tsImport = createRequire(import.meta.url)('typescript') as typeof ts
+    if (!isSupportedTypescriptVersion(tsImport)) {
+      return null
+    }
+
+    cachedImport = tsImport
+    return cachedImport
     // eslint-disable-next-line sonarjs/no-ignored-exceptions
   } catch (_error) {
     return null
   }
-  return cachedImport
+}
+
+function isSupportedTypescriptVersion(typescriptImport: typeof ts): boolean {
+  return requiredTypescriptAttributes.every(attribute =>
+    Object.hasOwn(typescriptImport, attribute),
+  )
 }

--- a/rules/sort-imports/read-closest-ts-config-by-path.ts
+++ b/rules/sort-imports/read-closest-ts-config-by-path.ts
@@ -3,7 +3,10 @@ import type ts from 'typescript'
 import * as path from 'node:path'
 import * as fs from 'node:fs'
 
-import { getTypescriptImport } from './get-typescript-import'
+import {
+  type TypescriptImport,
+  getTypescriptImport,
+} from './get-typescript-import'
 
 /**
  * Heavily inspired from:
@@ -113,7 +116,7 @@ export function readClosestTsConfigByPath({
  * @throws {Error} If the config file cannot be read or parsed.
  */
 function getCompilerOptions(
-  typescriptImport: typeof ts,
+  typescriptImport: TypescriptImport,
   contextCwd: string,
   filePath: string,
 ): ReadClosestTsConfigByPathValue {

--- a/test/rules/sort-imports/get-typescript-import.test.ts
+++ b/test/rules/sort-imports/get-typescript-import.test.ts
@@ -44,7 +44,22 @@ describe('getTypescriptImport', () => {
     expect(mockCreateRequire).toHaveBeenCalledExactlyOnceWith('typescript')
   })
 
-  it('loads typescript once if typescript exists', () => {
+  it("doesn't load typescript if it exists but is missing at least one required key (Typescript 7)", () => {
+    mockCreateRequire.mockReturnValue({
+      convertCompilerOptionsFromJson: () => {},
+      isExternalModuleNameRelative: () => {},
+      createModuleResolutionCache: () => {},
+      parseJsonConfigFileContent: () => {},
+      readConfigFile: () => {},
+      sys: {},
+    } as unknown as typeof ts)
+
+    let result = getTypescriptImport()
+
+    expect(result).toBeNull()
+  })
+
+  it('loads typescript once if typescript exists and exposes all the necessary keys', () => {
     mockCreateRequire.mockReturnValue(ts)
 
     getTypescriptImport()

--- a/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
+++ b/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
@@ -30,6 +30,7 @@ let mockParseJsonConfigFileContent: Mock<
 let mockRequire: Mock<(moduleId: string) => typeof ts> = vi.fn(
   () =>
     ({
+      ...ts,
       createModuleResolutionCache: (
         _contextCwd: string,
         getCanonicalFileName: (fileName: string) => string,
@@ -44,7 +45,6 @@ let mockRequire: Mock<(moduleId: string) => typeof ts> = vi.fn(
         mockConvertCompilerOptionsFromJson(content),
       readConfigFile: (filePath: string): ts.ParsedCommandLine =>
         mockReadConfigFile(filePath),
-      sys: ts.sys,
     }) as unknown as typeof ts,
 )
 


### PR DESCRIPTION
- Fixes #757.

# Description

Our rules optionally support TypeScript (`sort-imports`). TypeScript 7 isn't supported for now, as it's not exposing the things we need like previous versions.

Let's add a check to disable it if that's the case.