### PR TITLE
perf: build a sortable list's fix once instead of once per report

### DIFF
--- a/rules/sort-switch-case.ts
+++ b/rules/sort-switch-case.ts
@@ -13,11 +13,11 @@ import { isConditionExpression } from './sort-switch-case/is-condition-expressio
 import { validateCustomSortConfig } from '../utils/validate-custom-sort-config'
 import { reportErrors, ORDER_ERROR, RIGHT, LEFT } from '../utils/report-errors'
 import { createNodeIndexMap } from '../utils/create-node-index-map'
+import { createFixProvider } from '../utils/create-fix-provider'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { rangeToDiff } from '../utils/range-to-diff'
 import { getSettings } from '../utils/get-settings'
 import { isSortable } from '../utils/is-sortable'
-import { makeFixes } from '../utils/make-fixes'
 import { sortNodes } from '../utils/sort-nodes'
 import { pairwise } from '../utils/pairwise'
 import { complete } from '../utils/complete'
@@ -106,6 +106,11 @@ export default createEslintRule<Options, MessageId>({
         )
 
         let nodeIndexMap = createNodeIndexMap(sortedCaseNameSortingNodes)
+        let getCaseNameFix = createFixProvider({
+          sortedNodes: sortedCaseNameSortingNodes,
+          nodes: caseNodesSortingNodeGroup,
+          sourceCode,
+        })
 
         pairwise(caseNodesSortingNodeGroup, (left, right) => {
           if (!left) {
@@ -120,10 +125,8 @@ export default createEslintRule<Options, MessageId>({
           }
 
           reportErrors({
-            sortedNodes: sortedCaseNameSortingNodes,
-            nodes: caseNodesSortingNodeGroup,
             messageIds: [ORDER_ERROR_ID],
-            sourceCode,
+            getFix: getCaseNameFix,
             context,
             right,
             left,
@@ -243,6 +246,11 @@ export default createEslintRule<Options, MessageId>({
         .flat()
       let sortingNodeGroupsForBlockSortFlat =
         sortingNodeGroupsForBlockSort.flat()
+      let getBlockFix = createFixProvider({
+        sortedNodes: sortedSortingNodeGroupsForBlockSort,
+        nodes: sortingNodeGroupsForBlockSortFlat,
+        sourceCode,
+      })
       pairwise(sortingNodeGroupsForBlockSortFlat, (left, right) => {
         if (!left) {
           return
@@ -257,13 +265,7 @@ export default createEslintRule<Options, MessageId>({
           fix: fixer =>
             hasUnsortedNodes ?
               [] /* Raise errors but only sort on second iteration. */
-            : makeFixes({
-                sortedNodes: sortedSortingNodeGroupsForBlockSort,
-                nodes: sortingNodeGroupsForBlockSortFlat,
-                hasCommentAboveMissing: false,
-                sourceCode,
-                fixer,
-              }),
+            : getBlockFix({ hasCommentAboveMissing: false, fixer }),
           data: {
             [RIGHT]: right.name,
             [LEFT]: left.name,

--- a/test/rules/sort-objects.test.ts
+++ b/test/rules/sort-objects.test.ts
@@ -12241,6 +12241,45 @@ describe('sort-objects', () => {
             `,
             options: [{ type: 'alphabetical', order: 'asc' }],
           },
+          {
+            errors: [
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: { right: 'd', left: 'e' },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: { right: 'c', left: 'd' },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: { right: 'b', left: 'c' },
+              },
+              {
+                messageId: 'unexpectedObjectsOrder',
+                data: { right: 'a', left: 'b' },
+              },
+            ],
+            output: dedent`
+              let obj = {
+                a: 5,
+                b: 4, // trailing b
+                c: 3,
+                d: 2,
+                e: 1 // trailing e
+              }
+            `,
+            code: dedent`
+              let obj = {
+                e: 1, // trailing e
+                d: 2,
+                c: 3,
+                b: 4, // trailing b
+                a: 5
+              }
+            `,
+            options: [{ type: 'alphabetical', order: 'asc' }],
+          },
         ],
         valid: [
           {

--- a/test/rules/sort-switch-case.test.ts
+++ b/test/rules/sort-switch-case.test.ts
@@ -446,6 +446,42 @@ describe('sort-switch-case', () => {
       })
     })
 
+    it('sorts several unsorted case name groups in one pass', async () => {
+      await invalid({
+        errors: [
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: { right: 'a1', left: 'a2' },
+          },
+          {
+            messageId: 'unexpectedSwitchCaseOrder',
+            data: { right: 'b1', left: 'b2' },
+          },
+        ],
+        output: dedent`
+          switch (value) {
+            case 'a1':
+            case 'a2':
+              return 'a'
+            case 'b1':
+            case 'b2':
+              return 'b'
+          }
+        `,
+        code: dedent`
+          switch (value) {
+            case 'a2':
+            case 'a1':
+              return 'a'
+            case 'b2':
+            case 'b1':
+              return 'b'
+          }
+        `,
+        options: [options],
+      })
+    })
+
     it('works with grouped cases with default', async () => {
       await valid({
         code: dedent`
@@ -3572,6 +3608,47 @@ describe('sort-switch-case', () => {
                 data: { right: 'a', left: 'b' },
               },
             ],
+            options: [{ type: 'alphabetical', order: 'asc' }],
+          },
+          {
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: { right: 'c', left: 'd' },
+              },
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: { right: 'b', left: 'c' },
+              },
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: { right: 'a', left: 'b' },
+              },
+            ],
+            output: dedent`
+              switch (x) {
+                case 'a': // a
+                  break
+                case 'b': // b
+                  break
+                case 'c': // c
+                  break
+                case 'd': // d
+                  break
+              }
+            `,
+            code: dedent`
+              switch (x) {
+                case 'd': // d
+                  break
+                case 'c': // c
+                  break
+                case 'b': // b
+                  break
+                case 'a': // a
+                  break
+              }
+            `,
             options: [{ type: 'alphabetical', order: 'asc' }],
           },
         ],

--- a/test/utils/create-fix-provider.test.ts
+++ b/test/utils/create-fix-provider.test.ts
@@ -1,0 +1,77 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SortingNode } from '../../types/sorting-node'
+
+import { createFixProvider } from '../../utils/create-fix-provider'
+import { makeFixes } from '../../utils/make-fixes'
+
+vi.mock('../../utils/make-fixes', () => ({ makeFixes: vi.fn() }))
+
+describe('create-fix-provider', () => {
+  beforeEach(() => {
+    vi.mocked(makeFixes).mockReset()
+  })
+
+  it('builds the fix once and returns the same value on every call', () => {
+    vi.mocked(makeFixes).mockReturnValue([
+      { range: [2, 4], text: 'A' },
+      { range: [6, 8], text: 'B' },
+    ] as TSESLint.RuleFix[])
+    let getFix = createFixProvider(getMakeFixesParameters())
+
+    let firstFix = getFix({ hasCommentAboveMissing: false, fixer })
+    let secondFix = getFix({ hasCommentAboveMissing: false, fixer })
+
+    expect(secondFix).toBe(firstFix)
+    expect(makeFixes).toHaveBeenCalledExactlyOnceWith({
+      ...getMakeFixesParameters(),
+      hasCommentAboveMissing: false,
+      fixer,
+    })
+  })
+
+  it('caches an empty fix list instead of rebuilding it', () => {
+    vi.mocked(makeFixes).mockReturnValue([])
+    let getFix = createFixProvider(getMakeFixesParameters())
+
+    let firstFix = getFix({ hasCommentAboveMissing: false, fixer })
+    let secondFix = getFix({ hasCommentAboveMissing: false, fixer })
+
+    expect(secondFix).toBe(firstFix)
+    expect(makeFixes).toHaveBeenCalledExactlyOnceWith({
+      ...getMakeFixesParameters(),
+      hasCommentAboveMissing: false,
+      fixer,
+    })
+  })
+
+  it('keeps a separate slot for each hasCommentAboveMissing value', () => {
+    vi.mocked(makeFixes)
+      .mockReturnValueOnce([{ range: [0, 1], text: 'A' }] as TSESLint.RuleFix[])
+      .mockReturnValueOnce([{ range: [2, 3], text: 'B' }] as TSESLint.RuleFix[])
+    let getFix = createFixProvider(getMakeFixesParameters())
+
+    let withoutComment = getFix({ hasCommentAboveMissing: false, fixer })
+    let withComment = getFix({ hasCommentAboveMissing: true, fixer })
+
+    expect(makeFixes).toHaveBeenCalledTimes(2)
+    expect(withoutComment).toEqual([{ range: [0, 1], text: 'A' }])
+    expect(withComment).toEqual([{ range: [2, 3], text: 'B' }])
+  })
+
+  let fixer = {} as TSESLint.RuleFixer
+
+  function getMakeFixesParameters(): {
+    sourceCode: TSESLint.SourceCode
+    sortedNodes: SortingNode[]
+    nodes: SortingNode[]
+  } {
+    return {
+      sourceCode: { text: '0123456789' } as unknown as TSESLint.SourceCode,
+      sortedNodes: [],
+      nodes: [],
+    }
+  }
+})

--- a/test/utils/merge-fixes.test.ts
+++ b/test/utils/merge-fixes.test.ts
@@ -1,0 +1,56 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import { describe, expect, it } from 'vitest'
+
+import { mergeFixes } from '../../utils/merge-fixes'
+
+describe('merge-fixes', () => {
+  it('returns an empty list unchanged', () => {
+    let fixes: TSESLint.RuleFix[] = []
+
+    expect(mergeFixes({ sourceCode: getSourceCodeMock(), fixes })).toBe(fixes)
+  })
+
+  it('returns a single-fix list unchanged', () => {
+    let fixes = [{ range: [2, 4], text: 'A' }] as TSESLint.RuleFix[]
+
+    expect(mergeFixes({ sourceCode: getSourceCodeMock(), fixes })).toBe(fixes)
+  })
+
+  it('merges out-of-order fixes and splices the original text into the gap', () => {
+    let fixes = [
+      { range: [6, 8], text: 'B' },
+      { range: [2, 4], text: 'A' },
+    ] as TSESLint.RuleFix[]
+
+    expect(mergeFixes({ sourceCode: getSourceCodeMock(), fixes })).toEqual({
+      range: [2, 8],
+      text: 'A45B',
+    })
+  })
+
+  it('orders fixes sharing a range start by their range end', () => {
+    let fixes = [
+      { range: [2, 6], text: 'B' },
+      { range: [2, 2], text: 'A' },
+    ] as TSESLint.RuleFix[]
+
+    expect(mergeFixes({ sourceCode: getSourceCodeMock(), fixes })).toEqual({
+      range: [2, 6],
+      text: 'AB',
+    })
+  })
+
+  it('returns overlapping fixes unchanged', () => {
+    let fixes = [
+      { range: [2, 6], text: 'A' },
+      { range: [4, 8], text: 'B' },
+    ] as TSESLint.RuleFix[]
+
+    expect(mergeFixes({ sourceCode: getSourceCodeMock(), fixes })).toBe(fixes)
+  })
+
+  function getSourceCodeMock(): TSESLint.SourceCode {
+    return { text: '0123456789' } as unknown as TSESLint.SourceCode
+  }
+})

--- a/test/utils/report-all-errors.test.ts
+++ b/test/utils/report-all-errors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Linter } from 'eslint'
+
+import type * as MakeFixesModule from '../../utils/make-fixes'
+
+import rule from '../../rules/sort-objects'
+
+let makeFixesCalls = 0
+
+vi.mock('../../utils/make-fixes', async importOriginal => {
+  let original = await importOriginal<typeof MakeFixesModule>()
+  return {
+    ...original,
+    makeFixes: (...parameters: Parameters<typeof original.makeFixes>) => {
+      makeFixesCalls++
+      return original.makeFixes(...parameters)
+    },
+  }
+})
+
+describe('report-all-errors', () => {
+  it('builds the whole-list fix once per unsorted list, not once per report', () => {
+    let keys = Array.from(
+      { length: 200 },
+      (_, index) => `k${String(200 - index).padStart(3, '0')}`,
+    )
+    let code = `let o = {\n${keys.map(key => `  ${key}: 1,`).join('\n')}\n}\n`
+    let linter = new Linter({ configType: 'flat' })
+
+    let messages = linter.verify(code, getConfig(), 'file.js')
+
+    let fixTexts = new Set(messages.map(message => message.fix!.text))
+
+    expect(messages).toHaveLength(199)
+    expect(makeFixesCalls).toBe(1)
+    expect(fixTexts.size).toBe(1)
+  })
+
+  function getConfig(): Linter.Config[] {
+    return [
+      {
+        rules: {
+          'perfectionist/sort-objects': [
+            'error',
+            { type: 'alphabetical', order: 'asc' },
+          ],
+        },
+        plugins: { perfectionist: { rules: { 'sort-objects': rule } } },
+        files: ['**/*.js'],
+      },
+    ] as unknown as Linter.Config[]
+  }
+})

--- a/utils/create-fix-provider.ts
+++ b/utils/create-fix-provider.ts
@@ -1,0 +1,108 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import type { SortingNode } from '../types/sorting-node'
+import type { MakeFixesParameters } from './make-fixes'
+
+import { mergeFixes } from './merge-fixes'
+import { makeFixes } from './make-fixes'
+
+/**
+ * Returns the fix for one report of a sortable list.
+ *
+ * Called from inside a report's `fix` callback. Repeated calls with the same
+ * `hasCommentAboveMissing` value return the very same value.
+ */
+export type FixProvider = (
+  parameters: FixProviderParameters,
+) => TSESLint.RuleFix[] | TSESLint.RuleFix
+
+/**
+ * Parameters a fix provider is called with for one report.
+ */
+interface FixProviderParameters {
+  /**
+   * Whether the reported pair is missing its required comment above.
+   */
+  hasCommentAboveMissing: boolean
+
+  /**
+   * ESLint fixer object of the report currently being created.
+   */
+  fixer: TSESLint.RuleFixer
+}
+
+/**
+ * Creates a provider that builds a sortable list's fix at most once.
+ *
+ * Every report of a list carries the same whole-list fix, but `makeFixes` walks
+ * the entire list on each call and ESLint invokes the `fix` callback of every
+ * report eagerly. A list with `n` misplaced elements therefore costs `n`
+ * reports times `O(n)` work and retains `n` copies of the whole-list string.
+ *
+ * The provider computes that fix lazily on the first report that asks for it,
+ * merges it into the single `{ range, text }` object ESLint would have built
+ * anyway, and hands the same object to every later report. ESLint's `cloneFix`
+ * copies the `text` by reference, so the retained text collapses from `O(n²)`
+ * to `O(n)` characters.
+ *
+ * The provider's lifetime is the closure's — exactly one sortable list. It must
+ * never be hoisted above the loop that owns the invariant `nodes` and
+ * `sortedNodes` arrays, or one list's fix would be handed to another list's
+ * reports.
+ *
+ * Building is deferred to the `fix` callback on purpose: ESLint skips fix
+ * normalization entirely when fixes are disabled, so `--fix`-less hosts and
+ * language servers keep paying nothing.
+ *
+ * Two slots are kept, keyed on `hasCommentAboveMissing`, because `makeFixes`
+ * branches on it. They are filled lazily and independently, and the miss is
+ * detected with `=== undefined` rather than `??=`: `makeFixes` legitimately
+ * returns an empty array, and a nullish-coalescing slot would recompute it on
+ * every report and silently keep the quadratic behavior.
+ *
+ * @example
+ *
+ * ```ts
+ * let getFix = createFixProvider({
+ *   sortedNodes,
+ *   sourceCode,
+ *   options,
+ *   nodes,
+ * })
+ * pairwise(nodes, (left, right) => {
+ *   context.report({
+ *     fix: fixer => getFix({ hasCommentAboveMissing: false, fixer }),
+ *     // ...
+ *   })
+ * })
+ * ```
+ *
+ * @template T - Type of sorting node.
+ * @param makeFixesParameters - Everything `makeFixes` needs that is invariant
+ *   across the list's reports.
+ * @returns Provider returning the list's merged fix.
+ */
+export function createFixProvider<T extends SortingNode>(
+  makeFixesParameters: Omit<
+    MakeFixesParameters<T>,
+    'hasCommentAboveMissing' | 'fixer'
+  >,
+): FixProvider {
+  let cachedFixes = new Map<boolean, TSESLint.RuleFix[] | TSESLint.RuleFix>()
+
+  return ({ hasCommentAboveMissing, fixer }) => {
+    let cachedFix = cachedFixes.get(hasCommentAboveMissing)
+    if (cachedFix === undefined) {
+      cachedFix = mergeFixes({
+        fixes: makeFixes({
+          ...makeFixesParameters,
+          hasCommentAboveMissing,
+          fixer,
+        }),
+        sourceCode: makeFixesParameters.sourceCode,
+      })
+      cachedFixes.set(hasCommentAboveMissing, cachedFix)
+    }
+    return cachedFix
+  }
+}

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -15,7 +15,7 @@ import { makeOrderFixes } from './make-order-fixes'
  *
  * @template T - Type of sorting node extending the base SortingNode.
  */
-interface MakeFixesParameters<T extends SortingNode> {
+export interface MakeFixesParameters<T extends SortingNode> {
   /**
    * Optional configuration for various sorting behaviors.
    */

--- a/utils/merge-fixes.ts
+++ b/utils/merge-fixes.ts
@@ -1,0 +1,100 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+/**
+ * Parameters for merging a list of fixes into a single fix.
+ */
+interface MergeFixesParameters {
+  /**
+   * ESLint source code object, used to splice the original text back into the
+   * gaps between fix ranges.
+   */
+  sourceCode: TSESLint.SourceCode
+
+  /**
+   * Fixes to merge. The array is never mutated.
+   */
+  fixes: TSESLint.RuleFix[]
+}
+
+/**
+ * Merges a list of fixes into the single whole-range fix that the linter would
+ * have built itself.
+ *
+ * This reproduces `mergeFixes` from
+ * `node_modules/eslint/lib/linter/file-report.js:241-278` for the fix shapes
+ * this plugin emits. That algorithm is byte-identical across the whole peer
+ * range (`^8.45.0 || ^9.0.0 || ^10.0.0`); it only moved from
+ * `report-translator.js` to `file-report.js` in 9.39.
+ *
+ * Doing the merge here lets one merged fix be shared by every report of the
+ * same list. ESLint then takes the `assertValidFix(fix); return cloneFix(fix)`
+ * path and `cloneFix` copies `text` by reference, so `n` messages retain one
+ * string instead of `n` copies of it.
+ *
+ * Notes on the deliberate differences from ESLint's implementation:
+ *
+ * - The `|| a.range[1] - b.range[1]` tiebreak is load-bearing, not decorative.
+ *   `makeFixes` concatenates order fixes with comment-after or newlines fixes
+ *   whose ranges interleave, and a zero-width insertion at offset `x` regularly
+ *   shares its start with a replacement that begins at `x`. Sorting on the
+ *   start offset alone silently under-covers the merged range instead of
+ *   failing loudly.
+ * - Three of ESLint's branches are not reproduced because they are unreachable
+ *   here: the `if (fix.range[0] >= 0)` guard, the `0` term of `Math.max(0,
+ *   start, lastPos)` (replaced by initializing `lastPosition` to `start`), and
+ *   the trailing `text += originalText.slice(..., end)`. Every fix range comes
+ *   from an AST node or token, so it is never negative, and non-overlap makes
+ *   `lastPosition === end` after the loop, which makes that trailing slice
+ *   provably empty. ESLint's `fixes.length === 1` shortcut is subsumed by the
+ *   `length < 2` early return.
+ * - Overlapping fixes fall back to the original array instead of throwing. ESLint
+ *   raises `Fix objects must not be overlapped in a report.` from its own
+ *   `mergeFixes`, and oxlint has no overlap check at all, so returning the
+ *   unmerged array leaves both hosts behaving exactly as they do today. The
+ *   cost is that a future fixer which starts overlapping quietly keeps the
+ *   O(n²) path instead of announcing itself.
+ *
+ * @example
+ *
+ * ```ts
+ * mergeFixes({
+ *   fixes: [
+ *     { range: [6, 8], text: 'B' },
+ *     { range: [2, 4], text: 'A' },
+ *   ],
+ *   sourceCode, // text: '0123456789'
+ * })
+ * // { range: [2, 8], text: 'A45B' }
+ * ```
+ *
+ * @param params - Parameters for merging.
+ * @returns The merged fix, or the original array when there is nothing to merge
+ *   or the fixes overlap.
+ */
+export function mergeFixes({
+  sourceCode,
+  fixes,
+}: MergeFixesParameters): TSESLint.RuleFix[] | TSESLint.RuleFix {
+  if (fixes.length < 2) {
+    return fixes
+  }
+
+  let sortedFixes = fixes.toSorted(
+    (a, b) => a.range[0] - b.range[0] || a.range[1] - b.range[1],
+  )
+  let [start] = sortedFixes.at(0)!.range
+  let [, end] = sortedFixes.at(-1)!.range
+
+  let lastPosition = start
+  let text = ''
+  for (let fix of sortedFixes) {
+    let [fixStart, fixEnd] = fix.range
+    if (fixStart < lastPosition) {
+      return fixes
+    }
+    text += sourceCode.text.slice(lastPosition, fixStart) + fix.text
+    lastPosition = fixEnd
+  }
+
+  return { range: [start, end], text }
+}

--- a/utils/report-all-errors.ts
+++ b/utils/report-all-errors.ts
@@ -11,6 +11,7 @@ import { getCommentAboveThatShouldExist } from './get-comment-above-that-should-
 import { isNodeDependentOnOtherNode } from './is-node-dependent-on-other-node'
 import { getNewlinesBetweenErrors } from './get-newlines-between-errors'
 import { createNodeIndexMap } from './create-node-index-map'
+import { createFixProvider } from './create-fix-provider'
 import { getGroupIndex } from './get-group-index'
 import { reportErrors } from './report-errors'
 import { pairwise } from './pairwise'
@@ -238,6 +239,15 @@ export function reportAllErrors<
       )
     : new Set<SortingNodeWithDependencies>()
 
+  let getFix = createFixProvider({
+    sortedNodes: sortedNodesExcludingEslintDisabled,
+    ignoreFirstNodeHighestBlockComment,
+    newlinesBetweenValueGetter,
+    sourceCode,
+    options,
+    nodes,
+  })
+
   pairwise(nodes, (left, right) => {
     let leftInfo =
       left ?
@@ -324,16 +334,11 @@ export function reportAllErrors<
     }
 
     reportErrors({
-      sortedNodes: sortedNodesExcludingEslintDisabled,
-      ignoreFirstNodeHighestBlockComment,
       firstUnorderedNodeDependentOnRight,
-      newlinesBetweenValueGetter,
       commentAboveMissing,
       messageIds,
-      sourceCode,
-      options,
       context,
-      nodes,
+      getFix,
       right,
       left,
     })

--- a/utils/report-errors.ts
+++ b/utils/report-errors.ts
@@ -1,11 +1,7 @@
 import type { TSESLint } from '@typescript-eslint/utils'
 
-import type { NewlinesBetweenValueGetter } from './get-newlines-between-errors'
-import type { CommonPartitionOptions } from '../types/common-partition-options'
-import type { CommonGroupsOptions } from '../types/common-groups-options'
+import type { FixProvider } from './create-fix-provider'
 import type { SortingNode } from '../types/sorting-node'
-
-import { makeFixes } from './make-fixes'
 
 const NODE_DEPENDENT_ON_RIGHT = 'nodeDependentOnRight'
 
@@ -47,18 +43,12 @@ interface ReportErrorsParameters<
   MessageIds extends string,
   T extends SortingNode,
 > {
-  options?: Pick<CommonPartitionOptions, 'partitionByComment'> &
-    CommonGroupsOptions<string, unknown, unknown>
-  newlinesBetweenValueGetter?: NewlinesBetweenValueGetter<T>
   context: TSESLint.RuleContext<MessageIds, unknown[]>
-  ignoreFirstNodeHighestBlockComment?: boolean
   firstUnorderedNodeDependentOnRight?: T
-  sourceCode: TSESLint.SourceCode
   commentAboveMissing?: string
   messageIds: MessageIds[]
-  sortedNodes: T[]
+  getFix: FixProvider
   left: null | T
-  nodes: T[]
   right: T
 }
 
@@ -121,15 +111,10 @@ interface ReportErrorsParameters<
  */
 export function reportErrors<MessageIds extends string, T extends SortingNode>({
   firstUnorderedNodeDependentOnRight,
-  ignoreFirstNodeHighestBlockComment,
-  newlinesBetweenValueGetter,
   commentAboveMissing,
-  sortedNodes,
   messageIds,
-  sourceCode,
   context,
-  options,
-  nodes,
+  getFix,
   right,
   left,
 }: ReportErrorsParameters<MessageIds, T>): void {
@@ -144,15 +129,9 @@ export function reportErrors<MessageIds extends string, T extends SortingNode>({
         [LEFT_GROUP]: left?.group,
       },
       fix: (fixer: TSESLint.RuleFixer) =>
-        makeFixes({
+        getFix({
           hasCommentAboveMissing: !!commentAboveMissing,
-          ignoreFirstNodeHighestBlockComment,
-          newlinesBetweenValueGetter,
-          sortedNodes,
-          sourceCode,
-          options,
           fixer,
-          nodes,
         }),
       node: right.node,
       messageId,


### PR DESCRIPTION
### Description

`reportErrors` attached a `fix` callback to every reported pair, and each one rebuilt the fix for the whole list. ESLint calls those eagerly and retains the merged string per message, so `n` misplaced elements cost `O(n)` reports × `O(n)` work and `O(n²)` retained characters — on a plain `eslint` run, no `--fix`.

Now the fix is built at most once per list, lazily, and merged into the single `{ range, text }` ESLint would have built anyway. `cloneFix` copies `text` by reference, so retained text drops to `O(n)`.

Results - `sort-objects`, reversed N-key object

| N | time | heap |
|---|---|---|
| 1000 | 891 → **159 ms** | 177 → **76 MB** |
| 2000 | 3728 → **431 ms** | 593 → **56 MB** |
| 5000 | OOM → **2144 ms** | — → **69 MB** |

`sort-switch-case` at N=800: 567 → **82 ms**.

### Reviewer notes

N/A.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
