### PR TITLE
docs: refine sort-arrays example configuration selector

### DIFF
--- a/docs/content/rules/sort-arrays.mdx
+++ b/docs/content/rules/sort-arrays.mdx
@@ -342,7 +342,7 @@ Example configuration 1: only sort arrays followed by `as const`.
     'error',
     {
       useConfigurationIf: {
-        matchesAstSelector: 'TSAsExpression > ArrayExpression',
+        matchesAstSelector: 'TSAsExpression[typeAnnotation.typeName.name=const] > ArrayExpression',
       },
       type: 'alphabetical',
     },


### PR DESCRIPTION
Update the `matchesAstSelector` to only match `as const` assertions, making the example more accurate and specific to the described use case.

### Pre-merge checklist

- [x] No similar open PR exists
- [ ] Description explains problem/solution or links an issue
- [ ] Tests added/updated when needed
