### PR TITLE
docs: fix dead legacy config links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ export default [
 ]
 ```
 
-### Legacy Config ([`.eslintrc.js`](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated))
+### Legacy Config ([`.eslintrc.js`](https://eslint.org/docs/v9.x/use/configure/configuration-files-deprecated))
 
 <!-- prettier-ignore -->
 ```js
@@ -159,7 +159,7 @@ export default [
 ]
 ```
 
-### Legacy Config ([`.eslintrc.js`](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated))
+### Legacy Config ([`.eslintrc.js`](https://eslint.org/docs/v9.x/use/configure/configuration-files-deprecated))
 
 <!-- prettier-ignore -->
 ```js


### PR DESCRIPTION
### Description

Click `.eslintrc.js` in either `### Legacy Config` heading and you land on ESLint's not-found page. Both point at `https://eslint.org/docs/latest/use/configure/configuration-files-deprecated`, and `latest` is ESLint 10 these days, which doesn't have that page. Bit of a shame, since the legacy sections are exactly where a reader wants to know what the file should look like.

    https://eslint.org/docs/latest/use/configure/configuration-files-deprecated   404
    https://eslint.org/docs/v9.x/use/configure/configuration-files-deprecated     200

The v9.x one is the same page, same title, still documenting `.eslintrc.json` and the rest. I tried `head`, `v10.x`, `v8.x` and `v7.x` aswell and they all 404, so v9 looks like only channel left carrying it.

Its in the published package too, readme lines 125 and 162 of `eslint-plugin-perfectionist@5.11.0`, so npmjs.com has the dead link on the package page. That one only clears on the next release.

### Reviewer notes

Readme only, no code. The two Flat Config headings a few lines up point at `latest/use/configure/configuration-files`, which is still live, so I've left those alone.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [ ] Tests added/updated when needed (nothing to test on a readme link)
