### PR TITLE
fix: don't fail on tsconfig files without input files

### DIFF
--- a/test/utils/tsconfig/read-closest-ts-config-by-path.test.ts
+++ b/test/utils/tsconfig/read-closest-ts-config-by-path.test.ts
@@ -123,6 +123,36 @@ describe('readClosestTsConfigByPath', () => {
       )
     })
 
+    it('ignores benign diagnostics about missing input files', () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadConfigFileReturnValue()
+      mockParseJsonConfigFileContent.mockReturnValue({
+        errors: [{ code: 18002 }, { code: 18003 }] as Diagnostic[],
+        options: compilerOptions,
+        fileNames: [],
+      })
+
+      let result = readClosestTsConfigByPath(testInput)
+
+      expect(result?.compilerOptions).toEqual(compilerOptions)
+    })
+
+    it('throws when fatal errors are mixed with benign diagnostics', () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadConfigFileReturnValue()
+      mockParseJsonConfigFileContent.mockReturnValue({
+        errors: [{ code: 18003 }, { code: 1 }] as Diagnostic[],
+        fileNames: [],
+        options: {},
+      })
+
+      expect(() =>
+        readClosestTsConfigByPath(testInput),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Error getting compiler options: [{"code":1}]]`,
+      )
+    })
+
     describe('when caching hits', () => {
       it('returns a local tsconfig.json without calling existsSync a second time', () => {
         mockExistsSync.mockReturnValue(true)

--- a/utils/tsconfig/read-closest-ts-config-by-path.ts
+++ b/utils/tsconfig/read-closest-ts-config-by-path.ts
@@ -30,6 +30,26 @@ export interface ReadClosestTsConfigByPathValue {
 }
 
 /**
+ * TS18002: The 'files' list in config file is empty.
+ */
+const EMPTY_FILES_LIST_DIAGNOSTIC_CODE = 18002
+
+/**
+ * TS18003: No inputs were found in config file.
+ */
+const NO_INPUTS_FOUND_DIAGNOSTIC_CODE = 18003
+
+/**
+ * Diagnostics that don't affect compiler options resolution. They only concern
+ * the list of input files, which is irrelevant here, and are commonly emitted
+ * for empty or solution-style tsconfig files.
+ */
+const IGNORED_DIAGNOSTIC_CODES = new Set([
+  EMPTY_FILES_LIST_DIAGNOSTIC_CODE,
+  NO_INPUTS_FOUND_DIAGNOSTIC_CODE,
+])
+
+/**
  * Cache mapping directories to their nearest tsconfig file path. Speeds up
  * config resolution for files in the same directory.
  */
@@ -140,9 +160,12 @@ function getCompilerOptions(
     typescriptImport.sys,
     path.dirname(filePath),
   )
-  if (parsedContent.errors.length > 0) {
+  let fatalErrors = parsedContent.errors.filter(
+    error => !IGNORED_DIAGNOSTIC_CODES.has(error.code),
+  )
+  if (fatalErrors.length > 0) {
     throw new Error(
-      `Error getting compiler options: ${JSON.stringify(parsedContent.errors)}`,
+      `Error getting compiler options: ${JSON.stringify(fatalErrors)}`,
     )
   }
 


### PR DESCRIPTION
### Description

Ignore TS18002/TS18003 tsconfig diagnostics - they only concern input files and don't affect compiler options resolution.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
