### PR TITLE
fix: add safety semicolon when the next element continues an expression

### DIFF
--- a/test/rules/sort-classes.test.ts
+++ b/test/rules/sort-classes.test.ts
@@ -5037,6 +5037,146 @@ describe('sort-classes', () => {
       })
     })
 
+    it('adds a safety semicolon when the next member starts with a generator', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              left: 'Symbol.iterator',
+              rightGroup: 'property',
+              leftGroup: 'method',
+              right: 'items',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Collection {
+            items = [];
+            *[Symbol.iterator]() { yield 1 }
+          }
+        `,
+        code: dedent`
+          class Collection {
+            *[Symbol.iterator]() { yield 1 }
+            items = []
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('adds a safety semicolon when the next member starts with a computed key', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedClassesOrder',
+            data: { left: 'key', right: 'a' },
+          },
+        ],
+        output: dedent`
+          class Class {
+            a = 1;
+            [key] = 2
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key] = 2
+            a = 1
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('adds a safety semicolon when the next member is an index signature', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              leftGroup: 'index-signature',
+              rightGroup: 'property',
+              left: '[key: string]',
+              right: 'b',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        options: [
+          {
+            ...options,
+            groups: ['property', 'index-signature'],
+          },
+        ],
+        output: dedent`
+          class Class {
+            b = 1;
+            [key: string]: string
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key: string]: string
+            b = 1
+          }
+        `,
+      })
+    })
+
+    it('adds a safety semicolon to an accessor moved above a computed member', async () => {
+      await invalid({
+        errors: [
+          {
+            data: {
+              rightGroup: 'accessor-property',
+              leftGroup: 'method',
+              left: 'key',
+              right: 'a',
+            },
+            messageId: 'unexpectedClassesGroupOrder',
+          },
+        ],
+        output: dedent`
+          class Class {
+            accessor a = 1;
+            [key]() {}
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key]() {}
+            accessor a = 1
+          }
+        `,
+        options: [options],
+      })
+    })
+
+    it('keeps a property without an initializer free of a safety semicolon', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedClassesOrder',
+            data: { left: 'key', right: 'a' },
+          },
+        ],
+        output: dedent`
+          class Class {
+            a: number
+            [key] = 2
+          }
+        `,
+        code: dedent`
+          class Class {
+            [key] = 2
+            a: number
+          }
+        `,
+        options: [options],
+      })
+    })
+
     it.each([
       '^[rgb]$',
       ['noMatch', '^[rgb]$'],
@@ -11408,7 +11548,7 @@ describe('sort-classes', () => {
         ],
         output: dedent`
           class Class {
-            static b = 'b'
+            static b = 'b';
 
             [key in O]
 

--- a/test/rules/sort-imports.test.ts
+++ b/test/rules/sort-imports.test.ts
@@ -736,6 +736,28 @@ describe('sort-imports', () => {
       })
     })
 
+    it('adds a safety semicolon when the statement after the imports starts with a computed member access', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedImportsOrder',
+            data: { right: 'a', left: 'b' },
+          },
+        ],
+        output: dedent`
+          const a = require('a');
+          const b = require('b');
+          [1].forEach(element => element)
+        `,
+        code: dedent`
+          const b = require('b')
+          const a = require('a');
+          [1].forEach(element => element)
+        `,
+        options: [options],
+      })
+    })
+
     it('groups and sorts CommonJS require imports by type and source', async () => {
       await valid({
         code: dedent`

--- a/utils/does-node-end-with-expression.ts
+++ b/utils/does-node-end-with-expression.ts
@@ -1,0 +1,42 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
+/**
+ * Determines whether the node's source text ends with an expression.
+ *
+ * Automatic Semicolon Insertion only terminates an element at a line break when
+ * the next token cannot continue it. An element whose text ends with an
+ * expression can be continued, so a token such as `[`, `(` or `*` placed on the
+ * following line is absorbed into that expression instead of starting a new
+ * element.
+ *
+ * @example
+ *
+ * ```ts
+ * // Ends with an expression: `[Symbol.iterator]` would be read as a member
+ * // access on `[]` if it were moved onto the next line.
+ * class Collection {
+ *   items = []
+ * }
+ *
+ * // Does not end with an expression: a type annotation cannot be continued.
+ * class Collection {
+ *   items: string[]
+ * }
+ * ```
+ *
+ * @param node - AST node to inspect.
+ * @returns True if a following token could continue the node's text.
+ */
+export function doesNodeEndWithExpression(node: TSESTree.Node): boolean {
+  switch (node.type) {
+    case AST_NODE_TYPES.VariableDeclaration:
+      return true
+    case AST_NODE_TYPES.PropertyDefinition:
+    case AST_NODE_TYPES.AccessorProperty:
+      return node.value !== null
+    default:
+      return false
+  }
+}

--- a/utils/is-expression-continuation-token.ts
+++ b/utils/is-expression-continuation-token.ts
@@ -1,0 +1,33 @@
+import type { TSESTree } from '@typescript-eslint/types'
+
+/**
+ * First characters of the tokens that continue the expression written on the
+ * previous line instead of starting a new element.
+ */
+const EXPRESSION_CONTINUATION_CHARACTERS = new Set([
+  '[',
+  '(',
+  '`',
+  '*',
+  '+',
+  '-',
+  '/',
+  '<',
+])
+
+/**
+ * Determines whether a token continues the expression that precedes it.
+ *
+ * Such a token prevents Automatic Semicolon Insertion from terminating the
+ * previous element at the line break: `[` starts a member access or a computed
+ * key, `*` a multiplication or a generator, a backtick a tagged template, and
+ * so on.
+ *
+ * @param token - Token that follows the element, if any.
+ * @returns True if the token continues the preceding expression.
+ */
+export function isExpressionContinuationToken(
+  token: TSESTree.Token | undefined | null,
+): boolean {
+  return EXPRESSION_CONTINUATION_CHARACTERS.has(token?.value.charAt(0) ?? '')
+}

--- a/utils/make-order-fixes.ts
+++ b/utils/make-order-fixes.ts
@@ -3,6 +3,8 @@ import type { TSESLint } from '@typescript-eslint/utils'
 import type { CommonPartitionOptions } from '../types/common-partition-options'
 import type { SortingNode } from '../types/sorting-node'
 
+import { isExpressionContinuationToken } from './is-expression-continuation-token'
+import { doesNodeEndWithExpression } from './does-node-end-with-expression'
 import { getNodeRange } from './get-node-range'
 
 /**
@@ -129,11 +131,19 @@ export function makeOrderFixes({
       nextToken?.loc.start.line === node.loc.end.line
     let isNextTokenSafeCharacter =
       nextToken?.value === ';' || nextToken?.value === ','
+    let nextSortedSortingNode = sortedNodes.at(i + 1)
+    let followingToken =
+      nextSortedSortingNode ?
+        sourceCode.getFirstToken(nextSortedSortingNode.node)
+      : nextToken
+    let isFollowedByExpressionContinuation =
+      doesNodeEndWithExpression(sortedNode) &&
+      isExpressionContinuationToken(followingToken)
     if (
       addSafetySemicolonWhenInline &&
-      isNextTokenOnSameLineAsNode &&
       !sortedNextNodeEndsWithSafeCharacter &&
-      !isNextTokenSafeCharacter
+      !isNextTokenSafeCharacter &&
+      (isNextTokenOnSameLineAsNode || isFollowedByExpressionContinuation)
     ) {
       sortedNodeCode += ';'
     }


### PR DESCRIPTION
### Description

Add safety semicolons when a reordered element is followed by a token that can continue its expression across a line break. This prevents syntax errors and unintended behavior changes when sorting class members and CommonJS imports.

### Reviewer notes

N/A.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
