### PR TITLE
fix: take into account extended tsconfigs

### DIFF
--- a/rules/sort-imports/get-typescript-import.ts
+++ b/rules/sort-imports/get-typescript-import.ts
@@ -14,7 +14,6 @@ let cachedImport: typeof ts | undefined
 let hasTriedLoadingTypescript: boolean = false
 
 let requiredTypescriptAttributes = [
-  'convertCompilerOptionsFromJson',
   'createModuleResolutionCache',
   'isExternalModuleNameRelative',
   'parseJsonConfigFileContent',

--- a/rules/sort-imports/read-closest-ts-config-by-path.ts
+++ b/rules/sort-imports/read-closest-ts-config-by-path.ts
@@ -136,34 +136,24 @@ function getCompilerOptions(
   }
 
   let parsedContent = typescriptImport.parseJsonConfigFileContent(
-    configFileRead,
+    configFileRead.config,
     typescriptImport.sys,
     path.dirname(filePath),
   )
-
-  let compilerOptionsConverted =
-    typescriptImport.convertCompilerOptionsFromJson(
-      // eslint-disable-next-line typescript/no-unsafe-member-access
-      parsedContent.raw.config.compilerOptions,
-      path.dirname(filePath),
-    )
-
-  if (compilerOptionsConverted.errors.length > 0) {
+  if (parsedContent.errors.length > 0) {
     throw new Error(
-      `Error getting compiler options: ${JSON.stringify(
-        compilerOptionsConverted.errors,
-      )}`,
+      `Error getting compiler options: ${JSON.stringify(parsedContent.errors)}`,
     )
   }
 
   let cache = typescriptImport.createModuleResolutionCache(
     contextCwd,
     fileName => typescriptImport.sys.resolvePath(fileName),
-    compilerOptionsConverted.options,
+    parsedContent.options,
   )
 
   let output: ReadClosestTsConfigByPathValue = {
-    compilerOptions: compilerOptionsConverted.options,
+    compilerOptions: parsedContent.options,
     cache,
   }
 

--- a/test/rules/sort-imports/get-typescript-import.test.ts
+++ b/test/rules/sort-imports/get-typescript-import.test.ts
@@ -46,7 +46,6 @@ describe('getTypescriptImport', () => {
 
   it("doesn't load typescript if it exists but is missing at least one required key (Typescript 7)", () => {
     mockCreateRequire.mockReturnValue({
-      convertCompilerOptionsFromJson: () => {},
       isExternalModuleNameRelative: () => {},
       createModuleResolutionCache: () => {},
       parseJsonConfigFileContent: () => {},

--- a/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
+++ b/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable typescript/no-unsafe-member-access */
-
 import type { Diagnostic } from 'typescript'
 import type { PathLike } from 'node:fs'
 import type { Mock } from 'vitest'
@@ -16,9 +14,6 @@ vi.mock(import('node:fs'), () => ({
   existsSync: (filePath: PathLike): boolean =>
     mockExistsSync(filePath as string),
 }))
-
-let mockConvertCompilerOptionsFromJson: Mock<(content: object) => unknown> =
-  vi.fn()
 
 let mockReadConfigFile: Mock<(filePath: string) => ts.ParsedCommandLine> =
   vi.fn()
@@ -41,8 +36,6 @@ let mockRequire: Mock<(moduleId: string) => typeof ts> = vi.fn(
       },
       parseJsonConfigFileContent: (content: object): ts.ParsedCommandLine =>
         mockParseJsonConfigFileContent(content),
-      convertCompilerOptionsFromJson: (content: object) =>
-        mockConvertCompilerOptionsFromJson(content),
       readConfigFile: (filePath: string): ts.ParsedCommandLine =>
         mockReadConfigFile(filePath),
     }) as unknown as typeof ts,
@@ -66,17 +59,11 @@ let testInput = {
   contextCwd: '../../../',
 }
 
-let tsConfigContent = {
-  raw: {
-    config: {
-      compilerOptions: {
-        baseUrl: './packages/package',
-      },
-    },
-  },
-} as ts.ParsedCommandLine
-
 describe('readClosestTsConfigByPath', () => {
+  let compilerOptions = {
+    baseUrl: './packages/package',
+  }
+
   let readClosestTsConfigByPath: typeof testedFunction
 
   beforeEach(async () => {
@@ -120,12 +107,13 @@ describe('readClosestTsConfigByPath', () => {
       )
     })
 
-    it("throws an error if the compiler options can't be converted", () => {
+    it('throws an error if the config has parse errors', () => {
       mockExistsSync.mockReturnValue(true)
       mockReadConfigFileReturnValue()
-      mockParseJsonConfigFileContentReturnValue()
-      mockConvertCompilerOptionsFromJson.mockReturnValue({
+      mockParseJsonConfigFileContent.mockReturnValue({
         errors: [{ code: 1 }] as Diagnostic[],
+        fileNames: [],
+        options: {},
       })
 
       expect(() =>
@@ -140,14 +128,11 @@ describe('readClosestTsConfigByPath', () => {
         mockExistsSync.mockReturnValue(true)
         mockReadConfigFileReturnValue()
         mockParseJsonConfigFileContentReturnValue()
-        mockConvertCompilerOptionsFromJsonReturnValue()
 
         readClosestTsConfigByPath(testInput)
         let result = readClosestTsConfigByPath(testInput)
 
-        expect(result?.compilerOptions).toEqual(
-          tsConfigContent.raw.config.compilerOptions,
-        )
+        expect(result?.compilerOptions).toEqual(compilerOptions)
         expect(mockExistsSync).toHaveBeenCalledExactlyOnceWith(
           path.normalize('../../repos/repo/packages/package/tsconfig.json'),
         )
@@ -159,7 +144,6 @@ describe('readClosestTsConfigByPath', () => {
         )
         mockReadConfigFileReturnValue()
         mockParseJsonConfigFileContentReturnValue()
-        mockConvertCompilerOptionsFromJsonReturnValue()
 
         // This should call to fs.existsSync three times: c, b, a.
         readClosestTsConfigByPath({
@@ -179,9 +163,7 @@ describe('readClosestTsConfigByPath', () => {
           contextCwd: './',
         })
 
-        expect(result?.compilerOptions).toEqual(
-          tsConfigContent.raw.config.compilerOptions,
-        )
+        expect(result?.compilerOptions).toEqual(compilerOptions)
         expect(mockExistsSync).toHaveBeenCalledTimes(4)
       })
 
@@ -191,7 +173,6 @@ describe('readClosestTsConfigByPath', () => {
         )
         mockReadConfigFileReturnValue()
         mockParseJsonConfigFileContentReturnValue()
-        mockConvertCompilerOptionsFromJsonReturnValue()
 
         /**
          * This should call to fs.existsSync 4 times: d, c, b, a.
@@ -213,25 +194,45 @@ describe('readClosestTsConfigByPath', () => {
           contextCwd: '../../',
         })
 
-        expect(result?.compilerOptions).toEqual(
-          tsConfigContent.raw.config.compilerOptions,
-        )
+        expect(result?.compilerOptions).toEqual(compilerOptions)
         expect(mockExistsSync).toHaveBeenCalledTimes(6)
       })
     })
 
     describe('when caching misses', () => {
+      it('passes the raw config to parseJsonConfigFileContent and returns the parsed options', () => {
+        mockExistsSync.mockReturnValue(true)
+        let rawConfig = {
+          compilerOptions: { baseUrl: './packages/package' },
+          extends: '../tsconfig.base.json',
+        }
+        mockReadConfigFileReturnValue({ config: rawConfig })
+        let resolvedOptions = {
+          baseUrl: './packages/package',
+          paths: { '@/*': ['src/*'] },
+        }
+        mockParseJsonConfigFileContent.mockReturnValue({
+          options: resolvedOptions,
+          fileNames: [],
+          errors: [],
+        })
+
+        let result = readClosestTsConfigByPath(testInput)
+
+        expect(mockParseJsonConfigFileContent).toHaveBeenCalledExactlyOnceWith(
+          rawConfig,
+        )
+        expect(result?.compilerOptions).toEqual(resolvedOptions)
+      })
+
       it('returns a local tsconfig.json when matched', () => {
         mockExistsSync.mockReturnValue(true)
         mockReadConfigFileReturnValue()
         mockParseJsonConfigFileContentReturnValue()
-        mockConvertCompilerOptionsFromJsonReturnValue()
 
         let result = readClosestTsConfigByPath(testInput)
 
-        expect(result?.compilerOptions).toEqual(
-          tsConfigContent.raw.config.compilerOptions,
-        )
+        expect(result?.compilerOptions).toEqual(compilerOptions)
       })
 
       it('returns a parent tsconfig.json when matched', () => {
@@ -241,13 +242,10 @@ describe('readClosestTsConfigByPath', () => {
         )
         mockReadConfigFileReturnValue()
         mockParseJsonConfigFileContentReturnValue()
-        mockConvertCompilerOptionsFromJsonReturnValue()
 
         let result = readClosestTsConfigByPath(testInput)
 
-        expect(result?.compilerOptions).toEqual(
-          tsConfigContent.raw.config.compilerOptions,
-        )
+        expect(result?.compilerOptions).toEqual(compilerOptions)
       })
 
       it('throws when searching fails.', () => {
@@ -282,16 +280,11 @@ describe('readClosestTsConfigByPath', () => {
     }
 
     function mockParseJsonConfigFileContentReturnValue(): void {
-      mockParseJsonConfigFileContent.mockReturnValue(tsConfigContent)
-    }
-
-    function mockConvertCompilerOptionsFromJsonReturnValue(): void {
-      mockConvertCompilerOptionsFromJson.mockReturnValue({
-        options: tsConfigContent.raw.config.compilerOptions,
+      mockParseJsonConfigFileContent.mockReturnValue({
+        options: compilerOptions,
+        fileNames: [],
         errors: [],
       })
     }
   })
 })
-
-/* eslint-enable typescript/no-unsafe-member-access */

--- a/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
+++ b/test/rules/sort-imports/read-closest-ts-config-by-path.test.ts
@@ -143,9 +143,9 @@ describe('readClosestTsConfigByPath', () => {
         mockConvertCompilerOptionsFromJsonReturnValue()
 
         readClosestTsConfigByPath(testInput)
-        let actual = readClosestTsConfigByPath(testInput)
+        let result = readClosestTsConfigByPath(testInput)
 
-        expect(actual?.compilerOptions).toEqual(
+        expect(result?.compilerOptions).toEqual(
           tsConfigContent.raw.config.compilerOptions,
         )
         expect(mockExistsSync).toHaveBeenCalledExactlyOnceWith(
@@ -168,19 +168,18 @@ describe('readClosestTsConfigByPath', () => {
           tsconfigRootDir: './a',
           contextCwd: '../../',
         })
-
         /**
          * This should call to fs.existsSync once: e, then it should retrieve c
          * from cache, pointing to a.
          */
-        let actual = readClosestTsConfigByPath({
+        let result = readClosestTsConfigByPath({
           tsconfigFilename: 'tsconfig.json',
           filePath: './a/b/c/e/f.ts',
           tsconfigRootDir: './a',
           contextCwd: './',
         })
 
-        expect(actual?.compilerOptions).toEqual(
+        expect(result?.compilerOptions).toEqual(
           tsConfigContent.raw.config.compilerOptions,
         )
         expect(mockExistsSync).toHaveBeenCalledTimes(4)
@@ -203,19 +202,18 @@ describe('readClosestTsConfigByPath', () => {
           tsconfigRootDir: './a',
           contextCwd: '../../',
         })
-
         /**
          * This should call to fs.existsSync 2: g, f Then it should retrieve b
          * from cache, pointing to a.
          */
-        let actual = readClosestTsConfigByPath({
+        let result = readClosestTsConfigByPath({
           tsconfigFilename: 'tsconfig.json',
           filePath: './a/b/f/g/h.ts',
           tsconfigRootDir: './a',
           contextCwd: '../../',
         })
 
-        expect(actual?.compilerOptions).toEqual(
+        expect(result?.compilerOptions).toEqual(
           tsConfigContent.raw.config.compilerOptions,
         )
         expect(mockExistsSync).toHaveBeenCalledTimes(6)
@@ -229,9 +227,9 @@ describe('readClosestTsConfigByPath', () => {
         mockParseJsonConfigFileContentReturnValue()
         mockConvertCompilerOptionsFromJsonReturnValue()
 
-        let actual = readClosestTsConfigByPath(testInput)
+        let result = readClosestTsConfigByPath(testInput)
 
-        expect(actual?.compilerOptions).toEqual(
+        expect(result?.compilerOptions).toEqual(
           tsConfigContent.raw.config.compilerOptions,
         )
       })
@@ -245,9 +243,9 @@ describe('readClosestTsConfigByPath', () => {
         mockParseJsonConfigFileContentReturnValue()
         mockConvertCompilerOptionsFromJsonReturnValue()
 
-        let actual = readClosestTsConfigByPath(testInput)
+        let result = readClosestTsConfigByPath(testInput)
 
-        expect(actual?.compilerOptions).toEqual(
+        expect(result?.compilerOptions).toEqual(
           tsConfigContent.raw.config.compilerOptions,
         )
       })


### PR DESCRIPTION
### Description

`sort-imports` allows reading the nearest `tsconfig.json` file. In the current implementation however, it doesn't take into account `tsconfig` extension, meaning that settings set at a higher level aren't taken into account.